### PR TITLE
[222_82] 清理标签页工具栏相关代码

### DIFF
--- a/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
@@ -75,8 +75,6 @@ pretty-val : string
 (define (on-buffer-management-changed pretty-val)
   (let ((can-use-tabbar? (== pretty-val "Multiple documents share window")))
     (begin
-      (set-boolean-preference "tab bar" can-use-tabbar?)
-      (show-icon-bar 4 can-use-tabbar?)
       (set-pretty-preference "buffer management" pretty-val)
     )))
 

--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -28,9 +28,7 @@
         ((== var "focus dependent icons")
          (show-icon-bar 2 (== val "on")))
         ((== var "user provided icons")
-         (show-icon-bar 3 (== val "on")))
-        ((== var "tab bar")
-         (show-icon-bar 4 (== val "on")))))
+         (show-icon-bar 3 (== val "on")))))
 
 (define (notify-status-bar var val)
   (show-footer (== val "on")))
@@ -60,7 +58,6 @@
 (define-preferences
   ("header" "on" notify-header)
   ("main icon bar" "off" notify-icon-bar)
-  ("tab bar" "on" notify-icon-bar)
   ("mode dependent icons" "on" notify-icon-bar)
   ("focus dependent icons" "on" notify-icon-bar)
   ("user provided icons" "off" notify-icon-bar)
@@ -125,8 +122,7 @@
          (var (cond ((== n 0) "main icon bar")
                     ((== n 1) "mode dependent icons")
                     ((== n 2) "focus dependent icons")
-                    ((== n 3) "user provided icons")
-                    ((== n 4) "tab bar"))))
+                    ((== n 3) "user provided icons"))))
     (if (== (windows-number) 1)
         (set-boolean-preference var val)
         (show-icon-bar n val))

--- a/src/Graphics/Gui/message.hpp
+++ b/src/Graphics/Gui/message.hpp
@@ -575,18 +575,6 @@ set_main_icons (widget w, widget bar) {
 }
 
 inline void
