### PR TITLE
[212_6]Fix export as image for jpeg,tif

### DIFF
--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (binary convert)
-  (:use (binary common)))
+  (:use (binary common)
+        (convert images image-format)))
 
 (define (convert-binary-candidates)
   (cond ((os-macos?)

--- a/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
+++ b/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (binary pdftocairo)
-  (:use (binary common)))
+  (:use (binary common)
+        (convert images image-format)))
 
 (define (pdftocairo-binary-candidates)
   (cond ((os-macos?)
@@ -36,9 +37,10 @@
 (tm-define (pdf-file->pdftocairo-raster x opts)
   (let* ((dest (assoc-ref opts 'dest))
          (fullname (url-concretize dest))
-         (fm (url-format fullname))
-         (transp (if (== fm "png") "-transp " ""))
          (suffix (url-suffix fullname))
+         (fm* (format-from-suffix suffix))
+         (fm (if (== fm* "tif") "tiff" fm*))
+         (transp (if (== fm "png") "-transp " ""))
          (name (string-drop-right fullname (+ 1 (string-length suffix))))
          (res (get-raster-resolution opts))
          (cmd (url->system (find-binary-pdftocairo))))

--- a/TeXmacs/plugins/image/progs/image/pdf.scm
+++ b/TeXmacs/plugins/image/progs/image/pdf.scm
@@ -36,6 +36,12 @@
   ;;(:option "texmacs->image:raster-resolution" "300")
   )
 
+(converter pdf-file tif-file
+  (:require (has-binary-pdftocairo?))
+  (:function-with-options pdf-file->pdftocairo-raster)
+  ;;(:option "texmacs->image:raster-resolution" "300")
+  )
+
 ;;(converter pdf-file postscript-document
 ;;  (:require (has-pdftocairo?))
 ;;  (:shell "pdftocairo" "-eps" from to))

--- a/TeXmacs/progs/convert/images/tmimage.scm
+++ b/TeXmacs/progs/convert/images/tmimage.scm
@@ -232,7 +232,7 @@
         (let* ((sufl (string-length suffix))
                (surl (url->string myurl))
                (sl (string-length surl)))
-          (set! myurl (string->url (string-append (substring surl 0 (- sl sufl)) "pdf"))))))
+          (set! myurl (string->url (string-append (substring surl (- sl sufl) sl) "pdf"))))))
 
     ;; TODO Handle when output file already exists (presently we overwritte without warning)
 

--- a/TeXmacs/progs/convert/images/tmimage.scm
+++ b/TeXmacs/progs/convert/images/tmimage.scm
@@ -232,7 +232,7 @@
         (let* ((sufl (string-length suffix))
                (surl (url->string myurl))
                (sl (string-length surl)))
-          (set! myurl (string->url (string-append (substring surl (- sl sufl) sl) "pdf"))))))
+          (set! myurl (string->url (string-append (substring surl 0 (- sl sufl)) "pdf"))))))
 
     ;; TODO Handle when output file already exists (presently we overwritte without warning)
 

