### PR TITLE
[0110] 移除失效快捷键提示并调整 tab 键提示文案

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -2678,3 +2678,4 @@
 ("Login Now" "立即登录")
 ("User Center" "用户中心")
 ("Use extensible brackets" "使用可伸缩括号")
+("Use \\space (eg. 1cm) in order to insert a blank with specified width" "使用 \\space（例如 1cm）来插入指定宽度的空白")

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -210,9 +210,8 @@
 (tm-define (kbd-variant t forwards?)
   (:require (tree-is-buffer? t))
   (if (and (not (complete-try?)) forwards?)
-      (with sh (kbd-system-rewrite (kbd-find-inv-binding '(kbd-alternate-tab)))
-        (set-message `(concat "Use " ,sh " in order to insert a tab")
-                     "tab"))))
+      (set-message (translate "Use \\space (eg. 1cm) in order to insert a blank with specified width")
+                   "tab")))
 
 ;; 辅助函数：定义 enumerate-tag-list
 (define (enumerate-tag-list)

--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -418,9 +418,7 @@
   ("A-space" (make-space "0.2spc"))
   ("A-S-space" (make-space "-0.2spc"))
   ("M-space" (make-space "0.2spc"))
-  ("M-S-space" (make-space "-0.2spc"))
-  ("M-tab" (kbd-alternate-tab))
-  ("M-S-tab" (kbd-shift-alternate-tab)))
+  ("M-S-space" (make-space "-0.2spc")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Gnome keymap
@@ -484,8 +482,6 @@
 (kbd-map
   (:profile gnome)
   (:require (and (not (in-prog?)) (not (in-verbatim?))))
-  ("M-tab" (kbd-alternate-tab))
-  ("M-S-tab" (kbd-shift-alternate-tab))
   ("M-space" (make-space "0.2spc"))
   ("M-S-space" (make-space "-0.2spc")))
 
@@ -547,8 +543,6 @@
 (kbd-map
   (:profile kde)
   (:require (and (not (in-prog?)) (not (in-verbatim?))))
-  ("M-tab" (kbd-alternate-tab))
-  ("M-S-tab" (kbd-shift-alternate-tab))
   ("M-space" (make-space "0.2spc"))
   ("M-S-space" (make-space "-0.2spc")))
 
@@ -762,8 +756,6 @@
 (kbd-map
   (:profile windows)
   (:require (and (not (in-prog?)) (not (in-verbatim?))))
-  ("M-tab" (kbd-alternate-tab))
-  ("M-S-tab" (kbd-shift-alternate-tab))
   ("M-space" (make-space "0.2spc"))
   ("M-S-space" (make-space "-0.2spc")))
 

--- a/devel/0110.md
+++ b/devel/0110.md
@@ -1,0 +1,64 @@
+# [0110] 移除失效快捷键提示并调整 tab 键提示文案
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `TeXmacs/progs/generic/generic-edit.scm`
+- `TeXmacs/progs/generic/generic-kbd.scm`
+- `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm`
+
+## 如何测试
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，新建一个空白文档
+2. 在普通文本区域按下 `tab` 键
+3. 确认底部状态栏提示为：`Use \space (eg. 1cm) in order to insert a blank with specified width`
+4. 确认不再提示类似 `Use super+tab in order to insert a tab` 的信息
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+# 确认修改仅涉及指定文件
+git diff --stat
+```
+
+## What
+
+在普通文本（buffer）中按下 `tab` 键且没有自动补全可用时，移除对失效快捷键 `super+tab`（或 `win+tab`）的引用，并将提示文案调整为建议使用 `\space` 命令。
+
+具体改动：
+1. 修改 `TeXmacs/progs/generic/generic-edit.scm` 中 `kbd-variant` 在 `tree-is-buffer?` 上下文下的实现
+2. 移除动态查找 `kbd-alternate-tab` 快捷键绑定的逻辑（`kbd-find-inv-binding` + `kbd-system-rewrite`）
+3. 将提示信息改为固定文案：`Use \space (eg. 1cm) in order to insert a blank with specified width`
+4. 从 `TeXmacs/progs/generic/generic-kbd.scm` 的 emacs、gnome、kde、windows 四个 keymap profile 中移除 `M-tab` 和 `M-S-tab` 到 `kbd-alternate-tab` / `kbd-shift-alternate-tab` 的绑定
+5. 在 `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` 中添加新提示文案的中文翻译
+
+## Why
+
+在 Windows/Linux 环境下，`tab` 键在普通文本中按下时，如果没有触发自动补全，会提示用户使用 `super+tab`（或 `win+tab`）来插入制表符。但这个快捷键在多数桌面环境中已被系统占用（用于切换窗口/应用），实际无法使用，属于失效提示。同时，直接插入制表符并不是 TeXmacs/Mogan 中的推荐做法，使用 `\space` 命令插入指定宽度的空白更符合排版语义。
+
+## How
+
+将原来的动态提示逻辑：
+
+```scheme
+(tm-define (kbd-variant t forwards?)
+  (:require (tree-is-buffer? t))
+  (if (and (not (complete-try?)) forwards?)
+      (with sh (kbd-system-rewrite (kbd-find-inv-binding '(kbd-alternate-tab)))
+        (set-message `(concat "Use " ,sh " in order to insert a tab")
+                     "tab"))))
+```
+
+改为固定提示文案：
+
+```scheme
+(tm-define (kbd-variant t forwards?)
+  (:require (tree-is-buffer? t))
+  (if (and (not (complete-try?)) forwards?)
+      (set-message "Use \\space (eg. 1cm) in order to insert a blank with specified width"
+                   "tab")))
+```


### PR DESCRIPTION
## 摘要
在 Windows/Linux 环境下，`tab` 键在普通文本中按下且没有自动补全可用时，移除了对失效快捷键 `super+tab`（或 `win+tab`）的引用，并将提示文案调整为建议使用 `\space` 命令插入指定宽度的空白。

## 改动内容
- 修改 `TeXmacs/progs/generic/generic-edit.scm`：将 `kbd-variant` 在 `tree-is-buffer?` 上下文下的动态提示改为固定文案
- 修改 `TeXmacs/progs/generic/generic-kbd.scm`：从 emacs、gnome、kde、windows 四个 keymap profile 中移除 `M-tab` 和 `M-S-tab` 到 `kbd-alternate-tab` / `kbd-shift-alternate-tab` 的绑定
- 修改 `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm`：添加新提示文案的中文翻译
- 新增 `devel/0110.md`：任务开发文档

## 测试步骤
1. 启动 Mogan，新建一个空白文档
2. 在普通文本区域按下 `tab` 键
3. 确认底部状态栏提示为：`Use \space (eg. 1cm) in order to insert a blank with specified width`
4. 确认不再提示类似 `Use super+tab in order to insert a tab` 的信息

🤖 Generated with [Claude Code](https://claude.com/claude-code)