-set_tab_pages_visibility (widget w, bool visible) {
-  // set visibility of tab bar
-  send<bool> (w, SLOT_TAB_PAGES_VISIBILITY, visible);
-}
-
-inline bool
-get_tab_pages_visibility (widget w) {
-  // get visibility of tab bar
-  return query<bool> (w, SLOT_TAB_PAGES_VISIBILITY);
-}
-
-inline void
 set_tab_pages (widget w, widget bar) {
   // set tab bar
   write (w, SLOT_TAB_PAGES, bar);

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -180,7 +180,6 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
   visibility[7] = (mask & 128) == 128;   // left side tools
   visibility[8] = (mask & 256) == 256;   // bottom tools
   visibility[9] = (mask & 512) == 512;   // extra bottom tools
-  visibility[10]= (mask & 1024) == 1024; // tab page bar
   visibility[11]= (mask & 2048) == 2048; // auxiliary widget
 
 #ifdef OS_WASM
@@ -936,8 +935,6 @@ qt_tm_widget_rep::update_visibility () {
   bool old_bottomVisibility= bottomTools->isVisible ();
   bool old_extraVisibility = extraTools->isVisible ();
   bool old_auxVisibility   = auxiliaryWidget->isVisible ();
-  bool old_tabVisibility=
-      tabPageContainer ? tabPageContainer->isVisible () : false;
   bool old_statusVisibility= mainwindow ()->statusBar ()->isVisible ();
   bool old_titleVisibility = windowAgent->titleBar ()->isVisible ();
 
@@ -951,7 +948,6 @@ qt_tm_widget_rep::update_visibility () {
   bool new_leftVisibility  = visibility[7];
   bool new_bottomVisibility= visibility[8];
   bool new_extraVisibility = visibility[9];
-  bool new_tabVisibility   = visibility[10] && visibility[0];
   bool new_auxVisibility   = visibility[11];
   bool new_titleVisibility = visibility[0];
 
@@ -967,7 +963,6 @@ qt_tm_widget_rep::update_visibility () {
     new_bottomVisibility= false;
     new_extraVisibility = false;
     new_auxVisibility   = false;
-    new_tabVisibility   = true;
     new_titleVisibility = true;
   }
 
@@ -991,8 +986,6 @@ qt_tm_widget_rep::update_visibility () {
     extraTools->setVisible (new_extraVisibility);
   if (XOR (old_auxVisibility, new_auxVisibility))
     auxiliaryWidget->setVisible (new_auxVisibility);
-  if (tabPageContainer && XOR (old_tabVisibility, new_tabVisibility))
-    tabPageContainer->setVisible (new_tabVisibility);
   if (XOR (old_titleVisibility, new_titleVisibility))
     windowAgent->titleBar ()->setVisible (new_titleVisibility);
   if (XOR (old_statusVisibility, new_statusVisibility))
@@ -1148,11 +1141,6 @@ qt_tm_widget_rep::send (slot s, blackbox val) {
   case SLOT_EXTRA_TOOLS_VISIBILITY: {
     check_type<bool> (val, s);
     visibility[9]= open_box<bool> (val);
-    update_visibility ();
-  } break;
-  case SLOT_TAB_PAGES_VISIBILITY: {
-    check_type<bool> (val, s);
-    visibility[10]= open_box<bool> (val);
     update_visibility ();
   } break;
   case SLOT_AUXILIARY_WIDGET_VISIBILITY: {
@@ -1311,10 +1299,6 @@ qt_tm_widget_rep::query (slot s, int type_id) {
   case SLOT_EXTRA_TOOLS_VISIBILITY:
     check_type_id<bool> (type_id, s);
     return close_box<bool> (visibility[9]);
-
-  case SLOT_TAB_PAGES_VISIBILITY:
-    check_type_id<bool> (type_id, s);
-    return close_box<bool> (visibility[10]);
 
   case SLOT_AUXILIARY_WIDGET_VISIBILITY:
     check_type_id<bool> (type_id, s);
@@ -1808,7 +1792,6 @@ qt_tm_embedded_widget_rep::send (slot s, blackbox val) {
   case SLOT_LEFT_TOOLS_VISIBILITY:
   case SLOT_BOTTOM_TOOLS_VISIBILITY:
   case SLOT_EXTRA_TOOLS_VISIBILITY:
-  case SLOT_TAB_PAGES_VISIBILITY:
   case SLOT_AUXILIARY_WIDGET_VISIBILITY:
   case SLOT_NOTIFICATION_BAR:
   case SLOT_AUXILIARY_WIDGET:
@@ -1868,7 +1851,6 @@ qt_tm_embedded_widget_rep::query (slot s, int type_id) {
   case SLOT_LEFT_TOOLS_VISIBILITY:
   case SLOT_BOTTOM_TOOLS_VISIBILITY:
   case SLOT_EXTRA_TOOLS_VISIBILITY:
-  case SLOT_TAB_PAGES_VISIBILITY:
   case SLOT_AUXILIARY_WIDGET_VISIBILITY:
     check_type_id<bool> (type_id, s);
     return close_box<bool> (false);

--- a/src/Texmacs/Data/new_window.cpp
+++ b/src/Texmacs/Data/new_window.cpp
@@ -85,7 +85,7 @@ public:
 };
 
 url
-new_window (bool map_flag, tree geom, bool force_tab_bar) {
+new_window (bool map_flag, tree geom) {
   int mask= 0;
   if (get_preference ("header") == "on") mask+= 1;
   if (get_preference ("main icon bar") == "on") mask+= 2;
@@ -97,7 +97,7 @@ new_window (bool map_flag, tree geom, bool force_tab_bar) {
   // if (get_preference ("left tools") == "on") mask += 128;
   if (get_preference ("bottom tools") == "on") mask+= 256;
   if (get_preference ("extra tools") == "on") mask+= 512;
-  if (force_tab_bar || get_preference ("tab bar") == "on") mask+= 1024;
+  mask+= 1024;
   url*      id  = tm_new<url> (url_none ());
   command   quit= tm_new<kill_window_command_rep> (id);
   tm_window win = tm_new<tm_window_rep> (texmacs_widget (mask, quit), geom);
@@ -303,7 +303,7 @@ ensure_window (tree geom) {
     // 先设置标题，再创建 view，确保标签页显示正确的标题
     string title= is_community_stem () ? "Mogan STEM" : "Liii STEM";
     set_title_buffer (name, title);
-    url win= new_window (true, geom, true);
+    url win= new_window (true, geom);
     window_set_view (win, get_passive_view (name), true);
     return win;
 #else

--- a/src/Texmacs/Data/new_window.hpp
+++ b/src/Texmacs/Data/new_window.hpp
@@ -26,7 +26,7 @@ void       switch_to_window (url win);
 void       switch_to_parent_window ();
 
 url  create_buffer ();
-url  new_window (bool map_flag= true, tree geom= "", bool force_tab_bar= false);
+url  new_window (bool map_flag= true, tree geom= "");
 url  open_window (tree geom= "");
 url  ensure_window (tree geom= "");
 void clone_window ();

--- a/src/Texmacs/Window/tm_frame.cpp
+++ b/src/Texmacs/Window/tm_frame.cpp
@@ -17,7 +17,7 @@
 #include "tm_window.hpp"
 #include "url.hpp"
 
-#define NUM_TOOLBARS 4
+#define NUM_TOOLBARS 3
 
 /******************************************************************************
  * Constructor and destructor

--- a/src/Texmacs/Window/tm_window.cpp
+++ b/src/Texmacs/Window/tm_window.cpp
@@ -505,7 +505,6 @@ tm_window_rep::set_icon_bar_flag (int which, bool flag) {
   else if (which == 1) set_mode_icons_visibility (wid, flag);
   else if (which == 2) set_focus_icons_visibility (wid, flag);
   else if (which == 3) set_user_icons_visibility (wid, flag);
-  else if (which == 4) set_tab_pages_visibility (wid, flag);
 }
 
 void
@@ -546,7 +545,6 @@ tm_window_rep::get_icon_bar_flag (int which) {
   else if (which == 1) return get_mode_icons_visibility (wid);
   else if (which == 2) return get_focus_icons_visibility (wid);
   else if (which == 3) return get_user_icons_visibility (wid);
-  else if (which == 4) return get_tab_pages_visibility (wid);
   else return false;
 }
 


### PR DESCRIPTION
移除与标签页工具栏显示/隐藏相关的所有死代码：
- Scheme: 移除 tab bar 偏好设置、notify-icon-bar 和 toggle-visible-icon-bar 中 index=4 的处理
- Scheme: 移除 preferences-widgets 中的 tab bar 偏好设置
- C++: 移除 new_window 中的 force_tab_bar 参数，无条件启用标签页
- C++: 移除 tm_window/tm_frame 中 toolbar index 4 的映射
- C++: 移除 message.hpp 中的 tab pages visibility 辅助函数
- C++: 移除 qt_tm_widget 中 SLOT_TAB_PAGES_VISIBILITY 的处理逻辑

标签页工具栏已是核心 UI 元素，不可隐藏。