### PR TITLE
[0101] 修复 Latin Modern Math 数学模式下希腊字母斜体问题

### DIFF
--- a/TeXmacs/tests/tmu/0101.tmu
+++ b/TeXmacs/tests/tmu/0101.tmu
@@ -1,0 +1,43 @@
+<TMU|<tuple|1.1.0|2026.2.4>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  TeXmacs Computer Roman
+
+  <\equation*>
+    \<alpha\>+\<beta\>+\<gamma\>
+  </equation*>
+
+  Asana Math
+
+  <\equation*>
+    <with|font|Asana Math|\<alpha\>+\<beta\>+\<gamma\>>
+  </equation*>
+
+  Stix Math
+
+  <\equation*>
+    <with|font|Stix Math|\<alpha\>+\<beta\>+\<gamma\>>
+  </equation*>
+
+  Latin Modern Math
+
+  <\equation*>
+    <with|font|Latin Modern Math|\<alpha\>+\<beta\>+\<gamma\>>
+  </equation*>
+
+  Libetinus Math
+
+  <\equation*>
+    <with|font|Libertinus Math|\<alpha\>+\<beta\>+\<gamma\>>
+  </equation*>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|34321DE8-B31D-4600-8D44-9D4203D4F250>
+  </collection>
+</initial>

--- a/devel/0101.md
+++ b/devel/0101.md
@@ -2,10 +2,8 @@
 
 ## 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
-- [11_41.md](11_41.md) - Latin Modern Math 数学模式下希腊字母斜体问题修复
 - [11_42.md](11_42.md) - 相关任务文档
-- [11_44.md](11_44.md) - Unicode 根号下沉问题修复
-- [11_45.md](11_45.md) - Noto CJK SC 光标倾斜问题修复
+- [206_19.md](206_19.md) - 修复 Latin Modern Math 字体在数学模式下无法输入 "h" 的问题
 
 ## 任务相关的代码文件
 - `src/Graphics/Fonts/smart_font.cpp`

