### PR TITLE
[0608] 修复可折叠 Python 块无法选择 Conda 环境的问题

### DIFF
--- a/TeXmacs/progs/dynamic/fold-menu.scm
+++ b/TeXmacs/progs/dynamic/fold-menu.scm
@@ -69,9 +69,14 @@
 
 (tm-menu (supported-executable-menu)
   (for (name (session-list))
-    (with menu-name (session-name name)
-      ((eval menu-name)
-       (make-script-input* name "default")))))
+    (let* ((menu-name (session-name name))
+           (l (connection-variants name)))
+      (assuming (== l (list "default"))
+        ((eval menu-name) (make-script-input* name "default")))
+      (assuming (!= l (list "default"))
+        (-> (eval menu-name)
+            (for (variant l)
+              ((eval `(verbatim ,variant)) (make-script-input* name variant))))))))
 
 (menu-bind insert-fold-menu
   (-> "Folded"

--- a/devel/0608.md
+++ b/devel/0608.md
@@ -1,0 +1,43 @@
+# [0608] 修复可折叠 Python 块无法选择 Conda 环境的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/dynamic/fold-menu.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+# Scheme 单元测试不适用，需要手动验证菜单行为
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 启动 Mogan STEM
+2. 打开 Insert > Fold > Executable 菜单
+3. 确认 Python 项现在显示子菜单箭头（当有多个 conda 环境时）
+4. 悬停/点击 Python 项，应能看到 conda 环境列表（如 conda_base、conda_test 等）
+5. 选择某个 conda 环境后，应能正确插入对应环境的 script-input 块
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+# 检查修改的文件
+git diff TeXmacs/progs/dynamic/fold-menu.scm
+```
+
+## 5 What
+修复 Insert > Fold > Executable > Python 菜单无法选择 Conda 环境的问题。
+
+1. 修改 `supported-executable-menu`，使其与 `supported-programs-menu` 和 `supported-sessions-menu` 保持一致，检查 `connection-variants` 并在有多个变体时显示子菜单。
+
+## 6 Why
+在 Mogan STEM 中，Python 插件支持通过 Conda 管理多个 Python 环境（如 conda_base、conda_test 等）。这些环境在 Insert > Session 菜单和 Programs 菜单中都能正确显示为子菜单，但在 Insert > Fold > Executable 菜单中，Python 项直接使用了默认环境，没有提供 Conda 环境选择，导致用户无法在该位置切换 Python 环境。
+
+## 7 How
+`supported-executable-menu` 原先的实现直接对每个 session 调用 `(make-script-input* name "default")`，没有检查是否有其他变体。Python 插件通过 `:launch` 注册了多个 Conda 环境变体，这些变体存储在 `connection-variants` 中。
+
+修复方案：参考 `supported-programs-menu` 的实现，使用 `connection-variants` 获取变体列表。当只有一个 "default" 变体时，保持原有行为直接创建菜单项；当有多个变体时，使用 `->` 创建带箭头的子菜单，让用户可以选择具体的 Conda 环境。


### PR DESCRIPTION
## 问题描述

在 Mogan STEM 中，Insert > Fold > Executable > Python 菜单无法选择 Conda 环境，直接使用了默认环境。而在 Insert > Session 和 Programs 菜单中，Python 项可以正确显示 Conda 环境子菜单（如 conda_base、conda_test、conda_stem、conda_sage 等）。

## 原因分析

`TeXmacs/progs/dynamic/fold-menu.scm` 中的 `supported-executable-menu` 直接对每个 session 调用 `(make-script-input* name \"default\")`，没有检查 `connection-variants`，因此 Python 的 Conda 环境子菜单没有显示。

## 修复方案

修改 `supported-executable-menu`，使其与 `supported-programs-menu` 和 `supported-sessions-menu` 保持一致：
- 使用 `connection-variants` 获取变体列表
- 当只有一个 \"default\" 变体时，保持原有行为
- 当有多个变体时，显示子菜单让用户选择具体的 Conda 环境
- 使用 `(eval `(verbatim ,variant))` 防止 Conda 环境名称被翻译系统翻译为中文

## 如何测试

1. 确保系统安装了 Conda，并且配置了多个 Conda 环境
2. 启动 Mogan STEM，将界面语言设置为中文
3. 打开 **插入 > 折叠 > 可运行** 菜单
4. 将鼠标悬停在 **Python** 上
5. 确认出现子菜单，显示可用的 Conda 环境列表（应为英文，如 default、conda_base、conda_stem 等）
6. 选择一个非默认的 Conda 环境
7. 确认插入了对应环境的可折叠 Python 代码块（script-input）
8. 检查代码块的 session 属性是否指向所选的 Conda 环境

## 修改文件

- `TeXmacs/progs/dynamic/fold-menu.scm`
- `devel/0608.md`