### PR TITLE
[0118] 首行缩进在节、代码块、列表后生效

### DIFF
--- a/TeXmacs/packages/customize/algorithm/framed-program.ts
+++ b/TeXmacs/packages/customize/algorithm/framed-program.ts
@@ -105,7 +105,7 @@
   </macro>>
 
   <assign|pseudo-code|<\macro|body>
-    <\surround||<no-indent*>>
+    <\surround||<if|<value|indent-after-block>||<no-indent*>>>
       <\framed-quoted>
         <\with|par-first|0fn|par-par-sep|0fn|item-hsep|<macro|1.5fn>>
           <\framed-code>

--- a/TeXmacs/packages/customize/algorithm/modern-program.ts
+++ b/TeXmacs/packages/customize/algorithm/modern-program.ts
@@ -45,7 +45,7 @@
   </active*>
 
   <assign|render-code|<\macro|body>
-    <\surround||<no-indent*>>
+    <\surround||<if|<value|indent-after-block>||<no-indent*>>>
       <\padded*>
         <\indent>
           <\with|par-first|0fn|par-par-sep|0fn|item-hsep|<macro|1tab>|numbered-offset|<value|code-numbered-offset>>

--- a/TeXmacs/packages/customize/list/compact-list.ts
+++ b/TeXmacs/packages/customize/list/compact-list.ts
@@ -34,7 +34,7 @@
   <assign|render-list|<\macro|body>
     <\padded-normal|<item-vsep>|<item-vsep>>
       <\indent-left|<item-hsep>>
-        <surround|<no-page-break*>|<no-indent*>|<arg|body>>
+        <surround|<no-page-break*>|<if|<value|indent-after-block>||<no-indent*>>|<arg|body>>
       </indent-left>
     </padded-normal>
   </macro>>

--- a/TeXmacs/packages/environment/env-program.ts
+++ b/TeXmacs/packages/environment/env-program.ts
@@ -32,7 +32,7 @@
   <assign|code-numbered-offset|0.5tab>
 
   <assign|render-code|<\macro|body>
-    <\surround||<no-indent*>>
+    <\surround||<if|<value|indent-after-block>||<no-indent*>>>
       <\padded*>
         <\indent>
           <\with|par-first|0fn|par-par-sep|0fn|item-hsep|<macro|1tab>|numbered-offset|<value|code-numbered-offset>>

--- a/TeXmacs/packages/section/section-base.ts
+++ b/TeXmacs/packages/section/section-base.ts
@@ -106,7 +106,7 @@
     </src-comment>
   </active*>
 
-  <assign|sectional-no-indent|<macro|<no-indent*>>>
+  <assign|sectional-no-indent|<macro|<if|<value|indent-after-block>||<no-indent*>>>>
 
   <assign|sectional-short|<macro|name|<no-indent><arg|name>>>
 

--- a/TeXmacs/packages/standard/std-list.ts
+++ b/TeXmacs/packages/standard/std-list.ts
@@ -109,7 +109,7 @@
   <assign|render-list|<\macro|body>
     <\padded-normal|<item-vsep>|<item-vsep>>
       <\indent-left|<item-hsep>>
-        <surround|<no-page-break*>|<no-indent*>|<arg|body>>
+        <surround|<no-page-break*>|<if|<value|indent-after-block>||<no-indent*>>|<arg|body>>
       </indent-left>
     </padded-normal>
   </macro>>
@@ -249,7 +249,7 @@
   <assign|description-paragraphs|<\macro|body>
     <\with|item*|<value|item-paragraph>>
       <\padded-normal|<item-vsep>|<item-vsep>>
-        <surround|<no-page-break*>|<no-indent*>|<arg|body>>
+        <surround|<no-page-break*>|<if|<value|indent-after-block>||<no-indent*>>|<arg|body>>
       </padded-normal>
     </with>
   </macro>>

--- a/TeXmacs/packages/standard/std-markup.ts
+++ b/TeXmacs/packages/standard/std-markup.ts
@@ -665,6 +665,8 @@
 
   <assign|indent-par-first|1.5fn>
 
+  <assign|indent-after-block|false>
+
   <assign|padded-par-par-sep|0.6666fn>
 
   <assign|math-color|<value|color>>

--- a/TeXmacs/styles/article.ts
+++ b/TeXmacs/styles/article.ts
@@ -27,6 +27,8 @@
 
   <use-package|std|env|title-generic|header-article|section-article>
 
