### PR TITLE
[201_35] 修复嵌套环境中的编号泄露

### DIFF
--- a/TeXmacs/tests/tmu/201_35.tmu
+++ b/TeXmacs/tests/tmu/201_35.tmu
@@ -82,7 +82,7 @@
 
     <item>in equation, line6 label: <reference|l4>
 
-    <item>in eqnarry, line 8 label (after eq-number): <reference|eqn>
+    <item>in eqnarray, line 8 label (after eq-number): <reference|eqn>
 
     <item>in (framed) theorem 1, line10 label: <reference|eq:1.1>
 
@@ -112,7 +112,7 @@
 
     <item>in equation, line6 label: <smart-ref|l4>
 
-    <item>in eqnarry, line 8 label (after eq-number): <smart-ref|eqn>
+    <item>in eqnarray, line 8 label (after eq-number): <smart-ref|eqn>
 
     <item>in (framed) theorem 1, line10 label: <smart-ref|eq:1.1>
 

--- a/TeXmacs/tests/tmu/201_35.tmu
+++ b/TeXmacs/tests/tmu/201_35.tmu
@@ -1,6 +1,6 @@
-<TMU|<tuple|1.1.0|2026.2.0>>
+<TMU|<tuple|1.1.0|2026.2.4>>
 
-<style|<tuple|generic|number-europe|smart-ref>>
+<style|<tuple|generic|number-europe|smart-ref|preview-ref>>
 
 <\body>
   <\frame>
@@ -29,9 +29,45 @@
     sin<around*|(|x|)>=cos<around*|(|<frac|\<pi\>|2>-x|)><label|l4>
   </equation>
 
+  <\eqnarray>
+    <tformat|<table|<row|<cell|1>|<cell|+>|<cell|2=3<eq-number>>>|<row|<cell|4>|<cell|->|<cell|5=-1<eq-number><label|eqn>>>|<row|<cell|9>|<cell|\<times\>>|<cell|9=81<eq-number>>>>>
+  </eqnarray>
+
+  <\framed>
+    <\theorem>
+      <label|thm:1a>theorem 1 start.
+
+      <\equation>
+        A x=\<lambda\>x<label|eq:1.1>
+      </equation>
+
+      <\align>
+        <tformat|<table|<row|<cell|f<around*|(|x|)>\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>>>>|<row|<cell|\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-z<around*|(|x|)>|\<\|\|\>>+<around*|\<\|\|\>|z<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>><label|eq:1.2><eq-number>>>>>
+      </align>
+
+      theorem 1 end.<label|thm:1b>
+    </theorem>
+  </framed>
+
   \;
 
-  <with|font-series|bold|reference>:
+  <\theorem>
+    <label|thm:2a>theorem 2 start.
+
+    <\equation>
+      A x=\<lambda\>x<label|eq:2.1>
+    </equation>
+
+    <\align>
+      <tformat|<table|<row|<cell|f<around*|(|x|)>\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>><eq-number><label|eq:2.2>>>|<row|<cell|\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-z<around*|(|x|)>|\<\|\|\>>+<around*|\<\|\|\>|z<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>>>>>>
+    </align>
+
+    theorem 2 end.<label|thm:2b>
+  </theorem>
+
+  \;
+
+  <new-page*><with|font-series|bold|reference>:
 
   <\itemize>
     <item>in frame, line1 label: <reference|eq1>, line2 label: <reference|eq2>
@@ -45,6 +81,20 @@
     <item>in equation, line5 label: <reference|l3>
 
     <item>in equation, line6 label: <reference|l4>