--- a/devel/0101.md
+++ b/devel/0101.md
@@ -1,0 +1,77 @@
+# [0101] Latin Modern Math 数学模式下希腊字母斜体问题修复
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [11_41.md](11_41.md) - Latin Modern Math 数学模式下希腊字母斜体问题修复
+- [11_42.md](11_42.md) - 相关任务文档
+- [11_44.md](11_44.md) - Unicode 根号下沉问题修复
+- [11_45.md](11_45.md) - Noto CJK SC 光标倾斜问题修复
+
+## 任务相关的代码文件
+- `src/Graphics/Fonts/smart_font.cpp`
+- `tests/Graphics/Fonts/smart_font_test.cpp`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+xmake b smart_font_test
+xmake r smart_font_test
+```
+
+新增 `test_latin_modern_math_italic_greek` 测试用例，验证在 `Latin Modern Math` 字体、`mathitalic` 模式下：
+- `<alpha>` 映射到 `<#1D6FC>`（数学斜体小写 alpha）
+- `<beta>` 映射到 `<#1D6FD>`（数学斜体小写 beta）
+- `<gamma>` 映射到 `<#1D6FE>`（数学斜体小写 gamma）
+
+### 非确定性测试（文档验证）
+打开 Mogan，在数学模式下输入希腊字母（如 `\alpha`、`\beta`、`\gamma`），使用 Latin Modern Math 字体，确认希腊字母显示为斜体而非正体。
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b smart_font_test
+xmake r smart_font_test
+```
+
+## What
+
+修复 Latin Modern Math 字体在数学模式下希腊字母显示为正体而非斜体的问题。
+
+1. 在 `smart_font_rep::resolve` 中，当主字体支持原始希腊字符时，增加判断逻辑：若处于数学模式、字符为希腊字母、且当前 shape 不是 `mathupright`，则优先尝试使用斜体希腊字母码点（U+1D6E2+ 区域）。
+2. 只有当主字体不支持对应的斜体希腊字母码点时，才回退到原始码点。
+3. 新增 C++ 单元测试 `test_latin_modern_math_italic_greek`，通过 `advance` 函数验证 alpha、beta、gamma 的映射结果。
+
+## Why
+
+在数学模式下使用 Latin Modern Math 字体时：
+- 拉丁字母（a-z, A-Z）在 `advance` 中被硬编码映射到 Unicode 数学字母数字符号区（U+1D434+），显示为斜体。
+- 希腊字母（如 `<alpha>`）不在该硬编码映射中，进入 `resolve` 处理后直接使用基本希腊字母码点（U+03B1+）。Unicode 标准中基本希腊字母区块的默认字形为正体，导致数学模式下希腊字母显示为正体，与拉丁字母的斜体风格不一致。
+
+对于 `roman` 等 `is_math_family` 字体，`REWRITE_MATH` 机制会将数学字符转换到正确的 Unicode 区域，因此正常。但 Latin Modern Math 未被纳入该机制。
+
+## How
+
+修改 `resolve` 函数中 `fn[SUBFONT_MAIN]->supports (c)` 分支的逻辑：
+
+```cpp
+bool prefer_italic_greek= false;
+if (math_kind != 0 && is_greek (c) && use_italic_greek (a) &&
+    shape != "mathupright") {
+  string gc= substitute_italic_greek (c);
+  if (gc != "" && fn[SUBFONT_MAIN]->supports (gc)) {
+    prefer_italic_greek= true;
+  }
+}
+if (!prefer_italic_greek) {
+  return sm->add_char (tuple ("main"), c);
+}
+```
+
+当 `prefer_italic_greek` 为 true 时，不直接返回 "main" 子字体，而是继续执行后续逻辑。后续代码（约 1189 行）会检测到希腊字母并通过 `substitute_italic_greek` 将其映射到数学斜体希腊字母区域（U+1D6E2+），从而确保 Latin Modern Math 渲染出斜体字形。
+
+测试用例通过 `advance` 函数间接验证：
+- `advance` 在处理 `<alpha>` 等希腊字母时会调用 `resolve`
+- `resolve` 中的斜体优先逻辑使最终返回的字符被重写为 `<#1D6FC>` 等斜体码点

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -1144,7 +1144,17 @@ smart_font_rep::resolve (string c) {
   string range= get_unicode_range (c);
   // 如果设置了字体，就优先使用当前设置的字体
   if (fn[SUBFONT_MAIN]->supports (c)) {
-    return sm->add_char (tuple ("main"), c);
+    bool prefer_italic_greek= false;
+    if (math_kind != 0 && is_greek (c) && use_italic_greek (a) &&
+        shape != "mathupright") {
+      string gc= substitute_italic_greek (c);
+      if (gc != "" && fn[SUBFONT_MAIN]->supports (gc)) {
+        prefer_italic_greek= true;
+      }
+    }
+    if (!prefer_italic_greek) {
+      return sm->add_char (tuple ("main"), c);
+    }
   }
 
   if (range == "emoji") {

--- a/tests/Graphics/Fonts/smart_font_test.cpp
+++ b/tests/Graphics/Fonts/smart_font_test.cpp
@@ -36,6 +36,7 @@ private slots:
   void test_resolve_chinese_puncts ();
   void test_resolve_200B ();
   void test_get_right_slope ();
+  void test_latin_modern_math_italic_greek ();
 };
 
 void
@@ -108,6 +109,35 @@ TestSmartFont::test_get_right_slope () {
   fn    = smart_font ("sys-chinese", "rm", "bold", "right", 10, 600);
   fn_rep= (smart_font_rep*) fn.rep;
   QCOMPARE (fn_rep->get_right_slope (utf8_to_cork ("典")), 0.0);
+}
+
+void
+TestSmartFont::test_latin_modern_math_italic_greek () {
+  font fn= smart_font ("Latin Modern Math", "rm", "medium", "mathitalic", 10,
+                       600);
+  smart_font_rep* fn_rep= (smart_font_rep*) fn.rep;
+
+  int    pos;
+  string r;
+  int    nr;
+
+  // Test alpha in mathitalic mode should map to math italic alpha (U+1D6FC)
+  pos= 0;
+  fn_rep->advance ("<alpha>", pos, r, nr);
+  QCOMPARE (pos, N (string ("<alpha>")));
+  qcompare (r, "<#1D6FC>");
+
+  // Test beta in mathitalic mode should map to math italic beta (U+1D6FD)
+  pos= 0;
+  fn_rep->advance ("<beta>", pos, r, nr);
+  QCOMPARE (pos, N (string ("<beta>")));
+  qcompare (r, "<#1D6FD>");
+
+  // Test gamma in mathitalic mode should map to math italic gamma (U+1D6FE)
+  pos= 0;
+  fn_rep->advance ("<gamma>", pos, r, nr);
+  QCOMPARE (pos, N (string ("<gamma>")));
+  qcompare (r, "<#1D6FE>");
 }
 
 QTEST_MAIN (TestSmartFont)

--- a/tests/Graphics/Fonts/smart_font_test.cpp
+++ b/tests/Graphics/Fonts/smart_font_test.cpp
@@ -113,8 +113,8 @@ TestSmartFont::test_get_right_slope () {
 
 void
 TestSmartFont::test_latin_modern_math_italic_greek () {
-  font fn= smart_font ("Latin Modern Math", "rm", "medium", "mathitalic", 10,
-                       600);
+  font fn=
+      smart_font ("Latin Modern Math", "rm", "medium", "mathitalic", 10, 600);
   smart_font_rep* fn_rep= (smart_font_rep*) fn.rep;
 
   int    pos;


### PR DESCRIPTION
## 摘要
修复 Latin Modern Math 字体在数学模式下希腊字母显示为正体而非斜体的问题。

## 改动内容
1. `src/Graphics/Fonts/smart_font.cpp`: 在 `resolve` 函数中，当主字体支持原始希腊字符时，增加斜体希腊字母优先逻辑。
2. `tests/Graphics/Fonts/smart_font_test.cpp`: 新增 `test_latin_modern_math_italic_greek` 单元测试。
3. `devel/0101.md`: 新增开发文档。

## 测试
```bash
xmake b smart_font_test
xmake r smart_font_test
```