### PR TITLE
[212_7] 修复导出PDF时中英文混合文件名导致的标题乱码

### DIFF
--- a/TeXmacs/tests/tmu/212_7_中文_English.tmu
+++ b/TeXmacs/tests/tmu/212_7_中文_English.tmu
@@ -1,0 +1,14 @@
+<TMU|<tuple|1.1.0|2026.2.3>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  用于测试导出PDF的标题
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/212_7.md
+++ b/devel/212_7.md
@@ -1,0 +1,37 @@
+# [212_7] 修复导出 PDF 时中英文混合文件名导致的标题乱码
+
+## 相关文档
+- [212_6](212_6.md) - 修复 PDF 导出时不可见字符导致的渲染问题
+- [222_66](222_66.md) - 修复超链接预览中异常显示的中文字符
+
+## 任务相关的代码文件
+- `src/Edit/Editor/edit_main.cpp`
+
+## 如何测试
+1. 创建一个文件名为中英文混合（如 `中文English.tm`）的文档
+2. 确保文档没有设置 `global-title` 和 `doc-title`
+3. 导出为 PDF
+4. 使用 PDF 阅读器查看文档属性中的标题，应正确显示为 `中文English.tm`
+
+## 2026/05/08 修复 PDF 标题乱码
+
+### What
+在 `edit_main.cpp` 的 `get_metadata` 函数中，当回退到文件名作为标题时，添加 `cork_to_utf8` 转换。
+
+### Why
+`edit_main_rep::get_metadata` 在获取 `title` 元数据时，前两个来源（`global-title` 和 `doc-title`）都使用了 `cork_to_utf8` 转换，但第三个来源（文件名）没有：
+
+```cpp
+if (kind == "title") return as_string (tail (get_name ()));
+```
+
+TeXmacs 内部字符串使用 Cork 编码，文件名在某些情况下可能是 Cork 编码（如 `<#4E2D><#6587>English.tm`）。缺少 `cork_to_utf8` 转换会导致 PDF 元数据中的标题出现乱码。
+
+这与 [222_66] 中修复超链接预览乱码的思路一致：在将内部字符串传递给需要 UTF-8 的外部系统（如 PDF 库或 UI）时，需要进行 `cork_to_utf8` 转换。
+
+### How
+将上述代码改为：
+
+```cpp
+if (kind == "title") return cork_to_utf8 (as_string (tail (get_name ())));
+```

--- a/devel/212_7.md
+++ b/devel/212_7.md
@@ -6,12 +6,13 @@
 
 ## 任务相关的代码文件
 - `src/Edit/Editor/edit_main.cpp`
+- `TeXmacs/tests/tmu/212_7_中文_English.tmu`
 
 ## 如何测试
-1. 创建一个文件名为中英文混合（如 `中文English.tm`）的文档
+1. 打开测试文件 `TeXmacs/tests/tmu/212_7_中文_English.tmu`
 2. 确保文档没有设置 `global-title` 和 `doc-title`
 3. 导出为 PDF
-4. 使用 PDF 阅读器查看文档属性中的标题，应正确显示为 `中文English.tm`
+4. 使用 PDF 阅读器查看文档属性中的标题，应正确显示为 `212_7_中文_English.tmu`
 
 ## 2026/05/08 修复 PDF 标题乱码
 

--- a/src/Edit/Editor/edit_main.cpp
+++ b/src/Edit/Editor/edit_main.cpp
@@ -170,7 +170,7 @@ edit_main_rep::get_metadata (string kind) {
   if (val != "") return val;
   val= cork_to_utf8 (search_metadata (subtree (et, rp), kind));
   if (val != "") return val;
-  if (kind == "title") return as_string (tail (get_name ()));
+  if (kind == "title") return cork_to_utf8 (as_string (tail (get_name ())));
   return "";
 }
 


### PR DESCRIPTION
在 edit_main_rep::get_metadata 中，当回退到文件名作为 PDF 标题时， 添加 cork_to_utf8 转换，确保 PDF 元数据中的标题正确显示。