### PR TITLE
[0127] 修复图片缓存和缓冲区视图的内存泄漏

### DIFF
--- a/devel/0127.md
+++ b/devel/0127.md
@@ -1,0 +1,129 @@
+# [0127] 修复图片缓存和缓冲区视图的内存泄漏
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+
+### 修改的文件
+- `src/Graphics/Pictures/picture.cpp` - 在 `picture_cache_clean()` 中调用 Qt 图片缓存清理函数
+- `src/Texmacs/Data/new_buffer.cpp` - 将 `remove_buffer` 中删除 view 的循环改为倒序遍历
+
+### 新增的文件
+- `tests/Data/picture_cache_test.cpp` - picture cache 清理操作的单元测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b picture_cache_test
+xmake r picture_cache_test
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 编译并启动 Mogan STEM
+   ```bash
+   xmake b stem
+   xmake r stem
+   ```
+2. 重复执行以下操作并观察内存占用：
+   - 打开包含大量图片的文档
+   - 关闭文档
+   - 通过系统工具（如 `top`、`htop` 或任务管理器）观察 Mogan 进程的内存占用变化
+3. 预期结果：内存占用在文档关闭后应趋于稳定，不应持续增长到 5G 以上
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+bin/format
+xmake b picture_cache_test
+xmake r picture_cache_test
+xmake b stem
+```
+
+确认编译和测试通过后提交并创建 PR：
+
+```bash
+git add -A
+git commit -m "[0127] 修复图片缓存和缓冲区视图的内存泄漏"
+git push origin da/200_27/0127_memory_leak
+gh pr create
+```
+
+## 5 What
+
+修复两个导致内存泄漏的问题，解决软件长期使用后内存占用高达 5G 的现象。
+
+1. 在 `picture_cache_clean()` 中补充调用 `qt_clean_picture_cache()`，确保 Qt 端的图片缓存得到清理
+2. 将 `remove_buffer()` 中删除 view 的循环从正序改为倒序，避免删除元素时索引错乱导致部分 view 未被释放
+3. 新增 `picture_cache_test.cpp` 单元测试，验证图片缓存清理相关操作不会崩溃
+
+## 6 Why
+
+- Mogan 长期使用后内存占用持续增长，最高可达 5G，严重影响用户体验
+- `qt_clean_picture_cache()` 在代码中仅被声明但从未被调用，导致 Qt 图片缓存不断累积
+- `remove_buffer()` 正序删除 view 时，`delete_view` 会修改 `buf->vws` 数组，导致后续元素索引前移，部分 view 无法被正确删除，造成内存泄漏
+
+## 7 How
+
+### 7.1 修复 Qt 图片缓存未清理的问题
+
+在 `src/Graphics/Pictures/picture.cpp` 中，`qt_clean_picture_cache()` 原先仅在 `picture_cache_clean()` 函数之后做了空声明，从未实际调用：
+
+```cpp
+void
+picture_cache_clean () {
+  // ... 清理逻辑 ...
+  picture_blacklist= hashmap<tree, int> ();
+}
+
+#ifdef QTTEXMACS
+void qt_clean_picture_cache ();
+#endif
+```
+
+修复方式：将声明移到函数之前，并在 `picture_cache_clean()` 末尾调用该函数：
+
+```cpp
+#ifdef QTTEXMACS
+void qt_clean_picture_cache ();
+#endif
+
+void
+picture_cache_clean () {
+  // ... 清理逻辑 ...
+  picture_blacklist= hashmap<tree, int> ();
+#ifdef QTTEXMACS
+  qt_clean_picture_cache ();
+#endif
+}
+```
+
+### 7.2 修复 remove_buffer 中视图删除的索引错乱问题
+
+在 `src/Texmacs/Data/new_buffer.cpp` 中，`remove_buffer()` 原使用正序遍历删除 view：
+
+```cpp
+for (int i= 0; i < N (buf->vws); i++)
+  delete_view (abstract_view (buf->vws[i]));
+```
+
+`delete_view` 内部会从 `buf->vws` 中移除被删除的 view，导致数组收缩，后续 view 的索引前移。正序遍历时，删除第 0 个元素后，原来第 1 个元素变为第 0 个，但循环变量 `i` 已递增为 1，导致该元素被跳过，产生内存泄漏。
+
+修复方式：改为倒序遍历：
+
+```cpp
+for (int i= N (buf->vws) - 1; i >= 0; i--)
+  delete_view (abstract_view (buf->vws[i]));
+```
+
+倒序删除时，被删除元素之后的元素索引会发生变化，但已处理过的元素（索引更大的那些）不受影响，因此不会漏删。
+
+### 7.3 新增单元测试
+
+新增 `tests/Data/picture_cache_test.cpp`，覆盖以下场景：
+- 空缓存状态下调用 `picture_cache_clean` 不崩溃
+- 空缓存状态下调用 `picture_cache_reset` 不崩溃
+- `picture_cache_reserve` / `picture_cache_release` / `picture_cache_clean` 的完整流程不崩溃

--- a/src/Graphics/Pictures/picture.cpp
+++ b/src/Graphics/Pictures/picture.cpp
@@ -167,6 +167,10 @@ picture_cache_release (url file_name, int w, int h, tree eff, int pixel) {
   if (picture_count[key] <= 0) picture_blacklist (key)++;
 }
 
+#ifdef QTTEXMACS
+void qt_clean_picture_cache ();
+#endif
+
 void
 picture_cache_clean () {
   static time_t last_gc= 0;
@@ -184,11 +188,10 @@ picture_cache_clean () {
     }
   }
   picture_blacklist= hashmap<tree, int> ();
-}
-
 #ifdef QTTEXMACS
-void qt_clean_picture_cache ();
+  qt_clean_picture_cache ();
 #endif
+}
 
 void
 picture_cache_reset () {

--- a/src/Texmacs/Data/new_buffer.cpp
+++ b/src/Texmacs/Data/new_buffer.cpp
@@ -100,7 +100,7 @@ remove_buffer (tm_buffer buf) {
   int nr, n= N (bufs);
   for (nr= 0; nr < n; nr++)
     if (bufs[nr] == buf) {
-      for (int i= 0; i < N (buf->vws); i++)
+      for (int i= N (buf->vws) - 1; i >= 0; i--)
         delete_view (abstract_view (buf->vws[i]));
       if (n == 1 && number_of_servers () == 0) get_server ()->quit ();
       for (int i= nr; i < n - 1; i++)

--- a/tests/Data/picture_cache_test.cpp
+++ b/tests/Data/picture_cache_test.cpp
@@ -1,0 +1,62 @@
+
+/******************************************************************************
+ * MODULE     : picture_cache_test.cpp
+ * DESCRIPTION: picture cache cleanup 的单元测试
+ * COPYRIGHT  : (C) 2025
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "picture.hpp"
+#include "renderer.hpp"
+
+class TestPictureCache : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init ();
+  void test_picture_cache_clean_does_not_crash ();
+  void test_picture_cache_reset_does_not_crash ();
+  void test_cached_load_and_clean ();
+};
+
+void
+TestPictureCache::init () {
+  init_lolly ();
+}
+
+void
+TestPictureCache::test_picture_cache_clean_does_not_crash () {
+  // 验证空缓存状态下调用 picture_cache_clean 不会崩溃
+  picture_cache_clean ();
+  QVERIFY (true);
+}
+
+void
+TestPictureCache::test_picture_cache_reset_does_not_crash () {
+  // 验证空缓存状态下调用 picture_cache_reset 不会崩溃
+  picture_cache_reset ();
+  QVERIFY (true);
+}
+
+void
+TestPictureCache::test_cached_load_and_clean () {
+  // 验证 picture_cache_reserve / picture_cache_release / picture_cache_clean
+  // 的完整流程不会崩溃
+  url test_url= url ("test://dummy/image.png");
+
+  picture_cache_reserve (test_url, 100, 100, "", PIXEL);
+  picture_cache_release (test_url, 100, 100, "", PIXEL);
+
+  // 此时该条目应在黑名单中，picture_cache_clean 可安全清理
+  picture_cache_clean ();
+  QVERIFY (true);
+}
+
+QTEST_MAIN (TestPictureCache)
+#include "picture_cache_test.moc"


### PR DESCRIPTION
## 变更摘要

- 修复 `picture_cache_clean()` 中未调用 `qt_clean_picture_cache()` 导致的 Qt 端图片缓存泄漏
- 修复 `remove_buffer()` 正序删除 view 导致的索引错乱和部分 view 未释放问题
- 新增 `picture_cache_test.cpp` 单元测试

## 测试

- [x] `xmake b picture_cache_test && xmake r picture_cache_test` 通过
- [x] `xmake b stem` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)