+  <assign|indent-after-block|true>
+
   \;
 </body>
 

--- a/devel/0118.md
+++ b/devel/0118.md
@@ -1,0 +1,46 @@
+# [0118] 首行缩进在节、代码块、列表后生效
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `TeXmacs/packages/standard/std-markup.ts` - 定义新开关变量 `indent-after-block`
+- `TeXmacs/packages/section/section-base.ts` - 节标题后的首行缩进控制
+- `TeXmacs/packages/standard/std-list.ts` - 列表环境（含 `description-paragraphs`）后的首行缩进控制
+- `TeXmacs/packages/customize/list/compact-list.ts` - 紧凑列表环境后的首行缩进控制
+- `TeXmacs/packages/environment/env-program.ts` - 代码块后的首行缩进控制
+- `TeXmacs/packages/customize/algorithm/framed-program.ts` - 带框算法代码块后的首行缩进控制
+- `TeXmacs/packages/customize/algorithm/modern-program.ts` - 现代算法代码块后的首行缩进控制
+- `TeXmacs/styles/article.ts` - article 样式默认开启
+
+## 如何测试
+
+### 非确定性测试（文档验证）
+1. 新建 article 文档，加载 `indent-paragraphs` 包
+2. 在节标题后输入段落，观察首行是否缩进
+3. 在代码块后输入段落，观察首行是否缩进
+4. 在有序/无序列表后输入段落，观察首行是否缩进
+5. 新建 generic 文档，重复上述步骤，确认首行不缩进（保持旧行为）
+
+## 如何提交
+
+```bash
+xmake b tests && xmake r tests
+```
+
+## What
+在样式语言中新增开关 `indent-after-block`，控制节、代码块、列表等结构后的段落是否保留首行缩进。
+
+- generic 等样式默认关闭（保持现有行为）
+- article 样式默认开启
+- 用户可在导言区通过 `<assign|indent-after-block|true/false>` 手动覆盖
+
+## Why
+目前首行缩进在节、小节、代码块、有序列表等结构后默认被显式抑制（`<no-indent*>`），这与 LaTeX article 等主流排版引擎的行为不一致。很多论文排版场景需要这些结构后的段落也能正常首行缩进。
+
+## How
+1. 在 `std-markup.ts` 中定义新变量 `indent-after-block`，默认值为 `false`
+2. 修改 `section-base.ts` 中的 `sectional-no-indent`，使其仅在 `indent-after-block` 为 `false` 时发射 `<no-indent*>`
+3. 修改 `std-list.ts` 中的 `render-list`，使其尾部 `<no-indent*>` 受开关控制
+4. 修改 `env-program.ts` 中的 `render-code`，使其尾部 `<no-indent*>` 受开关控制
+5. 在 `article.ts` 中设置 `<assign|indent-after-block|true>`，使 article 样式默认开启该特性


### PR DESCRIPTION
## 摘要
在样式语言中新增开关 `indent-after-block`，控制节、代码块、列表等结构后的段落是否保留首行缩进。

## 变更内容
- `std-markup.ts`: 定义新变量 `indent-after-block`，默认 `false`
- `section-base.ts`: `sectional-no-indent` 仅在开关关闭时发射 `<no-indent*>`
- `std-list.ts`: `render-list` 尾部 `<no-indent*>` 受开关控制
- `compact-list.ts`: 紧凑列表尾部 `<no-indent*>` 受开关控制
- `env-program.ts`: `render-code` 尾部 `<no-indent*>` 受开关控制
- `framed-program.ts` / `modern-program.ts`: 算法代码块尾部 `<no-indent*>` 受开关控制
- `article.ts`: article 样式默认开启 `<assign|indent-after-block|true>`

## 测试方式
1. 新建 article 文档，加载 `indent-paragraphs` 包
2. 在节标题后输入段落，观察首行是否缩进
3. 在代码块后输入段落，观察首行是否缩进
4. 在有序/无序列表后输入段落，观察首行是否缩进
5. 新建 generic 文档，重复上述步骤，确认首行不缩进（保持旧行为）

## 默认行为
- generic 等样式：保持现有行为（关闭）
- article 样式：默认开启，与 LaTeX article 等主流排版引擎行为一致

🤖 Generated with [Claude Code](https://claude.com/code)