### PR TITLE
[0120] 隐藏 PDF 阅读模式底部状态栏

### DIFF
--- a/devel/0120.md
+++ b/devel/0120.md
@@ -130,3 +130,10 @@ QString             currentPdfPath;
 - 滚动距离为 `viewport()->height() * 0.9`（约 90% 视口高度）。
 - 使用 `QScrollArea::verticalScrollBar()->setValue()` 实现平滑滚动。
 - 若当前已滚动到底部，则继续滚动到下一页顶部（或直接到底部保持连续阅读）。
+
+### 7.7 PDF 阅读模式隐藏底部状态栏
+
+**实现方式**：
+- 在 `qt_tm_widget_rep::update_visibility()` 中，当 `pdfTabMode` 为 `true` 时，将 `new_statusVisibility` 设为 `false`。
+- 仅在当前标签页为 PDF 时隐藏底部状态栏；切换到普通文档（tmu 等）时，`pdfTabMode` 恢复为 `false`，状态栏由 `visibility[5]` 正常控制，保持显示。
+- 与启动页模式（`startupTabMode`）保持一致，均隐藏状态栏以提供沉浸式阅读体验。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1021,7 +1021,7 @@ qt_tm_widget_rep::update_visibility () {
     new_modeVisibility  = false;
     new_focusVisibility = false;
     new_userVisibility  = false;
-    new_statusVisibility= true;
+    new_statusVisibility= false;
     new_sideVisibility  = false;
     new_leftVisibility  = false;
     new_bottomVisibility= false;


### PR DESCRIPTION
## 摘要

在 PDF 阅读模式下隐藏底部状态栏（footer/status bar），提供与启动页模式一致的沉浸式阅读体验。

## 改动

- `src/Plugins/Qt/qt_tm_widget.cpp`: 当 `pdfTabMode` 为 `true` 时，将 `new_statusVisibility` 设为 `false`
- `devel/0120.md`: 补充子任务文档（7.7 节）

## 行为

- 打开 PDF 标签页时，底部状态栏自动隐藏
- 切换到普通文档（tmu 等）时，`pdfTabMode` 恢复为 `false`，状态栏由 `visibility[5]` 正常控制，保持显示

🤖 Generated with [Claude Code](https://claude.com/code)