+
+    <item>in eqnarry, line 8 label (after eq-number): <reference|eqn>
+
+    <item>in (framed) theorem 1, line10 label: <reference|eq:1.1>
+
+    <item>in (framed) theorem 1, line11 label: <reference|eq:1.2>
+
+    <item>in (framed) theorem 1, its own label before start: <reference|thm:1a>, label after end: <reference|thm:1b>
+
+    <item>in (unframed) theorem 2, line12 label: <reference|eq:2.1>
+
+    <item>in (unframed) theorem 2, line13 label (after eq-number): <reference|eq:2.2>
+
+    <item>in (unframed) theorem 2, its own label before start: <reference|thm:2a>, label after end: <reference|thm:2b>
   </itemize>
 
   \;
@@ -54,13 +104,27 @@
   <\itemize>
     <item>in frame, line1 label: <smart-ref|eq1>, line2 label: <smart-ref|eq2>
 
-    <item>in align line3 label before eq-number:<smart-ref|l1a>, label after eq-number: <smart-ref|l1b>
+    <item>in align line3 label before eq-number: <smart-ref|l1a>, label after eq-number: <smart-ref|l1b>
 
-    <item>in align line4 label before eq-number:<smart-ref|l2a>, label after eq-number: <smart-ref|l2b>
+    <item>in align line4 label before eq-number: <smart-ref|l2a>, label after eq-number: <smart-ref|l2b>
 
     <item>in equation, line5 label: <smart-ref|l3>
 
     <item>in equation, line6 label: <smart-ref|l4>
+
+    <item>in eqnarry, line 8 label (after eq-number): <smart-ref|eqn>
+
+    <item>in (framed) theorem 1, line10 label: <smart-ref|eq:1.1>
+
+    <item>in (framed) theorem 1, line11 label: <smart-ref|eq:1.2>
+
+    <item>in (framed) theorem 1, its own label before start: <smart-ref|thm:1a>, label after end: <smart-ref|thm:1b>
+
+    <item>in (unframed) theorem 2, line12 label: <smart-ref|eq:2.1>
+
+    <item>in (unframed) theorem 2, line13 label (after eq-number): <smart-ref|eq:2.2>
+
+    <item>in (unframed) theorem 2, its own label before start: <smart-ref|thm:2a>, label after end: <smart-ref|thm:2b>
   </itemize>
 
   \;
@@ -70,6 +134,7 @@
   <\collection>
     <associate|page-medium|paper>
     <associate|page-screen-margin|false>
+    <associate|stem-doc-id|F520EF24-3E5F-4E60-8C91-09C7042CF9B0>
   </collection>
 </initial>
 
@@ -77,11 +142,22 @@
   <\collection>
     <associate|eq1|<tuple|1|1>>
     <associate|eq2|<tuple|2|1>>
+    <associate|eq:1.1|<tuple|10|1>>
+    <associate|eq:1.2|<tuple|11|1>>
+    <associate|eq:2.1|<tuple|12|1>>
+    <associate|eq:2.2|<tuple|13|1>>
+    <associate|eqn|<tuple|8|1>>
     <associate|l1a|<tuple|3|1>>
     <associate|l1b|<tuple|3|1>>
     <associate|l2a|<tuple|4|1>>
     <associate|l2b|<tuple|4|1>>
     <associate|l3|<tuple|5|1>>
     <associate|l4|<tuple|6|1>>
+    <associate|thm:1|<tuple|1|1>>
+    <associate|thm:1a|<tuple|1|?>>
+    <associate|thm:1b|<tuple|1|?>>
+    <associate|thm:2|<tuple|2|1>>
+    <associate|thm:2a|<tuple|2|?>>
+    <associate|thm:2b|<tuple|2|?>>
   </collection>
 </references>

--- a/devel/201_35.md
+++ b/devel/201_35.md
@@ -1,14 +1,24 @@
 # [201_35] align环境编号后 smart-ref 以及 reference 失效
 
 ## 如何测试
-打开 `TeXmacs\tests\tmu\201_35.tmu` ，查看 smart-ref 和 reference 的公式编号是否正确
+1. 打开 `TeXmacs\tests\tmu\201_35.tmu` 
+2. 查看 smart-ref 和 reference 的公式编号是否符合预期（如：line n 的公式应该编号为 n ，theorem 的编号应该为定理的编号）
 
