### PR TITLE
[0800] 图片/表格 preview-ref 的编号不正确

### DIFF
--- a/TeXmacs/progs/link/ref-edit.scm
+++ b/TeXmacs/progs/link/ref-edit.scm
@@ -398,16 +398,28 @@
          `(,(tm-label t) ,@(map clean-preview (tm-children t))))
         (else t)))
 
+(define (get-binding-value id)
+; get-reference 返回 buf->data->ref[id]，格式为 (tuple display_value page_ref)
+; 未保存文件时 tooltip 排版环境无法加载 ref map，因此不能用 get-binding 获取
+  (and-let* ((val (get-reference id)))
+    (let ((v (if (and (tree? val) (== (tree-label val) 'tuple)
+                      (>= (tree-arity val) 1))
+                 (tree-ref val 0)
+                 val)))
+      (and (not (== (tree-label v) 'uninit)) v))))
+
 (define (fix-fig_or_tb-number doc id)
 ; preview 不是在原文档上下文里排版，而是把目标片段单独拿出来排版
 ; 在排版 figure / table 时，这个临时区域的 figure-nr / table-nr 从 0 开始计数，因此预览框里的编号永远是 1
 ; 这里用一个宏包装，the-figure / the-table 时当前 figure / table 计数器，用于生成显示用编号
-; 这里先通过 get-binding 从文档中获取真实编号，这样在 *-figure / *-table 展开渲染时就能获取正确的编号
-  (cond ((tm-in? doc '(small-figure big-figure))
-         `(with "the-figure" (macro (get-binding ,id)) ,doc))
-        ((tm-in? doc '(small-table big-table))
-         `(with "the-table" (macro (get-binding ,id)) ,doc))
-        (else doc)))
+; 这里先通过 get-binding-value 从文档中获取真实编号，这样在 *-figure / *-table 展开渲染时就能获取正确的编号
+  (let ((v (get-binding-value id))
+        (tag (cond ((tm-in? doc '(small-figure big-figure)) "the-figure")
+                   ((tm-in? doc '(small-table big-table)) "the-table")
+                   (else #f))))
+    (when (and v tag)
+      (set! doc `(with ,tag (macro ,v) ,doc)))
+    doc))
 
 (define (preview-expand-context? t)
   (tree-in? t '(theorem proposition lemma corollary conjecture

--- a/devel/0800.md
+++ b/devel/0800.md
@@ -1,7 +1,25 @@
 # [0800] 图片/表格 preview-ref 的编号不正确
 
 ## 如何测试
-打开 `TeXmacs\tests\tmu\0800.tmu`，将鼠标悬停在图片/表格的 smart-ref 上，查看预览气泡中图片/表格的编号是否正确（与文档中的编号一致）
+1. 打开 `TeXmacs\tests\tmu\0800.tmu`，将鼠标悬停在图片/表格的 smart-ref 上，查看预览气泡中图片/表格的编号是否正确（与文档中的编号一致）
+2. 选中图片，查看焦点工具栏的 "Style options"，勾选 "Prefix by section number"，查看预览气泡中的编号是否同步更新（附带上了章节号）
+3. 打开一个新文档，复制 `TeXmacs\tests\tmu\0800.tmu` 内容到新文档中，不保存文件，再次查看编号是否正确（不可以出现"?"）
+
+## 2026/5/13
+### What
+文件未保存时，preview-ref 预览气泡中图片/表格的编号显示为 "?"。
+
+### Why
+tooltip 排版时通过 `texmacs_output_widget` 创建独立环境，该函数在 `tm_button.cpp` 中检查 `exists (url_system (prj->label))`——文件必须存在于磁盘才会加载 `buf->data->ref`。
+
+未保存的文件不满足此条件，导致 tooltip 环境的 `local_ref` 为空，`get-binding` 返回 `UNINIT`。
+
+### How
+将 `(get-binding id)` 替换为 `get-binding-value`，通过 `get-reference` 直接从编辑器的活环境中获取 binding 值
+
+_get-reference 返回 buf->data->ref[id]，格式为 (tuple display_value page_ref)_
+
+这样无论文件是否保存，只要编辑器已计算出编号，tooltip 排版就能获得正确的 binding 值。
 
 ## 2026/5/11
 ### What


### PR DESCRIPTION
# [0800] 图片/表格 preview-ref 的编号不正确

## 如何测试
1. 打开 `TeXmacs\tests\tmu\0800.tmu`，将鼠标悬停在图片/表格的 smart-ref 上，查看预览气泡中图片/表格的编号是否正确（与文档中的编号一致）
2. 选中图片，查看焦点工具栏的 "Style options"，勾选 "Prefix by section number"，查看预览气泡中的编号是否同步更新（附带上了章节号）
3. 打开一个新文档，复制 `TeXmacs\tests\tmu\0800.tmu` 内容到新文档中，不保存文件，再次查看编号是否正确（不可以出现"?"）

## 2026/5/13
### What
文件未保存时，preview-ref 预览气泡中图片/表格的编号显示为 "?"。

### Why
tooltip 排版时通过 `texmacs_output_widget` 创建独立环境，该函数在 `tm_button.cpp` 中检查 `exists (url_system (prj->label))`——文件必须存在于磁盘才会加载 `buf->data->ref`。

未保存的文件不满足此条件，导致 tooltip 环境的 `local_ref` 为空，`get-binding` 返回 `UNINIT`。

### How
将 `(get-binding id)` 替换为 `get-binding-value`，通过 `get-reference` 直接从编辑器的活环境中获取 binding 值

_get-reference 返回 buf->data->ref[id]，格式为 (tuple display_value page_ref)_

这样无论文件是否保存，只要编辑器已计算出编号，tooltip 排版就能获得正确的 binding 值。