### PR TITLE
[0600] 修复 smart-ref 对 corollary 和 assumption 无效的问题

### DIFF
--- a/TeXmacs/packages/utilities/smart-ref.ts
+++ b/TeXmacs/packages/utilities/smart-ref.ts
@@ -72,7 +72,7 @@
 
   <assign|corollary-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>
 
-  <assign|corrolary-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>>
+  <assign|corrolary-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>
 
   <assign|def-ref|<xmacro|args|<extern|ext-typed-ref|Definition|<quote-arg|args>>>>
 

--- a/TeXmacs/packages/utilities/smart-ref.ts
+++ b/TeXmacs/packages/utilities/smart-ref.ts
@@ -70,7 +70,9 @@
 
   <assign|corr-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>
 
-  <assign|corrolary-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>
+  <assign|corollary-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>
+
+  <assign|corrolary-ref|<xmacro|args|<extern|ext-typed-ref|Corollary|<quote-arg|args>>>>>
 
   <assign|def-ref|<xmacro|args|<extern|ext-typed-ref|Definition|<quote-arg|args>>>>
 
@@ -89,6 +91,10 @@
   <assign|ax-ref|<xmacro|args|<extern|ext-typed-ref|Axiom|<quote-arg|args>>>>
 
   <assign|axiom-ref|<xmacro|args|<extern|ext-typed-ref|Axiom|<quote-arg|args>>>>
+
+  <assign|ass-ref|<xmacro|args|<extern|ext-typed-ref|Assumption|<quote-arg|args>>>>
+
+  <assign|assumption-ref|<xmacro|args|<extern|ext-typed-ref|Assumption|<quote-arg|args>>>>
 
   <assign|conv-ref|<xmacro|args|<extern|ext-typed-ref|Convention|<quote-arg|args>>>>
 

--- a/TeXmacs/tests/tmu/0600.tmu
+++ b/TeXmacs/tests/tmu/0600.tmu
@@ -1,0 +1,66 @@
+<TMU|<tuple|1.1.0|2026.2.0>>
+
+<style|<tuple|generic|number-europe|smart-ref>>
+
+<\body>
+  <section|Smart-ref for corollary and assumption>
+
+  <\corollary>
+    <label|corollary:test1>
+
+    This is a test corollary.
+  </corollary>
+
+  <\assumption>
+    <label|assumption:test1>
+
+    This is a test assumption.
+  </assumption>
+
+  <\corollary>
+    <label|cor:test2>
+
+    This is another corollary with cor prefix.
+  </corollary>
+
+  <\assumption>
+    <label|ass:test2>
+
+    This is another assumption with ass prefix.
+  </assumption>
+
+  <with|font-series|bold|smart-ref for corollary:>
+
+  <\itemize>
+    <item><smart-ref|corollary:test1>
+
+    <item><smart-ref|cor:test2>
+
+    <item><smart-ref|corr:test3> (non-existent label)
+  </itemize>
+
+  <with|font-series|bold|smart-ref for assumption:>
+
+  <\itemize>
+    <item><smart-ref|assumption:test1>
+
+    <item><smart-ref|ass:test2>
+
+    <item><smart-ref|assumption:test3> (non-existent label)
+  </itemize>
+
+  <with|font-series|bold|typed ref:>
+
+  <\itemize>
+    <item><corollary-ref|corollary:test1>
+
+    <item><assumption-ref|assumption:test1>
+  </itemize>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0600.md
+++ b/devel/0600.md
@@ -1,0 +1,33 @@
+# [0600] smart-ref 对 corollary 无效
+
+## 如何测试
+打开 `TeXmacs/tests/tmu/0600.tmu`，查看 smart-ref 和 typed ref 的渲染是否正确：
+
+- `<smart-ref|corollary:test1>` 应显示为 "Corollary 1"
+- `<smart-ref|cor:test2>` 应显示为 "Corollary 2"
+- `<corollary-ref|corollary:test1>` 应显示为 "Corollary 1"
+- `<smart-ref|assumption:test1>` 应显示为 "Assumption 1"
+- `<smart-ref|ass:test2>` 应显示为 "Assumption 2"
+- `<assumption-ref|assumption:test1>` 应显示为 "Assumption 1"
+
+## 2026/05/09
+### What
+修复 `smart-ref` 对 `corollary` 和 `assumption` 环境无效的问题。
+
+当 label 以 `corollary:`、`assumption:` 等完整环境名作为前缀时，`smart-ref` 无法识别对应的类型，导致引用只显示编号而不显示类型名称（如只显示 "1" 而不是 "Corollary 1"）。
+
+### Why
+`smart-ref` 系统通过检查当前样式中是否存在 `<prefix>-ref` 宏来推断引用类型。在 `smart-ref.ts` 中：
+
+- corollary 只定义了 `co-ref`、`cor-ref`、`corr-ref` 和拼写错误的 `corrolary-ref`，缺少正确的 `corollary-ref`
+- assumption 完全没有定义任何对应的 typed ref 宏（如 `ass-ref`、`assumption-ref`）
+
+因此当用户将 label 命名为 `corollary:xxx` 或 `assumption:xxx` 时，`smart-ref-type` 无法匹配到对应的宏，回退为 `unknown` 类型，导致只显示纯编号。
+
+### How
+在 `TeXmacs/packages/utilities/smart-ref.ts` 中补充缺失的宏定义：
+
+1. 在 corollary 段添加 `<assign|corollary-ref|...>`
+2. 在 axiom 段之后添加 `<assign|ass-ref|...>` 和 `<assign|assumption-ref|...>`
+
+同时保留已有的拼写错误 `corrolary-ref` 以保持向后兼容。

