### PR TITLE
[216_1] 修复 216_1 引入的初始化延后导致的 section tag 问题

### DIFF
--- a/devel/216_1.md
+++ b/devel/216_1.md
@@ -94,3 +94,23 @@
 3. **状态判断**：
    - `is_startup_tab_file(file)`：检查文件路径是否为 `tmfs://startup-tab`
    - `is_startup_tab_current_view()`：检查 current view 的 buffer 是否为 startup-tab
+
+## 2026/04/28 修复 216_1 引入的初始化延后问题
+
+### 问题描述
+216_1 的更改（启动标签页骨架 + 入口绑定）导致部分初始化流程延后，使得 `src/Data/Tree/tree_traverse.cpp` 中 `init_sections()` 函数内的以下两行 Scheme 调用运行时机异常：
+```cpp
+eval("(use-modules (text text-drd))");
+object l = eval("(append (section-tag-list) (section*-tag-list))");
+```
+由于初始化延后，`section-tag-list` 和 `section*-tag-list` 返回的结果中可能包含 `UNKNOWN` 标签。若直接将 `UNKNOWN` 插入 `section_tags`，会导致后续遍历或查找章节标签时出现未定义行为。
+
+### 修复方案
+在 `init_sections()` 的循环中增加 `UNKNOWN` 检查，过滤掉无效标签：
+```cpp
+tree_label tl = as_tree_label(as_symbol(car(l)));
+if (tl != UNKNOWN) {
+  section_tags->insert(tl);
+}
+```
+相关修复提交见 `src/Data/Tree/tree_traverse.cpp`。

--- a/src/Data/Tree/tree_traverse.cpp
+++ b/src/Data/Tree/tree_traverse.cpp
@@ -776,7 +776,10 @@ init_sections () {
     eval ("(use-modules (text text-drd))");
     object l= eval ("(append (section-tag-list) (section*-tag-list))");
     while (!is_null (l)) {
-      section_tags->insert (as_tree_label (as_symbol (car (l))));
+      tree_label tl= as_tree_label (as_symbol (car (l)));
+      if (tl != UNKNOWN) {
+        section_tags->insert (tl);
+      }
       l= cdr (l);
     }
   }


### PR DESCRIPTION
- 在 init_sections() 中增加 UNKNOWN 标签过滤
- 更新 devel/216_1.md 文档