### PR TITLE
[222_80] 为 big-figure 和 big-table 添加 prefix by section number 选项

### DIFF
--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -1274,11 +1274,11 @@
 
 (tm-define (standard-options l)
   (:require (in? l (numbered-unnumbered-append '(small-figure big-figure))))
-  (list "figure-captions-above"))
+  (list "figure-captions-above" "number-long-article"))
 
 (tm-define (standard-options l)
   (:require (in? l (numbered-unnumbered-append '(small-table big-table))))
-  (list "table-captions-above"))
+  (list "table-captions-above" "number-long-article"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Detached notes

--- a/devel/222_80.md
+++ b/devel/222_80.md
@@ -1,0 +1,35 @@
+# 222_80 为 big-figure 和 big-table 环境添加 "prefix by section number" 选项
+
+## 如何测试
+
+1. 打开 Mogan，新建一个文档，选择 article 样式
+2. 插入几个 section 和 big-figure
+3. 选中 big-figure，查看焦点工具栏的 "Style options"
+4. 勾选 "Prefix by section number"
+5. 预期结果：big-figure 的编号会变成 `section-nr.figure-nr` 格式（如 1.1、1.2）
+6. 在新的 section 中插入 big-figure
+7. 预期结果：编号会重新开始，如 `2.1`、`2.2` 等
+8. 对 big-table 重复上述测试步骤，预期行为相同
+
+## 2026/05/06 实现 big-figure 和 big-table 的 section number 前缀选项
+
+### What
+为 big-figure 和 big-table 环境的焦点工具栏添加 "Prefix by section number" 选项。
+
+### Why
+目前 theorem 环境在焦点工具栏中有 "Prefix by section number" 选项（通过 `number-long-article` 包实现），而 big-figure 和 big-table 环境没有。用户期望 figure 和 table 也能像 theorem 那样按 section number 前缀编号。
+
+### How
+在 `TeXmacs/progs/text/text-menu.scm` 中：
+- 为 figure 的 `standard-options` 添加 `"number-long-article"`
+- 为 table 的 `standard-options` 添加 `"number-long-article"`
+
+这样焦点工具栏会自动从 `document-style.scm` 中读取 `number-long-article` 的描述，显示为 "Prefix by section number" 复选框。
+
+### 涉及文件
+- `TeXmacs/progs/text/text-menu.scm`
+  - 修改 figure 的 `standard-options`，添加 `"number-long-article"`
+  - 修改 table 的 `standard-options`，添加 `"number-long-article"`
+
+### 实现说明
+`number-long-article` 包定义了 `display-std-env` 宏，将 `std-env` 组中所有环境的编号前缀为 section number。由于 figure 和 table 的计数器已属于 `std-env` 组（通过 `figure-env` 组间接加入），启用 `number-long-article` 后它们的编号会自动带有 section number 前缀。


### PR DESCRIPTION
# [222_80] 为 big-figure 和 big-table 环境添加 "prefix by section number" 选项

## 如何测试

1. 打开 Mogan，新建一个文档，选择 article 样式
2. 插入几个 section 和 big-figure
3. 选中 big-figure，查看焦点工具栏的 "Style options"
4. 勾选 "Prefix by section number"
5. 预期结果：big-figure 的编号会变成 `section-nr.figure-nr` 格式（如 1.1、1.2）
6. 在新的 section 中插入 big-figure
7. 预期结果：编号会重新开始，如 `2.1`、`2.2` 等
8. 对 big-table 重复上述测试步骤，预期行为相同

## 2026/05/06 实现 big-figure 和 big-table 的 section number 前缀选项

### What
为 big-figure 和 big-table 环境的焦点工具栏添加 "Prefix by section number" 选项。

### Why
目前 theorem 环境在焦点工具栏中有 "Prefix by section number" 选项（通过 `number-long-article` 包实现），而 big-figure 和 big-table 环境没有。用户期望 figure 和 table 也能像 theorem 那样按 section number 前缀编号。

### How
在 `TeXmacs/progs/text/text-menu.scm` 中：
- 为 figure 的 `standard-options` 添加 `"number-long-article"`
- 为 table 的 `standard-options` 添加 `"number-long-article"`

这样焦点工具栏会自动从 `document-style.scm` 中读取 `number-long-article` 的描述，显示为 "Prefix by section number" 复选框。

### 涉及文件
- `TeXmacs/progs/text/text-menu.scm`
  - 修改 figure 的 `standard-options`，添加 `"number-long-article"`
  - 修改 table 的 `standard-options`，添加 `"number-long-article"`

### 实现说明
`number-long-article` 包定义了 `display-std-env` 宏，将 `std-env` 组中所有环境的编号前缀为 section number。由于 figure 和 table 的计数器已属于 `std-env` 组（通过 `figure-env` 组间接加入），启用 `number-long-article` 后它们的编号会自动带有 section number 前缀。