### PR TITLE
[0132] 放大缩小时跟随光标

### DIFF
--- a/devel/0132.md
+++ b/devel/0132.md
@@ -1,0 +1,216 @@
+# [0132] 放大缩小时跟随光标
+
+任务编号使用 0000 到 9999 的四位数字格式。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0131](../0131.md) - 移除 Openssl 插件及相关加密通信功能
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/texmacs/texmacs/tm-view.scm`
+- `TeXmacs/progs/texmacs/menus/view-menu.scm`
+- `TeXmacs/progs/generic/generic-kbd.scm`
+- `src/Edit/Interface/edit_interface.cpp`
+- `src/Edit/Interface/edit_interface.hpp`
+- `src/Edit/Interface/edit_repaint.cpp`
+- `src/Graphics/Renderer/renderer.cpp`
+- `src/Graphics/Renderer/renderer.hpp`
+- `src/Texmacs/Window/tm_window.cpp`
+- `src/Texmacs/Window/tm_frame.cpp`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 编译并启动 Mogan
+2. 打开一个多页文档，将光标定位到页面中间某处
+3. 使用 `Ctrl + +` 放大或 `Ctrl + -` 缩小
+4. 验证放大/缩小后光标仍然保持在视口中央（或相对位置不变）
+5. 重复测试不同缩放级别和不同光标位置
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+
+让放大和缩小功能以光标位置为中心进行缩放，保持光标在视口中的相对位置不变。
+
+1. 了解当前放大缩小功能的完整调用链
+2. 在 zoom factor 改变时计算新的滚动位置，使光标位置保持不变
+3. 更新相关代码并验证效果
+
+## 6 Why
+
+目前放大和缩小只是简单地改变 zoom factor 并重绘，光标会随内容一起移动甚至移出视口。用户每次缩放后都需要手动滚动来找回光标位置，体验很差。跟随光标缩放是现代编辑器的标准行为。
+
+## 7 How
+
+### 7.1 当前放大缩小功能的实现
+
+#### 7.1.1 前端交互层（Scheme）
+
+用户通过以下方式触发缩放：
+- **菜单**：`TeXmacs/progs/texmacs/menus/view-menu.scm:131-140`
+  - "Zoom in" 调用 `(zoom-in (sqrt (sqrt 2.0)))`，系数约为 1.189
+  - "Zoom out" 调用 `(zoom-out (sqrt (sqrt 2.0)))`
+  - 固定比例菜单：50%、71%、100%、141%、200%
+- **快捷键**：`TeXmacs/progs/generic/generic-kbd.scm:405-407`
+  - `C-+` / `C--` / `C-0`（恢复 100%）
+
+核心 Scheme 函数定义在 `TeXmacs/progs/texmacs/texmacs/tm-view.scm`：
+- `change-zoom-factor(z)`：设置窗口 zoom factor，范围限制在 0.04 ~ 25.0，调用 `(set-window-zoom-factor z)` 后触发 `(notify-change 1)`
+- `zoom-in(x)`：获取当前 zoom，乘以 x 后调用 `change-zoom-factor`
+- `zoom-out(x)`：调用 `(zoom-in (/ 1.0 x))`
+
+#### 7.1.2 C++ 层调用链
+
+1. **Scheme -> C++ Glue**：`set-window-zoom-factor` 通过 glue 绑定到 C++
+2. **`tm_frame_rep::set_window_zoom_factor`** (`src/Texmacs/Window/tm_frame.cpp:275`)：
+   - 限制 zoom 范围 0.04 ~ 25.0
+   - 调用 `normal_zoom()` 进行规范化（`320.0 / ceil(320.0 / zoom - 0.01)`）
+   - 调用 `concrete_window()->set_window_zoom_factor(zoom)`
+3. **`tm_window_rep::set_window_zoom_factor`** (`src/Texmacs/Window/tm_window.cpp:572`)：
+   - `zoomf = retina_zoom * zoom`
+   - 调用 `::set_zoom_factor(wid, zoomf)` 发送 `SLOT_ZOOM_FACTOR` 消息
+4. **Qt 层接收**：`qt_simple_widget_rep::handle_set_zoom_factor` (`src/Plugins/Qt/qt_simple_widget.cpp:124`)：
+   - 调用 `canvas()->tm_widget()->handle_set_zoom_factor(new_zoom)`
+5. **编辑器层**：`edit_interface_rep::handle_set_zoom_factor` (`src/Edit/Interface/edit_interface.cpp:1327`)：
+   - 调用 `set_zoom_factor(zoom)`
+
+#### 7.1.3 编辑器 zoom 状态更新
+
+`edit_interface_rep::set_zoom_factor` (`src/Edit/Interface/edit_interface.cpp:168`) 更新以下成员：
+- `zoomf = zoom`：当前 zoom factor
+- `magf = zoomf / std_shrinkf`：magnification factor
+- `pixel = (SI) tm_round((std_shrinkf * PIXEL) / zoomf)`：屏幕像素大小
+- `zpixel = max((SI) tm_round(std_shrinkf * PIXEL), pixel)`：zoomed pixel
+
+编辑器构造函数中 (`edit_interface.cpp:65`)，`zoomf` 初始化为：
+```cpp
+zoomf(get_zoom(this, buf))
+```
+其中 `get_zoom` 逻辑：
+- 如果 buffer 数据包含 `"no-zoom"`，使用 `buf->data->init[ZOOM_FACTOR]`
+- 否则使用 `retina_zoom * ed->sv->get_default_zoom_factor()`
+
+#### 7.1.4 渲染层 zoom 处理
+
+`renderer_rep::set_zoom_factor` (`src/Graphics/Renderer/renderer.cpp:178`) 是底层渲染 zoom 的核心：
+- 缩放原点 `ox, oy`
+- 缩放裁剪区域 `cx1, cy1, cx2, cy2`
+- 更新 `zoomf`、`shrinkf = round(std_shrinkf / zoomf)`、`pixel`、`retina_pixel`
+
+在重绘时 (`edit_repaint.cpp`)，绘制前后会设置/重置 zoom factor：
+```cpp
+win->set_zoom_factor(zoomf);
+ren->set_zoom_factor(zoomf);
+// ... 绘制 ...
+ren->reset_zoom_factor();
+win->reset_zoom_factor();
+```
+
+#### 7.1.5 Retina Zoom
+
+系统级缩放因子 `retina_zoom`（`src/Graphics/Renderer/renderer.cpp:31`）：
+- macOS 默认 1
+- Linux/Windows 默认 2
+- WASM 默认 2
+
+编辑器最终使用的 zoom = `retina_zoom * 用户设置的 window_zoom_factor`
+
+#### 7.1.6 当前问题的根源
+
+当 zoom factor 改变时，整个调用链只做了两件事：
+1. 更新 zoomf / magf / pixel 等值
+2. 触发重绘
+
+完全没有考虑**滚动位置的调整**。因此放大后，内容变大，原来在视口中央的光标会移到下方/右方；缩小后则相反。
+
+### 7.2 解决方案
+
+#### 7.2.1 核心思路
+
+zoom 改变时，保持光标在视口中的**相对位置**不变。即：光标在视口中的逻辑偏移按比例缩放，从而保证光标在屏幕上的物理位置不变。
+
+#### 7.2.2 坐标系分析
+
+通过代码分析，明确以下坐标系关系：
+
+- **`cu->ox, cu->oy`**：光标逻辑坐标（文档坐标，与 zoom 无关）
+- **`get_scroll_x/y`**：逻辑 scroll 坐标 = 底层物理 scroll / `magf`
+- **`scroll_to(x, y)`**：接收逻辑坐标，内部乘以 `magf` 传给底层 SERVER
+- **`magf = zoomf / std_shrinkf`**：magnification factor，逻辑坐标与物理坐标的转换因子
+- **`update_visible()` 中的 `vx1..vy2`**：视口逻辑范围 = 物理 visible / `magf`
+
+#### 7.2.3 公式推导
+
+设 zoom 改变前：
+- 光标逻辑坐标：`(cx, cy)`
+- 逻辑 scroll 坐标：`(sx, sy)`
+- magf：`m1`
+
+光标在视口中的**逻辑偏移**：
+- `dx = cx - sx`
+- `dy = cy - sy`
+
+zoom 改变后（`m2` 为新 magf）：
+- 视口逻辑宽度变为原来的 `m1/m2` 倍（因为物理宽度不变，除以更大的 magf 得到更小的逻辑宽度）
+- 要保持光标在视口中的**相对比例**不变，逻辑偏移也应按 `m1/m2` 缩放
+- 新逻辑偏移：`dx' = dx × m1/m2`，`dy' = dy × m1/m2`
+
+因此新的逻辑 scroll 坐标：
+```
+sx' = cx - dx' = cx - (cx - sx) × m1/m2
+sy' = cy - dy' = cy - (cy - sy) × m1/m2
+```
+
+#### 7.2.4 实现位置与方式
+
+修改 `edit_interface_rep::set_zoom_factor`（`src/Edit/Interface/edit_interface.cpp:168`）：
+
+1. 保存旧的 `magf`
+2. 获取当前光标逻辑坐标 `get_cursor()`
+3. 获取当前逻辑 scroll 坐标 `get_scroll_x/y()`
+4. 按原有逻辑更新 `zoomf`、`magf`、`pixel`、`zpixel`
+5. 若光标有效，按上述公式计算新的 scroll 坐标
+6. 调用 `scroll_to(new_sx, new_sy)` 调整视口
+
+边界处理：
+- 构造函数中调用 `set_zoom_factor` 时，`is_attached(this)` 为 false，直接跳过 scroll 调整
+- 光标无效（`cu->valid == false`）时不调整 scroll
+- 使用 `tm_round` 进行整数舍入
+
+#### 7.2.5 采用 TDD 开发
+
+由于 `edit_interface_rep` 依赖 Qt/Window/Server 等大量运行时组件，难以直接实例化测试。将核心计算逻辑提取为独立纯函数，对其编写单元测试：
+
+```cpp
+static void
+compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                     double old_magf, double new_magf,
+                     SI& new_sx, SI& new_sy) {
+  new_sx= cursor_x - (SI) tm_round ((cursor_x - old_sx) * old_magf / new_magf);
+  new_sy= cursor_y - (SI) tm_round ((cursor_y - old_sy) * old_magf / new_magf);
+}
+```
+
+测试覆盖以下场景：
+1. **放大 2 倍**：光标在视口中央，scroll 应向内收缩
+2. **缩小 1/2**：光标在视口中央，scroll 应向外扩展
+3. **光标在视口边缘**：放大后光标仍应在边缘
+4. **整数舍入边界**：验证 `tm_round` 处理精度
+
+实现步骤：
+1. 编写 `compute_zoom_scroll` 的单元测试（先失败）
+2. 提取函数并通过测试
+3. 在 `set_zoom_factor` 中集成调用
+4. 运行非确定性测试（手动验证 Mogan 行为）

--- a/devel/0132.md
+++ b/devel/0132.md
@@ -17,6 +17,8 @@
 - `src/Graphics/Renderer/renderer.hpp`
 - `src/Texmacs/Window/tm_window.cpp`
 - `src/Texmacs/Window/tm_frame.cpp`
+- `src/Plugins/Qt/QTMScrollView.cpp`
+- `tests/Edit/Interface/zoom_scroll_test.cpp`
 
 ## 3 如何测试
 
@@ -175,7 +177,7 @@ sy' = cy - dy' = cy - (cy - sy) × m1/m2
 
 #### 7.2.4 实现位置与方式
 
-修改 `edit_interface_rep::set_zoom_factor`（`src/Edit/Interface/edit_interface.cpp:168`）：
+修改 `edit_interface_rep::set_zoom_factor`（`src/Edit/Interface/edit_interface.cpp:175`）：
 
 1. 保存旧的 `magf`
 2. 调用 `update_visible()` 获取当前视口逻辑范围 `vx1..vy2`
@@ -190,14 +192,6 @@ sy' = cy - dy' = cy - (cy - sy) × m1/m2
 - 构造函数中调用 `set_zoom_factor` 时，`is_attached(this)` 为 false，直接跳过 scroll 调整
 - 光标无效（`cu->valid == false`）时不调整 scroll
 - 使用 `tm_round` 进行整数舍入
-
-#### 7.2.5 消除闪烁
-
-直接调用 `scroll_to` 会在 Qt 层触发 `setSliderPosition` -> `scrollContentsBy` -> `the_gui->force_update()`，导致一次额外的完整重绘循环，产生明显闪烁。
-
-修复方式：在 `QTMScrollView::setOrigin`（`src/Plugins/Qt/QTMScrollView.cpp:85`）中，更新滚动条 slider position 前先用 `blockSignals(true)` 阻止信号发射，更新完成后恢复 `blockSignals(false)`，同时手动同步 `p_origin`。这样可以切断 `scrollContentsBy` 的触发链路，消除闪烁，且不影响后续 paint 事件的正确渲染。
-
-#### 7.2.6 采用 TDD 开发
 
 #### 7.2.5 采用 TDD 开发
 

--- a/devel/0132.md
+++ b/devel/0132.md
@@ -178,16 +178,26 @@ sy' = cy - dy' = cy - (cy - sy) × m1/m2
 修改 `edit_interface_rep::set_zoom_factor`（`src/Edit/Interface/edit_interface.cpp:168`）：
 
 1. 保存旧的 `magf`
-2. 获取当前光标逻辑坐标 `get_cursor()`
-3. 获取当前逻辑 scroll 坐标 `get_scroll_x/y()`
+2. 调用 `update_visible()` 获取当前视口逻辑范围 `vx1..vy2`
+3. 计算视口中心作为参考点：`old_cx = (vx1 + vx2) / 2`，`old_cy = (vy1 + vy2) / 2`
 4. 按原有逻辑更新 `zoomf`、`magf`、`pixel`、`zpixel`
-5. 若光标有效，按上述公式计算新的 scroll 坐标
-6. 调用 `scroll_to(new_sx, new_sy)` 调整视口
+5. 若光标有效（`cu->valid`），按上述公式计算新的 scroll 坐标
+6. 调用 `scroll_to(new_cx, new_cy)` 调整视口
+
+**注意**：早期实现使用 `get_scroll_x/y()` 作为参考点，但 `scroll_to` 实际以视口中心为目标，导致每次缩放都向上偏移。最终改用 `update_visible()` 计算的视口中心，行为正确。
 
 边界处理：
 - 构造函数中调用 `set_zoom_factor` 时，`is_attached(this)` 为 false，直接跳过 scroll 调整
 - 光标无效（`cu->valid == false`）时不调整 scroll
 - 使用 `tm_round` 进行整数舍入
+
+#### 7.2.5 消除闪烁
+
+直接调用 `scroll_to` 会在 Qt 层触发 `setSliderPosition` -> `scrollContentsBy` -> `the_gui->force_update()`，导致一次额外的完整重绘循环，产生明显闪烁。
+
+修复方式：在 `QTMScrollView::setOrigin`（`src/Plugins/Qt/QTMScrollView.cpp:85`）中，更新滚动条 slider position 前先用 `blockSignals(true)` 阻止信号发射，更新完成后恢复 `blockSignals(false)`，同时手动同步 `p_origin`。这样可以切断 `scrollContentsBy` 的触发链路，消除闪烁，且不影响后续 paint 事件的正确渲染。
+
+#### 7.2.6 采用 TDD 开发
 
 #### 7.2.5 采用 TDD 开发
 

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -166,23 +166,16 @@ edit_interface_rep::get_pixel_size () {
 
 void
 compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                     double old_magf, double new_magf,
-                     SI& new_sx, SI& new_sy) {
+                     double old_magf, double new_magf, SI& new_sx, SI& new_sy) {
   new_sx= cursor_x - (SI) tm_round ((cursor_x - old_sx) * old_magf / new_magf);
   new_sy= cursor_y - (SI) tm_round ((cursor_y - old_sy) * old_magf / new_magf);
 }
 
 void
 edit_interface_rep::set_zoom_factor (double zoom) {
-  double old_magf= magf;
+  if (zoom == zoomf) return;
 
-  // 获取旧视口中央（在更新 magf 之前，确保逻辑坐标一致）
-  SI old_cx= 0, old_cy= 0;
-  if (is_attached (this) && old_magf > 0.0) {
-    update_visible ();
-    old_cx= (vx1 + vx2) / 2;
-    old_cy= (vy1 + vy2) / 2;
-  }
+  double old_magf= magf;
 
   zoomf = zoom;
   magf  = zoomf / std_shrinkf;
@@ -192,6 +185,9 @@ edit_interface_rep::set_zoom_factor (double zoom) {
   if (is_attached (this) && old_magf > 0.0 && magf > 0.0) {
     cursor cu= get_cursor ();
     if (cu->valid) {
+      update_visible ();
+      SI old_cx= (vx1 + vx2) / 2;
+      SI old_cy= (vy1 + vy2) / 2;
       SI new_cx, new_cy;
       compute_zoom_scroll (cu->ox, cu->oy, old_cx, old_cy, old_magf, magf,
                            new_cx, new_cy);

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -175,20 +175,32 @@ compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
 void
 edit_interface_rep::set_zoom_factor (double zoom) {
   double old_magf= magf;
-  zoomf          = zoom;
-  magf           = zoomf / std_shrinkf;
-  pixel          = (SI) tm_round ((std_shrinkf * PIXEL) / zoomf);
-  zpixel         = max ((SI) tm_round (std_shrinkf * PIXEL), pixel);
+
+  // 获取旧状态（在更新 magf 之前，确保逻辑坐标一致）
+  SI old_sx= 0, old_sy= 0, old_vw= 0, old_vh= 0;
+  if (is_attached (this) && old_magf > 0.0) {
+    old_sx= get_scroll_x ();
+    old_sy= get_scroll_y ();
+    update_visible ();
+    old_vw= vx2 - vx1;
+    old_vh= vy2 - vy1;
+  }
+
+  zoomf = zoom;
+  magf  = zoomf / std_shrinkf;
+  pixel = (SI) tm_round ((std_shrinkf * PIXEL) / zoomf);
+  zpixel= max ((SI) tm_round (std_shrinkf * PIXEL), pixel);
 
   if (is_attached (this) && old_magf > 0.0 && magf > 0.0) {
     cursor cu= get_cursor ();
     if (cu->valid) {
-      SI old_sx= get_scroll_x ();
-      SI old_sy= get_scroll_y ();
-      SI new_sx, new_sy;
-      compute_zoom_scroll (cu->ox, cu->oy, old_sx, old_sy, old_magf, magf,
-                           new_sx, new_sy);
-      scroll_to (new_sx, new_sy);
+      // get_scroll_x/y 返回视口左上角，scroll_to 期望视口中央
+      SI old_cx= old_sx + old_vw / 2;
+      SI old_cy= old_sy + old_vh / 2;
+      SI new_cx, new_cy;
+      compute_zoom_scroll (cu->ox, cu->oy, old_cx, old_cy, old_magf, magf,
+                           new_cx, new_cy);
+      scroll_to (new_cx, new_cy);
     }
   }
 }

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -165,11 +165,32 @@ edit_interface_rep::get_pixel_size () {
 }
 
 void
+compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                     double old_magf, double new_magf,
+                     SI& new_sx, SI& new_sy) {
+  new_sx= cursor_x - (SI) tm_round ((cursor_x - old_sx) * old_magf / new_magf);
+  new_sy= cursor_y - (SI) tm_round ((cursor_y - old_sy) * old_magf / new_magf);
+}
+
+void
 edit_interface_rep::set_zoom_factor (double zoom) {
-  zoomf = zoom;
-  magf  = zoomf / std_shrinkf;
-  pixel = (SI) tm_round ((std_shrinkf * PIXEL) / zoomf);
-  zpixel= max ((SI) tm_round (std_shrinkf * PIXEL), pixel);
+  double old_magf= magf;
+  zoomf          = zoom;
+  magf           = zoomf / std_shrinkf;
+  pixel          = (SI) tm_round ((std_shrinkf * PIXEL) / zoomf);
+  zpixel         = max ((SI) tm_round (std_shrinkf * PIXEL), pixel);
+
+  if (is_attached (this) && old_magf > 0.0 && magf > 0.0) {
+    cursor cu= get_cursor ();
+    if (cu->valid) {
+      SI old_sx= get_scroll_x ();
+      SI old_sy= get_scroll_y ();
+      SI new_sx, new_sy;
+      compute_zoom_scroll (cu->ox, cu->oy, old_sx, old_sy, old_magf, magf,
+                           new_sx, new_sy);
+      scroll_to (new_sx, new_sy);
+    }
+  }
 }
 
 void

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -176,14 +176,12 @@ void
 edit_interface_rep::set_zoom_factor (double zoom) {
   double old_magf= magf;
 
-  // 获取旧状态（在更新 magf 之前，确保逻辑坐标一致）
-  SI old_sx= 0, old_sy= 0, old_vw= 0, old_vh= 0;
+  // 获取旧视口中央（在更新 magf 之前，确保逻辑坐标一致）
+  SI old_cx= 0, old_cy= 0;
   if (is_attached (this) && old_magf > 0.0) {
-    old_sx= get_scroll_x ();
-    old_sy= get_scroll_y ();
     update_visible ();
-    old_vw= vx2 - vx1;
-    old_vh= vy2 - vy1;
+    old_cx= (vx1 + vx2) / 2;
+    old_cy= (vy1 + vy2) / 2;
   }
 
   zoomf = zoom;
@@ -194,9 +192,6 @@ edit_interface_rep::set_zoom_factor (double zoom) {
   if (is_attached (this) && old_magf > 0.0 && magf > 0.0) {
     cursor cu= get_cursor ();
     if (cu->valid) {
-      // get_scroll_x/y 返回视口左上角，scroll_to 期望视口中央
-      SI old_cx= old_sx + old_vw / 2;
-      SI old_cy= old_sy + old_vh / 2;
       SI new_cx, new_cy;
       compute_zoom_scroll (cu->ox, cu->oy, old_cx, old_cy, old_magf, magf,
                            new_cx, new_cy);

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -166,8 +166,7 @@ edit_interface_rep::get_pixel_size () {
 
 void
 compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                     double old_magf, double new_magf,
-                     SI& new_sx, SI& new_sy) {
+                     double old_magf, double new_magf, SI& new_sx, SI& new_sy) {
   new_sx= cursor_x - (SI) tm_round ((cursor_x - old_sx) * old_magf / new_magf);
   new_sy= cursor_y - (SI) tm_round ((cursor_y - old_sy) * old_magf / new_magf);
 }

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -166,16 +166,23 @@ edit_interface_rep::get_pixel_size () {
 
 void
 compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                     double old_magf, double new_magf, SI& new_sx, SI& new_sy) {
+                     double old_magf, double new_magf,
+                     SI& new_sx, SI& new_sy) {
   new_sx= cursor_x - (SI) tm_round ((cursor_x - old_sx) * old_magf / new_magf);
   new_sy= cursor_y - (SI) tm_round ((cursor_y - old_sy) * old_magf / new_magf);
 }
 
 void
 edit_interface_rep::set_zoom_factor (double zoom) {
-  if (zoom == zoomf) return;
-
   double old_magf= magf;
+
+  // 获取旧视口中央（在更新 magf 之前，确保逻辑坐标一致）
+  SI old_cx= 0, old_cy= 0;
+  if (is_attached (this) && old_magf > 0.0) {
+    update_visible ();
+    old_cx= (vx1 + vx2) / 2;
+    old_cy= (vy1 + vy2) / 2;
+  }
 
   zoomf = zoom;
   magf  = zoomf / std_shrinkf;
@@ -185,9 +192,6 @@ edit_interface_rep::set_zoom_factor (double zoom) {
   if (is_attached (this) && old_magf > 0.0 && magf > 0.0) {
     cursor cu= get_cursor ();
     if (cu->valid) {
-      update_visible ();
-      SI old_cx= (vx1 + vx2) / 2;
-      SI old_cy= (vy1 + vy2) / 2;
       SI new_cx, new_cy;
       compute_zoom_scroll (cu->ox, cu->oy, old_cx, old_cy, old_magf, magf,
                            new_cx, new_cy);

--- a/src/Plugins/Qt/QTMScrollView.cpp
+++ b/src/Plugins/Qt/QTMScrollView.cpp
@@ -84,12 +84,20 @@ QTMScrollView::QTMScrollView (QWidget* _parent)
 void
 QTMScrollView::setOrigin (QPoint newOrigin) {
   if (!isVisible ()) return;
-  if (newOrigin.x () != p_origin.x ())
+  if (newOrigin.x () != p_origin.x ()) {
+    p_origin.setX (newOrigin.x ());
+    QAbstractScrollArea::horizontalScrollBar ()->blockSignals (true);
     QAbstractScrollArea::horizontalScrollBar ()->setSliderPosition (
         newOrigin.x ());
-  if (newOrigin.y () != p_origin.y ())
+    QAbstractScrollArea::horizontalScrollBar ()->blockSignals (false);
+  }
+  if (newOrigin.y () != p_origin.y ()) {
+    p_origin.setY (newOrigin.y ());
+    QAbstractScrollArea::verticalScrollBar ()->blockSignals (true);
     QAbstractScrollArea::verticalScrollBar ()->setSliderPosition (
         newOrigin.y ());
+    QAbstractScrollArea::verticalScrollBar ()->blockSignals (false);
+  }
 }
 
 void

--- a/src/Plugins/Qt/QTMScrollView.cpp
+++ b/src/Plugins/Qt/QTMScrollView.cpp
@@ -84,20 +84,12 @@ QTMScrollView::QTMScrollView (QWidget* _parent)
 void
 QTMScrollView::setOrigin (QPoint newOrigin) {
   if (!isVisible ()) return;
-  if (newOrigin.x () != p_origin.x ()) {
-    p_origin.setX (newOrigin.x ());
-    QAbstractScrollArea::horizontalScrollBar ()->blockSignals (true);
+  if (newOrigin.x () != p_origin.x ())
     QAbstractScrollArea::horizontalScrollBar ()->setSliderPosition (
         newOrigin.x ());
-    QAbstractScrollArea::horizontalScrollBar ()->blockSignals (false);
-  }
-  if (newOrigin.y () != p_origin.y ()) {
-    p_origin.setY (newOrigin.y ());
-    QAbstractScrollArea::verticalScrollBar ()->blockSignals (true);
+  if (newOrigin.y () != p_origin.y ())
     QAbstractScrollArea::verticalScrollBar ()->setSliderPosition (
         newOrigin.y ());
-    QAbstractScrollArea::verticalScrollBar ()->blockSignals (false);
-  }
 }
 
 void

--- a/tests/Edit/Interface/zoom_scroll_test.cpp
+++ b/tests/Edit/Interface/zoom_scroll_test.cpp
@@ -9,10 +9,9 @@
 #include <QtTest/QtTest>
 
 // Forward declare the function under test (defined in edit_interface.cpp)
-extern void
-compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                     double old_magf, double new_magf,
-                     SI& new_sx, SI& new_sy);
+extern void compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                                 double old_magf, double new_magf, SI& new_sx,
+                                 SI& new_sy);
 
 class TestZoomScroll : public QObject {
   Q_OBJECT
@@ -26,104 +25,45 @@ private slots:
   void test_rounding_precision ();
 };
 
-// 光标在视口中央，放大2倍：scroll 应向光标靠拢
+static void
+assert_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                    double old_magf, double new_magf, SI expected_sx,
+                    SI expected_sy) {
+  SI new_sx, new_sy;
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+  QCOMPARE (new_sx, expected_sx);
+  QCOMPARE (new_sy, expected_sy);
+}
+
 void
 TestZoomScroll::test_zoom_in_centered () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 500, old_sy= 500;   // scroll 在光标左上方
-  double old_magf= 1.0, new_magf= 2.0;
-  SI     new_sx, new_sy;
-
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-
-  // 光标偏移 = 1000 - 500 = 500，缩放后 = 500 * 1/2 = 250
-  // 新 scroll = 1000 - 250 = 750
-  QCOMPARE (new_sx, 750);
-  QCOMPARE (new_sy, 750);
+  assert_zoom_scroll (1000, 1000, 500, 500, 1.0, 2.0, 750, 750);
 }
 
-// 光标在视口中央，缩小1/2：scroll 应远离光标
 void
 TestZoomScroll::test_zoom_out_centered () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 500, old_sy= 500;
-  double old_magf= 2.0, new_magf= 1.0;
-  SI     new_sx, new_sy;
-
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-
-  // 光标偏移 = 1000 - 500 = 500，缩放后 = 500 * 2/1 = 1000
-  // 新 scroll = 1000 - 1000 = 0
-  QCOMPARE (new_sx, 0);
-  QCOMPARE (new_sy, 0);
+  assert_zoom_scroll (1000, 1000, 500, 500, 2.0, 1.0, 0, 0);
 }
 
-// 光标在视口左边缘，放大2倍：光标应仍在边缘
 void
 TestZoomScroll::test_zoom_in_at_edge () {
-  SI cursor_x= 500, cursor_y= 500;
-  SI old_sx= 500, old_sy= 500;   // scroll 正好在光标处（光标在视口左边缘）
-  double old_magf= 1.0, new_magf= 2.0;
-  SI     new_sx, new_sy;
-
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-
-  // 光标偏移 = 0，缩放后仍为 0
-  // 新 scroll = 500
-  QCOMPARE (new_sx, 500);
-  QCOMPARE (new_sy, 500);
+  assert_zoom_scroll (500, 500, 500, 500, 1.0, 2.0, 500, 500);
 }
 
-// 光标在视口右边缘，缩小1/2
 void
 TestZoomScroll::test_zoom_out_at_edge () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 1000, old_sy= 1000; // scroll 正好在光标处（光标在视口左边缘）
-  double old_magf= 2.0, new_magf= 1.0;
-  SI     new_sx, new_sy;
-
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-
-  // 光标偏移 = 0，缩放后仍为 0
-  QCOMPARE (new_sx, 1000);
-  QCOMPARE (new_sy, 1000);
+  assert_zoom_scroll (1000, 1000, 1000, 1000, 2.0, 1.0, 1000, 1000);
 }
 
-// zoom 不变时，scroll 应保持不变
 void
 TestZoomScroll::test_no_zoom_change () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 300, old_sy= 400;
-  double old_magf= 1.5, new_magf= 1.5;
-  SI     new_sx, new_sy;
-
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-
-  QCOMPARE (new_sx, old_sx);
-  QCOMPARE (new_sy, old_sy);
+  assert_zoom_scroll (1000, 1000, 300, 400, 1.5, 1.5, 300, 400);
 }
 
-// 验证整数舍入精度
 void
 TestZoomScroll::test_rounding_precision () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 333, old_sy= 333;
-  double old_magf= 1.0, new_magf= 3.0;
-  SI     new_sx, new_sy;
-
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-
-  // 光标偏移 = 1000 - 333 = 667，缩放后 = 667 * 1/3 = 222.333...
-  // tm_round(222.333...) = 222
-  // 新 scroll = 1000 - 222 = 778
-  QCOMPARE (new_sx, 778);
-  QCOMPARE (new_sy, 778);
+  assert_zoom_scroll (1000, 1000, 333, 333, 1.0, 3.0, 778, 778);
 }
 
 QTEST_MAIN (TestZoomScroll)

--- a/tests/Edit/Interface/zoom_scroll_test.cpp
+++ b/tests/Edit/Interface/zoom_scroll_test.cpp
@@ -9,10 +9,9 @@
 #include <QtTest/QtTest>
 
 // Forward declare the function under test (defined in edit_interface.cpp)
-extern void
-compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                     double old_magf, double new_magf,
-                     SI& new_sx, SI& new_sy);
+extern void compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                                 double old_magf, double new_magf, SI& new_sx,
+                                 SI& new_sy);
 
 class TestZoomScroll : public QObject {
   Q_OBJECT
@@ -29,8 +28,8 @@ private slots:
 // 光标在视口中央，放大2倍：scroll 应向光标靠拢
 void
 TestZoomScroll::test_zoom_in_centered () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 500, old_sy= 500;   // scroll 在光标左上方
+  SI     cursor_x= 1000, cursor_y= 1000;
+  SI     old_sx= 500, old_sy= 500; // scroll 在光标左上方
   double old_magf= 1.0, new_magf= 2.0;
   SI     new_sx, new_sy;
 
@@ -46,8 +45,8 @@ TestZoomScroll::test_zoom_in_centered () {
 // 光标在视口中央，缩小1/2：scroll 应远离光标
 void
 TestZoomScroll::test_zoom_out_centered () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 500, old_sy= 500;
+  SI     cursor_x= 1000, cursor_y= 1000;
+  SI     old_sx= 500, old_sy= 500;
   double old_magf= 2.0, new_magf= 1.0;
   SI     new_sx, new_sy;
 
@@ -63,8 +62,8 @@ TestZoomScroll::test_zoom_out_centered () {
 // 光标在视口左边缘，放大2倍：光标应仍在边缘
 void
 TestZoomScroll::test_zoom_in_at_edge () {
-  SI cursor_x= 500, cursor_y= 500;
-  SI old_sx= 500, old_sy= 500;   // scroll 正好在光标处（光标在视口左边缘）
+  SI     cursor_x= 500, cursor_y= 500;
+  SI     old_sx= 500, old_sy= 500; // scroll 正好在光标处（光标在视口左边缘）
   double old_magf= 1.0, new_magf= 2.0;
   SI     new_sx, new_sy;
 
@@ -80,8 +79,8 @@ TestZoomScroll::test_zoom_in_at_edge () {
 // 光标在视口右边缘，缩小1/2
 void
 TestZoomScroll::test_zoom_out_at_edge () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 1000, old_sy= 1000; // scroll 正好在光标处（光标在视口左边缘）
+  SI     cursor_x= 1000, cursor_y= 1000;
+  SI     old_sx= 1000, old_sy= 1000; // scroll 正好在光标处（光标在视口左边缘）
   double old_magf= 2.0, new_magf= 1.0;
   SI     new_sx, new_sy;
 
@@ -96,8 +95,8 @@ TestZoomScroll::test_zoom_out_at_edge () {
 // zoom 不变时，scroll 应保持不变
 void
 TestZoomScroll::test_no_zoom_change () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 300, old_sy= 400;
+  SI     cursor_x= 1000, cursor_y= 1000;
+  SI     old_sx= 300, old_sy= 400;
   double old_magf= 1.5, new_magf= 1.5;
   SI     new_sx, new_sy;
 
@@ -111,8 +110,8 @@ TestZoomScroll::test_no_zoom_change () {
 // 验证整数舍入精度
 void
 TestZoomScroll::test_rounding_precision () {
-  SI cursor_x= 1000, cursor_y= 1000;
-  SI old_sx= 333, old_sy= 333;
+  SI     cursor_x= 1000, cursor_y= 1000;
+  SI     old_sx= 333, old_sy= 333;
   double old_magf= 1.0, new_magf= 3.0;
   SI     new_sx, new_sy;
 

--- a/tests/Edit/Interface/zoom_scroll_test.cpp
+++ b/tests/Edit/Interface/zoom_scroll_test.cpp
@@ -1,0 +1,130 @@
+
+/******************************************************************************
+ * MODULE     : zoom_scroll_test.cpp
+ * DESCRIPTION: Test zoom scroll computation logic
+ * COPYRIGHT  : (C) 2026
+ ******************************************************************************/
+
+#include "base.hpp"
+#include <QtTest/QtTest>
+
+// Forward declare the function under test (defined in edit_interface.cpp)
+extern void
+compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                     double old_magf, double new_magf,
+                     SI& new_sx, SI& new_sy);
+
+class TestZoomScroll : public QObject {
+  Q_OBJECT
+
+private slots:
+  void test_zoom_in_centered ();
+  void test_zoom_out_centered ();
+  void test_zoom_in_at_edge ();
+  void test_zoom_out_at_edge ();
+  void test_no_zoom_change ();
+  void test_rounding_precision ();
+};
+
+// 光标在视口中央，放大2倍：scroll 应向光标靠拢
+void
+TestZoomScroll::test_zoom_in_centered () {
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 500, old_sy= 500;   // scroll 在光标左上方
+  double old_magf= 1.0, new_magf= 2.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 1000 - 500 = 500，缩放后 = 500 * 1/2 = 250
+  // 新 scroll = 1000 - 250 = 750
+  QCOMPARE (new_sx, 750);
+  QCOMPARE (new_sy, 750);
+}
+
+// 光标在视口中央，缩小1/2：scroll 应远离光标
+void
+TestZoomScroll::test_zoom_out_centered () {
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 500, old_sy= 500;
+  double old_magf= 2.0, new_magf= 1.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 1000 - 500 = 500，缩放后 = 500 * 2/1 = 1000
+  // 新 scroll = 1000 - 1000 = 0
+  QCOMPARE (new_sx, 0);
+  QCOMPARE (new_sy, 0);
+}
+
+// 光标在视口左边缘，放大2倍：光标应仍在边缘
+void
+TestZoomScroll::test_zoom_in_at_edge () {
+  SI cursor_x= 500, cursor_y= 500;
+  SI old_sx= 500, old_sy= 500;   // scroll 正好在光标处（光标在视口左边缘）
+  double old_magf= 1.0, new_magf= 2.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 0，缩放后仍为 0
+  // 新 scroll = 500
+  QCOMPARE (new_sx, 500);
+  QCOMPARE (new_sy, 500);
+}
+
+// 光标在视口右边缘，缩小1/2
+void
+TestZoomScroll::test_zoom_out_at_edge () {
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 1000, old_sy= 1000; // scroll 正好在光标处（光标在视口左边缘）
+  double old_magf= 2.0, new_magf= 1.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 0，缩放后仍为 0
+  QCOMPARE (new_sx, 1000);
+  QCOMPARE (new_sy, 1000);
+}
+
+// zoom 不变时，scroll 应保持不变
+void
+TestZoomScroll::test_no_zoom_change () {
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 300, old_sy= 400;
+  double old_magf= 1.5, new_magf= 1.5;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  QCOMPARE (new_sx, old_sx);
+  QCOMPARE (new_sy, old_sy);
+}
+
+// 验证整数舍入精度
+void
+TestZoomScroll::test_rounding_precision () {
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 333, old_sy= 333;
+  double old_magf= 1.0, new_magf= 3.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 1000 - 333 = 667，缩放后 = 667 * 1/3 = 222.333...
+  // tm_round(222.333...) = 222
+  // 新 scroll = 1000 - 222 = 778
+  QCOMPARE (new_sx, 778);
+  QCOMPARE (new_sy, 778);
+}
+
+QTEST_MAIN (TestZoomScroll)
+#include "zoom_scroll_test.moc"

--- a/tests/Edit/Interface/zoom_scroll_test.cpp
+++ b/tests/Edit/Interface/zoom_scroll_test.cpp
@@ -9,9 +9,10 @@
 #include <QtTest/QtTest>
 
 // Forward declare the function under test (defined in edit_interface.cpp)
-extern void compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                                 double old_magf, double new_magf, SI& new_sx,
-                                 SI& new_sy);
+extern void
+compute_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
+                     double old_magf, double new_magf,
+                     SI& new_sx, SI& new_sy);
 
 class TestZoomScroll : public QObject {
   Q_OBJECT
@@ -25,45 +26,104 @@ private slots:
   void test_rounding_precision ();
 };
 
-static void
-assert_zoom_scroll (SI cursor_x, SI cursor_y, SI old_sx, SI old_sy,
-                    double old_magf, double new_magf, SI expected_sx,
-                    SI expected_sy) {
-  SI new_sx, new_sy;
-  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
-                       new_sx, new_sy);
-  QCOMPARE (new_sx, expected_sx);
-  QCOMPARE (new_sy, expected_sy);
-}
-
+// 光标在视口中央，放大2倍：scroll 应向光标靠拢
 void
 TestZoomScroll::test_zoom_in_centered () {
-  assert_zoom_scroll (1000, 1000, 500, 500, 1.0, 2.0, 750, 750);
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 500, old_sy= 500;   // scroll 在光标左上方
+  double old_magf= 1.0, new_magf= 2.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 1000 - 500 = 500，缩放后 = 500 * 1/2 = 250
+  // 新 scroll = 1000 - 250 = 750
+  QCOMPARE (new_sx, 750);
+  QCOMPARE (new_sy, 750);
 }
 
+// 光标在视口中央，缩小1/2：scroll 应远离光标
 void
 TestZoomScroll::test_zoom_out_centered () {
-  assert_zoom_scroll (1000, 1000, 500, 500, 2.0, 1.0, 0, 0);
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 500, old_sy= 500;
+  double old_magf= 2.0, new_magf= 1.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 1000 - 500 = 500，缩放后 = 500 * 2/1 = 1000
+  // 新 scroll = 1000 - 1000 = 0
+  QCOMPARE (new_sx, 0);
+  QCOMPARE (new_sy, 0);
 }
 
+// 光标在视口左边缘，放大2倍：光标应仍在边缘
 void
 TestZoomScroll::test_zoom_in_at_edge () {
-  assert_zoom_scroll (500, 500, 500, 500, 1.0, 2.0, 500, 500);
+  SI cursor_x= 500, cursor_y= 500;
+  SI old_sx= 500, old_sy= 500;   // scroll 正好在光标处（光标在视口左边缘）
+  double old_magf= 1.0, new_magf= 2.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 0，缩放后仍为 0
+  // 新 scroll = 500
+  QCOMPARE (new_sx, 500);
+  QCOMPARE (new_sy, 500);
 }
 
+// 光标在视口右边缘，缩小1/2
 void
 TestZoomScroll::test_zoom_out_at_edge () {
-  assert_zoom_scroll (1000, 1000, 1000, 1000, 2.0, 1.0, 1000, 1000);
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 1000, old_sy= 1000; // scroll 正好在光标处（光标在视口左边缘）
+  double old_magf= 2.0, new_magf= 1.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 0，缩放后仍为 0
+  QCOMPARE (new_sx, 1000);
+  QCOMPARE (new_sy, 1000);
 }
 
+// zoom 不变时，scroll 应保持不变
 void
 TestZoomScroll::test_no_zoom_change () {
-  assert_zoom_scroll (1000, 1000, 300, 400, 1.5, 1.5, 300, 400);
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 300, old_sy= 400;
+  double old_magf= 1.5, new_magf= 1.5;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  QCOMPARE (new_sx, old_sx);
+  QCOMPARE (new_sy, old_sy);
 }
 
+// 验证整数舍入精度
 void
 TestZoomScroll::test_rounding_precision () {
-  assert_zoom_scroll (1000, 1000, 333, 333, 1.0, 3.0, 778, 778);
+  SI cursor_x= 1000, cursor_y= 1000;
+  SI old_sx= 333, old_sy= 333;
+  double old_magf= 1.0, new_magf= 3.0;
+  SI     new_sx, new_sy;
+
+  compute_zoom_scroll (cursor_x, cursor_y, old_sx, old_sy, old_magf, new_magf,
+                       new_sx, new_sy);
+
+  // 光标偏移 = 1000 - 333 = 667，缩放后 = 667 * 1/3 = 222.333...
+  // tm_round(222.333...) = 222
+  // 新 scroll = 1000 - 222 = 778
+  QCOMPARE (new_sx, 778);
+  QCOMPARE (new_sy, 778);
 }
 
 QTEST_MAIN (TestZoomScroll)


### PR DESCRIPTION
## 摘要

实现放大缩小时视口跟随光标位置，保持光标在视口中的相对位置不变。

## 改动内容

- `src/Edit/Interface/edit_interface.cpp`: 在 `set_zoom_factor` 中计算新的 scroll 坐标，使光标位置在缩放后保持不变
- `tests/Edit/Interface/zoom_scroll_test.cpp`: 提取纯函数 `compute_zoom_scroll` 并编写单元测试
- `devel/0132.md`: 任务文档

## 测试计划

- [x] `xmake b zoom_scroll_test` 编译通过
- [x] `xmake r zoom_scroll_test` 测试通过
- [x] 手动验证：打开多页文档，使用 `Ctrl + +/-` 缩放，光标保持在视口相对位置

🤖 Generated with [Claude Code](https://claude.com/claude-code)