### PR TITLE
[0117] 修复单元格内 cell-hyphen 开启后无法换行的问题

### DIFF
--- a/TeXmacs/tests/tmu/0117.tmu
+++ b/TeXmacs/tests/tmu/0117.tmu
@@ -1,0 +1,16 @@
+<TMU|<tuple|1.1.0|2026.2.4>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  <tabular|<tformat|<cwith|1|1|1|1|cell-hyphen|t>|<table|<row|<\cell>
+    ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+  </cell>>>>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0117.md
+++ b/devel/0117.md
@@ -1,0 +1,49 @@
+# [0117] 修复单元格内 cell-hyphen 开启后无法换行的问题
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Typeset/Table/cell.cpp`
+- `src/Typeset/Table/cell.hpp`
+- `tests/Typeset/Table/table_performance_test.cpp`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+xmake test table_performance_test
+```
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，打开 `TeXmacs/tests/tmu/0117.tmu`
+2. 观察单元格内容是否换行（应显示为多行）
+3. 对比正文段落中长串 `d` 的换行行为，单元格内应一致
+
+## 如何提交
+
+```bash
+xmake build
+xmake test table_performance_test
+```
+
+## What
+
+修复当 `cell-hyphen` 设置为 `t`（开启单元格内换行）时，单元格内容仍然不换行的问题。
+
+## Why
+
+在 `cell-hyphen` 为 `t` 时，单元格内容应该像正文段落一样在超出可用宽度时自动换行。但当前实现中，`cell::compute_width` 在 `large=true` 时查询了内容的**自然宽度**（即不换行时的总宽度），并将列宽设置为该自然宽度。随后 `finish_horizontal` 使用这个列宽作为段落排版宽度，由于宽度恰好等于内容自然宽度，内容永远不需要换行，导致 `cell-hyphen` 失效。
+
+## How
+
+在 `cell::compute_width` 中，当 `cell-hyphen != "n"` 且查询自然宽度时，将查询结果限制在页面可用宽度（`page_user_width`）以内。这样列宽不会超过页面宽度，段落排版时内容会在页面边界处正确换行，与正文段落行为保持一致。
+
+具体修改 `src/Typeset/Table/cell.cpp` 中的 `cell_rep::compute_width` 方法，在 `else if (!is_nil (lz) && large)` 分支中加入宽度限制逻辑：
+
+```cpp
+SI page_w, d1, d2, d3, d4, d5, d6, d7;
+env->get_page_pars (page_w, d1, d2, d3, d4, d5, d6, d7);
+SI max_w= page_w - lsep - rsep - lborder - rborder;
+if (fw->width > max_w) fw->width= max_w;
+```

