### PR TITLE
[0607] 修复 APPENDIX 下公式编号前缀显示为 0 的问题

### DIFF
--- a/TeXmacs/packages/customize/theorem/number-long-article.ts
+++ b/TeXmacs/packages/customize/theorem/number-long-article.ts
@@ -27,7 +27,7 @@
 
   <drd-props|equation-prefix-sep|macro-parameter|regular>
 
-  <assign|display-std-env|<macro|nr|<number|<value|section-nr>|arabic><equation-prefix-sep><arg|nr>>>
+  <assign|display-std-env|<macro|nr|<section-prefix><arg|nr>>>
 
   \;
 </body>

--- a/TeXmacs/tests/tmu/0607.tmu
+++ b/TeXmacs/tests/tmu/0607.tmu
@@ -1,0 +1,58 @@
+<TMU|<tuple|1.1.0|2026.2.4>>
+
+<style|<tuple|generic|number-europe|preview-ref|number-long-article>>
+
+<\body>
+  <appendix|>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <appendix|>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <appendix|>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|786A3DE7-5809-4330-8D5E-10FCE8819B60>
+  </collection>
+</initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|A|?>>
+    <associate|auto-2|<tuple|B|?>>
+    <associate|auto-3|<tuple|C|?>>
+  </collection>
+</references>
+
+<\auxiliary>
+  <\collection>
+    <\associate|toc>
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix A<space|2spc>><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-1><vspace|0.5fn>
+    </associate>
+  </collection>
+</auxiliary>

--- a/TeXmacs/tests/tmu/0607.tmu
+++ b/TeXmacs/tests/tmu/0607.tmu
@@ -32,6 +32,26 @@
   <\equation>
     \<alpha\>\<neq\>\<beta\>
   </equation>
+
+  <section|Section >
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <section|Section >
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
+
+  <\equation>
+    \<alpha\>\<neq\>\<beta\>
+  </equation>
 </body>
 
 <\initial>
@@ -46,6 +66,9 @@
     <associate|auto-1|<tuple|A|?>>
     <associate|auto-2|<tuple|B|?>>
     <associate|auto-3|<tuple|C|?>>
+    <associate|auto-4|<tuple|1|?>>
+    <associate|auto-5|<tuple|2|?>>
+    <associate|auto-6|<tuple|1.1.1|?>>
   </collection>
 </references>
 
@@ -53,6 +76,10 @@
   <\collection>
     <\associate|toc>
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix A<space|2spc>><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-1><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix B<space|2spc>><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-2><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix C<space|2spc>><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-3><vspace|0.5fn>
     </associate>
   </collection>
 </auxiliary>

--- a/devel/0607.md
+++ b/devel/0607.md
@@ -1,0 +1,73 @@
+# [0607] 修复 APPENDIX 下公式编号前缀显示为 0 的问题
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+- [number-long-article.ts](../TeXmacs/packages/customize/theorem/number-long-article.ts) - 公式编号前缀配置文件
+
+## 2 任务相关的代码文件
+
+- `TeXmacs/packages/customize/theorem/number-long-article.ts`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+
+```bash
+# 无直接单元测试，需通过文档验证
+```
+
+### 3.2 非确定性测试（文档验证）
+
+1. 打开 Mogan STEM
+2. 新建文档，使用 `generic` 样式
+3. 在 Document -> Style -> Add package 中添加 `number-long-article`
+4. 插入一个 APPENDIX（Document -> Section -> Appendix）
+5. 在 APPENDIX 下插入一个 equation（Insert -> Mathematics -> Equation）
+6. 确认公式编号显示为 `(A.1)`、`(A.2)` 等，而非 `(0.1)`、`(0.2)`
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+git diff
+# 确认仅修改了 number-long-article.ts 和新增了 0607.md
+git add -A
+git commit -m "修复 APPENDIX 下公式编号前缀显示为 0 的问题"
+```
+
+## 5 What
+
+修复在 APPENDIX（附录）章节下，当开启 "prefix by section number" 时，公式编号前缀错误显示为 `0`（如 `(0.1)`、`(0.2)`）的问题，使其正确显示为附录字母前缀（如 `(A.1)`、`(A.2)`）。
+
+1. 修改 `number-long-article.ts` 中的 `display-std-env` 宏定义
+2. 将硬编码的 `<number|<value|section-nr>|arabic>` 改为使用 `<section-prefix>`
+3. 新增 `0607.md` 任务文档
+
+## 6 Why
+
+在 `number-long-article.ts` 中，公式编号前缀通过 `<number|<value|section-nr>|arabic>` 硬编码获取章节编号，并始终使用阿拉伯数字格式。当进入 APPENDIX 时，`section-nr` 计数器已被重置为 0（因为 `appendix-clean` 会调用 `reset-section`），而附录的编号应使用 `appendix-nr` 计数器，并以 `Alpha` 格式显示（A、B、C...）。
+
+因此，原来的硬编码方式导致 APPENDIX 下的公式编号前缀始终显示为 `0`，而非正确的附录字母。
+
+## 7 How
+
+`section-base.ts` 中已经定义了 `section-prefix` 宏，它会根据当前上下文返回正确的章节前缀：
+
+- 普通章节：`section-prefix` = `<the-section><section-prefix-sep>`，如 `1.`、`2.`
+- 附录章节：`appendix-clean` 会将 `section-prefix` 设置为 `<value|appendix-prefix>`，即 `<the-appendix><appendix-prefix-sep>`，如 `A.`、`B.`
+
+因此，将 `display-std-env` 从：
+
+```
+<assign|display-std-env|<macro|nr|<number|<value|section-nr>|arabic><equation-prefix-sep><arg|nr>>>
+```
+
+修改为：
+
+```
+<assign|display-std-env|<macro|nr|<section-prefix><arg|nr>>>
+```
+
+这样，`display-std-env` 会复用 `section-prefix` 的已有逻辑，自动适配普通章节和附录章节的编号格式，无需硬编码 `section-nr` 和 `arabic`。

--- a/devel/0607.md
+++ b/devel/0607.md
@@ -20,11 +20,7 @@
 ### 3.2 非确定性测试（文档验证）
 
 1. 打开 Mogan STEM
-2. 新建文档，使用 `generic` 样式
-3. 在 Document -> Style -> Add package 中添加 `number-long-article`
-4. 插入一个 APPENDIX（Document -> Section -> Appendix）
-5. 在 APPENDIX 下插入一个 equation（Insert -> Mathematics -> Equation）
-6. 确认公式编号显示为 `(A.1)`、`(A.2)` 等，而非 `(0.1)`、`(0.2)`
+2. 打开 `0607.tmu` 检查公式编号是否以大写字母为前缀
 
 ## 4 如何提交
 


### PR DESCRIPTION
1. 打开 Mogan STEM
2. 打开 `0607.tmu` 检查公式编号是否以大写字母为前缀