--- a/devel/0600.md
+++ b/devel/0600.md
@@ -1,4 +1,4 @@
-# [0600] smart-ref 对 corollary 无效
+# [0600] 修复 smart-ref 对 corollary 和 assumption 无效的问题
 
 ## 如何测试
 打开 `TeXmacs/tests/tmu/0600.tmu`，查看 smart-ref 和 typed ref 的渲染是否正确：


### PR DESCRIPTION
# [0600] 修复 smart-ref 对 corollary 和 assumption 无效的问题

## 如何测试
打开 `TeXmacs/tests/tmu/0600.tmu`，查看 smart-ref 和 typed ref 的渲染是否正确：

- `<smart-ref|corollary:test1>` 应显示为 "Corollary 1"
- `<smart-ref|cor:test2>` 应显示为 "Corollary 2"
- `<corollary-ref|corollary:test1>` 应显示为 "Corollary 1"
- `<smart-ref|assumption:test1>` 应显示为 "Assumption 1"
- `<smart-ref|ass:test2>` 应显示为 "Assumption 2"
- `<assumption-ref|assumption:test1>` 应显示为 "Assumption 1"

## 2026/05/09
### What
修复 `smart-ref` 对 `corollary` 和 `assumption` 环境无效的问题。

当 label 以 `corollary:`、`assumption:` 等完整环境名作为前缀时，`smart-ref` 无法识别对应的类型，导致引用只显示编号而不显示类型名称（如只显示 "1" 而不是 "Corollary 1"）。

### Why
`smart-ref` 系统通过检查当前样式中是否存在 `<prefix>-ref` 宏来推断引用类型。在 `smart-ref.ts` 中：

- corollary 只定义了 `co-ref`、`cor-ref`、`corr-ref` 和拼写错误的 `corrolary-ref`，缺少正确的 `corollary-ref`
- assumption 完全没有定义任何对应的 typed ref 宏（如 `ass-ref`、`assumption-ref`）

因此当用户将 label 命名为 `corollary:xxx` 或 `assumption:xxx` 时，`smart-ref-type` 无法匹配到对应的宏，回退为 `unknown` 类型，导致只显示纯编号。

### How
在 `TeXmacs/packages/utilities/smart-ref.ts` 中补充缺失的宏定义：

1. 在 corollary 段添加 `<assign|corollary-ref|...>`
2. 在 axiom 段之后添加 `<assign|ass-ref|...>` 和 `<assign|assumption-ref|...>`

同时保留已有的拼写错误 `corrolary-ref` 以保持向后兼容。