--- a/src/Typeset/Table/cell.cpp
+++ b/src/Typeset/Table/cell.cpp
@@ -299,7 +299,7 @@ cell_rep::compute_width (SI& mw, SI& lw, SI& rw, bool large) {
     // cout << "Query" << LF << INDENT;
     format fm= lz->query (LAZY_BOX, make_query_vstream_width (0, 0));
     // cout << UNINDENT << "Queried" << LF;
-    format_width fw= (format_width) fm;
+    format_width fw    = (format_width) fm;
     SI           cell_w= fw->width;
     if (hyphen != "n") {
       SI page_w, d1, d2, d3, d4, d5, d6, d7;

--- a/src/Typeset/Table/cell.cpp
+++ b/src/Typeset/Table/cell.cpp
@@ -300,10 +300,17 @@ cell_rep::compute_width (SI& mw, SI& lw, SI& rw, bool large) {
     format fm= lz->query (LAZY_BOX, make_query_vstream_width (0, 0));
     // cout << UNINDENT << "Queried" << LF;
     format_width fw= (format_width) fm;
-    mw             = fw->width + lsep + rsep + lborder + rborder;
+    SI           cell_w= fw->width;
+    if (hyphen != "n") {
+      SI page_w, d1, d2, d3, d4, d5, d6, d7;
+      env->get_page_pars (page_w, d1, d2, d3, d4, d5, d6, d7);
+      SI max_w= page_w - lsep - rsep - lborder - rborder;
+      if (cell_w > max_w) cell_w= max_w;
+    }
+    mw= cell_w + lsep + rsep + lborder + rborder;
     if (lr_flag) {
       lw= lsep + lborder;
-      rw= fw->width + rsep + rborder;
+      rw= cell_w + rsep + rborder;
     }
   }
   else {

--- a/tests/Typeset/Table/table_performance_test.cpp
+++ b/tests/Typeset/Table/table_performance_test.cpp
@@ -166,6 +166,7 @@ private slots:
   // New tests for optimization validations
   void test_handle_decorations_correctness ();
   void test_handle_decorations_performance ();
+  void test_cell_hyphen_wrapping ();
   void cleanupTestCase ();
 };
 
@@ -630,6 +631,57 @@ TestTablePerformance::test_handle_decorations_performance () {
     QVERIFY (rows_after > rows_before);
     QVERIFY (cols_after > cols_before);
   }
+}
+
+void
+TestTablePerformance::test_cell_hyphen_wrapping () {
+  cache_refresh ();
+  edit_env env= create_test_env ();
+
+  // Create a very long string that exceeds page width
+  string long_text;
+  for (int i= 0; i < 200; i++)
+    long_text << "d";
+
+  // Create table without wrapping (cell-hyphen = "n")
+  tree table_no_wrap (TFORMAT, tree (TABLE, 1));
+  tree row_no_wrap (ROW, 1);
+  row_no_wrap[0]     = tree (CELL, tree (DOCUMENT, long_text));
+  table_no_wrap[0][0]= row_no_wrap;
+
+  // Create table with wrapping (cell-hyphen = "t")
+  tree table_wrap (TFORMAT);
+  table_wrap << tree (CWITH, "1", "1", "1", "1", "cell-hyphen", "t");
+  table_wrap << tree (TABLE, 1);
+  tree row_wrap (ROW, 1);
+  row_wrap[0]     = tree (CELL, tree (DOCUMENT, long_text));
+  table_wrap[1][0]= row_wrap;
+
+  // Typeset table without wrapping
+  table tab_no_wrap (env);
+  tab_no_wrap->typeset (table_no_wrap, path ());
+  tab_no_wrap->position_columns (true);
+  tab_no_wrap->finish_horizontal ();
+  tab_no_wrap->position_rows ();
+  tab_no_wrap->finish ();
+
+  // Typeset table with wrapping
+  table tab_wrap (env);
+  tab_wrap->typeset (table_wrap, path ());
+  tab_wrap->position_columns (true);
+  tab_wrap->finish_horizontal ();
+  tab_wrap->position_rows ();
+  tab_wrap->finish ();
+
+  SI width_no_wrap= tab_no_wrap->T[0][0]->b->w ();
+  SI width_wrap   = tab_wrap->T[0][0]->b->w ();
+
+  qDebug () << "No wrap width:" << width_no_wrap;
+  qDebug () << "Wrap width:" << width_wrap;
+
+  // When cell-hyphen is enabled, the cell should wrap and be narrower
+  // than the non-wrapping case
+  QVERIFY (width_wrap < width_no_wrap);
 }
 
 void


### PR DESCRIPTION
## 问题

当 `cell-hyphen` 设置为 `t`（开启单元格内换行）时，单元格内容仍然不换行。

## 根因

`cell::compute_width` 在 `large=true` 时查询内容的自然宽度（即不换行时的总宽度），并将列宽设置为该自然宽度。随后 `finish_horizontal` 使用这个列宽作为段落排版宽度，由于宽度恰好等于内容自然宽度，内容永远不需要换行，导致 `cell-hyphen` 失效。

## 修复

在 `cell::compute_width` 中，当 `cell-hyphen != \"n\"` 且查询自然宽度时，将查询结果限制在页面可用宽度（`page_user_width`）以内。这样列宽不会超过页面宽度，段落排版时内容会在页面边界处正确换行，与正文段落行为保持一致。

## 测试

- 新增 `test_cell_hyphen_wrapping` 单元测试：验证开启 `cell-hyphen` 后单元格宽度显著小于不开启时的宽度
- 全部 `table_performance_test` 18 个用例通过
- 完整项目编译通过