-- line1 的 label 编号应该都是1（这一次修改的修复样例）
-- line2 的 label 编号应该都是2（这一次修改的修复样例）
-- line3 的 label 编号应该都是3
-- line4 的 label 编号应该都是4
-- line5 的 label 编号应该都是5
-- line6 的 label 编号应该都是6
+## 2026/5/11
+### What
+修复 theorem 等编号环境中嵌套 equation 后，环境正文后续 `<label>` 被错误绑定为最后一个 equation 编号的问题
+
+### Why
+`equation` 内部的 `<next-equation>` 会通过一参 `set-binding` 更新 `the-label`。之前 `SURROUND` 结束后没有恢复旧的 `the-label`，导致公式编号**泄漏**到外层编号环境；
+
+若外层再套 `frame`，内容会走 table cell/concat/lazy 排版路径，单独修改 bridge 路径无法覆盖
+
+### How
+将 `the-label` 的作用域限制在 `SURROUND` 内部：
+
+在 `bridge_surround_rep::my_typeset`、`concater_rep::typeset_surround`、`lazy_surround_rep` 构造时**缓存**旧 `the-label`，当完成 prefix/body/suffix 排版或 lazy body 构造后**恢复**。
+
+`typeset_row` 仍只负责 `defer-tags/the-tags` 的行级隔离，无需改动
 
 ## 2026/2/28
 ### What

