### PR TITLE
[0114] 页面边白输入框改为原生 QSpinBox 数字调节框

### DIFF
--- a/TeXmacs/progs/generic/document-widgets.scm
+++ b/TeXmacs/progs/generic/document-widgets.scm
@@ -363,19 +363,16 @@
             (aligned
               (item (text "(Odd page) Left:")
                 (hlist
-                  (numeric-input (page-margin-set-mm-initial u "page-odd" answer) "4em"
-                                 0 500 1 (page-margin-get-mm-initial u "page-odd"))
-                  // // (text "mm")))
+                  (numeric-input (page-margin-set-mm-initial u "page-odd" answer) "4em" "mm"
+                                 0 500 1 (page-margin-get-mm-initial u "page-odd"))))
               (item (text "(Even page) Left:")
                 (hlist
-                  (numeric-input (page-margin-set-mm-initial u "page-even" answer) "4em"
-                                 0 500 1 (page-margin-get-mm-initial u "page-even"))
-                  // // (text "mm")))
+                  (numeric-input (page-margin-set-mm-initial u "page-even" answer) "4em" "mm"
+                                 0 500 1 (page-margin-get-mm-initial u "page-even"))))
               (item (text "(Odd page) Right:")
                 (hlist
-                  (numeric-input (page-margin-set-mm-initial u "page-right" answer) "4em"
-                                 0 500 1 (page-margin-get-mm-initial u "page-right"))
-                  // // (text "mm")))
+                  (numeric-input (page-margin-set-mm-initial u "page-right" answer) "4em" "mm"
+                                 0 500 1 (page-margin-get-mm-initial u "page-right"))))
               (item (text "Top:")
                 (input (initial-set u "page-top" answer) "string"
                        (list (initial-get u "page-top")) "6em"))

--- a/TeXmacs/progs/generic/document-widgets.scm
+++ b/TeXmacs/progs/generic/document-widgets.scm
@@ -324,6 +324,19 @@
 ;; Document -> Page / Margins
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define (page-margin-get-mm-initial u var)
+  (let ((val (initial-get u var)))
+    (cond ((or (not val) (== val "") (== val "auto")) 30)
+          ((tm-length? val)
+           (with decoded (length-decode val)
+             (if decoded
+                 (inexact->exact (round (/ decoded 6047.0)))
+                 30)))
+          (else 30))))
+
+(define (page-margin-set-mm-initial u var val)
+  (initial-set u var (string-append (number->string val) "mm")))
+
 (tm-widget (page-formatter-margins u quit)
   (padded
     (refreshable "page-margin-toggles"
@@ -349,14 +362,20 @@
         (if (!= (initial-get u "page-width-margin") "true")
             (aligned
               (item (text "(Odd page) Left:")
-                (input (initial-set u "page-odd" answer) "string"
-                       (list (initial-get u "page-odd")) "6em"))
+                (hlist
+                  (numeric-input (page-margin-set-mm-initial u "page-odd" answer) "4em"
+                                 0 500 1 (page-margin-get-mm-initial u "page-odd"))
+                  // // (text "mm")))
               (item (text "(Even page) Left:")
-                (input (initial-set u "page-even" answer) "string"
-                       (list (initial-get u "page-odd")) "6em"))
+                (hlist
+                  (numeric-input (page-margin-set-mm-initial u "page-even" answer) "4em"
+                                 0 500 1 (page-margin-get-mm-initial u "page-even"))
+                  // // (text "mm")))
               (item (text "(Odd page) Right:")
-                (input (initial-set u "page-right" answer) "string"
-                       (list (initial-get u "page-right")) "6em"))
+                (hlist
+                  (numeric-input (page-margin-set-mm-initial u "page-right" answer) "4em"
+                                 0 500 1 (page-margin-get-mm-initial u "page-right"))
+                  // // (text "mm")))
               (item (text "Top:")
                 (input (initial-set u "page-top" answer) "string"
                        (list (initial-get u "page-top")) "6em"))

--- a/TeXmacs/progs/generic/format-tools.scm
+++ b/TeXmacs/progs/generic/format-tools.scm
@@ -359,19 +359,19 @@
           (aligned
             (item (text "Left:")
               (hlist
-                (numeric-input (page-margin-set-mm win "page-odd" answer) "4em"
+                (numeric-input (page-margin-set-mm win "page-odd" answer) "4em" "mm"
                                0 500 1 (page-margin-get-mm win "page-odd"))
-                // // (text "mm") // // (text "(odd pages)") // >>>))
+                // // (text "(odd pages)") // >>>))
             (item (text "")
               (hlist
-                (numeric-input (page-margin-set-mm win "page-even" answer) "4em"
+                (numeric-input (page-margin-set-mm win "page-even" answer) "4em" "mm"
                                0 500 1 (page-margin-get-mm win "page-even"))
-                // // (text "mm") // // (text "(even pages)") >>>))
+                // // (text "(even pages)") >>>))
             (item (text "Right:")
               (hlist
-                (numeric-input (page-margin-set-mm win "page-right" answer) "4em"
+                (numeric-input (page-margin-set-mm win "page-right" answer) "4em" "mm"
                                0 500 1 (page-margin-get-mm win "page-right"))
-                // // (text "mm") // // (text "(odd pages)") // >>>))
+                // // (text "(odd pages)") // >>>))
             (item (text "Top:")
               (input (window-set-init win "page-top" answer) "string"
                      (list (window-get-init win "page-top")) "6em"))

--- a/TeXmacs/progs/generic/format-tools.scm
+++ b/TeXmacs/progs/generic/format-tools.scm
@@ -322,6 +322,19 @@
 ;; Global page margins
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define (page-margin-get-mm win var)
+  (let ((val (window-get-init win var)))
+    (cond ((or (not val) (== val "") (== val "auto")) 30)
+          ((tm-length? val)
+           (with decoded (length-decode val)
+             (if decoded
+                 (inexact->exact (round (/ decoded 6047.0)))
+                 30)))
+          (else 30))))
+
+(define (page-margin-set-mm win var val)
+  (window-set-init win var (string-append (number->string val) "mm")))
+
 (tm-widget (page-margins-tool win)
   (padded
     (aligned
@@ -346,19 +359,19 @@
           (aligned
             (item (text "Left:")
               (hlist
-                (input (window-set-init win "page-odd" answer) "string"
-                       (list (window-get-init win "page-odd")) "6em")
-                // // (text "(odd pages)") // >>>))
+                (numeric-input (page-margin-set-mm win "page-odd" answer) "4em"
+                               0 500 1 (page-margin-get-mm win "page-odd"))
+                // // (text "mm") // // (text "(odd pages)") // >>>))
             (item (text "")
               (hlist
-                (input (window-set-init win "page-even" answer) "string"
-                       (list (window-get-init win "page-odd")) "6em")
-                // // (text "(even pages)") >>>))
+                (numeric-input (page-margin-set-mm win "page-even" answer) "4em"
+                               0 500 1 (page-margin-get-mm win "page-even"))
+                // // (text "mm") // // (text "(even pages)") >>>))
             (item (text "Right:")
               (hlist
-                (input (window-set-init win "page-right" answer) "string"
-                       (list (window-get-init win "page-right")) "6em")
-                // // (text "(odd pages)") // >>>))
+                (numeric-input (page-margin-set-mm win "page-right" answer) "4em"
+                               0 500 1 (page-margin-get-mm win "page-right"))
+                // // (text "mm") // // (text "(odd pages)") // >>>))
             (item (text "Top:")
               (input (window-set-init win "page-top" answer) "string"
                      (list (window-get-init win "page-top")) "6em"))

--- a/TeXmacs/progs/kernel/gui/gui-markup.scm
+++ b/TeXmacs/progs/kernel/gui/gui-markup.scm
@@ -335,6 +335,10 @@
   (:synopsis "Make input field")
   `(list 'input (lambda (answer) ,cmd) ,type (lambda () ,proposals) ,width))
 
+(tm-define-macro ($numeric-input cmd width min max step def)
+  (:synopsis "Make numeric input field")
+  `(list 'numeric-input (lambda (answer) ,cmd) ,width ,min ,max ,step ,def))
+
 (tm-define-macro ($toggle cmd on)
   (:synopsis "Make input toggle")
   `(list 'toggle (lambda (answer) ,cmd) (lambda () ,on)))

--- a/TeXmacs/progs/kernel/gui/gui-markup.scm
+++ b/TeXmacs/progs/kernel/gui/gui-markup.scm
@@ -335,9 +335,9 @@
   (:synopsis "Make input field")
   `(list 'input (lambda (answer) ,cmd) ,type (lambda () ,proposals) ,width))
 
-(tm-define-macro ($numeric-input cmd width min max step def)
+(tm-define-macro ($numeric-input cmd width unit min max step def)
   (:synopsis "Make numeric input field")
-  `(list 'numeric-input (lambda (answer) ,cmd) ,width ,min ,max ,step ,def))
+  `(list 'numeric-input (lambda (answer) ,cmd) ,width ,unit ,min ,max ,step ,def))
 
 (tm-define-macro ($toggle cmd on)
   (:synopsis "Make input toggle")

--- a/TeXmacs/progs/kernel/gui/menu-convert.scm
+++ b/TeXmacs/progs/kernel/gui/menu-convert.scm
@@ -195,6 +195,10 @@
            `(input-popup ,type ,cmd ,width ,(car props)
                          (choice-list ,cmd ,(car props) ,@props))))))
 
+(tm-define (markup-numeric-input cmd* width min max step def)
+  (with cmd (unary-mangled cmd*)
+    `(numeric-input ,cmd ,width ,min ,max ,step ,def)))
+
 (tm-define (markup-enum cmd* props val style width)
   ;; TODO: handle inert style
   (with cmd (unary-mangled cmd*)
@@ -448,9 +452,15 @@
 
 (define (build-menu-input p style)
   "Make @(input :%1 :string? :%1 :string?) menu item."
-  (with (tag cmd type props width) p    
+  (with (tag cmd type props width) p
     (markup-input (object->command (menu-protect cmd)) type (props)
                   style width)))
+
+(define (build-numeric-input p style)
+  "Make @(numeric-input :%6) menu item."
+  (with (tag cmd width min max step def) p
+    (markup-numeric-input (object->command (menu-protect cmd)) width min max step
+                          def)))
 
 (define (build-enum p style)
   "Make @(enum :%3 :string?) item."
@@ -943,6 +953,8 @@
     ,(lambda (p style bar?) (list (build-texmacs-input p style))))
   (input (:%1 :string? :%1 :string?)
          ,(lambda (p style bar?) (list (build-menu-input p style))))
+  (numeric-input (:%1 :string? :integer? :integer? :integer? :integer?)
+         ,(lambda (p style bar?) (list (build-numeric-input p style))))
   (enum (:%3 :string?)
         ,(lambda (p style bar?) (list (build-enum p style))))
   (choice (:%3)

--- a/TeXmacs/progs/kernel/gui/menu-convert.scm
+++ b/TeXmacs/progs/kernel/gui/menu-convert.scm
@@ -195,9 +195,9 @@
            `(input-popup ,type ,cmd ,width ,(car props)
                          (choice-list ,cmd ,(car props) ,@props))))))
 
-(tm-define (markup-numeric-input cmd* width min max step def)
+(tm-define (markup-numeric-input cmd* width unit min max step def)
   (with cmd (unary-mangled cmd*)
-    `(numeric-input ,cmd ,width ,min ,max ,step ,def)))
+    `(numeric-input ,cmd ,width ,unit ,min ,max ,step ,def)))
 
 (tm-define (markup-enum cmd* props val style width)
   ;; TODO: handle inert style
@@ -457,10 +457,10 @@
                   style width)))
 
 (define (build-numeric-input p style)
-  "Make @(numeric-input :%6) menu item."
-  (with (tag cmd width min max step def) p
-    (markup-numeric-input (object->command (menu-protect cmd)) width min max step
-                          def)))
+  "Make @(numeric-input :%7) menu item."
+  (with (tag cmd width unit min max step def) p
+    (markup-numeric-input (object->command (menu-protect cmd)) width unit min max
+                          step def)))
 
 (define (build-enum p style)
   "Make @(enum :%3 :string?) item."
@@ -953,7 +953,7 @@
     ,(lambda (p style bar?) (list (build-texmacs-input p style))))
   (input (:%1 :string? :%1 :string?)
          ,(lambda (p style bar?) (list (build-menu-input p style))))
-  (numeric-input (:%1 :string? :integer? :integer? :integer? :integer?)
+  (numeric-input (:%1 :string? :string? :integer? :integer? :integer? :integer?)
          ,(lambda (p style bar?) (list (build-numeric-input p style))))
   (enum (:%3 :string?)
         ,(lambda (p style bar?) (list (build-enum p style))))

--- a/TeXmacs/progs/kernel/gui/menu-define.scm
+++ b/TeXmacs/progs/kernel/gui/menu-define.scm
@@ -118,7 +118,7 @@
   `($input ,@(cdr x)))
 
 (define (gui-make-numeric-input x)
-  (require-format x '(numeric-input :%6))
+  (require-format x '(numeric-input :%7))
   `($numeric-input ,@(cdr x)))
 
 (define (gui-make-enum x)

--- a/TeXmacs/progs/kernel/gui/menu-define.scm
+++ b/TeXmacs/progs/kernel/gui/menu-define.scm
@@ -117,6 +117,10 @@
   (require-format x '(input :%4))
   `($input ,@(cdr x)))
 
+(define (gui-make-numeric-input x)
+  (require-format x '(numeric-input :%6))
+  `($numeric-input ,@(cdr x)))
+
 (define (gui-make-enum x)
   (require-format x '(enum :%4))
   `($enum ,@(cdr x)))
@@ -412,6 +416,7 @@
   (texmacs-output ,gui-make-texmacs-output)
   (texmacs-input ,gui-make-texmacs-input)
   (input ,gui-make-input)
+  (numeric-input ,gui-make-numeric-input)
   (enum ,gui-make-enum)
   (choice ,gui-make-choice)
   (choices ,gui-make-choices)

--- a/TeXmacs/progs/kernel/gui/menu-widget.scm
+++ b/TeXmacs/progs/kernel/gui/menu-widget.scm
@@ -293,9 +293,15 @@
 
 (define (make-menu-input p style)
   "Make @(input :%1 :string? :%1 :string?) menu item."
-  (with (tag cmd type props width) p    
+  (with (tag cmd type props width) p
     (widget-input (object->command (menu-protect cmd)) type (props)
                   style width)))
+
+(define (make-numeric-input p style)
+  "Make @(numeric-input :%6) menu item."
+  (with (tag cmd width min max step def) p
+    (widget-numeric-input (object->command (menu-protect cmd)) width min max step
+                          def)))
 
 (define (make-enum p style)
   "Make @(enum :%3 :string?) item."
@@ -862,6 +868,8 @@
     ,(lambda (p style bar?) (list (make-texmacs-input p style))))
   (input (:%1 :string? :%1 :string?)
          ,(lambda (p style bar?) (list (make-menu-input p style))))
+  (numeric-input (:%1 :string? :integer? :integer? :integer? :integer?)
+         ,(lambda (p style bar?) (list (make-numeric-input p style))))
   (enum (:%3 :string?)
         ,(lambda (p style bar?) (list (make-enum p style))))
   (choice (:%3)

--- a/TeXmacs/progs/kernel/gui/menu-widget.scm
+++ b/TeXmacs/progs/kernel/gui/menu-widget.scm
@@ -298,10 +298,10 @@
                   style width)))
 
 (define (make-numeric-input p style)
-  "Make @(numeric-input :%6) menu item."
-  (with (tag cmd width min max step def) p
-    (widget-numeric-input (object->command (menu-protect cmd)) width min max step
-                          def)))
+  "Make @(numeric-input :%7) menu item."
+  (with (tag cmd width unit min max step def) p
+    (widget-numeric-input (object->command (menu-protect cmd)) width unit min max
+                          step def)))
 
 (define (make-enum p style)
   "Make @(enum :%3 :string?) item."
@@ -868,7 +868,7 @@
     ,(lambda (p style bar?) (list (make-texmacs-input p style))))
   (input (:%1 :string? :%1 :string?)
          ,(lambda (p style bar?) (list (make-menu-input p style))))
-  (numeric-input (:%1 :string? :integer? :integer? :integer? :integer?)
+  (numeric-input (:%1 :string? :string? :integer? :integer? :integer? :integer?)
          ,(lambda (p style bar?) (list (make-numeric-input p style))))
   (enum (:%3 :string?)
         ,(lambda (p style bar?) (list (make-enum p style))))

--- a/TeXmacs/progs/prog/glue-symbols.scm
+++ b/TeXmacs/progs/prog/glue-symbols.scm
@@ -639,6 +639,7 @@
 "widget-empty"
 "widget-text"
 "widget-input"
+"widget-numeric-input"
 "widget-enum"
 "widget-choice"
 "widget-choices"

--- a/devel/0114.md
+++ b/devel/0114.md
@@ -1,0 +1,129 @@
+# [0114] 页面边白输入框改为数字调节框
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+
+### C++ 层（新增 QSpinBox widget 支持）
+- `src/Graphics/Gui/widget.hpp`
+- `src/Plugins/Qt/qt_dialogues.hpp`
+- `src/Plugins/Qt/qt_dialogues.cpp`
+- `src/Plugins/Qt/qt_widget.cpp`
+- `src/Scheme/L5/glue_widget.lua`
+- `build/glue/glue_widget.cpp`（构建时自动生成，但需重新生成）
+
+### Scheme 层（新增 `numeric-input` GUI 原语）
+- `TeXmacs/progs/kernel/gui/gui-markup.scm`
+- `TeXmacs/progs/kernel/gui/menu-define.scm`
+- `TeXmacs/progs/kernel/gui/menu-convert.scm`
+- `TeXmacs/progs/kernel/gui/menu-widget.scm`
+- `TeXmacs/progs/prog/glue-symbols.scm`
+
+### 业务层（使用 `numeric-input`）
+- `TeXmacs/progs/generic/format-tools.scm` - 侧边栏页面边白工具
+- `TeXmacs/progs/generic/document-widgets.scm` - 文档页面设置弹窗
+
+## 如何测试
+
+### 编译
+由于新增了 C++ 代码，需要重新编译：
+```bash
+xmake build
+```
+
+xmake 会自动根据 `glue_widget.lua` 重新生成 `build/glue/glue_widget.cpp`。
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，新建文档
+2. 打开右侧工具栏 -> Document -> Page -> Margins
+3. 观察 Left（odd pages）、Left（even pages）、Right（odd pages）三个输入框：
+   - 默认值应显示为数字（如 `30`）
+   - 应为原生 Qt 数字调节框（QSpinBox），带上下箭头按钮
+   - 旁边应有 `mm` 单位标签
+   - 点击上下箭头或输入数字，数值实时变化并写入环境变量
+4. 当值为 `auto` 时，默认显示 `30`
+5. 同样测试 Document -> Page -> Margins 弹窗中的三个输入框
+
+## 如何提交
+
+```bash
+# 编译前检查
+xmake build
+
+# 提交（注意 build/glue/glue_widget.cpp 是生成文件，不应提交）
+```
+
+## What
+
+将页面边白（Margins）设置中的三个左右边距输入框，从自由文本输入改为原生 Qt 数字调节框（QSpinBox），并固定单位为 mm。
+
+本次 PR 仅修改以下三个输入框：
+1. **Left (odd pages)** — 对应环境变量 `page-odd`
+2. **Left (even pages)** — 对应环境变量 `page-even`
+3. **Right (odd pages)** — 对应环境变量 `page-right`
+
+具体改动：
+1. 当当前值为 `auto` 时，默认显示 `30`（对应 `30mm`）
+2. 输入框为原生 QSpinBox，只显示纯数字
+3. 单位 `mm` 以标签形式固定显示在旁边
+4. 通过 QSpinBox 的上下箭头每次增减 `1mm`
+5. 直接输入数字后自动追加 `mm` 单位并写入环境变量
+
+## Why
+
+当前边白输入框为自由文本（`string` 类型），默认值显示 `auto`，用户需要手动输入带单位的长度值（如 `30mm`），不够直观。改为原生数字调节框后：
+- 降低用户理解成本，无需记忆单位格式
+- 通过原生 QSpinBox 的上下箭头快速微调边距，体验更精致
+- 与大多数排版/设计软件的操作习惯保持一致
+
+## How
+
+### C++ 层：新增 `qt_numeric_input_widget_rep`
+
+在 `src/Plugins/Qt/qt_dialogues.hpp/cpp` 中新增 `qt_numeric_input_widget_rep` 类：
+
+- `as_qwidget()` 创建 `QSpinBox`，设置范围、步长、默认值
+- `commit()` 将数值通过 command 传递给 Scheme 层
+- `setValue()` 前通过 `blockSignals(true/false)` 避免刷新 widget 时触发不必要的 commit
+
+在 `src/Graphics/Gui/widget.hpp` 和 `src/Plugins/Qt/qt_widget.cpp` 中新增工厂函数：
+```cpp
+widget numeric_input_widget (command call_back, string width, int min_val,
+                             int max_val, int step, int def);
+```
+
+### Glue 层：新增 `widget-numeric-input`
+
+在 `src/Scheme/L5/glue_widget.lua` 中添加 `widget-numeric-input` 绑定：
+```lua
+{
+    scm_name = "widget-numeric-input",
+    cpp_name = "numeric_input_widget",
+    ret_type = "widget",
+    arg_list = { "command", "string", "int", "int", "int", "int" }
+}
+```
+
+并在 `TeXmacs/progs/prog/glue-symbols.scm` 中注册符号。
+
+### Scheme 层：新增 `numeric-input` GUI 原语
+
+在 `gui-markup.scm`、`menu-define.scm`、`menu-convert.scm`、`menu-widget.scm` 中依次添加 `numeric-input` 的支持，使其可以在 Scheme 菜单/widget 中直接使用：
+
+```scheme
+(numeric-input cmd width min max step def)
+```
+
+### 业务层：使用 `numeric-input`
+
+在 `format-tools.scm` 和 `document-widgets.scm` 中，将三个左右边距输入框改为：
+
+```scheme
+(numeric-input (page-margin-set-mm win "page-odd" answer) "4em"
+               0 500 1 (page-margin-get-mm win "page-odd"))
+```
+
+辅助函数保留：
+- `page-margin-get-mm` / `page-margin-get-mm-initial`：将环境变量值（含 `auto`、各种单位）转换为 mm 整数
+- `page-margin-set-mm` / `page-margin-set-mm-initial`：将整数转换为 `"<val>mm"` 写入环境变量

--- a/src/Graphics/Gui/widget.hpp
+++ b/src/Graphics/Gui/widget.hpp
@@ -182,6 +182,10 @@ widget input_text_widget (command call_back, string type, array<string> def,
 // default inputs (the first one should be displayed, if there is one)
 // an optional width may be specified for the input field
 // the width is specified in TeXmacs length format with units em, px or w
+widget numeric_input_widget (command call_back, string width, int min_val,
+                             int max_val, int step, int def);
+// a numeric input widget with a spin box for integer values
+// an optional width may be specified for the input field
 widget enum_widget (command cb, array<string> vals, string val, int st= 0,
                     string w= "1w");
 // select a value from a list of possible values

--- a/src/Graphics/Gui/widget.hpp
+++ b/src/Graphics/Gui/widget.hpp
@@ -182,10 +182,11 @@ widget input_text_widget (command call_back, string type, array<string> def,
 // default inputs (the first one should be displayed, if there is one)
 // an optional width may be specified for the input field
 // the width is specified in TeXmacs length format with units em, px or w
-widget numeric_input_widget (command call_back, string width, int min_val,
-                             int max_val, int step, int def);
+widget numeric_input_widget (command call_back, string width, string unit,
+                             int min_val, int max_val, int step, int def);
 // a numeric input widget with a spin box for integer values
 // an optional width may be specified for the input field
+// an optional unit suffix (e.g. "mm") may be displayed after the value
 widget enum_widget (command cb, array<string> vals, string val, int st= 0,
                     string w= "1w");
 // select a value from a list of possible values

--- a/src/Plugins/Qt/qt_dialogues.cpp
+++ b/src/Plugins/Qt/qt_dialogues.cpp
@@ -32,6 +32,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QVBoxLayout>
 #include <QVector>
 
@@ -432,4 +433,45 @@ qt_input_text_widget_rep::commit (bool flag) {
     the_gui->process_command (cmd, ok ? list_object (object (input))
                                       : list_object (object (false)));
   }
+}
+
+/******************************************************************************
+ * qt_numeric_input_widget_rep
+ ******************************************************************************/
+
+qt_numeric_input_widget_rep::qt_numeric_input_widget_rep (command _cmd,
+                                                          string  _width,
+                                                          int     _min_val,
+                                                          int     _max_val,
+                                                          int _step, int _def)
+    : qt_widget_rep (input_widget), cmd (_cmd), width (_width),
+      min_val (_min_val), max_val (_max_val), step (_step), value (_def) {}
+
+QWidget*
+qt_numeric_input_widget_rep::as_qwidget () {
+  QSpinBox* spin= new QSpinBox ();
+  qwid          = spin;
+  spin->setRange (min_val, max_val);
+  spin->setSingleStep (step);
+  spin->blockSignals (true);
+  spin->setValue (value);
+  spin->blockSignals (false);
+  spin->setObjectName ("numeric-input");
+
+  if (width != "") {
+    spin->setMinimumWidth (50);
+  }
+
+  QObject::connect (spin, QOverload<int>::of (&QSpinBox::valueChanged),
+                    [this] (int new_val) {
+                      value= new_val;
+                      commit ();
+                    });
+
+  return qwid;
+}
+
+void
+qt_numeric_input_widget_rep::commit () {
+  the_gui->process_command (cmd, list_object (object (value)));
 }

--- a/src/Plugins/Qt/qt_dialogues.cpp
+++ b/src/Plugins/Qt/qt_dialogues.cpp
@@ -441,10 +441,12 @@ qt_input_text_widget_rep::commit (bool flag) {
 
 qt_numeric_input_widget_rep::qt_numeric_input_widget_rep (command _cmd,
                                                           string  _width,
+                                                          string  _unit,
                                                           int     _min_val,
                                                           int     _max_val,
-                                                          int _step, int _def)
-    : qt_widget_rep (input_widget), cmd (_cmd), width (_width),
+                                                          int     _step,
+                                                          int     _def)
+    : qt_widget_rep (input_widget), cmd (_cmd), width (_width), unit (_unit),
       min_val (_min_val), max_val (_max_val), step (_step), value (_def) {}
 
 QWidget*
@@ -457,6 +459,10 @@ qt_numeric_input_widget_rep::as_qwidget () {
   spin->setValue (value);
   spin->blockSignals (false);
   spin->setObjectName ("numeric-input");
+
+  if (unit != "") {
+    spin->setSuffix (to_qstring (unit));
+  }
 
   if (width != "") {
     spin->setMinimumWidth (50);

--- a/src/Plugins/Qt/qt_dialogues.cpp
+++ b/src/Plugins/Qt/qt_dialogues.cpp
@@ -439,13 +439,9 @@ qt_input_text_widget_rep::commit (bool flag) {
  * qt_numeric_input_widget_rep
  ******************************************************************************/
 
-qt_numeric_input_widget_rep::qt_numeric_input_widget_rep (command _cmd,
-                                                          string  _width,
-                                                          string  _unit,
-                                                          int     _min_val,
-                                                          int     _max_val,
-                                                          int     _step,
-                                                          int     _def)
+qt_numeric_input_widget_rep::qt_numeric_input_widget_rep (
+    command _cmd, string _width, string _unit, int _min_val, int _max_val,
+    int _step, int _def)
     : qt_widget_rep (input_widget), cmd (_cmd), width (_width), unit (_unit),
       min_val (_min_val), max_val (_max_val), step (_step), value (_def) {}
 

--- a/src/Plugins/Qt/qt_dialogues.hpp
+++ b/src/Plugins/Qt/qt_dialogues.hpp
@@ -50,6 +50,25 @@ public:
 
 class qt_field_widget_rep;
 
+/*! A numeric input field with a spin box.
+ */
+class qt_numeric_input_widget_rep : public qt_widget_rep {
+protected:
+  command cmd;
+  string  width;
+  int     min_val;
+  int     max_val;
+  int     step;
+  int     value;
+
+public:
+  qt_numeric_input_widget_rep (command _cmd, string _width, int _min_val,
+                               int _max_val, int _step, int _def);
+
+  virtual QWidget* as_qwidget ();
+  void             commit ();
+};
+
 /*! A dialog with a list of inputs and ok and cancel buttons.
 
  In the general case each input is a qt_field_widget_rep which we lay out in a

--- a/src/Plugins/Qt/qt_dialogues.hpp
+++ b/src/Plugins/Qt/qt_dialogues.hpp
@@ -56,14 +56,15 @@ class qt_numeric_input_widget_rep : public qt_widget_rep {
 protected:
   command cmd;
   string  width;
+  string  unit;
   int     min_val;
   int     max_val;
   int     step;
   int     value;
 
 public:
-  qt_numeric_input_widget_rep (command _cmd, string _width, int _min_val,
-                               int _max_val, int _step, int _def);
+  qt_numeric_input_widget_rep (command _cmd, string _width, string _unit,
+                               int _min_val, int _max_val, int _step, int _def);
 
   virtual QWidget* as_qwidget ();
   void             commit ();

--- a/src/Plugins/Qt/qt_widget.cpp
+++ b/src/Plugins/Qt/qt_widget.cpp
@@ -591,6 +591,13 @@ input_text_widget (command call_back, string type, array<string> def, int style,
   return tm_new<qt_input_text_widget_rep> (call_back, type, def, style, width);
 }
 widget
+numeric_input_widget (command call_back, string width, int min_val, int max_val,
+                      int step, int def) {
+  if (headless_mode) return headless_widget ();
+  return tm_new<qt_numeric_input_widget_rep> (call_back, width, min_val,
+                                              max_val, step, def);
+}
+widget
 color_picker_widget (command call_back, bool bg, array<tree> proposals) {
   if (headless_mode) return headless_widget ();
   return tm_new<qt_color_picker_widget_rep> (call_back, bg, proposals);

--- a/src/Plugins/Qt/qt_widget.cpp
+++ b/src/Plugins/Qt/qt_widget.cpp
@@ -591,10 +591,10 @@ input_text_widget (command call_back, string type, array<string> def, int style,
   return tm_new<qt_input_text_widget_rep> (call_back, type, def, style, width);
 }
 widget
-numeric_input_widget (command call_back, string width, int min_val, int max_val,
-                      int step, int def) {
+numeric_input_widget (command call_back, string width, string unit, int min_val,
+                      int max_val, int step, int def) {
   if (headless_mode) return headless_widget ();
-  return tm_new<qt_numeric_input_widget_rep> (call_back, width, min_val,
+  return tm_new<qt_numeric_input_widget_rep> (call_back, width, unit, min_val,
                                               max_val, step, def);
 }
 widget

--- a/src/Scheme/L5/glue_widget.lua
+++ b/src/Scheme/L5/glue_widget.lua
@@ -186,6 +186,19 @@ function main()
                 }
             },
             {
+                scm_name = "widget-numeric-input",
+                cpp_name = "numeric_input_widget",
+                ret_type = "widget",
+                arg_list = {
+                    "command",
+                    "string",
+                    "int",
+                    "int",
+                    "int",
+                    "int"
+                }
+            },
+            {
                 scm_name = "widget-enum",
                 cpp_name = "enum_widget",
                 ret_type = "widget",

--- a/src/Scheme/L5/glue_widget.lua
+++ b/src/Scheme/L5/glue_widget.lua
@@ -192,6 +192,7 @@ function main()
                 arg_list = {
                     "command",
                     "string",
+                    "string",
                     "int",
                     "int",
                     "int",


### PR DESCRIPTION
## 改动摘要

将页面边白（Margins）设置中的三个左右边距输入框，从自由文本输入改为原生 Qt 数字调节框（QSpinBox），并固定单位为 mm。

## 主要修改

1. **C++ 层**：新增 `qt_numeric_input_widget_rep`，底层使用 `QSpinBox`
2. **Glue 层**：新增 `widget-numeric-input` 绑定
3. **Scheme 层**：新增 `numeric-input` GUI 原语
4. **业务层**：侧边栏和弹窗中的 Left/Right 三个输入框使用 `numeric-input`

## 行为变化

- `auto` 默认值显示为 `30mm`
- 输入框为原生 QSpinBox，范围 `0-500mm`，步长 `1mm`
- 单位 `mm` 固定显示在旁边
- 实时响应（valueChanged 信号直接触发写入）

## 测试建议

1. 打开右侧工具栏 Document -> Page -> Margins
2. 观察三个左右边距输入框是否为 QSpinBox
3. 测试上下箭头调节和直接输入
4. 同样测试 Document -> Page -> Margins 弹窗版

## 编译说明

需重新编译 C++ 代码（新增 widget 类型和 glue 绑定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)