### PR TITLE
[1005] 模板打开默认保存到 Documents/LiiiSTEM 目录

### DIFF
--- a/src/Plugins/Qt/qt_template_utils.cpp
+++ b/src/Plugins/Qt/qt_template_utils.cpp
@@ -22,6 +22,7 @@ qt_generate_document_save_path (const QString& templateName) {
   if (docsDir.isEmpty ()) {
     docsDir= QStandardPaths::writableLocation (QStandardPaths::HomeLocation);
   }
+  docsDir= QDir (docsDir).filePath ("LiiiSTEM");
 
   QString baseName= templateName;
   baseName.replace (QRegularExpression ("[\\\\/:*?\"<>|]"), "_");


### PR DESCRIPTION
## 变更内容

将模板打开时的默认保存目录从 `Documents` 改为 `Documents/LiiiSTEM`，跨平台生效（Linux/Windows/macOS）。

## 测试方式

1. 启动 Mogan，进入 Template Center
2. 点击一个已缓存的模板卡片
3. 检查 `Documents/LiiiSTEM` 目录下是否生成对应的 `.tmu` 文件

## 相关任务

[1005] 模版打开相关修复