--- a/src/Typeset/Bridge/bridge_surround.cpp
+++ b/src/Typeset/Bridge/bridge_surround.cpp
@@ -160,7 +160,7 @@ bridge_surround_rep::my_typeset_will_be_complete () {
 
 void
 bridge_surround_rep::my_typeset (int desired_status) {
-  tree old_label= env->local_begin ("the-label", env->read ("the-label"));
+  tree old_label= env->read ("the-label");
   if (corrupted || (N (ttt->old_patch) != 0)) {
     hashmap<string, tree> prev_back (UNINIT);
     env->local_start (prev_back);

--- a/src/Typeset/Bridge/bridge_surround.cpp
+++ b/src/Typeset/Bridge/bridge_surround.cpp
@@ -160,6 +160,7 @@ bridge_surround_rep::my_typeset_will_be_complete () {
 
 void
 bridge_surround_rep::my_typeset (int desired_status) {
+  tree old_label= env->local_begin ("the-label", env->read ("the-label"));
   if (corrupted || (N (ttt->old_patch) != 0)) {
     hashmap<string, tree> prev_back (UNINIT);
     env->local_start (prev_back);
@@ -179,4 +180,5 @@ bridge_surround_rep::my_typeset (int desired_status) {
   ttt->insert_marker (st, ip);
   ttt->insert_surround (a, b);
   body->typeset (desired_status);
+  env->local_end ("the-label", old_label);
 }

--- a/src/Typeset/Concat/concat_text.cpp
+++ b/src/Typeset/Concat/concat_text.cpp
@@ -267,12 +267,14 @@ concater_rep::typeset_surround (tree t, path ip) {
     typeset_error (t, ip);
     return;
   }
+  tree old_label= env->local_begin ("the-label", env->read ("the-label"));
   marker (descend (ip, 0));
   typeset (t[0], descend (ip, 0));
   array<line_item> b= ::typeset_concat (env, t[1], descend (ip, 1));
   typeset (t[2], descend (ip, 2));
   a << b;
   marker (descend (ip, 1));
+  env->local_end ("the-label", old_label);
 }
 
 void

--- a/src/Typeset/Concat/concat_text.cpp
+++ b/src/Typeset/Concat/concat_text.cpp
@@ -267,7 +267,7 @@ concater_rep::typeset_surround (tree t, path ip) {
     typeset_error (t, ip);
     return;
   }
-  tree old_label= env->local_begin ("the-label", env->read ("the-label"));
+  tree old_label= env->read ("the-label");
   marker (descend (ip, 0));
   typeset (t[0], descend (ip, 0));
   array<line_item> b= ::typeset_concat (env, t[1], descend (ip, 1));

--- a/src/Typeset/Line/lazy_typeset.cpp
+++ b/src/Typeset/Line/lazy_typeset.cpp
@@ -113,9 +113,9 @@ lazy_surround_rep::lazy_surround_rep (edit_env env, tree t, path ip)
     return;
   }
   tree old_label= env->local_begin ("the-label", env->read ("the-label"));
-  a  = typeset_concat (env, t[0], descend (ip, 0));
-  b  = typeset_concat (env, t[1], descend (ip, 1));
-  par= make_lazy (env, t[2], descend (ip, 2));
+  a             = typeset_concat (env, t[0], descend (ip, 0));
+  b             = typeset_concat (env, t[1], descend (ip, 1));
+  par           = make_lazy (env, t[2], descend (ip, 2));
   env->local_end ("the-label", old_label);
 }
 

--- a/src/Typeset/Line/lazy_typeset.cpp
+++ b/src/Typeset/Line/lazy_typeset.cpp
@@ -112,7 +112,7 @@ lazy_surround_rep::lazy_surround_rep (edit_env env, tree t, path ip)
     par= make_lazy (env, t[N (t) - 1], descend (ip, N (t) - 1));
     return;
   }
-  tree old_label= env->local_begin ("the-label", env->read ("the-label"));
+  tree old_label= env->read ("the-label");
   a             = typeset_concat (env, t[0], descend (ip, 0));
   b             = typeset_concat (env, t[1], descend (ip, 1));
   par           = make_lazy (env, t[2], descend (ip, 2));

--- a/src/Typeset/Line/lazy_typeset.cpp
+++ b/src/Typeset/Line/lazy_typeset.cpp
@@ -112,9 +112,11 @@ lazy_surround_rep::lazy_surround_rep (edit_env env, tree t, path ip)
     par= make_lazy (env, t[N (t) - 1], descend (ip, N (t) - 1));
     return;
   }
+  tree old_label= env->local_begin ("the-label", env->read ("the-label"));
   a  = typeset_concat (env, t[0], descend (ip, 0));
   b  = typeset_concat (env, t[1], descend (ip, 1));
   par= make_lazy (env, t[2], descend (ip, 2));
+  env->local_end ("the-label", old_label);
 }
 
 lazy_surround_rep::lazy_surround_rep (array<line_item> a2, array<line_item> b2,


### PR DESCRIPTION
# [201_35] align环境编号后 smart-ref 以及 reference 失效

## 如何测试
1. 打开 `TeXmacs\tests\tmu\201_35.tmu` 
2. 查看 smart-ref 和 reference 的公式编号是否符合预期（如：line n 的公式应该编号为 n ，theorem 的编号应该为定理的编号）

## 2026/5/11
### What
修复 theorem 等编号环境中嵌套 equation 后，环境正文后续 `<label>` 被错误绑定为最后一个 equation 编号的问题

### Why
`equation` 内部的 `<next-equation>` 会通过一参 `set-binding` 更新 `the-label`。之前 `SURROUND` 结束后没有恢复旧的 `the-label`，导致公式编号**泄漏**到外层编号环境；

若外层再套 `frame`，内容会走 table cell/concat/lazy 排版路径，单独修改 bridge 路径无法覆盖

### How
将 `the-label` 的作用域限制在 `SURROUND` 内部：

在 `bridge_surround_rep::my_typeset`、`concater_rep::typeset_surround`、`lazy_surround_rep` 构造时**缓存**旧 `the-label`，当完成 prefix/body/suffix 排版或 lazy body 构造后**恢复**。

`typeset_row` 仍只负责 `defer-tags/the-tags` 的行级隔离，无需改动