### PR TITLE
[0108] 主页 Open 卡片打开文件时默认定位到最近文档目录

### DIFF
--- a/devel/0108.md
+++ b/devel/0108.md
@@ -1,0 +1,71 @@
+# [0108] 主页 Open 卡片打开文件时默认定位到最近文档目录
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [222_32.md](222_32.md) - 保存文件时记录当前文件夹的地址
+
+## 任务相关的代码文件
+- src/Plugins/Qt/qt_home_page.cpp
+- src/Plugins/Qt/qt_home_page.hpp
+- TeXmacs/progs/texmacs/texmacs/tm-files.scm
+- TeXmacs/progs/kernel/boot/abbrevs.scm
+
+## 如何测试
+
+### 非确定性测试（文档验证）
+1. 启动应用，确保当前没有打开任何文档（处于启动页主页）
+2. 确认主页最近文档列表中有至少一个文档
+3. 点击主页 "Open" 卡片
+4. 观察弹出的文件对话框默认目录是否为最近文档列表中第一个文档所在的目录
+5. 清空最近文档列表（或在没有最近文档的情况下），再次点击 "Open"
+6. 确认此时行为与之前一致（使用 `last-file-dialog-directory` 或当前路径）
+
+## 2026/05/12 修复初次打开时默认路径未使用最近文档目录
+
+### What
+
+在主页点击 "Open" 卡片弹出文件对话框时，如果当前没有已打开的文档（buffer 为 scratch），且最近文档列表非空，则将文件对话框的默认目录设为最近文档列表中第一个文档所在的目录。
+
+具体改动：
+1. 修改 `QtHomePage::createDocumentWithStyle`，当 `styleId == "open"` 时，检查 `recentDocs_`
+2. 若 `recentDocs_` 非空，提取第一个文档的目录，通过 `(choose-file load-buffer ...)` 传入默认路径
+3. 若 `recentDocs_` 为空，保持原有行为调用 `(open-document)`
+
+### Why
+
+当前 `(open-document)` -> `(open-buffer)` -> `(choose-file ...)` 的调用链中，`choose-file` 在 buffer 为 scratch 时，只会回退到 `last-file-dialog-directory`（记录自上次保存或打开操作的目录）。这导致用户从主页点击 Open 时，对话框默认路径可能与最近文档列表中最新文档的目录不一致，增加了用户的导航成本。
+
+222_32 已经实现了保存/打开时记录目录到 `last-file-dialog-directory`，但该记录是全局的，不区分"最近文档"的语义。从主页的交互逻辑看，用户看到最近文档列表后点击 Open，最自然的期望就是能在这些文档所在的目录中继续浏览。
+
+### How
+
+在 `qt_home_page.cpp` 的 `createDocumentWithStyle` 中，将原来的：
+
+```cpp
+if (styleId == "open") {
+    eval_scheme ("(open-document)");
+    return;
+}
+```
+
+改为：
+
+```cpp
+if (styleId == "open") {
+    if (!recentDocs_.isEmpty ()) {
+        QString dir= QFileInfo (recentDocs_.first ().filePath).absolutePath ();
+        eval_scheme ("(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
+                     "(system->url " * qt_scheme_quote_utf8 (dir) * "))");
+    }
+    else {
+        eval_scheme ("(open-document)");
+    }
+    return;
+}
+```
+
+关键点：
+- `recentDocs_` 已按时间倒序排列，第一个即为最新文档
+- 使用 `QFileInfo::absolutePath()` 提取目录
+- 通过 `system->url` 将本地路径包装为 Scheme URL 对象，与 `abbrevs.scm` 中 `choose-file` 的处理方式保持一致
+- 保持向后兼容：无最近文档时完全回退到原有行为

--- a/src/Plugins/Qt/qt_home_page.cpp
+++ b/src/Plugins/Qt/qt_home_page.cpp
@@ -741,7 +741,14 @@ QtHomePage::createDocumentWithStyle (const QString& styleId) {
   }
 
   if (styleId == "open") {
-    eval_scheme ("(open-document)");
+    if (!recentDocs_.isEmpty ()) {
+      QString dir= QFileInfo (recentDocs_.first ().filePath).absolutePath ();
+      eval_scheme ("(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
+                   "(system->url " * qt_scheme_quote_utf8 (dir) * "))");
+    }
+    else {
+      eval_scheme ("(open-document)");
+    }
     return;
   }
 

--- a/src/Plugins/Qt/qt_home_page.cpp
+++ b/src/Plugins/Qt/qt_home_page.cpp
@@ -743,8 +743,10 @@ QtHomePage::createDocumentWithStyle (const QString& styleId) {
   if (styleId == "open") {
     if (!recentDocs_.isEmpty ()) {
       QString dir= QFileInfo (recentDocs_.first ().filePath).absolutePath ();
-      eval_scheme ("(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
-                   "(system->url " * qt_scheme_quote_utf8 (dir) * "))");
+      eval_scheme (
+          "(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
+          "(system->url " *
+          qt_scheme_quote_utf8 (dir) * "))");
     }
     else {
       eval_scheme ("(open-document)");


### PR DESCRIPTION
## 改进点

当用户处于启动页主页、尚未打开任何文档时，点击 \"Open\" 卡片弹出的文件对话框默认目录未与最近文档列表关联，导致用户需要手动导航到目标目录。

## 变更内容

- 修改 `QtHomePage::createDocumentWithStyle`，当 `styleId == \"open\"` 且 `recentDocs_` 非空时，提取最新最近文档的目录作为文件对话框的默认路径
- 无最近文档时完全保持原有行为

## 测试方式

1. 启动应用，确保没有打开任何文档
2. 确认主页最近文档列表非空
3. 点击 \"Open\" 卡片，文件对话框应默认定位到最新最近文档所在目录
4. 清空最近文档后再次点击，行为与之前一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)