### PR TITLE
[0120] PDF 阅读器支持 j/k 键滚动

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,13 @@
 - `da/200_27/xmake_debug`
 - `da/200_27/fix_pdf_rendering`
 
+## 提交规范
+
+1. 一个 PR 至少分为两个 commit：
+   - 第一个 commit 更新 `devel/xxxx.md` 任务文档
+   - 后续 commit 为代码改动
+2. 保持提交信息清晰、简洁，格式：`[编号] 简述`
+
 ## 代码推送规则
 
 1. 如果 remote 是 GitHub，使用 `gh` 命令推送代码并创建 PR

--- a/devel/0120.md
+++ b/devel/0120.md
@@ -137,3 +137,10 @@ QString             currentPdfPath;
 - 在 `qt_tm_widget_rep::update_visibility()` 中，当 `pdfTabMode` 为 `true` 时，将 `new_statusVisibility` 设为 `false`。
 - 仅在当前标签页为 PDF 时隐藏底部状态栏；切换到普通文档（tmu 等）时，`pdfTabMode` 恢复为 `false`，状态栏由 `visibility[5]` 正常控制，保持显示。
 - 与启动页模式（`startupTabMode`）保持一致，均隐藏状态栏以提供沉浸式阅读体验。
+
+### 7.8 `PDFReaderWidget` j/k 键滚动
+
+**实现方式**：
+- 在 `keyPressEvent(QKeyEvent* event)` 和 `eventFilter` 中检测 `Qt::Key_J` 和 `Qt::Key_K`。
+- `j` 向下滚动，`k` 向上滚动，滚动距离使用 `verticalScrollBar()->singleStep()`，与上下方向键行为一致。
+- 提供 Vim 风格的键盘导航体验。

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -751,6 +751,16 @@ PDFReaderWidget::keyPressEvent (QKeyEvent* event) {
     return;
   }
 
+  if (event->key () == Qt::Key_J || event->key () == Qt::Key_K) {
+    QScrollBar* vbar= scrollArea_->verticalScrollBar ();
+    if (vbar) {
+      int direction= (event->key () == Qt::Key_J) ? 1 : -1;
+      vbar->setValue (vbar->value () + direction * vbar->singleStep ());
+    }
+    event->accept ();
+    return;
+  }
+
   if (event->modifiers () & Qt::ControlModifier) {
     switch (event->key ()) {
     case Qt::Key_Plus:
@@ -798,6 +808,14 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
         if (vbar) {
           int scrollAmount= qRound (scrollArea_->viewport ()->height () * 0.9);
           vbar->setValue (vbar->value () + scrollAmount);
+        }
+        return true;
+      }
+      if (keyEvent->key () == Qt::Key_J || keyEvent->key () == Qt::Key_K) {
+        QScrollBar* vbar= scrollArea_->verticalScrollBar ();
+        if (vbar) {
+          int direction= (keyEvent->key () == Qt::Key_J) ? 1 : -1;
+          vbar->setValue (vbar->value () + direction * vbar->singleStep ());
         }
         return true;
       }


### PR DESCRIPTION
## 改动内容

- PDF 阅读器支持 Vim 风格的 j/k 键滚动
- j 向下滚动，k 向上滚动
- 滚动距离使用 `singleStep()`，与上下方向键行为一致
- 在 `keyPressEvent` 和 `viewport` 的 `eventFilter` 中同时处理，确保焦点在不同区域时都能响应

## Commit 组织

1. `[0120] 添加 j/k 键滚动功能文档` — 更新 `devel/0120.md`
2. `[0120] PDF 阅读器支持 j/k 键滚动` — 代码实现
3. `更新 CLAUDE.md：添加提交规范` — 项目规范文档

## 测试

- `xmake r qt_pdf_tab_utils_test`：3 passed
- `xmake r qt_pdf_preview_widget_test`：6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)