### PR TITLE
[0121] 修复绘图区域数学模式中光标左移导致的死循环

### DIFF
--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -241,12 +241,12 @@
 (tm-define (kbd-horizontal t forwards?)
   (:require (graphical-text-context? t))
   (with-define (move) ((if forwards? go-right go-left))
-    (go-to-next-inside move (lambda (t2) (equal? t (tree-ref t2 :up))))))
+    (go-to-next-inside move (lambda (t2) (tree-search-upwards t2 (lambda (u) (equal? u t)))))))
 
 (tm-define (kbd-vertical t downwards?)
   (:require (graphical-text-context? t))
   (with-define (move) ((if downwards? go-down go-up))
-    (go-to-next-inside move (lambda (t2) (equal? t (tree-ref t2 :up))))))
+    (go-to-next-inside move (lambda (t2) (tree-search-upwards t2 (lambda (u) (equal? u t)))))))
 
 (tm-define (kbd-extremal t forwards?)
   (:require (graphical-text-context? t))

--- a/devel/0121.md
+++ b/devel/0121.md
@@ -1,0 +1,52 @@
+# [0121] 修复绘图区域数学模式中光标左移导致的死循环
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-kbd.scm`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+# 暂无单元测试
+```
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，新建一个空白文档
+2. 插入一个绘图区域（如通过菜单 Insert -> Image -> Draw image）
+3. 在绘图区域中插入数学对象（如通过菜单 Insert -> Mathematics -> Formula at）
+4. 进入数学编辑模式，在公式中输入一些内容
+5. 持续按左方向键（或 Home 键），观察软件是否卡住
+6. 修复后光标应正常移动，软件不会无响应
+
+## 如何提交
+
+```bash
+xmake build
+```
+
+## What
+
+修复在绘图区域（graphics）的数学模式（math-at）中，按左方向键移动光标时软件卡死的问题。
+
+## Why
+
+在 `[23_21] Ban jump in text/math at of graphics area` 提交中，`graphics-kbd.scm` 的 `kbd-horizontal` 和 `kbd-vertical` 使用了一个 lambda 来判断光标是否还在 `graphical-text-context` 内部：
+
+```scheme
+(lambda (t2) (equal? t (tree-ref t2 :up)))
+```
+
+该 lambda 假设 `innermost-pattern` 检查到的节点 `t2` 的父节点就是 `t`（如 `math-at`）。但当 `math-at` 的内部结构比较扁平（光标直接位于 `math-at` 的子节点上，路径只有 3 层）时，`t2` 本身就是 `math-at`，其 `tree-ref :up` 是 `graphics`，不等于 `math-at`。此时 `innermost-pattern` 永远返回假，而 `go-left` 又一直在改变光标位置，导致 `go-to-next-inside-sub` 的 `do` 循环永远无法退出，形成死循环。
+
+## How
+
+将 lambda 改为向上遍历祖先链进行匹配：
+
+```scheme
+(lambda (t2) (tree-search-upwards t2 (lambda (u) (equal? u t))))
+```
+
+这样在扁平结构（`t2` 本身就是 `t`）和嵌套结构（`t2` 是 `t` 的后代）下都能正确匹配，保证光标在 `math-at` 或 `text-at` 内部移动时不会跳出，同时也不会触发死循环。


### PR DESCRIPTION
## 问题描述

在绘图区域（graphics）的数学模式（math-at）中，按左方向键移动光标时，软件会卡死。

## 根因分析

`[23_21] Ban jump in text/math at of graphics area` 提交中引入的 lambda：

```scheme
(lambda (t2) (equal? t (tree-ref t2 :up)))
```

在 `math-at` 内部结构扁平时光标路径只有 3 层，`innermost-pattern` 检查到的 `t2` 就是 `math-at` 本身，其 `tree-ref :up` 为 `graphics`，不等于 `math-at`，导致 `innermost-pattern` 永远返回假。同时 `go-left` 一直在改变光标位置，使得 `go-to-next-inside-sub` 的循环永远无法退出，形成死循环。

## 修复方案

将 lambda 改为向上遍历祖先链：

```scheme
(lambda (t2) (tree-search-upwards t2 (lambda (u) (equal? u t))))
```

这样在扁平结构和嵌套结构下都能正确匹配。

## 修改的文件

- `TeXmacs/progs/graphics/graphics-kbd.scm`
- `devel/0121.md`