--- a/devel/212_6.md
+++ b/devel/212_6.md
@@ -49,16 +49,5 @@ Added missing `(convert images image-format)` import. Without it, `get-raster-re
 ### 4. `TeXmacs/plugins/image/progs/image/pdf.scm`
 Registered `pdf-file → tif-file` converter via pdftocairo. Previously only ImageMagick had a TIFF converter, so systems without ImageMagick could not export TIFF.
 
-### 5. `TeXmacs/progs/convert/images/tmimage.scm`
-Fixed `substring` indexing bug in the format fallback path. The old code extracted the suffix instead of the path prefix, producing an invalid URL when falling back to PDF:
-
-```scheme
-;; BEFORE — extracts suffix portion, produces garbage like "tiffpdf"
-(substring surl (- sl sufl) sl)
-
-;; AFTER — extracts path without suffix, produces correct "/path/file.pdf"
-(substring surl 0 (- sl sufl))
-```
-
 ## Why
-mupdf's `save_picture` only supports PNG output. The old code unconditionally treated jpeg/tiff as bitmap formats, sending them through a rendering path that silently failed. The converter pipeline (pdftocairo/ImageMagick) also had bugs: missing imports, missing converter registrations, incorrect CLI flag generation, and a broken fallback path.
+mupdf's `save_picture` only supports PNG output. The old code unconditionally treated jpeg/tiff as bitmap formats, sending them through a rendering path that silently failed. The converter pipeline (pdftocairo/ImageMagick) also had bugs: missing imports, missing converter registrations, and incorrect CLI flag generation.

--- a/devel/212_6.md
+++ b/devel/212_6.md
@@ -1,0 +1,64 @@
+# 212_6: Fix export selection as image for jpeg, tiff
+
+## How to Test
+- Select text in a document
+- File → Export selection as image → save as `.jpg` → verify file is created and contains the selection
+- Repeat for `.tif` and `.tiff`
+- Also test `.png` and `.pdf` works as expected
+
+## Issue #2728
+JPEG and TIFF formats could not be exported via "Export Selected Area as Image".PNG and PDF export worked.
+
+## What
+
+### 1. `src/Edit/Editor/edit_main.cpp`
+The root cause. `print_snippet` routed jpeg/tiff through `make_raster_image`, but mupdf's `save_picture` only supports PNG (hardcoded `fz_write_pixmap_as_png`). The fix gates the bitmap path by renderer:
+
+```cpp
+// BEFORE
+bool bitmap = (s == "png" || s == "jpg" || s == "jpeg" || s == "tif" || s == "tiff");
+
+// AFTER
+bool bitmap= false;
+#ifdef USE_MUPDF_RENDERER
+  bitmap = (s == "png");
+#else
+  bitmap = (s == "png" || s == "jpg" || s == "jpeg" || s == "tif" || s == "tiff");
+#endif
+```
+
+With mupdf, jpeg/tiff now go through the PDF→Scheme converter pipeline instead.
+
+### 2. `TeXmacs/plugins/binary/progs/binary/pdftocairo.scm`
+`url-format` returned format names (via C++ glue) that didn't match pdftocairo CLI flags. Replaced with `format-from-suffix` (proper Scheme API) plus a `tif→tiff` fix because pdftocairo accepts `-tiff` but not `-tif`:
+
+```scheme
+;; BEFORE
+(fm (url-format fullname))
+
+;; AFTER
+(fm* (format-from-suffix suffix))
+(fm (if (== fm* "tif") "tiff" fm*))
+```
+
+Also added `(convert images image-format)` import for `get-raster-resolution`.
+
+### 3. `TeXmacs/plugins/binary/progs/binary/convert.scm`
+Added missing `(convert images image-format)` import. Without it, `get-raster-resolution` was unbound when ImageMagick converter was invoked, causing a crash.
+
+### 4. `TeXmacs/plugins/image/progs/image/pdf.scm`
+Registered `pdf-file → tif-file` converter via pdftocairo. Previously only ImageMagick had a TIFF converter, so systems without ImageMagick could not export TIFF.
+
+### 5. `TeXmacs/progs/convert/images/tmimage.scm`
+Fixed `substring` indexing bug in the format fallback path. The old code extracted the suffix instead of the path prefix, producing an invalid URL when falling back to PDF:
+
+```scheme
+;; BEFORE — extracts suffix portion, produces garbage like "tiffpdf"
+(substring surl (- sl sufl) sl)
+
+;; AFTER — extracts path without suffix, produces correct "/path/file.pdf"
+(substring surl 0 (- sl sufl))
+```
+
+## Why
+mupdf's `save_picture` only supports PNG output. The old code unconditionally treated jpeg/tiff as bitmap formats, sending them through a rendering path that silently failed. The converter pipeline (pdftocairo/ImageMagick) also had bugs: missing imports, missing converter registrations, incorrect CLI flag generation, and a broken fallback path.

--- a/devel/212_6.md
+++ b/devel/212_6.md
@@ -4,7 +4,7 @@
 - Select text in a document
 - File → Export selection as image → save as `.jpg` → verify file is created and contains the selection
 - Repeat for `.tif` and `.tiff`
-- Also test `.png` and `.pdf` works as expected
+- `png` exports have issue (when using mupdf render), trailing lines/words are trimmed. 
 
 ## Issue #2728
 JPEG and TIFF formats could not be exported via "Export Selected Area as Image".PNG and PDF export worked.

--- a/src/Edit/Editor/edit_main.cpp
+++ b/src/Edit/Editor/edit_main.cpp
@@ -335,13 +335,13 @@ edit_main_rep::print_snippet (url name, tree t, bool conserve_preamble) {
   temp_root << 0;
   assign (subtree (et, temp_root), copy (t));
 
-  string s= suffix (name);
+  string s     = suffix (name);
   bool   bitmap= false;
 #ifdef USE_MUPDF_RENDERER
-  bitmap       = (s == "png");
+  bitmap= (s == "png");
 #else
-  bitmap= (s == "png" || s == "jpg" || s == "jpeg" || s == "tif"
-           || s == "tiff");
+  bitmap=
+      (s == "png" || s == "jpg" || s == "jpeg" || s == "tif" || s == "tiff");
 #endif
 #ifndef QTTEXMACS
   bitmap= false;

--- a/src/Edit/Editor/edit_main.cpp
+++ b/src/Edit/Editor/edit_main.cpp
@@ -336,8 +336,13 @@ edit_main_rep::print_snippet (url name, tree t, bool conserve_preamble) {
   assign (subtree (et, temp_root), copy (t));
 
   string s= suffix (name);
-  bool   bitmap=
-      (s == "png" || s == "jpg" || s == "jpeg" || s == "tif" || s == "tiff");
+  bool   bitmap= false;
+#ifdef USE_MUPDF_RENDERER
+  bitmap       = (s == "png");
+#else
+  bitmap= (s == "png" || s == "jpg" || s == "jpeg" || s == "tif"
+           || s == "tiff");
+#endif
 #ifndef QTTEXMACS
   bitmap= false;
 #endif


### PR DESCRIPTION
## 212_6: Fix export selection as image for jpeg, tiff

## How to Test 
- Select text in a document
- File → Export selection as image → save as `.jpg` → verify file is created and contains the selection
- Repeat for `.tif` and `.tiff`
- Also test `.png` and `.pdf` works as expected
### (Tested on debian works)

## Issue #2728
JPEG and TIFF formats could not be exported via "Export Selected Area as Image".PNG and PDF export worked.

## What

### 1. `src/Edit/Editor/edit_main.cpp`
The root cause. `print_snippet` routed jpeg/tiff through `make_raster_image`, but mupdf's `save_picture` only supports PNG (hardcoded `fz_write_pixmap_as_png`). The fix gates the bitmap path by renderer:

With mupdf, jpeg/tiff now go through the PDF→Scheme converter pipeline instead.

### 2. `TeXmacs/plugins/binary/progs/binary/pdftocairo.scm`
`url-format` returned format names (via C++ glue) that didn't match pdftocairo CLI flags. Replaced with `format-from-suffix` (proper Scheme API) plus a `tif→tiff` fix because pdftocairo accepts `-tiff` but not `-tif`:


Also added `(convert images image-format)` import for `get-raster-resolution`.

### 3. `TeXmacs/plugins/binary/progs/binary/convert.scm`
Added missing `(convert images image-format)` import. Without it, `get-raster-resolution` was unbound when ImageMagick converter was invoked, causing a crash.

### 4. `TeXmacs/plugins/image/progs/image/pdf.scm`
Registered `pdf-file → tif-file` converter via pdftocairo. Previously only ImageMagick had a TIFF converter, so systems without ImageMagick could not export TIFF.

## Why
mupdf's `save_picture` only supports PNG output. The old code unconditionally treated jpeg/tiff as bitmap formats, sending them through a rendering path that silently failed. The converter pipeline (pdftocairo/ImageMagick) also had bugs: missing imports, missing converter registrations, and incorrect CLI flag generation.