### PR TITLE
[0102] 将 gf fix 加入 bin/format 并格式化 kernel 下三个目录

### DIFF
--- a/TeXmacs/progs/kernel/boot/ahash-table.scm
+++ b/TeXmacs/progs/kernel/boot/ahash-table.scm
@@ -134,14 +134,14 @@
 (define-public-macro (define-table name . l)
   `(begin
      (when (not (defined? (quote ,name)))
-       (if (defined? (#_quote tm-define))
+       (if (defined? 'tm-define)
          (tm-define ,name (make-ahash-table))
          (define-public ,name (make-ahash-table))))
-     (define-table-decls ,name ,(list (#_quote quasiquote) l)))
+     (define-table-decls ,name ,(list 'quasiquote l)))
 ) ;define-public-macro
 
 (define-public-macro (extend-table name . l)
-  `(define-table-decls ,name ,(list (#_quote quasiquote) l))
+  `(define-table-decls ,name ,(list 'quasiquote l))
 ) ;define-public-macro
 
 (define-public (define-collection-decls h l)
@@ -154,12 +154,12 @@
 (define-public-macro (define-collection name . l)
   `(begin
      (when (not (defined? (quote ,name)))
-       (if (defined? (#_quote tm-define))
+       (if (defined? 'tm-define)
          (tm-define ,name (make-ahash-table))
          (define-public ,name (make-ahash-table))))
-     (define-collection-decls ,name ,(list (#_quote quasiquote) l)))
+     (define-collection-decls ,name ,(list 'quasiquote l)))
 ) ;define-public-macro
 
 (define-public-macro (extend-collection name . l)
-  `(define-collection-decls ,name ,(list (#_quote quasiquote) l))
+  `(define-collection-decls ,name ,(list 'quasiquote l))
 ) ;define-public-macro

--- a/TeXmacs/progs/kernel/boot/boot-s7.scm
+++ b/TeXmacs/progs/kernel/boot/boot-s7.scm
@@ -73,8 +73,7 @@
 (define-macro (with-module module . body)
   `(let ((m ,module))
      (with-let m
-       (let-temporarily (((*texmacs-module* (#_quote *current-module*))
-                          (curlet)))
+       (let-temporarily (((*texmacs-module* '*current-module*) (curlet)))
          ,@body)))
 ) ;define-macro
 
@@ -147,12 +146,12 @@
 (define-macro (use-modules . modules)
   `(map (lambda (module)
           (let* ((m (resolve-module module))
-                 (ex (m (#_quote *exports*)))
+                 (ex (m '*exports*))
                  (exx (map (lambda (entry)
                              (if (member (car entry) ex) entry (values)))
                         m))
                  (en (apply inlet exx)))
-            (varlet (*texmacs-module* (#_quote *current-module*)) en)))
+            (varlet (*texmacs-module* '*current-module*) en)))
      (quote ,modules))
 ) ;define-macro
 

--- a/TeXmacs/progs/kernel/boot/compat-s7.scm
+++ b/TeXmacs/progs/kernel/boot/compat-s7.scm
@@ -132,11 +132,10 @@
 (define-public (make-record-type type fields) (inlet 'type type 'fields fields))
 
 (define-public (record-constructor rec-type)
-  (eval `(lambda ,(rec-type (#_quote fields))
-           (inlet (#_quote type)
-             ,(rec-type (#_quote type))
-             ,@(map (lambda (f) (values (list (#_quote quote) f) f))
-                 (rec-type (#_quote fields)))))
+  (eval `(lambda ,(rec-type 'fields)
+           (inlet 'type
+             ,(rec-type 'type)
+             ,@(map (lambda (f) (values (list 'quote f) f)) (rec-type 'fields))))
   ) ;eval
 ) ;define-public
 

--- a/TeXmacs/progs/kernel/boot/debug.scm
+++ b/TeXmacs/progs/kernel/boot/debug.scm
@@ -203,9 +203,7 @@
                           ) ;
                       ;; Display messages and run test.
                       `((display ,(string-append "  -- " test-desc "\n"))
-                        (,(if e?
-                            (#_quote regression-test-equal)
-                            (#_quote regression-test-nequal))
+                        (,(if e? 'regression-test-equal 'regression-test-nequal)
                          ,group-id
                          ,test-desc
                          ,result-in
@@ -342,10 +340,10 @@
   ;; Parameters are function names
   `(begin
      ,@(map (lambda (name)
-              `(if (not (procedure-property ,name (#_quote trace-wrapped)))
+              `(if (not (procedure-property ,name 'trace-wrapped))
                  (begin
                    (set! ,name (wrap-trace ,(symbol->string name) ,name))
-                   (set-procedure-property! ,name (#_quote trace-wrapped) ,#t))))
+                   (set-procedure-property! ,name 'trace-wrapped ,#t))))
          names))
 ) ;define-public-macro
 

--- a/TeXmacs/progs/kernel/boot/srfi.scm
+++ b/TeXmacs/progs/kernel/boot/srfi.scm
@@ -146,7 +146,7 @@
   ;; code of the corresponding body.
   (define (gen-clauses l length-name args-name)
     (cond ((null? l) (list '(else (error "too few arguments"))))
-          (else (cons `((,(if (dotted? (caar l)) (#_quote >=) (#_quote =))
+          (else (cons `((,(if (dotted? (caar l)) '>= '=)
                          ,length-name
                          ,(alength (caar l)))
                         (let ,(gen-temps (caar l) args-name) ,@(cdar l)))

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -340,40 +340,38 @@
 (tm-define (emulate-keyboard k)
   (delayed (raw-emulate-keyboard k)))
 
-#|
-extract-code-str
-从过程对象（Procedure）或列表中提取源码对象（S-Expression）。
-这是用于调试快捷键绑定的核心辅助函数，能够“透视”匿名 Lambda 函数的内部逻辑，
-并返回可供进一步程序处理的原始代码结构。
-
-语法
-----
-(extract-code-str proc)
-
-参数
-----
-proc : procedure | any
-    需要提取源码的目标对象。通常是 `kbd-get-map` 返回列表中的条件闭包或命令闭包。
-    如果是 procedure，尝试获取其源码；如果是普通列表或其他数据，则按原样处理。
-
-返回值
-----
-any (list | symbol)
-- 返回对象源码的原始 Scheme 结构（S-Expression）。
-- 如果输入是 `(lambda () (func))`，则返回列表 `(func)`（保留括号结构）。
-- 如果输入是 `(lambda () (func arg))`，则返回列表 `(func arg)`。
-
-逻辑
-----
-1. 源码获取：首先检查输入是否为过程，如果是则调用 `procedure-source` 获取源码列表。
-2. Lambda 识别：
-   - 检查源码是否为列表 (pair)。
-   - 检查第一个元素是否为符号 `lambda`。
-   - 检查列表长度是否足够包含函数体 (cddr)。
-3. 剥离外壳：
-   - 如果确认为 Lambda 结构，直接提取第三个元素 `(caddr src)` 作为函数体代码。
-   - 注意：不进行额外的 `car` 拆包，完整保留函数体内的逻辑结构。
-|#
+;;extract-code-str
+;;从过程对象（Procedure）或列表中提取源码对象（S-Expression）。
+;;这是用于调试快捷键绑定的核心辅助函数，能够“透视”匿名 Lambda 函数的内部逻辑，
+;;并返回可供进一步程序处理的原始代码结构。
+;;
+;;语法
+;;----
+;;(extract-code-str proc)
+;;
+;;参数
+;;----
+;;proc : procedure | any
+;;    需要提取源码的目标对象。通常是 `kbd-get-map` 返回列表中的条件闭包或命令闭包。
+;;    如果是 procedure，尝试获取其源码；如果是普通列表或其他数据，则按原样处理。
+;;
+;;返回值
+;;----
+;;any (list | symbol)
+;;- 返回对象源码的原始 Scheme 结构（S-Expression）。
+;;- 如果输入是 `(lambda () (func))`，则返回列表 `(func)`（保留括号结构）。
+;;- 如果输入是 `(lambda () (func arg))`，则返回列表 `(func arg)`。
+;;
+;;逻辑
+;;----
+;;1. 源码获取：首先检查输入是否为过程，如果是则调用 `procedure-source` 获取源码列表。
+;;2. Lambda 识别：
+;;   - 检查源码是否为列表 (pair)。
+;;   - 检查第一个元素是否为符号 `lambda`。
+;;   - 检查列表长度是否足够包含函数体 (cddr)。
+;;3. 剥离外壳：
+;;   - 如果确认为 Lambda 结构，直接提取第三个元素 `(caddr src)` 作为函数体代码。
+;;   - 注意：不进行额外的 `car` 拆包，完整保留函数体内的逻辑结构。
 (define (extract-code-str proc)
   (let* ((src (if (procedure? proc) (procedure-source proc) proc))
          (code (if (and (pair? src) 
@@ -383,45 +381,43 @@ any (list | symbol)
                    src)))
     code))
 
-#|
-get-kbd-bindings
-获取指定按键序列的所有绑定详情，并以结构化数据的形式返回。
-这是一个高层调试工具，用于查看某个快捷键在不同上下文（条件）下的行为定义。
-
-语法
-----
-(get-kbd-bindings key-str)
-
-参数
-----
-key-str : string
-    按键序列字符串，例如 "return"、"C-x C-f" 或 "tab"。
-
-返回值
-----
-list
-- 如果按键未定义：返回 `(not-bound)`。
-- 如果按键已定义：返回一个列表的列表，格式为：
-  `(( (条件代码列表...) 命令代码 "帮助文档" ) ...)`
-  示例：`(( ((inside-replace-buffer?)) (replace-one ...) "" ) ...)`
-  注意：这里的条件和命令是 Scheme 代码对象（List），而非字符串。
-
-逻辑
-----
-1. 获取原始映射：调用 `kbd-get-map` 获取按键对应的原始关联列表 (Association List)。
-2. 空值检查：如果 `kbd-get-map` 返回 #f，则返回 `(not-bound)`。
-3. 遍历处理：使用 `map` 遍历原始列表中的每一项绑定：
-   - 条件处理：原始数据的 car 部分是条件闭包列表，对其中每个元素调用 `extract-code-str` 获取源码对象。
-   - 命令处理：原始数据的 cadr 部分是命令闭包，对其调用 `extract-code-str` 获取源码对象。
-   - 帮助文档：原始数据的 caddr 部分是字符串，保持原样。
-4. 结果组装：将处理后的条件代码列表、命令代码对象和帮助文档重新组装成一个新的列表返回。
-
-注意
-----
-1. 本函数使用 `tm-define` 定义，使其在 Mogan/TeXmacs 的模块系统中可见。
-2. 返回结果中的条件部分始终是一个列表（如 `((cond1) (cond2))`），
-   因为 Mogan 允许一个快捷键绑定同时依赖多个条件（逻辑与关系）。
-|#
+;;get-kbd-bindings
+;;获取指定按键序列的所有绑定详情，并以结构化数据的形式返回。
+;;这是一个高层调试工具，用于查看某个快捷键在不同上下文（条件）下的行为定义。
+;;
+;;语法
+;;----
+;;(get-kbd-bindings key-str)
+;;
+;;参数
+;;----
+;;key-str : string
+;;    按键序列字符串，例如 "return"、"C-x C-f" 或 "tab"。
+;;
+;;返回值
+;;----
+;;list
+;;- 如果按键未定义：返回 `(not-bound)`。
+;;- 如果按键已定义：返回一个列表的列表，格式为：
+;;  `(( (条件代码列表...) 命令代码 "帮助文档" ) ...)`
+;;  示例：`(( ((inside-replace-buffer?)) (replace-one ...) "" ) ...)`
+;;  注意：这里的条件和命令是 Scheme 代码对象（List），而非字符串。
+;;
+;;逻辑
+;;----
+;;1. 获取原始映射：调用 `kbd-get-map` 获取按键对应的原始关联列表 (Association List)。
+;;2. 空值检查：如果 `kbd-get-map` 返回 #f，则返回 `(not-bound)`。
+;;3. 遍历处理：使用 `map` 遍历原始列表中的每一项绑定：
+;;   - 条件处理：原始数据的 car 部分是条件闭包列表，对其中每个元素调用 `extract-code-str` 获取源码对象。
+;;   - 命令处理：原始数据的 cadr 部分是命令闭包，对其调用 `extract-code-str` 获取源码对象。
+;;   - 帮助文档：原始数据的 caddr 部分是字符串，保持原样。
+;;4. 结果组装：将处理后的条件代码列表、命令代码对象和帮助文档重新组装成一个新的列表返回。
+;;
+;;注意
+;;----
+;;1. 本函数使用 `tm-define` 定义，使其在 Mogan/TeXmacs 的模块系统中可见。
+;;2. 返回结果中的条件部分始终是一个列表（如 `((cond1) (cond2))`），
+;;   因为 Mogan 允许一个快捷键绑定同时依赖多个条件（逻辑与关系）。
 (tm-define (get-kbd-bindings key-str)
   (let ((raw-map (kbd-get-map key-str)))
     (if (not raw-map)
@@ -436,35 +432,33 @@ list
                    help)))
              raw-map))))
 
-#|
-get-bindings-by-command
-根据指定的命令代码，反向查找绑定了该命令的所有快捷键及其生效条件。
-
-语法
-----
-(get-bindings-by-command target-cmd)
-
-参数
-----
-target-cmd : list | symbol
-    目标命令的源码结构。
-    例如：
-    - 查找特定调用：`'(search-next-match #t)`
-    - 查找简单命令：`'(make 'select-region)`
-
-返回值
-----
-list
-- 返回一个列表，其中每个元素结构为 `(按键字符串 (条件代码列表...))`。
-- 示例：`(("F3" ((inside-search-or-replace-buffer?))) ("return" (...)))`
-
-逻辑
-----
-1. 遍历：扫描 `kbd-map-table` 中的每一个按键定义。
-2. 提取：对每个绑定的命令闭包调用 `extract-code-str` 获取其源码对象。
-3. 比对：使用 `equal?` 将提取出的命令源码与 `target-cmd` 进行深度比对。
-4. 收集：如果匹配，将 `(Key Conditions)` 加入结果列表。
-|#
+;;get-bindings-by-command
+;;根据指定的命令代码，反向查找绑定了该命令的所有快捷键及其生效条件。
+;;
+;;语法
+;;----
+;;(get-bindings-by-command target-cmd)
+;;
+;;参数
+;;----
+;;target-cmd : list | symbol
+;;    目标命令的源码结构。
+;;    例如：
+;;    - 查找特定调用：`'(search-next-match #t)`
+;;    - 查找简单命令：`'(make 'select-region)`
+;;
+;;返回值
+;;----
+;;list
+;;- 返回一个列表，其中每个元素结构为 `(按键字符串 (条件代码列表...))`。
+;;- 示例：`(("F3" ((inside-search-or-replace-buffer?))) ("return" (...)))`
+;;
+;;逻辑
+;;----
+;;1. 遍历：扫描 `kbd-map-table` 中的每一个按键定义。
+;;2. 提取：对每个绑定的命令闭包调用 `extract-code-str` 获取其源码对象。
+;;3. 比对：使用 `equal?` 将提取出的命令源码与 `target-cmd` 进行深度比对。
+;;4. 收集：如果匹配，将 `(Key Conditions)` 加入结果列表。
 (tm-define (get-bindings-by-command target-cmd)
   (let ((all-entries (ahash-table->list kbd-map-table))
         (matches '()))
@@ -487,42 +481,40 @@ list
 
 
 
-#|
-get-bindings-by-condition
-根据指定的条件列表，反向查找所有匹配的快捷键及其对应的命令代码。
-此函数用于回答“在某个特定环境（如表格中、数学模式中）下，定义了哪些快捷键？”
-
-语法
-----
-(get-bindings-by-condition target-conds)
-
-参数
-----
-target-conds : list
-    目标条件源码列表。这是一个由 Scheme 代码对象（S-expression）组成的列表。
-    例如：
-    - 查找无条件绑定：`()`
-    - 查找数学模式绑定：`'((and (== (get-env "mode") "text") (not (in-graphics?))))` 或 `(list '(and (== (get-env "mode") "text") (not (in-graphics?))))`
-    - 查找特定条件：`'((inside-replace-buffer?))`
-
-返回值
-----
-list
-- 返回一个列表，其中每个元素也是一个列表，结构为 `(按键字符串 命令代码对象)`。
-- 示例：`(("return" (replace-one ...)) ("C-2" (insert ...)))`
-
-逻辑
-----
-1. 获取全集：调用 `ahash-table->list` 将 `kbd-map-table` 哈希表转换为遍历列表。
-2. 双层遍历：
-   - 外层遍历每一个按键定义（Key Entry）。
-   - 内层遍历该按键下的每一个上下文重载（Context Entry）。
-3. 源码比对：
-   - 使用 `extract-code-str` 提取当前上下文中的条件源码。
-   - 使用 `equal?` 将提取出的条件与参数 `target-conds` 进行深度比对。
-4. 收集结果：
-   - 如果匹配成功，提取对应的命令源码，并将 `(Key Command)` 组合加入结果列表。
-|#
+;;get-bindings-by-condition
+;;根据指定的条件列表，反向查找所有匹配的快捷键及其对应的命令代码。
+;;此函数用于回答“在某个特定环境（如表格中、数学模式中）下，定义了哪些快捷键？”
+;;
+;;语法
+;;----
+;;(get-bindings-by-condition target-conds)
+;;
+;;参数
+;;----
+;;target-conds : list
+;;    目标条件源码列表。这是一个由 Scheme 代码对象（S-expression）组成的列表。
+;;    例如：
+;;    - 查找无条件绑定：`()`
+;;    - 查找数学模式绑定：`'((and (== (get-env "mode") "text") (not (in-graphics?))))` 或 `(list '(and (== (get-env "mode") "text") (not (in-graphics?))))`
+;;    - 查找特定条件：`'((inside-replace-buffer?))`
+;;
+;;返回值
+;;----
+;;list
+;;- 返回一个列表，其中每个元素也是一个列表，结构为 `(按键字符串 命令代码对象)`。
+;;- 示例：`(("return" (replace-one ...)) ("C-2" (insert ...)))`
+;;
+;;逻辑
+;;----
+;;1. 获取全集：调用 `ahash-table->list` 将 `kbd-map-table` 哈希表转换为遍历列表。
+;;2. 双层遍历：
+;;   - 外层遍历每一个按键定义（Key Entry）。
+;;   - 内层遍历该按键下的每一个上下文重载（Context Entry）。
+;;3. 源码比对：
+;;   - 使用 `extract-code-str` 提取当前上下文中的条件源码。
+;;   - 使用 `equal?` 将提取出的条件与参数 `target-conds` 进行深度比对。
+;;4. 收集结果：
+;;   - 如果匹配成功，提取对应的命令源码，并将 `(Key Command)` 组合加入结果列表。
 (tm-define (get-bindings-by-condition target-conds)
   (let ((all-entries (ahash-table->list kbd-map-table))
         (matches '()))
@@ -546,24 +538,22 @@ list
     ;; 返回结果（反转以保持发现顺序，虽不强求）
     (reverse matches)))
 
-#|
-kbd-conflict-query
-冲突查询函数
-检查在新按键序列（new-key）下，是否存在与给定条件（conds）完全一致的绑定。
-
-参数
-----
-conds   : list
-    条件源码列表（S-Expression），例如 '((and (== (get-env "mode") "text") (not (in-graphics?)))) 或 '()。
-new-key : string
-    待检查的新按键序列，例如 "C-a"。
-
-返回值
-----
-any | #f
-- 如果存在冲突：返回冲突绑定的命令源码（通常是一个列表）。
-- 如果无冲突：返回 #f。
-|#
+;;kbd-conflict-query
+;;冲突查询函数
+;;检查在新按键序列（new-key）下，是否存在与给定条件（conds）完全一致的绑定。
+;;
+;;参数
+;;----
+;;conds   : list
+;;    条件源码列表（S-Expression），例如 '((and (== (get-env "mode") "text") (not (in-graphics?)))) 或 '()。
+;;new-key : string
+;;    待检查的新按键序列，例如 "C-a"。
+;;
+;;返回值
+;;----
+;;any | #f
+;;- 如果存在冲突：返回冲突绑定的命令源码（通常是一个列表）。
+;;- 如果无冲突：返回 #f。
 (tm-define (kbd-conflict-query conds new-key)
   (let ((raw-map (kbd-get-map new-key)))
     (if raw-map
@@ -582,39 +572,37 @@ any | #f
                     (loop (cdr entries))))))
         #f)))
 
-#|
-kbd-execute-edit
-编辑执行函数
-根据给定的条件，删除旧按键绑定（如果存在），并创建新按键绑定。
-
-参数
-----
-conds   : list
-    条件源码列表。
-cmd     : any
-    命令源码（S-Expression），例如 '(insert "alpha")。
-old-key : string
-    旧按键序列。如果非空，函数将尝试移除该按键下匹配 conds 的绑定。
-new-key : string
-    新按键序列。如果非空，函数将在该按键下创建指向 cmd 的新绑定。
-
-逻辑 (四种状态)
---------------
-1. 清理旧绑定 (Old Key)：
-   若 old-key 非空，遍历其映射表，寻找条件源码与 conds 完全匹配的条目。
-   找到后，利用原始闭包对象将其从哈希表中移除。
-
-2. 应用新绑定 (New Key)：
-   若 new-key 非空，将 conds 和 cmd 动态编译为闭包，插入到 new-key 的映射表中。
-   **若 new-key 为空，则跳过此步。**
-
-四种行为
---------
-- 新增: old-key="", new-key="C-a" -> 旧的无动作，新增 C-a 绑定。
-- 修改: old-key="C-b", new-key="C-a"  -> 将绑定从 C-b 搬到 C-a。
-- 删除: old-key="C-b",  new-key="" -> C-b 被解绑，且没有新绑定生成。
-- 无效操作：都为空，直接返回。
-|#
+;;kbd-execute-edit
+;;编辑执行函数
+;;根据给定的条件，删除旧按键绑定（如果存在），并创建新按键绑定。
+;;
+;;参数
+;;----
+;;conds   : list
+;;    条件源码列表。
+;;cmd     : any
+;;    命令源码（S-Expression），例如 '(insert "alpha")。
+;;old-key : string
+;;    旧按键序列。如果非空，函数将尝试移除该按键下匹配 conds 的绑定。
+;;new-key : string
+;;    新按键序列。如果非空，函数将在该按键下创建指向 cmd 的新绑定。
+;;
+;;逻辑 (四种状态)
+;;--------------
+;;1. 清理旧绑定 (Old Key)：
+;;   若 old-key 非空，遍历其映射表，寻找条件源码与 conds 完全匹配的条目。
+;;   找到后，利用原始闭包对象将其从哈希表中移除。
+;;
+;;2. 应用新绑定 (New Key)：
+;;   若 new-key 非空，将 conds 和 cmd 动态编译为闭包，插入到 new-key 的映射表中。
+;;   **若 new-key 为空，则跳过此步。**
+;;
+;;四种行为
+;;--------
+;;- 新增: old-key="", new-key="C-a" -> 旧的无动作，新增 C-a 绑定。
+;;- 修改: old-key="C-b", new-key="C-a"  -> 将绑定从 C-b 搬到 C-a。
+;;- 删除: old-key="C-b",  new-key="" -> C-b 被解绑，且没有新绑定生成。
+;;- 无效操作：都为空，直接返回。
 (tm-define (kbd-execute-edit conds cmd old-key new-key)
   ;; 1. 如果提供了旧按键，则尝试删除旧绑定
   (when (and (string? old-key) (> (string-length old-key) 0))

--- a/TeXmacs/progs/kernel/library/base.scm
+++ b/TeXmacs/progs/kernel/library/base.scm
@@ -19,25 +19,22 @@
 
 (define (xor-sub l)
   (cond ((null? l) #f)
-	((car l) (not (xor-sub (cdr l))))
-	(else (xor-sub (cdr l)))))
+        ((car l) (not (xor-sub (cdr l))))
+        (else (xor-sub (cdr l)))
+  ) ;cond
+) ;define
 
-(define-public (xor . l)
-  "Exclusive or of all elements in @l."
-  (xor-sub l))
+(define-public (xor . l) "Exclusive or of all elements in @l." (xor-sub l))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Numbers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (float->string s)
-  (number->string s))
+(define-public (float->string s) (number->string s))
 
-(define-public (string->float s)
-  (exact->inexact (string->number s)))
+(define-public (string->float s) (exact->inexact (string->number s)))
 
-(define-public (string-number? s)
-  (and (string? s) (cpp-string-number? s)))
+(define-public (string-number? s) (and (string? s) (cpp-string-number? s)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Strings
@@ -47,7 +44,8 @@
 
 (define-public (char->string c)
   "Convert @c to a string"
-  (list->string (list c)))
+  (list->string (list c))
+) ;define-public
 
 (define-public (tm-char-whitespace? c)
   "Is @c a whitespace character?"
@@ -55,186 +53,236 @@
   ;; versions of Guile.  These erroneous versions incorrectly recognize
   ;; characters such as A0 (hexadecimal), which breaks certain routines
   ;; involving unicode or cork.
-  (in? c '(#\space #\ht #\newline #\return)))
+  (in? c '(#\space #\ht #\newline #\return))
+) ;define-public
 
 (define-public (string-tail s n)
   "Return all but the first @n chars of @s."
-  (substring s n (string-length s)))
+  (substring s n (string-length s))
+) ;define-public
 
 (define-public (char-in-string? c s)
   "Test whether @c occurs in @s"
-  (!= (string-index s c) #f))
+  (!= (string-index s c) #f)
+) ;define-public
 
 (define-public (string-starts? s what)
   "Test whether @s starts with @what."
-  (let ((n (string-length s))
-	(k (string-length what)))
-    (and (>= n k) (== (substring s 0 k) what))))
+  (let ((n (string-length s)) (k (string-length what)))
+    (and (>= n k) (== (substring s 0 k) what))
+  ) ;let
+) ;define-public
 
 (define-public (string-ends? s what)
   "Test whether @s ends with @what."
-  (let ((n (string-length s))
-	(k (string-length what)))
-    (and (>= n k) (== (substring s (- n k) n) what))))
+  (let ((n (string-length s)) (k (string-length what)))
+    (and (>= n k) (== (substring s (- n k) n) what))
+  ) ;let
+) ;define-public
 
 (define-public (string-contains? s what)
   "Test whether @s contains @what as a substring."
-  (>= (string-search-forwards what 0 s) 0))
+  (>= (string-search-forwards what 0 s) 0)
+) ;define-public
 
 (define-public (force-string s)
   "Return @s if @s is a string and the empty string otherwise"
-  (if (string? s) s ""))
+  (if (string? s) s "")
+) ;define-public
 
-(provide-public (reverse-list->string cs)	; srfi-13
+(provide-public (reverse-list->string cs)
   "Efficient implementation of (compose list->string reverse)."
   ;; Not yet any more efficient, but this may be fixed in the future.
-  (list->string (reverse cs)))
+  (list->string (reverse cs))
+) ;provide-public
 
-(provide-public (string-join	ss . opt)	; srfi-13 (subset)
+(provide-public (string-join ss . opt)
   "Concatenate elements of @ss inserting separators."
-  (if (null? opt) (string-join ss " ")
-      (string-concatenate (list-intersperse ss (car opt)))))
+  (if (null? opt)
+    (string-join ss " ")
+    (string-concatenate (list-intersperse ss (car opt)))
+  ) ;if
+) ;provide-public
 
-(provide-public (string-drop-right s n)	; srfi-13
+(provide-public (string-drop-right s n)
   "Return all but the last @n chars of @s."
-  (substring s 0 (- (string-length s) n)))
+  (substring s 0 (- (string-length s) n))
+) ;provide-public
 
-(provide-public string-drop string-tail)	; srfi-13
+(provide-public string-drop string-tail)
 
-(provide-public (string-take s n)		; srfi-13
+(provide-public (string-take s n)
   "Return the first @n chars of @s."
-  (substring s 0 n))
+  (substring s 0 n)
+) ;provide-public
 
 (provide-public (string-take-right s n)
   "Return the last @n chars of @s."
   (let ((l (string-length s)))
-    (substring s (- l n) l)))
+    (substring s (- l n) l)
+  ) ;let
+) ;provide-public
 
-(define-public (tm-string-trim s)		; srfi-13 (subset)
+(define-public (tm-string-trim s)
   "Remove whitespace at start of @s."
-  (list->string (list-drop-while (string->list s) tm-char-whitespace?)))
+  (list->string (list-drop-while (string->list s) tm-char-whitespace?))
+) ;define-public
 
 (define-public (list-drop-right-while l pred)
-  (reverse! (list-drop-while (reverse l) pred)))
+  (reverse! (list-drop-while (reverse l) pred))
+) ;define-public
 
-(define-public (tm-string-trim-right s)	; srfi-13 (subset)
+(define-public (tm-string-trim-right s)
   "Remove whitespace at end of @s."
-  (list->string (list-drop-right-while (string->list s) tm-char-whitespace?)))
+  (list->string (list-drop-right-while (string->list s) tm-char-whitespace?))
+) ;define-public
 
-(define-public (tm-string-trim-both s)		; srfi-13 (subset)
+(define-public (tm-string-trim-both s)
   "Remove whitespace at start and end of @s."
-  (list->string
-   (list-drop-right-while
-    (list-drop-while (string->list s) tm-char-whitespace?)
-    tm-char-whitespace?)))
+  (list->string (list-drop-right-while (list-drop-while (string->list s) tm-char-whitespace?)
+                  tm-char-whitespace?
+                ) ;list-drop-right-while
+  ) ;list->string
+) ;define-public
 
-(provide-public (string-concatenate ss)	; srfi-13
+(provide-public (string-concatenate ss)
   "Append the elements of @ss toghether."
   ;; WARNING: not portable for long lists
-  (apply string-append ss))
+  (apply string-append ss)
+) ;provide-public
 
-(provide-public (string-map proc s) 		; srfi-13 (subset)
+(provide-public (string-map proc s)
   "Map @proc on every char of @s."
-  (list->string (map proc (string->list s))))
+  (list->string (map proc (string->list s)))
+) ;provide-public
 
-(provide-public (string-fold kons knil s) 	; srfi-13 (subset))
+(provide-public (string-fold kons knil s)
   "Fundamental string iterator."
-  (list-fold kons knil (string->list s)))
+  (list-fold kons knil (string->list s))
+) ;provide-public
 
-(provide-public (string-fold-right kons knil s) ; srfi-13 (subset)
+(provide-public (string-fold-right kons knil s)
   "Right to left fundamental string iterator."
-  (list-fold-right kons knil (string->list s)))
+  (list-fold-right kons knil (string->list s))
+) ;provide-public
 
 (define (string-split-lines/kons c cs+lines)
   (if (== c #\newline)
-      (cons '() cs+lines)
-      (cons (cons c (car cs+lines)) (cdr cs+lines))))
+    (cons '() cs+lines)
+    (cons (cons c (car cs+lines)) (cdr cs+lines))
+  ) ;if
+) ;define
 
 (define-public (string-split-lines s)
   "List of substrings of @s separated by newlines."
   (map list->string
-       (list-fold-right string-split-lines/kons '(()) (string->list s))))
+    (list-fold-right string-split-lines/kons '(()) (string->list s))
+  ) ;map
+) ;define-public
 
 (provide-public (string-tokenize-by-char s sep)
   "Cut string @s into pieces using @sep as a separator."
-  (with d (string-index s sep)
+  (with d
+    (string-index s sep)
     (if d
-	(cons (substring s 0 d)
-	      (string-tokenize-by-char (substring s (+ 1 d) (string-length s)) sep))
-	(list s))))
+      (cons (substring s 0 d)
+        (string-tokenize-by-char (substring s (+ 1 d) (string-length s)) sep)
+      ) ;cons
+      (list s)
+    ) ;if
+  ) ;with
+) ;provide-public
 
 (define-public (string-tokenize-by-char-n s sep n)
   "As @string-tokenize-by-char, but only cut first @n pieces"
-  (with d (string-index s sep)
+  (with d
+    (string-index s sep)
     (if (or (= n 0) (not d))
-	(list s)
-	(cons (substring s 0 d)
-	      (string-tokenize-by-char-n
-               (substring s (+ 1 d) (string-length s))
-               sep
-               (- n 1))))))
+      (list s)
+      (cons (substring s 0 d)
+        (string-tokenize-by-char-n (substring s (+ 1 d) (string-length s)) sep (- n 1))
+      ) ;cons
+    ) ;if
+  ) ;with
+) ;define-public
 
 (define-public (string-decompose s sep)
-  (with d (string-search-forwards sep 0 s)
+  (with d
+    (string-search-forwards sep 0 s)
     (if (< d 0)
-        (list s)
-        (cons (substring s 0 d)
-              (string-decompose (substring s (+ d (string-length sep))
-                                           (string-length s)) sep)))))
+      (list s)
+      (cons (substring s 0 d)
+        (string-decompose (substring s (+ d (string-length sep)) (string-length s)) sep)
+      ) ;cons
+    ) ;if
+  ) ;with
+) ;define-public
 
 (define-public (string-recompose l sep)
   "Turn list @l of strings into one string using @sep as separator."
   (if (char? sep) (set! sep (list->string (list sep))))
   (cond ((null? l) "")
-	((null? (cdr l)) (car l))
-	(else (string-append (car l) sep (string-recompose (cdr l) sep)))))
+        ((null? (cdr l)) (car l))
+        (else (string-append (car l) sep (string-recompose (cdr l) sep)))
+  ) ;cond
+) ;define-public
 
 (define-public (string-tokenize-comma s)
   "Cut string @s into pieces using comma as a separator and remove whitespace."
-  (map tm-string-trim-both (string-tokenize-by-char s #\,)))
+  (map tm-string-trim-both (string-tokenize-by-char s #\,))
+) ;define-public
 
 (define-public (string-recompose-comma l)
   "Turn list @l of strings into comma separated string."
-  (string-recompose l ", "))
+  (string-recompose l ", ")
+) ;define-public
 
 (define (property-pair->string p)
-  (string-append (car p) "=" (cdr p)))
+  (string-append (car p) "=" (cdr p))
+) ;define
 
 (define (string->property-pair s)
-  (with pos (string-index s #\=)
-    (if pos
-	(cons (string-take s pos) (string-drop s (+ pos 1)))
-	(cons s "true"))))
+  (with pos
+    (string-index s #\=)
+    (if pos (cons (string-take s pos) (string-drop s (+ pos 1))) (cons s "true"))
+  ) ;with
+) ;define
 
 (define-public (string->alist s)
   "Parse @s of the form \"var1=val1/.../varn=valn\" as an association list."
-  (map string->property-pair (string-tokenize-by-char s #\/)))
+  (map string->property-pair (string-tokenize-by-char s #\/))
+) ;define-public
 
 (define-public (alist->string l)
   "Pretty print the association list @l as a string."
-  (string-recompose (map property-pair->string l) "/"))
+  (string-recompose (map property-pair->string l) "/")
+) ;define-public
 
-(define-public (raw-quote s)
-  (string-append (string-append "\"" s "\"")))
+(define-public (raw-quote s) (string-append (string-append "\"" s "\"")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Some string-like functions on symbols
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (symbol<=? x y)
-  (string<=? (symbol->string x) (symbol->string y)))
+  (string<=? (symbol->string x) (symbol->string y))
+) ;define-public
 
 (define-public (symbol-starts? s1 s2)
-  (string-starts? (symbol->string s1) (symbol->string s2)))
+  (string-starts? (symbol->string s1) (symbol->string s2))
+) ;define-public
 
 (define-public (symbol-ends? s1 s2)
-  (string-ends? (symbol->string s1) (symbol->string s2)))
+  (string-ends? (symbol->string s1) (symbol->string s2))
+) ;define-public
 
 (define-public (symbol-drop s n)
-  (string->symbol (string-drop (symbol->string s) n)))
+  (string->symbol (string-drop (symbol->string s) n))
+) ;define-public
 
 (define-public (symbol-drop-right s n)
-  (string->symbol (string-drop-right (symbol->string s) n)))
+  (string->symbol (string-drop-right (symbol->string s) n))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Functions
@@ -242,11 +290,13 @@
 
 (define-public (compose g f)
   "Compose the functions @f and @g"
-  (lambda x (g (apply f x))))
+  (lambda x (g (apply f x)))
+) ;define-public
 
 (define-public (non pred?)
   "Return the negation of @pred?."
-  (lambda args (not (apply pred? args))))
+  (lambda args (not (apply pred? args)))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Objects
@@ -254,39 +304,46 @@
 
 (define-public (string->object s)
   "Parse @s and build scheme object"
-  (call-with-input-string s read))
+  (call-with-input-string s read)
+) ;define-public
 
 (define-public (object->string* obj)
   (cond ((null? obj) (object->string obj))
-	((pair? obj) (object->string obj))
-	((number? obj) (object->string obj))
-	((string? obj) (object->string obj))
-	((symbol? obj) (object->string obj))
-	((tree? obj) (object->string (tree->stree obj)))
-	(else (object->string #f))))
+        ((pair? obj) (object->string obj))
+        ((number? obj) (object->string obj))
+        ((string? obj) (object->string obj))
+        ((symbol? obj) (object->string obj))
+        ((tree? obj) (object->string (tree->stree obj)))
+        (else (object->string #f))
+  ) ;cond
+) ;define-public
 
 (define-public (func? x f . opts)
   "Is @x a list with first stree @f? Optionally test the length of @x."
   (let ((n (length opts)))
     (cond ((= n 0) (and (list? x) (nnull? x) (== (car x) f)))
-	  ((= n 1)
-	   (let ((nn (car opts)))
-             (and (list? x) (nnull? x)
-                  (== (car x) f) (= (length x) (+ nn 1)))))
-	  (else (error "Too many arguments.")))))
+          ((= n 1)
+           (let ((nn (car opts)))
+             (and (list? x) (nnull? x) (== (car x) f) (= (length x) (+ nn 1)))
+           ) ;let
+          ) ;
+          (else (error "Too many arguments."))
+    ) ;cond
+  ) ;let
+) ;define-public
 
 (define-public (tuple? x . opts)
   "Equivalent to @list? without options or to @func? otherwise"
-  (if (null? opts)
-      (list? x)
-      (apply func? (cons x opts))))
+  (if (null? opts) (list? x) (apply func? (cons x opts)))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Positions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (position-new . opts)
-  (position-new-path (if (null? opts) (cursor-path) (car opts))))
+  (position-new-path (if (null? opts) (cursor-path) (car opts)))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Urls
@@ -294,110 +351,115 @@
 
 (define-public (url->list u)
   (cond ((url-none? u) '())
-	((url-or? u) (append (url->list (url-ref u 1))
-			     (url->list (url-ref u 2))))
-	(else (list u))))
+        ((url-or? u) (append (url->list (url-ref u 1)) (url->list (url-ref u 2))))
+        (else (list u))
+  ) ;cond
+) ;define-public
 
 (define-public (list->url l)
   (cond ((null? l) (url-none))
-	((null? (cdr l)) (car l))
-	(else (url-or (car l) (list->url (cdr l))))))
+        ((null? (cdr l)) (car l))
+        (else (url-or (car l) (list->url (cdr l))))
+  ) ;cond
+) ;define-public
 
 (define-public (url-read-directory u wc)
-  (with d (url-expand (url-complete (url-append u (url-wildcard wc)) "r"))
-    (url->list d)))
+  (with d
+    (url-expand (url-complete (url-append u (url-wildcard wc)) "r"))
+    (url->list d)
+  ) ;with
+) ;define-public
 
-(define-public (url-remove u)
-  (system-remove u))
+(define-public (url-remove u) (system-remove u))
 
 (define-public (url-autosave u suf)
-  (and (not (url-rooted-web? u))
-       (not (url-rooted-tmfs? u))
-       (url-glue u suf)))
+  (and (not (url-rooted-web? u)) (not (url-rooted-tmfs? u)) (url-glue u suf))
+) ;define-public
 
-(define-public (url-wrap u)
-  #f)
+(define-public (url-wrap u) #f)
 
 (define-public (url->delta-unix u)
-  (with base (buffer-get-master (current-buffer))
+  (with base
+    (buffer-get-master (current-buffer))
     ;; Handle Windows drive letter issues - if different drives, return #f
     (cond ((and (or (os-mingw?) (os-win32?))
-                (!= (url-drive-letter u) (url-drive-letter base)))
-           #f)
-          ((and (url-rooted? u) (not (url-none? base)))
-           (url->unix (url-delta base u)))
-          (else (url->unix u)))))
+             (!= (url-drive-letter u) (url-drive-letter base))
+           ) ;and
+           #f
+          ) ;
+          ((and (url-rooted? u) (not (url-none? base))) (url->unix (url-delta base u)))
+          (else (url->unix u))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (first-in-path . l)
   (cond ((null? l) #f)
         ((url-exists-in-path? (car l)) (car l))
-        (else (apply first-in-path (cdr l)))))
+        (else (apply first-in-path (cdr l)))
+  ) ;cond
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Buffers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (current-buffer)
-  (with u (current-buffer-url)
-    (and (not (url-none? u)) u)))
+  (with u (current-buffer-url) (and (not (url-none? u)) u))
+) ;define-public
 
 (define-public (path->buffer p)
-  (with u (path-to-buffer p)
-    (and (not (url-none? u)) u)))
+  (with u (path-to-buffer p) (and (not (url-none? u)) u))
+) ;define-public
 
 (define-public (buffer->tree u)
-  (with t (buffer-get-body u)
-    (and (tree-active? t) t)))
+  (with t (buffer-get-body u) (and (tree-active? t) t))
+) ;define-public
 
-(define-public (tree->buffer t)
-  (and-with p (tree->path t)
-    (path->buffer p)))
+(define-public (tree->buffer t) (and-with p (tree->path t) (path->buffer p)))
 
 (define-public (buffer->path u)
-  (with t (buffer->tree u)
-    (and t (tree->path t))))
+  (with t (buffer->tree u) (and t (tree->path t)))
+) ;define-public
 
-(define-public (buffer-exists? name)
-  (in? (url->url name) (buffer-list)))
+(define-public (buffer-exists? name) (in? (url->url name) (buffer-list)))
 
-(define-public (buffer-master)
-  (buffer-get-master (current-buffer)))
+(define-public (buffer-master) (buffer-get-master (current-buffer)))
 
 (define-public (buffer-in-recent-menu? u)
-  (or (not (url-rooted-tmfs? u))
-      (string-starts? (url->unix u) "tmfs://part/")))
+  (or (not (url-rooted-tmfs? u)) (string-starts? (url->unix u) "tmfs://part/"))
+) ;define-public
 
 (define-public (buffer-in-menu? u)
   (or (buffer-in-recent-menu? u)
-      (string-starts? (url->unix u) "tmfs://help/")
-      (string-starts? (url->unix u) "tmfs://remote-file/")
-      (string-starts? (url->unix u) "tmfs://apidoc/")))
+    (string-starts? (url->unix u) "tmfs://help/")
+    (string-starts? (url->unix u) "tmfs://remote-file/")
+    (string-starts? (url->unix u) "tmfs://apidoc/")
+  ) ;or
+) ;define-public
 
 (define-public (window->buffer win)
-  (with u (window-to-buffer win)
-    (and (not (url-none? u)) u)))
+  (with u (window-to-buffer win) (and (not (url-none? u)) u))
+) ;define-public
 
 (define-public (buffer->window buf)
-  (with l (buffer->windows buf)
-    (and (nnull? l) (car l))))
+  (with l (buffer->windows buf) (and (nnull? l) (car l)))
+) ;define-public
 
 (define-public (current-view)
-  (with u (current-view-url)
-    (and (not (url-none? u)) u)))
+  (with u (current-view-url) (and (not (url-none? u)) u))
+) ;define-public
 
 (define-public (view->window vw)
-  (with win (view->window-url vw)
-    (and (not (url-none? win)) win)))
+  (with win (view->window-url vw) (and (not (url-none? win)) win))
+) ;define-public
 
 (define-public (view->window-of-tabpage vw)
-  (with win (view->window-of-tabpage-url vw)
-    (and (not (url-none? win)) win)))
+  (with win (view->window-of-tabpage-url vw) (and (not (url-none? win)) win))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Redirections
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (tm-with-output-to-string p)
-  (cout-buffer)
-  (p)
-  (cout-unbuffer))
+(define-public (tm-with-output-to-string p) (cout-buffer) (p) (cout-unbuffer))

--- a/TeXmacs/progs/kernel/library/content.scm
+++ b/TeXmacs/progs/kernel/library/content.scm
@@ -19,83 +19,89 @@
 
 (define-public (stree? x)
   (or (string? x)
-      (and (pair? x) (symbol? (car x))
-           (list? (cdr x)) (forall? stree? (cdr x)))))
+    (and (pair? x) (symbol? (car x)) (list? (cdr x)) (forall? stree? (cdr x)))
+  ) ;or
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for general content
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (tm-atomic? x)
-  (or (string? x)
-      (and (tree? x) (tree-atomic? x))))
+(define-public (tm-atomic? x) (or (string? x) (and (tree? x) (tree-atomic? x))))
 
 (define-public (tm-compound? x)
-  (or (pair? x)
-      (and (tree? x) (tree-compound? x))))
+  (or (pair? x) (and (tree? x) (tree-compound? x)))
+) ;define-public
 
 (define-public (tm-equal? x y)
-  (cond ((tree? x)
-	 (if (tree? y)
-	     (== x y)
-	     (tm-equal? (tree-explode x) y)))
-	((tree? y) (tm-equal? x (tree-explode y)))
-	((and (pair? x) (pair? y))
-	 (and (tm-equal? (car x) (car y))
-	      (tm-equal? (cdr x) (cdr y))))
-	(else (== x y))))
+  (cond ((tree? x) (if (tree? y) (== x y) (tm-equal? (tree-explode x) y)))
+        ((tree? y) (tm-equal? x (tree-explode y)))
+        ((and (pair? x) (pair? y))
+         (and (tm-equal? (car x) (car y)) (tm-equal? (cdr x) (cdr y)))
+        ) ;
+        (else (== x y))
+  ) ;cond
+) ;define-public
 
 (define-public (tm-length x)
   (cond ((string? x) (string-length x))
-	((list? x) (- (length x) 1))
-	((tree-atomic? x) (string-length (tree->string x)))
-	(else (tree-arity x))))
+        ((list? x) (- (length x) 1))
+        ((tree-atomic? x) (string-length (tree->string x)))
+        (else (tree-arity x))
+  ) ;cond
+) ;define-public
 
 (define-public (tm-arity x)
   (cond ((list? x) (- (length x) 1))
-	((string? x) 0)
-	(else (tree-arity x))))
+        ((string? x) 0)
+        (else (tree-arity x))
+  ) ;cond
+) ;define-public
 
 (define-public (tm->string x)
   (cond ((string? x) x)
         ((and (tree? x) (tree-atomic? x)) (tree->string x))
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define-public
 
-(define-public (tm->list x)
-  (if (list? x) x (tree->list x)))
+(define-public (tm->list x) (if (list? x) x (tree->list x)))
 
-(define-public (tm->stree t)
-  (tree->stree (tm->tree t)))
+(define-public (tm->stree t) (tree->stree (tm->tree t)))
 
-(define-public (tm-label x)
-  (if (pair? x) (car x) (tree-label x)))
+(define-public (tm-label x) (if (pair? x) (car x) (tree-label x)))
 
-(define-public (tm-car x)
-  (if (pair? x) (car x) (tree-label x)))
+(define-public (tm-car x) (if (pair? x) (car x) (tree-label x)))
 
-(define-public (tm-cdr x)
-  (cdr (if (pair? x) x (tree->list x))))
+(define-public (tm-cdr x) (cdr (if (pair? x) x (tree->list x))))
 
-(define-public (tm-children x)
-  (if (pair? x) (cdr x) (tree-children x)))
+(define-public (tm-children x) (if (pair? x) (cdr x) (tree-children x)))
 
 (define-public (tm-range x from to)
   (cond ((string? x) (substring x from to))
-	((list? x) (cons (car x) (sublist (cdr x) from to)))
-	((tree-atomic? x) (substring (tm->string x) from to))
-	(else (cons (tm-car x) (sublist (tm-cdr x) from to)))))
+        ((list? x) (cons (car x) (sublist (cdr x) from to)))
+        ((tree-atomic? x) (substring (tm->string x) from to))
+        (else (cons (tm-car x) (sublist (tm-cdr x) from to)))
+  ) ;cond
+) ;define-public
 
 (define-public (tm-func? x . args)
   (or (and (list? x) (apply func? (cons x args)))
-      (and (compound-tree? x) (apply func? (cons (tree->list x) args)))))
+    (and (compound-tree? x) (apply func? (cons (tree->list x) args)))
+  ) ;or
+) ;define-public
 
 (define-public (tm-is? x lab)
   (or (and (pair? x) (== (car x) lab))
-      (and (compound-tree? x) (== (tree-label x) lab))))
+    (and (compound-tree? x) (== (tree-label x) lab))
+  ) ;or
+) ;define-public
 
 (define-public (tm-in? x l)
   (or (and (pair? x) (in? (car x) l))
-      (and (compound-tree? x) (in? (tree-label x) l))))
+    (and (compound-tree? x) (in? (tree-label x) l))
+  ) ;or
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Searching for certain subtrees
@@ -105,32 +111,35 @@
   "Find first subtree which matches predicate."
   (cond ((pred? t) t)
         ((tm-atomic? t) #f)
-        (else (list-find (tm-children t) (cut tm-find <> pred?)))))
+        (else (list-find (tm-children t) (cut tm-find <> pred?)))
+  ) ;cond
+) ;define-public
 
 (define-public (tm-search t pred?)
   "Search list of subtrees which match a predicate."
   (cond ((pred? t) (list t))
         ((tm-atomic? t) (list))
-        (else (append-map (cut tm-search <> pred?) (tm-children t)))))
+        (else (append-map (cut tm-search <> pred?) (tm-children t)))
+  ) ;cond
+) ;define-public
 
-(define-public (tm-find-tag t tag)
-  (tm-find t (cut tm-is? <> tag)))
+(define-public (tm-find-tag t tag) (tm-find t (cut tm-is? <> tag)))
 
-(define-public (tm-search-tag t tag)
-  (tm-search t (cut tm-is? <> tag)))
+(define-public (tm-search-tag t tag) (tm-search t (cut tm-is? <> tag)))
 
 (define (tm-replace-sub t what? by)
   (cond ((what? t) (by t))
         ((tm-atomic? t) t)
-        (else `(,(tm-car t)
-                ,@(map (cut tm-replace-sub <> what? by) (tm-cdr t))))))
+        (else `(,(tm-car t) ,@(map (cut tm-replace-sub <> what? by) (tm-cdr t))))
+  ) ;cond
+) ;define
 
 (define-public (tm-replace t what by)
-  (cond ((not (procedure? what))
-         (tm-replace t (lambda (x) (tm-equal? x what)) by))
-        ((not (procedure? by))
-         (tm-replace t what (lambda (x) by)))
-        (else (tm-replace-sub t what by))))
+  (cond ((not (procedure? what)) (tm-replace t (lambda (x) (tm-equal? x what)) by))
+        ((not (procedure? by)) (tm-replace t what (lambda (x) by)))
+        (else (tm-replace-sub t what by))
+  ) ;cond
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TeXmacs lengths
@@ -138,76 +147,96 @@
 
 (define-public (tm-length-unit-search s pos)
   (cond ((nstring? s) #f)
-	((>= pos (string-length s)) #f)
-	((char-alphabetic? (string-ref s pos)) pos)
-	((== (string-ref s pos) #\%) pos)
-	(else (tm-length-unit-search s (+ pos 1)))))
+        ((>= pos (string-length s)) #f)
+        ((char-alphabetic? (string-ref s pos)) pos)
+        ((== (string-ref s pos) #\%) pos)
+        (else (tm-length-unit-search s (+ pos 1)))
+  ) ;cond
+) ;define-public
 
 (define-public (tm-make-length val unit)
-  (string-append (number->string val) unit))
+  (string-append (number->string val) unit)
+) ;define-public
 
 (define-public (tm-length? s)
   (if (tree? s)
-      (and (tree-atomic? s) (tm-length? (tree->string s)))
-      (and-with pos (tm-length-unit-search s 0)
-	(let ((s1 (substring s 0 pos))
-	      (s2 (substring s pos (string-length s))))
-	  (and (string-number? s1)
-	       (or (string-locase-alpha? s2) (== s2 "%")))))))
+    (and (tree-atomic? s) (tm-length? (tree->string s)))
+    (and-with pos
+      (tm-length-unit-search s 0)
+      (let ((s1 (substring s 0 pos)) (s2 (substring s pos (string-length s))))
+        (and (string-number? s1) (or (string-locase-alpha? s2) (== s2 "%")))
+      ) ;let
+    ) ;and-with
+  ) ;if
+) ;define-public
 
 (define-public (tm-length-value s)
   (if (tree? s)
-      (and (tree-atomic? s) (tm-length-value (tree->string s)))
-      (and-with pos (tm-length-unit-search s 0)
-	(string->number (substring s 0 pos)))))
+    (and (tree-atomic? s) (tm-length-value (tree->string s)))
+    (and-with pos (tm-length-unit-search s 0) (string->number (substring s 0 pos)))
+  ) ;if
+) ;define-public
 
 (define-public (tm-length-unit s)
   (if (tree? s)
-      (and (tree-atomic? s) (tm-length-unit (tree->string s)))
-      (and-with pos (tm-length-unit-search s 0)
-	(substring s pos (string-length s)))))
+    (and (tree-atomic? s) (tm-length-unit (tree->string s)))
+    (and-with pos (tm-length-unit-search s 0) (substring s pos (string-length s)))
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Collections
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (associate->binding t)
-  (and (tm-func? t 'associate 2)
-       (cons (cadr t) (caddr t))))
+  (and (tm-func? t 'associate 2) (cons (cadr t) (caddr t)))
+) ;define-public
 
 (define-public (collection->assoc col)
   (and (tm-func? col 'collection)
-       (with c (tm-children (tm->stree col))
-         (list-filter (map associate->binding c) identity))))
+    (with c
+      (tm-children (tm->stree col))
+      (list-filter (map associate->binding c) identity)
+    ) ;with
+  ) ;and
+) ;define-public
 
 (define-public (collection-ref col key)
-  (and-with l (collection->assoc col)
-    (assoc-ref l key)))
+  (and-with l (collection->assoc col) (assoc-ref l key))
+) ;define-public
 
 (define-public (collection-set col key val)
-  (and-with l (collection->assoc col)
+  (and-with l
+    (collection->assoc col)
     (set! l (assoc-set! l key val))
-    (assoc->collection l)))
+    (assoc->collection l)
+  ) ;and-with
+) ;define-public
 
-(define-public (binding->associate b)
-  `(associate ,(car b) ,(cdr b)))
+(define-public (binding->associate b) `(associate ,(car b) ,(cdr b)))
 
-(define-public (assoc->collection l)
-  `(collection ,@(map binding->associate l)))
+(define-public (assoc->collection l) `(collection ,@(map binding->associate l)))
 
 (define-public (collection-append c1 c2)
   (let* ((a1 (collection->assoc c1))
          (a2 (collection->assoc c2))
-         (a  (and a1 a2 (assoc-remove-duplicates* (append a1 a2)))))
-    (and a1 a2 (assoc->collection a))))
+         (a (and a1 a2 (assoc-remove-duplicates* (append a1 a2))))
+        ) ;
+    (and a1 a2 (assoc->collection a))
+  ) ;let*
+) ;define-public
 
 (define-public (collection-delta c1 c2)
   (let* ((a1 (collection->assoc c1))
          (a2 (collection->assoc c2))
-         (a  (and a1 a2 (assoc-delta a1 a2))))
-    (and a1 a2 (assoc->collection a))))
+         (a (and a1 a2 (assoc-delta a1 a2)))
+        ) ;
+    (and a1 a2 (assoc->collection a))
+  ) ;let*
+) ;define-public
 
 (define-public (collection-exclude c l)
-  (let* ((a (collection->assoc c))
-         (b (and a (assoc-exclude a l))))
-    (and a (assoc->collection b))))
+  (let* ((a (collection->assoc c)) (b (and a (assoc-exclude a l))))
+    (and a (assoc->collection b))
+  ) ;let*
+) ;define-public

--- a/TeXmacs/progs/kernel/library/iterator.scm
+++ b/TeXmacs/progs/kernel/library/iterator.scm
@@ -19,36 +19,45 @@
 
 (define-macro (iterator val next)
   "Primitive iterator constructor from value @val and next iterator @next."
-  `(lambda () (cons ,val ,next)))
+  `(lambda ,() (cons ,val ,next))
+) ;define-macro
 
 (define-public (range start end)
   "Range iterator from @start to @end (not included)."
-  (and (< start end)
-       (iterator start (range (+ start 1) end))))
+  (and (< start end) (iterator start (range (+ start 1) end)))
+) ;define-public
 
 (define-public (list->iterator l)
   "Convert the list @l to an iterator."
-  (and (nnull? l)
-       (iterator (car l) (list->iterator (cdr l)))))
+  (and (nnull? l) (iterator (car l) (list->iterator (cdr l))))
+) ;define-public
 
 (define-public (iterator-append . its)
   "Append the iterators @its."
   (cond ((null? its) #f)
-	((not (car its)) (apply iterator-append (cdr its)))
-	(else (let* ((next ((car its)))
-		     (cont (cons (cdr next) (cdr its))))
-		(iterator (car next) (apply iterator-append cont))))))
+        ((not (car its)) (apply iterator-append (cdr its)))
+        (else (let* ((next ((car its))) (cont (cons (cdr next) (cdr its))))
+                (iterator (car next) (apply iterator-append cont))
+              ) ;let*
+        ) ;else
+  ) ;cond
+) ;define-public
 
 (define-public (iterator-filter it pred?)
   "Get elements in iterator @it which match the predicate @pred?."
-  (with next #f
+  (with next
+    #f
     (while (and it (begin (set! next (it)) (not (pred? (car next)))))
-      (set! it (cdr next)))
-    (and it (lambda () next))))
+      (set! it (cdr next))
+    ) ;while
+    (and it (lambda () next))
+  ) ;with
+) ;define-public
 
 (define-public-macro (extract var it prop?)
   "Extract all values @var from iterator @it which match the property @prop?."
-  `(iterator-filter ,it (lambda (,var) ,prop?)))
+  `(iterator-filter ,it (lambda (,var) ,prop?))
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Traversal of iterators
@@ -56,34 +65,31 @@
 
 (define-public (iterator-value it)
   "Get current value of iterator @it."
-  (and it (car (it))))
+  (and it (car (it)))
+) ;define-public
 
 (define-public (iterator-next it)
   "Get next iterator after @it."
-  (and it (cdr (it))))
+  (and it (cdr (it)))
+) ;define-public
 
 (define-public-macro (iterator-read! it)
   "Read one value from iterator @it."
-  `(and ,it
-	(with next (,it)
-	  (set! ,it (cdr next))
-	  (car next))))
+  `(and ,it (with next (,it) (set! ,it (cdr next)) (car next)))
+) ;define-public-macro
 
 (define-public (iterator-apply it fun)
-  (while it
-    (with next (it)
-      (fun (car next))
-      (set! it (cdr next)))))
+  (while it (with next (it) (fun (car next)) (set! it (cdr next))))
+) ;define-public
 
 (define-public-macro (for-in var-it . body)
   "Execute @body for values in an iterator."
-  (let* ((var (car var-it))
-	 (it (cadr var-it))
-	 (fun `(lambda (,var) ,@body)))
-    `(iterator-apply ,it ,fun)))
+  (let* ((var (car var-it)) (it (cadr var-it)) (fun `(lambda (,var) ,@body)))
+    `(iterator-apply ,it ,fun)
+  ) ;let*
+) ;define-public-macro
 
 (define-public (iterator->list it)
   "Convert iterator @it into a list."
-  (if (not it) '()
-      (with next (it)
-	(cons (car next) (iterator->list (cdr next))))))
+  (if (not it) '() (with next (it) (cons (car next) (iterator->list (cdr next)))))
+) ;define-public

--- a/TeXmacs/progs/kernel/library/list.scm
+++ b/TeXmacs/progs/kernel/library/list.scm
@@ -21,152 +21,144 @@
   "Construct a list from head of several elements and a tail."
   ;; This function is in the kernel since GUILE-1.4.0
   (let ((r (reverse l)))
-    (append (reverse (cdr r)) (car r))))
+    (append (reverse (cdr r)) (car r))
+  ) ;let
+) ;provide-public
 
-(define-public (rcons l x)
-  "Append @x to @l at the end."
-  (append l (list x)))
+(define-public (rcons l x) "Append @x to @l at the end." (append l (list x)))
 
 (define-public (rcons* l . xs)
   "Append several elements @xs to @l at the end."
-  (append l xs))
+  (append l xs)
+) ;define-public
 
-(define-public-macro (set-cons! sym x)
-  `(set! ,sym (cons ,x ,sym)))
+(define-public-macro (set-cons! sym x) `(set! ,sym (cons ,x ,sym)))
 
-(define-public-macro (set-rcons! sym x)
-  `(set! ,sym (rcons ,sym ,x)))
+(define-public-macro (set-rcons! sym x) `(set! ,sym (rcons ,sym ,x)))
 
 (define-public (list-concatenate ls)
   "Append the elements of @ls toghether."
   ;; WARNING: not portable for long lists
-  (apply append ls))
+  (apply append ls)
+) ;define-public
 
 (define-public (list-intersperse l x)
   "Insert @x between each element of @l."
-  (if (null? l) '()
-      (cdr (list-fold-right (lambda (kar kdr) (cons* x kar kdr)) '() l))))
+  (if (null? l)
+    '()
+    (cdr (list-fold-right (lambda (kar kdr) (cons* x kar kdr)) '() l))
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Selectors
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(provide-public (first l)
-  "Get first element of @l."
-  (car l))
+(provide-public (first l) "Get first element of @l." (car l))
 
-(provide-public (second l)
-  "Get second element of @l."
-  (cadr l))
+(provide-public (second l) "Get second element of @l." (cadr l))
 
-(provide-public (third l)
-  "Get third element of @l."
-  (caddr l))
+(provide-public (third l) "Get third element of @l." (caddr l))
 
-(provide-public (fourth l)
-  "Get first element of @l."
-  (cadddr l))
+(provide-public (fourth l) "Get first element of @l." (cadddr l))
 
-(provide-public (fifth l)
-  "Get fifth element of @l."
-  (car (cddddr l)))
+(provide-public (fifth l) "Get fifth element of @l." (car (cddddr l)))
 
-(provide-public (sixth l)
-  "Get sixth element of @l."
-  (cadr (cddddr l)))
+(provide-public (sixth l) "Get sixth element of @l." (cadr (cddddr l)))
 
-(provide-public (seventh l)
-  "Get seventh element of @l."
-  (caddr (cddddr l)))
+(provide-public (seventh l) "Get seventh element of @l." (caddr (cddddr l)))
 
-(provide-public (eighth l)
-  "Get eighht element of @l."
-  (cadddr (cddddr l)))
+(provide-public (eighth l) "Get eighht element of @l." (cadddr (cddddr l)))
 
-(provide-public (ninth l)
-  "Get ninth element of @l."
-  (car (cddddr (cddddr l))))
+(provide-public (ninth l) "Get ninth element of @l." (car (cddddr (cddddr l))))
 
-(provide-public (tenth l)
-  "Get tenth element of @l."
-  (cadr (cddddr (cddddr l))))
+(provide-public (tenth l) "Get tenth element of @l." (cadr (cddddr (cddddr l))))
 
-(define-public (cAr l)
-  "Get last element of @l."
-  (car (last-pair l)))
+(define-public (cAr l) "Get last element of @l." (car (last-pair l)))
 
 (define-public (cDr l)
   "Remove last element from @l."
-  (reverse (cdr (reverse l))))
+  (reverse (cdr (reverse l)))
+) ;define-public
 
-(define-public (cADr l)
-  "Get before last element of @l."
-  (cadr (reverse l)))
+(define-public (cADr l) "Get before last element of @l." (cadr (reverse l)))
 
 (define-public (cDDr l)
   "Remove two last elements from @l"
-  (reverse (cddr (reverse l))))
+  (reverse (cddr (reverse l)))
+) ;define-public
 
 (define-public (cDDDr l)
   "Remove two last elements from @l"
-  (reverse (cdddr (reverse l))))
+  (reverse (cdddr (reverse l)))
+) ;define-public
 
-(define-public (cDdr l)
-  "Remove first and last elements from @l"
-  (cDr (cdr l)))
+(define-public (cDdr l) "Remove first and last elements from @l" (cDr (cdr l)))
 
 (define-public (cDddr l)
   "Remove two first and last elements from @l"
-  (cDr (cddr l)))
+  (cDr (cddr l))
+) ;define-public
 
 (define-public (cdAr l)
   "All but the first element of the last element of @l"
-  (cdr (cAr l)))
+  (cdr (cAr l))
+) ;define-public
 
 (define-public last cAr)
 (define-public but-last cDr)
 
 (provide-public (car+cdr p)
   "Fundamental pair deconstructor."
-  (values (car p) (cdr p)))
+  (values (car p) (cdr p))
+) ;provide-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extraction of sublists
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (list-head lis k)
-;  (check-arg integer? k take)
-  (let recur ((lis lis) (k k))
-    (if (zero? k) '()
-    (cons (car lis)
-          (recur (cdr lis) (- k 1))))))
+  (let recur
+    ((lis lis) (k k))
+    (if (zero? k) '() (cons (car lis) (recur (cdr lis) (- k 1))))
+  ) ;let
+) ;define-public
 
 (define-public (list-tail lis k)
-;  (check-arg integer? k drop)
-  (let iter ((lis lis) (k k))
-    (if (zero? k) lis (iter (cdr lis) (- k 1)))))
+  (let iter
+    ((lis lis) (k k))
+    (if (zero? k) lis (iter (cdr lis) (- k 1)))
+  ) ;let
+) ;define-public
 
 
-(define-public list-take list-head) ;; SRFI-1
-(define-public list-drop list-tail) ;; SRFI-1
+(define-public list-take list-head)
+;; SRFI-1
+(define-public list-drop list-tail)
+;; SRFI-1
 
 (define-public (list-take-right l i)
   "Return the last @i elements of @l."
-  (list-tail l (- (length l) i)))
+  (list-tail l (- (length l) i))
+) ;define-public
 
 (define-public (list-drop-right l i)
   "Return all but the last @i elements of @l."
-  (list-head l (- (length l) i)))
+  (list-head l (- (length l) i))
+) ;define-public
 
 (define-public (sublist l i j)
   "Extract sublist from @l beginning at @i and ending at @j."
-  (list-head (list-tail l i) (- j i)))
+  (list-head (list-tail l i) (- j i))
+) ;define-public
 
 (define-public (list-delete l x)
   "Remove all occurrences of @x from list @l."
   (cond ((null? l) l)
         ((== (car l) x) (list-delete (cdr l) x))
-        (else (cons (car l) (list-delete (cdr l) x)))))
+        (else (cons (car l) (list-delete (cdr l) x)))
+  ) ;cond
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Circulating lists
@@ -174,8 +166,11 @@
 
 (define-public (list-circulate-right l n)
   "Right circular shift of @n steps on @l."
-  (if (= n 1) (cons (last l) (but-last l))
-      (append (list-take-right l n) (list-drop-right l n))))
+  (if (= n 1)
+    (cons (last l) (but-last l))
+    (append (list-take-right l n) (list-drop-right l n))
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Fold, unfold & map
@@ -184,56 +179,82 @@
 (define-public (list-fold kons knil list1 . rest)
   "Fundamental list iterator."
   (if (null? rest)
-      (let f ((knil knil) (list1 list1))
-	(if (null? list1)
-	    knil
-	    (f (kons (car list1) knil) (cdr list1))))
-      (let f ((knil knil) (lists (cons list1 rest)))
-	(if (list-any null? lists)
-	    knil
-	    (let ((cars (map-in-order car lists))
-		  (cdrs (map-in-order cdr lists)))
-	      (f (apply kons (append! cars (list knil))) cdrs))))))
+    (let f
+      ((knil knil) (list1 list1))
+      (if (null? list1) knil (f (kons (car list1) knil) (cdr list1)))
+    ) ;let
+    (let f
+      ((knil knil) (lists (cons list1 rest)))
+      (if (list-any null? lists)
+        knil
+        (let ((cars (map-in-order car lists)) (cdrs (map-in-order cdr lists)))
+          (f (apply kons (append! cars (list knil))) cdrs)
+        ) ;let
+      ) ;if
+    ) ;let
+  ) ;if
+) ;define-public
 
 (define-public (list-fold-right kons knil clist1 . rest)
   "Fundamental list recursion operator."
   (if (null? rest)
-      (let f ((list1 clist1))
-	(if (null? list1) knil
-	    (kons (car list1) (f (cdr list1)))))
-      (let f ((lists (cons clist1 rest)))
-	(if (list-any null? lists) knil
-	    (apply kons (append! (map-in-order car lists)
-				 (list (f (map-in-order cdr lists)))))))))
+    (let f
+      ((list1 clist1))
+      (if (null? list1) knil (kons (car list1) (f (cdr list1))))
+    ) ;let
+    (let f
+      ((lists (cons clist1 rest)))
+      (if (list-any null? lists)
+        knil
+        (apply kons
+          (append! (map-in-order car lists) (list (f (map-in-order cdr lists))))
+        ) ;apply
+      ) ;if
+    ) ;let
+  ) ;if
+) ;define-public
 
 (provide-public (pair-fold kons knil clist1 . rest)
   "Analogous to @fold but applies @kons to pairs of @clist1..."
   (if (null? rest)
-      (let f ((knil knil) (list1 clist1))
-	(if (null? list1) knil
-	    (let ((tail (cdr list1)))
-	      (f (kons list1 knil) tail))))
-      (let f ((knil knil) (lists (cons clist1 rest)))
-	(if (list-any null? lists) knil
-	    (let ((tails (map-in-order cdr lists)))
-	      (f (apply kons (append! lists (list knil))) tails))))))
+    (let f
+      ((knil knil) (list1 clist1))
+      (if (null? list1) knil (let ((tail (cdr list1))) (f (kons list1 knil) tail)))
+    ) ;let
+    (let f
+      ((knil knil) (lists (cons clist1 rest)))
+      (if (list-any null? lists)
+        knil
+        (let ((tails (map-in-order cdr lists)))
+          (f (apply kons (append! lists (list knil))) tails)
+        ) ;let
+      ) ;if
+    ) ;let
+  ) ;if
+) ;provide-public
 
 (define-public (pair-fold-right kons knil clist1 . rest)
   "Analogous to @fold-right but applies @kons to pairs of @clist1..."
   (if (null? rest)
-    (let f ((list1 clist1))
-      (if (null? list1)
-	knil
-	(kons list1 (f (cdr list1)))))
-    (let f ((lists (cons clist1 rest)))
+    (let f
+      ((list1 clist1))
+      (if (null? list1) knil (kons list1 (f (cdr list1))))
+    ) ;let
+    (let f
+      ((lists (cons clist1 rest)))
       (if (list-any null? lists)
-	knil
-	(apply kons (append! lists (list (f (map-in-order cdr lists)))))))))
+        knil
+        (apply kons (append! lists (list (f (map-in-order cdr lists)))))
+      ) ;if
+    ) ;let
+  ) ;if
+) ;define-public
 
 (provide-public (append-map . params)
   "Apply @f to all elements of @l and append the resulting lists."
   ;; WARNING: not portable for long lists
-  (apply append (apply map-in-order params)))
+  (apply append (apply map-in-order params))
+) ;provide-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Filtering & partitioning
@@ -241,68 +262,95 @@
 
 (define-public (list-filter l pred?)
   "Return the list of elements from @l which match @pred?."
-  (apply append (map (lambda (x) (if (pred? x) (list x) (list))) l)))
+  (apply append (map (lambda (x) (if (pred? x) (list x) (list))) l))
+) ;define-public
 
 (provide-public (filter-map fun . args)
   "Composition of @map and @list-filter."
-  (list-filter (apply map (cons fun args)) identity))
+  (list-filter (apply map (cons fun args)) identity)
+) ;provide-public
 
 (define-public (list-partition l pred?)
   "Partition a @l into two parts according to @pred?."
-  (let rec ((l l))
+  (let rec
+    ((l l))
     (cond ((null? l) (values '() '()))
-	  ((pred? (car l)) (receive (in out) (rec (cdr l))
-			     (values (cons (car l) in) out)))
-	  (else (receive (in out) (rec (cdr l))
-		  (values in (cons (car l) out)))))))
+          ((pred? (car l))
+           (receive (in out) (rec (cdr l)) (values (cons (car l) in) out))
+          ) ;
+          (else (receive (in out) (rec (cdr l)) (values in (cons (car l) out))))
+    ) ;cond
+  ) ;let
+) ;define-public
 
 (define-public (list-break l pred?)
   "Break @l at the first element satisfying @pred?."
   ;; Adaptation of "break" (SRFI-26)
-  (let rec ((l l))
+  (let rec
+    ((l l))
     (cond ((null? l) (values '() '()))
-	  ((pred? (car l)) (values '() l))
-	  (else (receive (first last) (rec (cdr l))
-		  (values (cons (car l) first) last))))))
+          ((pred? (car l)) (values '() l))
+          (else (receive (first last) (rec (cdr l)) (values (cons (car l) first) last)))
+    ) ;cond
+  ) ;let
+) ;define-public
 
 (define-public (list-span l pred?)
   "Break @l at the first element not satisfying @pred?."
-  (list-break l (non pred?)))
+  (list-break l (non pred?))
+) ;define-public
 
 (define-public (list-drop-while l pred?)
   "Drop the first elements of @l while @pred? is satisfied."
-  (let next ((l l))
+  (let next
+    ((l l))
     (cond ((null? l) '())
-	  ((pred? (car l)) (next (cdr l)))
-	  (else l))))
+          ((pred? (car l)) (next (cdr l)))
+          (else l)
+    ) ;cond
+  ) ;let
+) ;define-public
 
 (define-public (list-scatter l pred? keep?)
   "Break @l in list of sublists at points satisfying @pred?."
-  (receive (head tail) (list-break l pred?)
-    (if (null? tail) (list head)
-	(with r (list-scatter (cdr tail) pred? keep?)
-	  (if keep?
-	      (cons* head (cons (car tail) (car r)) (cdr r))
-	      (cons head r))))))
+  (receive (head tail)
+    (list-break l pred?)
+    (if (null? tail)
+      (list head)
+      (with r
+        (list-scatter (cdr tail) pred? keep?)
+        (if keep? (cons* head (cons (car tail) (car r)) (cdr r)) (cons head r))
+      ) ;with
+    ) ;if
+  ) ;receive
+) ;define-public
 
 (define-public (list->assoc l)
   "Group entries of list @l two by two and construct association list"
-  (if (or (null? l) (null? (cdr l))) (list)
-      (cons (cons (car l) (cadr l)) (list->assoc (cddr l)))))
+  (if (or (null? l) (null? (cdr l)))
+    (list)
+    (cons (cons (car l) (cadr l)) (list->assoc (cddr l)))
+  ) ;if
+) ;define-public
 
 (define-public (assoc->list l)
   "intersperse all keys and values in @l into a flat list"
-  (append-map (lambda (x) (list (car x) (cdr x))) l))
+  (append-map (lambda (x) (list (car x) (cdr x))) l)
+) ;define-public
 
 (define-public (forall? pred? l)
   (cond ((null? l) #t)
-	((not (pred? (car l))) #f)
-	(else (forall? pred? (cdr l)))))
+        ((not (pred? (car l))) #f)
+        (else (forall? pred? (cdr l)))
+  ) ;cond
+) ;define-public
 
 (define-public (exists? pred? l)
   (cond ((null? l) #f)
-	((pred? (car l)) (pred? (car l)))
-	(else (exists? pred? (cdr l)))))
+        ((pred? (car l)) (pred? (car l)))
+        (else (exists? pred? (cdr l)))
+  ) ;cond
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Search and replace
@@ -310,124 +358,160 @@
 
 (define-public (list-find l pred?)
   "Applies @pred? on elements of @l until it evaluates to true."
-  (let next ((l l))
-    (if (null? l)
-        #f
-        (if (pred? (car l))
-            (car l)
-            (next (cdr l))))))
+  (let next
+    ((l l))
+    (if (null? l) #f (if (pred? (car l)) (car l) (next (cdr l))))
+  ) ;let
+) ;define-public
 
 (define-public (list-find-index l pred?)
   "Find first index in @l which matches @pred"
-  (let find ((l l) (i 0))
+  (let find
+    ((l l) (i 0))
     (cond ((null? l) #f)
-	  ((pred? (car l)) i)
-	  (else (find (cdr l) (+ i 1))))))
+          ((pred? (car l)) i)
+          (else (find (cdr l) (+ i 1)))
+    ) ;cond
+  ) ;let
+) ;define-public
 
 ;; Internal helper.
+
 (define (any1 pred? ls)
-  (if (null? ls) #f (or (pred? (car ls)) (any1 pred? (cdr ls)))))
+  (if (null? ls) #f (or (pred? (car ls)) (any1 pred? (cdr ls))))
+) ;define
 
 (define-public (list-any pred? ls . lists)
   "Applies @pred? on elements of @ls until it evaluates to true."
   ;; FIXME: pred? and ls should be interchanged
-  (if (null? lists) (any1 pred? ls)
-      (let lp ((lists (cons ls lists)))
-	(cond ((any1 null? lists) #f)
-	      ((any1 null? (map-in-order cdr lists))
-	       (apply pred? (map-in-order car lists)))
-	      (else (or (apply pred? (map-in-order car lists))
-			(lp (map-in-order cdr lists))))))))
+  (if (null? lists)
+    (any1 pred? ls)
+    (let lp
+      ((lists (cons ls lists)))
+      (cond ((any1 null? lists) #f)
+            ((any1 null? (map-in-order cdr lists)) (apply pred? (map-in-order car lists)))
+            (else (or (apply pred? (map-in-order car lists)) (lp (map-in-order cdr lists))))
+      ) ;cond
+    ) ;let
+  ) ;if
+) ;define-public
 
 ;; Internal helper.
+
 (define (every1 pred? ls)
-  (if (null? ls) #t (and (pred? (car ls)) (every1 pred? (cdr ls)))))
+  (if (null? ls) #t (and (pred? (car ls)) (every1 pred? (cdr ls))))
+) ;define
 
 (define-public (list-every pred? ls . lists)
   "Applies @pred? on elements of @ls until it evaluates to @#f."
   ;; FIXME: pred? and ls should be interchanged
-  (if (null? lists) (every1 pred? ls)
-      (let lp ((lists (cons ls lists)))
-	(cond ((any1 null? lists) #t)
-	      ((any1 null? (map-in-order cdr lists))
-	       (apply pred? (map-in-order car lists)))
-	      (else (and (apply pred? (map-in-order car lists))
-			 (lp (map-in-order cdr lists))))))))
+  (if (null? lists)
+    (every1 pred? ls)
+    (let lp
+      ((lists (cons ls lists)))
+      (cond ((any1 null? lists) #t)
+            ((any1 null? (map-in-order cdr lists)) (apply pred? (map-in-order car lists)))
+            (else (and (apply pred? (map-in-order car lists)) (lp (map-in-order cdr lists)))
+            ) ;else
+      ) ;cond
+    ) ;let
+  ) ;if
+) ;define-public
 
 (define-public (list-starts? l what)
   "Test whether @what is a prefix of @l."
   (cond ((null? what) #t)
-	((null? l) #f)
-	(else (and (== (car l) (car what))
-		   (list-starts? (cdr l) (cdr what))))))
+        ((null? l) #f)
+        (else (and (== (car l) (car what)) (list-starts? (cdr l) (cdr what))))
+  ) ;cond
+) ;define-public
 
 (define-public (list-replace l what by)
   "Replace @what by @by in @l."
   (cond ((null? l) l)
-	((list-starts? l what)
-	 (let ((tail (list-tail l (length what))))
-	   (append by (list-replace tail what by))))
-	(else (cons (car l) (list-replace (cdr l) what by)))))
+        ((list-starts? l what)
+         (let ((tail (list-tail l (length what))))
+           (append by (list-replace tail what by))
+         ) ;let
+        ) ;
+        (else (cons (car l) (list-replace (cdr l) what by)))
+  ) ;cond
+) ;define-public
 
 (define-public (list-common-left l1 l2)
   "Length of maximal common list on the left."
-  (if (or (npair? l1) (npair? l2) (!= (car l1) (car l2))) 0
-      (+ (list-common-left (cdr l1) (cdr l2)) 1)))
+  (if (or (npair? l1) (npair? l2) (!= (car l1) (car l2)))
+    0
+    (+ (list-common-left (cdr l1) (cdr l2)) 1)
+  ) ;if
+) ;define-public
 
 (define-public (list-common-right l1 l2)
   "Length of maximal common list on the right."
-  (list-common-left (reverse l1) (reverse l2)))
+  (list-common-left (reverse l1) (reverse l2))
+) ;define-public
 
 (define-public (list-common l1 l2)
   "Largest common sublist of @l1 and @l2."
-  (if (or (npair? l1) (npair? l2) (!= (car l1) (car l2))) (list)
-      (cons (car l1) (list-common (cdr l1) (cdr l2)))))
+  (if (or (npair? l1) (npair? l2) (!= (car l1) (car l2)))
+    (list)
+    (cons (car l1) (list-common (cdr l1) (cdr l2)))
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Set operations on lists
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (list-remove l x)
-  (list-filter l (lambda (y) (!= x y))))
+(define-public (list-remove l x) (list-filter l (lambda (y) (!= x y))))
 
 (define (list-remove-duplicates-sub t l)
   (cond ((null? l) l)
-	((ahash-ref t (car l)) (list-remove-duplicates-sub t (cdr l)))
-	(else
-	 (ahash-set! t (car l) #t)
-	 (cons (car l) (list-remove-duplicates-sub t (cdr l))))))
+        ((ahash-ref t (car l)) (list-remove-duplicates-sub t (cdr l)))
+        (else (ahash-set! t (car l) #t)
+          (cons (car l) (list-remove-duplicates-sub t (cdr l)))
+        ) ;else
+  ) ;cond
+) ;define
 
 (define-public (list-remove-duplicates l)
-  (with t (make-ahash-table)
-    (list-remove-duplicates-sub t l)))
+  (with t (make-ahash-table) (list-remove-duplicates-sub t l))
+) ;define-public
 
-(define-public (ahash-set->list s)
-  (map car (ahash-table->list s)))
+(define-public (ahash-set->list s) (map car (ahash-table->list s)))
 
 (define-public (list->ahash-set l)
-  (list->ahash-table (map (lambda (x) (cons x #t)) l)))
+  (list->ahash-table (map (lambda (x) (cons x #t)) l))
+) ;define-public
 
 (define-public (list-intersection l1 l2)
-  (with s (list->ahash-set l2)
-    (list-filter l1 (lambda (x) (ahash-ref s x)))))
+  (with s (list->ahash-set l2) (list-filter l1 (lambda (x) (ahash-ref s x))))
+) ;define-public
 
 (define-public (list-difference l1 l2)
-  (with s (list->ahash-set l2)
-    (list-filter l1 (lambda (x) (not (ahash-ref s x))))))
+  (with s
+    (list->ahash-set l2)
+    (list-filter l1 (lambda (x) (not (ahash-ref s x))))
+  ) ;with
+) ;define-public
 
 (define-public (list-union . ls)
-  (let* ((cumul (list))
-         (done? (make-ahash-table)))
+  (let* ((cumul (list)) (done? (make-ahash-table)))
     (for (l ls)
       (for (x l)
         (when (not (ahash-ref done? x))
           (set! cumul (cons x cumul))
-          (ahash-set! done? x #t))))
-    (reverse cumul)))
+          (ahash-set! done? x #t)
+        ) ;when
+      ) ;for
+    ) ;for
+    (reverse cumul)
+  ) ;let*
+) ;define-public
 
 (define-public (list-permutation? l1 l2)
-  (and (null? (list-difference l1 l2))
-       (null? (list-difference l2 l1))))
+  (and (null? (list-difference l1 l2)) (null? (list-difference l2 l1)))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Other operations on lists
@@ -435,59 +519,73 @@
 
 (define-public (list-and l)
   "Compute logical and of list @l of booleans."
-  (or (null? l) (and (car l) (list-and (cdr l)))))
+  (or (null? l) (and (car l) (list-and (cdr l))))
+) ;define-public
 
 (define-public (list-or l)
   "Compute logical or of list @l of booleans."
-  (and (nnull? l) (or (car l) (list-or (cdr l)))))
+  (and (nnull? l) (or (car l) (list-or (cdr l))))
+) ;define-public
 
 (define-public (list-length=2? x)
   "Is @x a proper list of exactly two elements?"
-  (and (pair? x)
-       (pair? (cdr x))
-       (null? (cddr x))))
+  (and (pair? x) (pair? (cdr x)) (null? (cddr x)))
+) ;define-public
 
 (define-public (iota count . rest)
   "Return a list containing count numbers"
   ;; It starts from start and adding step each time.
   ;; The default start is 0, the default step is 1.
   (let ((start (if (pair? rest) (car rest) 0))
-        (step (if (and (pair? rest) (pair? (cdr rest))) (cadr rest) 1)))
-    (let lp ((n 0) (acc '()))
-      (if (= n count)
-        (reverse! acc)
-        (lp (+ n 1) (cons (+ start (* n step)) acc))))))
+        (step (if (and (pair? rest) (pair? (cdr rest))) (cadr rest) 1))
+       ) ;
+    (let lp
+      ((n 0) (acc '()))
+      (if (= n count) (reverse! acc) (lp (+ n 1) (cons (+ start (* n step)) acc)))
+    ) ;let
+  ) ;let
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Operations on association lists
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (assoc-remove! t x)
-  (list-filter t (lambda (y) (!= x (car y)))))
+(define-public (assoc-remove! t x) (list-filter t (lambda (y) (!= x (car y)))))
 
 (define (assoc-remove-duplicates-sub t l)
   (cond ((null? l) l)
-	((ahash-ref t (caar l))
-         (assoc-remove-duplicates-sub t (cdr l)))
-	(else
-	 (ahash-set! t (caar l) #t)
-	 (cons (car l) (assoc-remove-duplicates-sub t (cdr l))))))
+        ((ahash-ref t (caar l)) (assoc-remove-duplicates-sub t (cdr l)))
+        (else (ahash-set! t (caar l) #t)
+          (cons (car l) (assoc-remove-duplicates-sub t (cdr l)))
+        ) ;else
+  ) ;cond
+) ;define
 
 (define-public (assoc-remove-duplicates l)
-  (with t (make-ahash-table)
-    (assoc-remove-duplicates-sub t l)))
+  (with t (make-ahash-table) (assoc-remove-duplicates-sub t l))
+) ;define-public
 
 (define-public (assoc-remove-duplicates* l)
-  (reverse (assoc-remove-duplicates (reverse l))))
+  (reverse (assoc-remove-duplicates (reverse l)))
+) ;define-public
 
 (define-public (assoc-difference l1 l2)
-  (with t (list->ahash-table l2)
-    (list-filter l1 (lambda (x) (not (ahash-ref t (car x)))))))
+  (with t
+    (list->ahash-table l2)
+    (list-filter l1 (lambda (x) (not (ahash-ref t (car x)))))
+  ) ;with
+) ;define-public
 
 (define-public (assoc-delta l1 l2)
-  (with t (list->ahash-table l1)
-    (list-filter l2 (lambda (x) (!= (ahash-ref t (car x)) (cdr x))))))
+  (with t
+    (list->ahash-table l1)
+    (list-filter l2 (lambda (x) (!= (ahash-ref t (car x)) (cdr x))))
+  ) ;with
+) ;define-public
 
 (define-public (assoc-exclude l1 l2)
-  (with s (list->ahash-set l2)
-    (list-filter l1 (lambda (x) (not (ahash-ref s (car x)))))))
+  (with s
+    (list->ahash-set l2)
+    (list-filter l1 (lambda (x) (not (ahash-ref s (car x)))))
+  ) ;with
+) ;define-public

--- a/TeXmacs/progs/kernel/library/patch.scm
+++ b/TeXmacs/progs/kernel/library/patch.scm
@@ -19,135 +19,131 @@
 
 (define-public (modification kind p . args)
   (if (string? kind) (set! kind (string->symbol kind)))
-  (cond ((== kind 'assign)
-	 (with (t) args (modification-assign p t)))
-	((== kind 'insert)
-	 (with (pos t) args (modification-insert p pos t)))
-	((== kind 'remove)
-	 (with (pos nr) args (modification-remove p pos nr)))
-	((== kind 'split)
-	 (with (pos as) args (modification-split p pos as)))
-	((== kind 'join)
-	 (with (pos) args (modification-join p pos)))
-	((== kind 'assign-node)
-	 (with (lab) args (modification-assign-node p lab)))
-	((== kind 'insert-node)
-	 (with (pos t) args (modification-insert-node p pos t)))
-	((== kind 'remove-node)
-	 (with (pos) args (modification-remove-node p pos)))
-	((== kind 'set-cursor)
-	 (with (pos t) args (modification-set-cursor p pos t)))
-	(else (texmacs-error "modification" "invalid modification type"))))
+  (cond ((== kind 'assign) (with (t) args (modification-assign p t)))
+        ((== kind 'insert) (with (pos t) args (modification-insert p pos t)))
+        ((== kind 'remove) (with (pos nr) args (modification-remove p pos nr)))
+        ((== kind 'split) (with (pos as) args (modification-split p pos as)))
+        ((== kind 'join) (with (pos) args (modification-join p pos)))
+        ((== kind 'assign-node) (with (lab) args (modification-assign-node p lab)))
+        ((== kind 'insert-node) (with (pos t) args (modification-insert-node p pos t)))
+        ((== kind 'remove-node) (with (pos) args (modification-remove-node p pos)))
+        ((== kind 'set-cursor) (with (pos t) args (modification-set-cursor p pos t)))
+        (else (texmacs-error "modification" "invalid modification type"))
+  ) ;cond
+) ;define-public
 
-(define-public (modification-type m)
-  (string->symbol (modification-kind m)))
+(define-public (modification-type m) (string->symbol (modification-kind m)))
 
 (define-public (scheme->modification m)
-  (with (k p t) m
-    (make-modification (symbol->string k) p t)))
+  (with (k p t) m (make-modification (symbol->string k) p t))
+) ;define-public
 
 (define-public (modification->scheme m)
   (list (modification-type m)
-	(modification-path m)
-	(tm->stree (modification-tree m))))
+    (modification-path m)
+    (tm->stree (modification-tree m))
+  ) ;list
+) ;define-public
 
 (define-public-macro (modification-apply! t m)
-  `(set! ,t (modification-inplace-apply ,t ,m)))
+  `(set! ,t (modification-inplace-apply ,t ,m))
+) ;define-public-macro
 
 (define-public (modification-can-push? m1 m2 t)
   ;; Assuming that both m1 and m2 can be applied to the document t,
   ;; determine whether they can be applied jointly to t.
-  (with i2 (modification-invert m2 t)
-    (modification-can-pull? m1 i2)))
+  (with i2 (modification-invert m2 t) (modification-can-pull? m1 i2))
+) ;define-public
 
 (define-public (modification-push m1 m2 t)
   ;; Assuming that both m1 and m2 can be applied to the document t,
   ;; and that both modifications can also be applied jointly,
   ;; return the modification m1* such that there exists a modification m2*
   ;; for which m2*;m1 is equivalent to m1*;m2
-  (with i2 (modification-invert m2 t)
-    (modification-pull m1 i2)))
+  (with i2 (modification-invert m2 t) (modification-pull m1 i2))
+) ;define-public
 
 (define-public (modification-co-push m1 m2 t)
   ;; Same as modification-push, but return m2* instead of m1*
   (let* ((p1 (patch-pair m1 (modification-invert m1 t)))
          (p2 (patch-pair m2 (modification-invert m2 t)))
-         (r (patch-co-push p1 p2 t)))
-    (patch-direct r)))
+         (r (patch-co-push p1 p2 t))
+        ) ;
+    (patch-direct r)
+  ) ;let*
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Content patches
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (patch-append . l)
-  (patch-compound l))
+(define-public (patch-append . l) (patch-compound l))
 
 (define-public (patch-children p)
-  (map (cut patch-ref p <>) (.. 0 (patch-arity p))))
+  (map (cut patch-ref p <>) (.. 0 (patch-arity p)))
+) ;define-public
 
 (define-public (patch->scheme p)
   (cond ((patch-pair? p)
          `(pair ,(modification->scheme (patch-direct p))
-                ,(modification->scheme (patch-inverse p))))
-        ((patch-compound? p)
-         `(compound ,@(map patch->scheme (patch-children p))))
-        ((patch-branch? p)
-         `(branch ,@(map patch->scheme (patch-children p))))
-        ((patch-birth? p)
-         `(birth ,(patch-get-birth p) ,(patch-get-author p)))
-        ((patch-author? p)
-         `(author ,(patch-get-author p) ,(patch-ref p 0)))
-        (else #f)))
+            ,(modification->scheme (patch-inverse p)))
+        ) ;
+        ((patch-compound? p) `(compound ,@(map patch->scheme (patch-children p))))
+        ((patch-branch? p) `(branch ,@(map patch->scheme (patch-children p))))
+        ((patch-birth? p) `(birth ,(patch-get-birth p) ,(patch-get-author p)))
+        ((patch-author? p) `(author ,(patch-get-author p) ,(patch-ref p 0)))
+        (else #f)
+  ) ;cond
+) ;define-public
 
 (define-public (scheme->patch p)
   (cond ((func? p 'pair)
-         (patch-pair (scheme->modification (cadr p))
-                     (scheme->modification (caddr p))))
-        ((func? p 'compound)
-         (patch-compound (map scheme->patch (cdr p))))
-        ((func? p 'branch)
-         (patch-branch (map scheme->patch (cdr p))))
-        ((func? p 'birth)
-         (patch-birth (cadr p) (caddr p)))
-        ((func? p 'author)
-         (patch-birth (cadr p) (scheme->patch (caddr p))))
-        (else #f)))
+         (patch-pair (scheme->modification (cadr p)) (scheme->modification (caddr p)))
+        ) ;
+        ((func? p 'compound) (patch-compound (map scheme->patch (cdr p))))
+        ((func? p 'branch) (patch-branch (map scheme->patch (cdr p))))
+        ((func? p 'birth) (patch-birth (cadr p) (caddr p)))
+        ((func? p 'author) (patch-birth (cadr p) (scheme->patch (caddr p))))
+        (else #f)
+  ) ;cond
+) ;define-public
 
-(define-public-macro (patch-apply! t m)
-  `(set! ,t (patch-inplace-apply ,t ,m)))
+(define-public-macro (patch-apply! t m) `(set! ,t (patch-inplace-apply ,t ,m)))
 
 (define-public (patch-can-push? p1 p2 t)
   ;; Assuming that both p1 and p2 can be applied to the document t,
   ;; determine whether they can be applied jointly to t.
-  (with i2 (patch-invert p2 t)
-    (patch-can-pull? p1 i2)))
+  (with i2 (patch-invert p2 t) (patch-can-pull? p1 i2))
+) ;define-public
 
 (define-public (patch-push p1 p2 t)
   ;; Assuming that both p1 and p2 can be applied to the document t,
   ;; and that both patches can also be applied jointly,
   ;; return the patch p1* such that there exists a patch p2*
   ;; for which p2*;p1 is equivalent to p1*;p2
-  (with i2 (patch-invert p2 t)
-    (patch-pull p1 i2)))
+  (with i2 (patch-invert p2 t) (patch-pull p1 i2))
+) ;define-public
 
 (define-public (patch-co-push p1 p2 t)
   ;; Same as patch-push, but return p2* instead of p1*
-  (let* ((i2 (patch-invert p2 t))
-         (i2* (patch-co-pull p1 i2))
-         (u (patch-apply t p1)))
-    (patch-invert i2* u)))
+  (let* ((i2 (patch-invert p2 t)) (i2* (patch-co-pull p1 i2)) (u (patch-apply t p1)))
+    (patch-invert i2* u)
+  ) ;let*
+) ;define-public
 
 (define-public (patch-equivalent? p1 p2 t)
   ;; For sanity checking
   (and (patch-applicable? p1 t)
-       (patch-applicable? p2 t)
-       (== (patch-apply t p1) (patch-apply t p2))))
+    (patch-applicable? p2 t)
+    (== (patch-apply t p1) (patch-apply t p2))
+  ) ;and
+) ;define-public
 
 (define-public (patch-strong-equivalent? p1 p2 t)
   ;; Strong sanity checking
   (and (patch-equivalent? p1 p2 t)
-       (let* ((u (patch-apply t p1))
-              (i1 (patch-invert p1 t))
-              (i2 (patch-invert p2 t)))
-         (and (patch-equivalent? i1 i2 u)
-              (== (patch-apply u i1) t)))))
+    (let* ((u (patch-apply t p1)) (i1 (patch-invert p1 t)) (i2 (patch-invert p2 t)))
+      (and (patch-equivalent? i1 i2 u) (== (patch-apply u i1) t))
+    ) ;let*
+  ) ;and
+) ;define-public

--- a/TeXmacs/progs/kernel/library/tree.scm
+++ b/TeXmacs/progs/kernel/library/tree.scm
@@ -11,83 +11,95 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel library tree)
-  (:use (kernel library list)))
+(texmacs-module (kernel library tree) (:use (kernel library list)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra routines on trees
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (tree . l)
-  (if (string? (car l))
-      (string->tree (car l))
-      (tm->tree l)))
+  (if (string? (car l)) (string->tree (car l)) (tm->tree l))
+) ;define-public
 
-(define-public (atomic-tree? t)
-  (and (tree? t) (tree-atomic? t)))
+(define-public (atomic-tree? t) (and (tree? t) (tree-atomic? t)))
 
-(define-public (compound-tree? t)
-  (and (tree? t) (tree-compound? t)))
+(define-public (compound-tree? t) (and (tree? t) (tree-compound? t)))
 
-(define-public (tree->list t)
-  (cons (tree-label t) (tree-children t)))
+(define-public (tree->list t) (cons (tree-label t) (tree-children t)))
 
-(define-public (tree->symbol t)
-  (string->symbol (tree->string t)))
+(define-public (tree->symbol t) (string->symbol (tree->string t)))
 
 (define-public (tree-number? t)
-  (and (tree-atomic? t) (string->number (tree->string t))))
+  (and (tree-atomic? t) (string->number (tree->string t)))
+) ;define-public
 
 (define-public (tree-integer? t)
-  (and (tree-atomic? t) (integer? (string->number (tree->string t)))))
+  (and (tree-atomic? t) (integer? (string->number (tree->string t))))
+) ;define-public
 
 (define-public (tree->number t)
-  (if (tree-atomic? t) (string->number (tree->string t)) 0))
+  (if (tree-atomic? t) (string->number (tree->string t)) 0)
+) ;define-public
 
 (define-public (tree-explode t)
-  (if (atomic-tree? t)
-      (tree->string t)
-      (cons (tree-label t) (tree-children t))))
+  (if (atomic-tree? t) (tree->string t) (cons (tree-label t) (tree-children t)))
+) ;define-public
 
 (define-public (tree-get-path t)
   (and (tree? t)
-       (let ((ip (tree-ip t)))
-	 (and (or (null? ip) (!= (cAr ip) -5))
-	      (reverse ip)))))
+    (let ((ip (tree-ip t)))
+      (and (or (null? ip) (!= (cAr ip) -5)) (reverse ip))
+    ) ;let
+  ) ;and
+) ;define-public
 
 (define-public (tree-func? t . args)
-  (and (compound-tree? t)
-       (apply func? (cons (tree->list t) args))))
+  (and (compound-tree? t) (apply func? (cons (tree->list t) args)))
+) ;define-public
 
 (define-public (tree-map-children fun t)
-  (tm->tree `(,(tree-label t)
-              ,@(map fun (tree-children t)))))
+  (tm->tree `(,(tree-label t) ,@(map fun (tree-children t))))
+) ;define-public
 
 (define-public (tree-map-accessible-children fun t)
-  (with rew (lambda (i)
-              (if (tree-accessible-child? t i)
-                  (fun (tree-ref t i))
-                  (tree-ref t i)))
-    (tm->tree `(,(tree-label t)
-                ,@(map rew (.. 0 (tree-arity t)))))))
+  (with rew
+    (lambda (i)
+      (if (tree-accessible-child? t i) (fun (tree-ref t i)) (tree-ref t i))
+    ) ;lambda
+    (tm->tree `(,(tree-label t) ,@(map rew (.. 0 (tree-arity t)))))
+  ) ;with
+) ;define-public
 
 (define-public (tree-search t pred?)
-  (with me (if (pred? t) (list t) '())
-    (if (tree-atomic? t) me
-	(append me (append-map (cut tree-search <> pred?)
-			       (tree-children t))))))
+  (with me
+    (if (pred? t) (list t) '())
+    (if (tree-atomic? t)
+      me
+      (append me (append-map (cut tree-search <> pred?) (tree-children t)))
+    ) ;if
+  ) ;with
+) ;define-public
 
 (define (prepend-index l i)
-  (if (null? l) l
-      (cons (map (lambda (x) (cons i x)) (car l))
-            (prepend-index (cdr l) (+ i 1)))))
+  (if (null? l)
+    l
+    (cons (map (lambda (x) (cons i x)) (car l)) (prepend-index (cdr l) (+ i 1)))
+  ) ;if
+) ;define
 
 (define-public (tree-search-indices t pred?)
-  (with me (if (pred? t) (list (list)) (list))
-    (if (tree-atomic? t) me
-        (let* ((l1 (map (cut tree-search-indices <> pred?) (tree-children t)))
-               (l2 (prepend-index l1 0)))
-          (append me (apply append l2))))))
+  (with me
+    (if (pred? t) (list (list)) (list))
+    (if (tree-atomic? t)
+      me
+      (let* ((l1 (map (cut tree-search-indices <> pred?) (tree-children t)))
+             (l2 (prepend-index l1 0))
+            ) ;
+        (append me (apply append l2))
+      ) ;let*
+    ) ;if
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Navigation inside trees
@@ -95,145 +107,167 @@
 
 (define-public (tree-up t . opt)
   "Get the parent of @t."
-  (let* ((p   (tree->path t))
-	 (nr  (if (null? opt) 1 (car opt)))
-	 (len (if (list? p) (length p) -1)))
-    (and (>= len nr) (path->tree (list-head p (- len nr))))))
+  (let* ((p (tree->path t))
+         (nr (if (null? opt) 1 (car opt)))
+         (len (if (list? p) (length p) -1))
+        ) ;
+    (and (>= len nr) (path->tree (list-head p (- len nr))))
+  ) ;let*
+) ;define-public
 
 (define-public (tree-outer t)
   "Get parent of @t except for buffer trees"
-  (and (not (tree-is-buffer? t))
-       (tree-up t)))
+  (and (not (tree-is-buffer? t)) (tree-up t))
+) ;define-public
 
 (define-public (tree-down t . opt)
   "Get the child where the cursor is."
-  (let* ((p   (tree->path t))
-	 (q   (cDr (cursor-path)))
-	 (nr  (if (null? opt) 1 (car opt))))
-    (and p (list-starts? (cDr q) p)
-	 (>= (length q) (+ (length p) nr))
-	 (path->tree (list-head q (+ (length p) nr))))))
+  (let* ((p (tree->path t)) (q (cDr (cursor-path))) (nr (if (null? opt) 1 (car opt))))
+    (and p
+      (list-starts? (cDr q) p)
+      (>= (length q) (+ (length p) nr))
+      (path->tree (list-head q (+ (length p) nr)))
+    ) ;and
+  ) ;let*
+) ;define-public
 
 (define-public (tree-index t)
   "Get the child number of @t in its parent."
-  (with p (tree->path t)
-    (and (pair? p) (cAr p))))
+  (with p (tree->path t) (and (pair? p) (cAr p)))
+) ;define-public
 
 (define-public (tree-down-index t)
   "Get the number of the child where the cursor is."
-  (let ((p (tree->path t))
-	(q (cDr (cursor-path))))
-    (and (list-starts? (cDr q) p)
-	 (list-ref q (length p)))))
+  (let ((p (tree->path t)) (q (cDr (cursor-path))))
+    (and (list-starts? (cDr q) p) (list-ref q (length p)))
+  ) ;let
+) ;define-public
 
 (define-public (tree-inside? t ref)
   "Is @t inside @ref?"
-  (let ((p (tree->path ref))
-	(q (tree->path t)))
-    (and p q (list-starts? q p))))
+  (let ((p (tree->path ref)) (q (tree->path t)))
+    (and p q (list-starts? q p))
+  ) ;let
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Cursor related trees
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (cursor-tree)
-  (path->tree (cDr (cursor-path))))
+(define-public (cursor-tree) (path->tree (cDr (cursor-path))))
 
-(define-public (cursor-tree*)
-  (path->tree (cDr (cursor-path*))))
+(define-public (cursor-tree*) (path->tree (cDr (cursor-path*))))
 
 (define-public (before-cursor)
-  (let* ((t (cursor-tree))
-	 (i (cAr (cursor-path))))
+  (let* ((t (cursor-tree)) (i (cAr (cursor-path))))
     (cond ((and (tree-atomic? t) (> i 0))
-	   (with s (tree->string t)
-	     (with j (string-previous s i)
-	       (substring s j i))))
-	  ((tree-atomic? t) #f)
-	  ((> i 0) t)
-	  (else #f))))
+           (with s (tree->string t) (with j (string-previous s i) (substring s j i)))
+          ) ;
+          ((tree-atomic? t) #f)
+          ((> i 0) t)
+          (else #f)
+    ) ;cond
+  ) ;let*
+) ;define-public
 
 (define-public (before-before-cursor)
-  (let* ((t (cursor-tree))
-	 (i (cAr (cursor-path))))
-    (and (tree-atomic? t) (> i 1)
-         (with s (tree->string t)
-           (with j (string-previous s i)
-             (and (> j 0)
-                  (with k (string-previous s j)
-                    (substring s k j))))))))
+  (let* ((t (cursor-tree)) (i (cAr (cursor-path))))
+    (and (tree-atomic? t)
+      (> i 1)
+      (with s
+        (tree->string t)
+        (with j
+          (string-previous s i)
+          (and (> j 0) (with k (string-previous s j) (substring s k j)))
+        ) ;with
+      ) ;with
+    ) ;and
+  ) ;let*
+) ;define-public
 
 (define-public (after-cursor)
-  (let* ((t (cursor-tree*))
-	 (i (cAr (cursor-path*))))
+  (let* ((t (cursor-tree*)) (i (cAr (cursor-path*))))
     (cond ((and (tree-atomic? t) (< i (string-length (tree->string t))))
-	   (with s (tree->string t)
-	     (with j (string-next s i)
-	       (substring s i j))))
-	  ((tree-atomic? t) #f)
-	  ((== i 0) t)
-	  (else #f))))
+           (with s (tree->string t) (with j (string-next s i) (substring s i j)))
+          ) ;
+          ((tree-atomic? t) #f)
+          ((== i 0) t)
+          (else #f)
+    ) ;cond
+  ) ;let*
+) ;define-public
 
-(define-public (focus-tree)
-  (path->tree (get-focus-path)))
+(define-public (focus-tree) (path->tree (get-focus-path)))
 
 (define-public (cursor-on-border? t)
-  (let* ((p (cursor-path))
-         (i (cAr p)))
+  (let* ((p (cursor-path)) (i (cAr p)))
     (and (== (cDr p) (tree->path t))
-         (or (== i 0)
-             (if (tree-atomic? t)
-                 (== i (string-length (tree->string t)))
-                 (== i 1))))))
+      (or (== i 0)
+        (if (tree-atomic? t) (== i (string-length (tree->string t))) (== i 1))
+      ) ;or
+    ) ;and
+  ) ;let*
+) ;define-public
 
 (define-public (cursor-inside? t)
-  (let* ((c (cursor-path))
-         (p (cDr c))
-         (q (tree->path t)))
+  (let* ((c (cursor-path)) (p (cDr c)) (q (tree->path t)))
     (and (list? q)
-         (if (tree-atomic? (cursor-tree))
-             (>= (length p) (length q))
-             (> (length p) (length q)))
-         (== (sublist p 0 (length q)) q)
-         (sublist c (length q) (length c)))))
+      (if (tree-atomic? (cursor-tree))
+        (>= (length p) (length q))
+        (> (length p) (length q))
+      ) ;if
+      (== (sublist p 0 (length q)) q)
+      (sublist c (length q) (length c))
+    ) ;and
+  ) ;let*
+) ;define-public
 
 (define-public (tree->fingerprint t)
-  (list (tree->path t) (tree-label t) (tree-arity t)
-        (list-common (tree->path t) (tree->path (focus-tree)))))
+  (list (tree->path t)
+    (tree-label t)
+    (tree-arity t)
+    (list-common (tree->path t) (tree->path (focus-tree)))
+  ) ;list
+) ;define-public
 
 (define-public (fingerprint->tree fp)
-  (with (p l n c) fp
-    (and-with t (path->tree p)
+  (with (p l n c)
+    fp
+    (and-with t
+      (path->tree p)
       (and (== l (tree-label t))
-           (== n (tree-arity t))
-           (== c (list-common (tree->path t) (tree->path (focus-tree))))
-           t))))
+        (== n (tree-arity t))
+        (== c (list-common (tree->path t) (tree->path (focus-tree))))
+        t
+      ) ;and
+    ) ;and-with
+  ) ;with
+) ;define-public
 
 (define-public-macro (push-focus t . body)
-  `(with pushed-focus (tree->fingerprint t)
-     ,@body))
+  `(with pushed-focus (tree->fingerprint t) ,@body)
+) ;define-public-macro
 
 (define-public-macro (pull-focus t . body)
-  `(and-with ,t (fingerprint->tree pushed-focus)
-     ,@body))
+  `(and-with ,t (fingerprint->tree pushed-focus) ,@body)
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Other special trees
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (table-cell-tree row col)
-  (path->tree (table-cell-path row col)))
+(define-public (table-cell-tree row col) (path->tree (table-cell-path row col)))
 
 (define the-action-tree #f)
 
 (define-public (exec-delayed-at cmd t)
-  (with old-t the-action-tree
+  (with old-t
+    the-action-tree
     (set! the-action-tree t)
-    (exec-delayed (lambda () (cmd) (set! the-action-tree old-t)))))
+    (exec-delayed (lambda () (cmd) (set! the-action-tree old-t)))
+  ) ;with
+) ;define-public
 
-(define-public (action-tree)
-  the-action-tree)
+(define-public (action-tree) the-action-tree)
 
-(define-public-macro (with-action t . body)
-  `(and-with ,t (action-tree)
-     ,@body))
+(define-public-macro (with-action t . body) `(and-with ,t (action-tree) ,@body))

--- a/TeXmacs/progs/kernel/logic/logic-bind.scm
+++ b/TeXmacs/progs/kernel/logic/logic-bind.scm
@@ -17,14 +17,12 @@
 ;; Is an expression a free variable?
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (free-variable name)
-  (list '#_quote name))
+(define-public (free-variable name) (list '#_quote name))
 
 (define-public (free-variable? expr)
   "Is the expression @expr a free variable?"
-  (and (list? expr)
-       (= (length expr) 2)
-       (== (car expr) '#_quote)))
+  (and (list? expr) (= (length expr) 2) (== (car expr) '#_quote))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Binding variables
@@ -32,26 +30,34 @@
 
 (define-public (bind-var var val bl)
   "Force a binding of variable @var to @val in @bl."
-  (list (acons var val bl)))
+  (list (acons var val bl))
+) ;define-public
 
 (define-public (bind-unify var val bl)
   "Bind variable @var to @val in @bl and unify if the binding already exists."
   (if (free-variable? val)
-      (let* ((var2 (cadr val))
-	     (val2 (assoc-ref bl var2)))
-	(if val2 (bind-unify var val2 bl)
-	    (let ((old-val (assoc-ref bl var)))
-	      (cond (old-val (bind-unify var2 old-val bl))
-		    ((== var var2) (list bl))
-		    ((and (number? var2)
-			  (or (not (number? var)) (< var var2)))
-		     (bind-var var2 (free-variable var) bl))
-		    (else (bind-var var val bl))))))
-      (let ((old-val (assoc-ref bl var)))
-	(cond ((not old-val) (bind-var var val bl))
-	      ((free-variable? old-val)
-	       (bind-unify (cadr old-val) val bl))
-	      (else (unify (list val) (list old-val) bl))))))
+    (let* ((var2 (cadr val)) (val2 (assoc-ref bl var2)))
+      (if val2
+        (bind-unify var val2 bl)
+        (let ((old-val (assoc-ref bl var)))
+          (cond (old-val (bind-unify var2 old-val bl))
+                ((== var var2) (list bl))
+                ((and (number? var2) (or (not (number? var)) (< var var2)))
+                 (bind-var var2 (free-variable var) bl)
+                ) ;
+                (else (bind-var var val bl))
+          ) ;cond
+        ) ;let
+      ) ;if
+    ) ;let*
+    (let ((old-val (assoc-ref bl var)))
+      (cond ((not old-val) (bind-var var val bl))
+            ((free-variable? old-val) (bind-unify (cadr old-val) val bl))
+            (else (unify (list val) (list old-val) bl))
+      ) ;cond
+    ) ;let
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Substitution
@@ -61,28 +67,39 @@
   "Substitute bindings @bl in expression @expr."
   ;; does full substitution if the bindings have been expanded
   (cond ((or (null? expr) (npair? expr)) expr)
-	((free-variable? expr)
-	 (let ((val (assoc-ref bl (cadr expr))))
-	   (if val val expr)))
-	(else (cons (bind-substitute (car expr) bl)
-		    (bind-substitute (cdr expr) bl)))))
+        ((free-variable? expr)
+         (let ((val (assoc-ref bl (cadr expr))))
+           (if val val expr)
+         ) ;let
+        ) ;
+        (else (cons (bind-substitute (car expr) bl) (bind-substitute (cdr expr) bl)))
+  ) ;cond
+) ;define-public
 
 (define-public (bind-substitute! expr bl)
   "In place substitution of bindings @bl in expression @expr."
   (if (pair? expr)
-      (begin
-	(if (free-variable? (car expr))
-	    (let ((val (assoc-ref bl (cadar expr))))
-	      (if val (set-car! expr val)))
-	    (bind-substitute! (car expr) bl))
-	(if (free-variable? (cdr expr))
-	    (let ((val (assoc-ref bl (caddr expr))))
-	      (if val (set-cdr! expr val)))
-	    (bind-substitute! (cdr expr) bl)))))
+    (begin
+      (if (free-variable? (car expr))
+        (let ((val (assoc-ref bl (cadar expr))))
+          (if val (set-car! expr val))
+        ) ;let
+        (bind-substitute! (car expr) bl)
+      ) ;if
+      (if (free-variable? (cdr expr))
+        (let ((val (assoc-ref bl (caddr expr))))
+          (if val (set-cdr! expr val))
+        ) ;let
+        (bind-substitute! (cdr expr) bl)
+      ) ;if
+    ) ;begin
+  ) ;if
+) ;define-public
 
 (define-public (bind-expand bl2)
   "Recursively substitute the bindings @bl2 in its own values."
   (let ((bl (copy-tree bl2)))
-       ; FIXME: would be better to have a cycle-safe copy
     (for-each (lambda (x) (bind-substitute! x bl)) bl)
-    bl))
+    bl
+  ) ;let
+) ;define-public

--- a/TeXmacs/progs/kernel/logic/logic-data.scm
+++ b/TeXmacs/progs/kernel/logic/logic-data.scm
@@ -12,88 +12,127 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel logic logic-data)
-  (:use (kernel logic logic-rules) (kernel logic logic-query)))
+  (:use (kernel logic logic-rules) (kernel logic logic-query))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Useful subroutines
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (is-assume? expr)
-  (and (pair? expr) (== (car expr) 'assume)))
+  (and (pair? expr) (== (car expr) 'assume))
+) ;define
 
 (define (quote-all l)
-  (map (lambda (x) (list 'quote x)) l))
+  (map (lambda (x) (list 'quote x)) l)
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extraction of logical information
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define logic-facts-table (make-ahash-table))
+
 (define logic-apply-table (make-ahash-table))
+
 (define logic-apply-list-table (make-ahash-table))
 
 (define-public (logic-holds? test . conds)
   "Does the relation @test hold under conditions @conds?"
-  (let* ((what (cons test conds))
-	 (handle (ahash-get-handle logic-facts-table what)))
-    (if handle (cdr handle)
-	(let ((ok (== (apply query what) '(()))))
-	  (ahash-set! logic-facts-table what ok)
-	  ok))))
+  (let* ((what (cons test conds)) (handle (ahash-get-handle logic-facts-table what)))
+    (if handle
+      (cdr handle)
+      (let ((ok (== (apply query what) '(()))))
+        (ahash-set! logic-facts-table what ok)
+        ok
+      ) ;let
+    ) ;if
+  ) ;let*
+) ;define-public
 
 (define (logic-unique-result l)
   "Retrieve the non-ambiguous functional result from a list of solutions @l."
-  (if (null? l) #f
-      (let ((bl (car l)))
-	(if (!= (length bl) 1)
-	    (error "Bad return values for logical apply")
-	    (let ((r (cdar bl)))
-	      (if (null? (cdr l)) r
-		  (if (!= r (logic-unique-result (cdr l)))
-		      (error "Ambiguous return values for logical apply")
-		      r)))))))
+  (if (null? l)
+    #f
+    (let ((bl (car l)))
+      (if (!= (length bl) 1)
+        (error "Bad return values for logical apply")
+        (let ((r (cdar bl)))
+          (if (null? (cdr l))
+            r
+            (if (!= r (logic-unique-result (cdr l)))
+              (error "Ambiguous return values for logical apply")
+              r
+            ) ;if
+          ) ;if
+        ) ;let
+      ) ;if
+    ) ;let
+  ) ;if
+) ;define
 
 (define-public (logic-apply fun . conds)
   "Retrieve unique @r such that @(rcons fun r) holds under conditions @conds."
-  (let* ((what (cons fun conds))
-	 (handle (ahash-get-handle logic-apply-table what)))
-    (if handle (cdr handle)
-	(let* ((goal (cons (append fun '('r)) conds))
-	       (val (logic-unique-result (apply query goal))))
-	  (ahash-set! logic-apply-table what val)
-	  val))))
+  (let* ((what (cons fun conds)) (handle (ahash-get-handle logic-apply-table what)))
+    (if handle
+      (cdr handle)
+      (let* ((goal (cons (append fun '('r)) conds))
+             (val (logic-unique-result (apply query goal)))
+            ) ;
+        (ahash-set! logic-apply-table what val)
+        val
+      ) ;let*
+    ) ;if
+  ) ;let*
+) ;define-public
 
 (define (logic-list-result l)
   "Retrieve the list of results from a list of solutions @l."
-  (if (null? l) l
-      (let ((bl (car l)))
-	(if (not (= (length bl) 1))
-	    (error "Bad return values for logical apply")
-	    (let ((r (cdar bl)))
-	      (cons r (logic-list-result (cdr l))))))))
+  (if (null? l)
+    l
+    (let ((bl (car l)))
+      (if (not (= (length bl) 1))
+        (error "Bad return values for logical apply")
+        (let ((r (cdar bl)))
+          (cons r (logic-list-result (cdr l)))
+        ) ;let
+      ) ;if
+    ) ;let
+  ) ;if
+) ;define
 
 (define-public (logic-apply-list fun . conds)
   "Retrieve list of @r such that @(rcons fun r) holds under conditions @conds."
   (let* ((what (cons fun conds))
-	 (handle (ahash-get-handle logic-apply-list-table what)))
-    (if handle (cdr handle)
-	(let* ((goal (cons (append fun '('r)) conds))
-	       (val (logic-list-result (apply query goal))))
-	  (ahash-set! logic-apply-list-table what val)
-	  val))))
+         (handle (ahash-get-handle logic-apply-list-table what))
+        ) ;
+    (if handle
+      (cdr handle)
+      (let* ((goal (cons (append fun '('r)) conds))
+             (val (logic-list-result (apply query goal)))
+            ) ;
+        (ahash-set! logic-apply-list-table what val)
+        val
+      ) ;let*
+    ) ;if
+  ) ;let*
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public interface for logic-holds? and logic-apply
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public-macro (logic-test? name . args)
-  `(logic-holds? (list ,(list 'quasiquote name) ,@args)))
+  `(logic-holds? (list ,(list 'quasiquote name) ,@args))
+) ;define-public-macro
 
 (define-public-macro (logic-lookup name . keys)
-  `(logic-apply (list ,(list 'quasiquote name) ,@keys)))
+  `(logic-apply (list ,(list 'quasiquote name) ,@keys))
+) ;define-public-macro
 
 (define-public-macro (logic-lookup-list name . keys)
-  `(logic-apply-list (list ,(list 'quasiquote name) ,@keys)))
+  `(logic-apply-list (list ,(list 'quasiquote name) ,@keys))
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of groups (should use logical programming soon)
@@ -101,63 +140,75 @@
 
 (define-public (logic-group-rules name l)
   (cond ((null? l) '())
-	((is-assume? (car l))
-	 (cons (car l) (logic-group-rules name (cdr l))))
-	(else
-	 (cons (list (list name (car l))) (logic-group-rules name (cdr l))))))
+        ((is-assume? (car l)) (cons (car l) (logic-group-rules name (cdr l))))
+        (else (cons (list (list name (car l))) (logic-group-rules name (cdr l))))
+  ) ;cond
+) ;define-public
 
 (define-public-macro (logic-group name . l)
-  `(logic-rules ,@(logic-group-rules name l)))
+  `(logic-rules ,@(logic-group-rules name l))
+) ;define-public-macro
 
 (define-public-macro (logic-in? x name . conds)
-  `(logic-holds? (list ,(list 'quasiquote name) ,x) ,@(quote-all conds)))
+  `(logic-holds? (list ,(list 'quasiquote name) ,x) ,@(quote-all conds))
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of tables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (logic-table-rule name binding)
-  (let ((key (car binding))
-	(im (cadr binding))
-	(conds (cddr binding)))
+  (let ((key (car binding)) (im (cadr binding)) (conds (cddr binding)))
     (if (and (pair? key) (== (car key) :or))
-	(let ((fun (lambda (skey)
-		     (logic-table-rule name (cons skey (cons im conds))))))
-	  (apply append (map fun (cdr key))))
-	(list (cons (list name key im) conds)))))
+      (let ((fun (lambda (skey) (logic-table-rule name (cons skey (cons im conds))))))
+        (apply append (map fun (cdr key)))
+      ) ;let
+      (list (cons (list name key im) conds))
+    ) ;if
+  ) ;let
+) ;define
 
 (define-public (logic-table-rules name l)
   (cond ((null? l) '())
-	((is-assume? (car l))
-	 (cons (car l) (logic-table-rules name (cdr l))))
-	(else (append (logic-table-rule name (car l))
-		      (logic-table-rules name (cdr l))))))
+        ((is-assume? (car l)) (cons (car l) (logic-table-rules name (cdr l))))
+        (else (append (logic-table-rule name (car l)) (logic-table-rules name (cdr l))))
+  ) ;cond
+) ;define-public
 
 (define-public-macro (logic-table name . l)
-  `(logic-rules ,@(logic-table-rules name l)))
+  `(logic-rules ,@(logic-table-rules name l))
+) ;define-public-macro
 
 (define-public-macro (logic-ref name key . conds)
-  ;;`(logic-apply (list ,(list 'quasiquote name) ,key) ,@(quote-all conds)))
-  `(logic-apply (list ,(list 'quasiquote name) ,key) ,@conds))
+  ;; `(logic-apply (list ,(list 'quasiquote name) ,key) ,@(quote-all conds)))
+  `(logic-apply (list ,(list 'quasiquote name) ,key) ,@conds)
+) ;define-public-macro
 
 (define-public-macro (logic-ref-list name key . conds)
-  ;;`(logic-apply-list (list ,(list 'quasiquote name) ,key) ,@(quote-all conds)))
-  `(logic-apply-list (list ,(list 'quasiquote name) ,key) ,@conds))
+  ;; `(logic-apply-list (list ,(list 'quasiquote name) ,key) ,@(quote-all conds)))
+  `(logic-apply-list (list ,(list 'quasiquote name) ,key) ,@conds)
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of dispatchers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (logic-dispatcher-rule rule)
-  (if (is-assume? rule) rule
-      (cons* (car rule) (list 'unquote (cadr rule)) (cddr rule))))
+  (if (is-assume? rule)
+    rule
+    (cons* (car rule) (list 'unquote (cadr rule)) (cddr rule))
+  ) ;if
+) ;define-public
 
 (define-public-macro (logic-dispatcher name . l)
-  `(logic-table ,name ,@(map logic-dispatcher-rule l)))
+  `(logic-table ,name ,@(map logic-dispatcher-rule l))
+) ;define-public-macro
 
 (define-public-macro (logic-dispatch name key . args)
   (let ((k (gensym)))
     (if (= (length args) 1)
-	`(let ((,k ,key))
-	   ((logic-ref ,name (car ,k)) ,k))
-	`((logic-ref ,name ,key) ,@args))))
+      `(let ((,k ,key)) ((logic-ref ,name (car ,k)) ,k))
+      `((logic-ref ,name ,key) ,@args)
+    ) ;if
+  ) ;let
+) ;define-public-macro

--- a/TeXmacs/progs/kernel/logic/logic-query.scm
+++ b/TeXmacs/progs/kernel/logic/logic-query.scm
@@ -12,7 +12,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel logic logic-query)
-  (:use (kernel logic logic-bind) (kernel logic logic-unify) (kernel logic logic-rules)))
+  (:use (kernel logic logic-bind)
+    (kernel logic logic-unify)
+    (kernel logic logic-rules)
+  ) ;:use
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constructing closures
@@ -23,20 +27,30 @@
 (define (logic-new)
   "Return a new free variable"
   (set! logic-serial (+ logic-serial 1))
-  logic-serial)
+  logic-serial
+) ;define
 
 (define (logic-closure expr bl)
   "Return the closure and bindings for @expr with bindings @bl"
   (cond ((or (null? expr) (npair? expr)) (cons expr bl))
-	((free-variable? expr)
-	 (let ((val (assoc-ref bl (cadr expr))))
-	   (if val (cons (free-variable val) bl)
-	       (let ((new-val (logic-new)))
-		 (cons (free-variable new-val)
-		       (acons (cadr expr) new-val bl))))))
-	(else (let* ((head (logic-closure (car expr) bl))
-		     (tail (logic-closure (cdr expr) (cdr head))))
-		(cons (cons (car head) (car tail)) (cdr tail))))))
+        ((free-variable? expr)
+         (let ((val (assoc-ref bl (cadr expr))))
+           (if val
+             (cons (free-variable val) bl)
+             (let ((new-val (logic-new)))
+               (cons (free-variable new-val) (acons (cadr expr) new-val bl))
+             ) ;let
+           ) ;if
+         ) ;let
+        ) ;
+        (else (let* ((head (logic-closure (car expr) bl))
+                     (tail (logic-closure (cdr expr) (cdr head)))
+                    ) ;
+                (cons (cons (car head) (car tail)) (cdr tail))
+              ) ;let*
+        ) ;else
+  ) ;cond
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Solving logical programs
@@ -45,54 +59,75 @@
 (define (logic-remove-above bl serial)
   "Remove local variables (above @serial) from bindings @bl."
   (cond ((null? bl) bl)
-	((and (number? (caar bl)) (> (caar bl) serial))
-	 (logic-remove-above (cdr bl) serial))
-	(else (cons (car bl) (logic-remove-above (cdr bl) serial))))) 
+        ((and (number? (caar bl)) (> (caar bl) serial))
+         (logic-remove-above (cdr bl) serial)
+        ) ;
+        (else (cons (car bl) (logic-remove-above (cdr bl) serial)))
+  ) ;cond
+) ;define
 
 (define (logic-return bls2 serial)
   "Return from a rule with solutions @bls2 and locals above @serial."
   ;; returns list of expanded bindings
-  (if (null? bls2) '()
-      (let* ((bl (bind-expand (car bls2)))
-	     (tail (logic-return (cdr bls2) serial)))
-	(if bl
-	    (cons (logic-remove-above bl serial) tail)
-	    tail))))
+  (if (null? bls2)
+    '()
+    (let* ((bl (bind-expand (car bls2))) (tail (logic-return (cdr bls2) serial)))
+      (if bl (cons (logic-remove-above bl serial) tail) tail)
+    ) ;let*
+  ) ;if
+) ;define
 
 (define (logic-try goal rule2 extra bl)
   "Try to prove @goal via @rule2 using extra rules @extra under bindings @bl."
   ;; returns list of expanded bindings
   ;; (for-each display (list "Try: " goal ", " rule2 "\n"))
   ;; (for-each display (list "Try: " goal ", " rule2 ", " bl "\n"))
-  (let ((serial logic-serial)
-	(rule (car (logic-closure rule2 '()))))
+  (let ((serial logic-serial) (rule (car (logic-closure rule2 '()))))
     (let* ((sols2 (unify (list goal) (list (car rule)) bl))
-	   (sols (map bind-expand sols2)))
-      (if (null? sols) sols
-	  (logic-return (logic-prove-any (cdr rule) extra sols) serial)))))
+           (sols (map bind-expand sols2))
+          ) ;
+      (if (null? sols)
+        sols
+        (logic-return (logic-prove-any (cdr rule) extra sols) serial)
+      ) ;if
+    ) ;let*
+  ) ;let
+) ;define
 
 (define (logic-exec goal prg extra bl)
   "Prove @goal from @prg using extra rules @extra under bindings @bl."
   ;; requires expanded bindings
-  (if (null? prg) '()
-      (let ((sols (logic-try goal (car prg) extra bl)))
-	(if (== sols (list bl)) sols
-	    (append sols (logic-exec goal (cdr prg) extra bl))))))
+  (if (null? prg)
+    '()
+    (let ((sols (logic-try goal (car prg) extra bl)))
+      (if (== sols (list bl)) sols (append sols (logic-exec goal (cdr prg) extra bl)))
+    ) ;let
+  ) ;if
+) ;define
 
 (define (logic-prove-any goals extra bls)
   "Prove @goals using extra rules @extra under any of the bindings in @bls."
   ;; requires list of expanded bindings
-  (if (null? bls) '()
-      (append (logic-prove goals extra (car bls))
-	      (logic-prove-any goals extra (cdr bls)))))
+  (if (null? bls)
+    '()
+    (append (logic-prove goals extra (car bls))
+      (logic-prove-any goals extra (cdr bls))
+    ) ;append
+  ) ;if
+) ;define
 
 (define (logic-prove goals extra bl)
   "Prove @goals using extra rules @extra under bindings @bl."
   ;; requires expanded bindings
-  (if (null? goals) (list bl)
-      (let* ((goal (bind-substitute (car goals) bl))
-	     (prg (append extra (logic-get-rules goal))))
-	(logic-prove-any (cdr goals) extra (logic-exec goal prg extra bl)))))
+  (if (null? goals)
+    (list bl)
+    (let* ((goal (bind-substitute (car goals) bl))
+           (prg (append extra (logic-get-rules goal)))
+          ) ;
+      (logic-prove-any (cdr goals) extra (logic-exec goal prg extra bl))
+    ) ;let*
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
@@ -100,7 +135,9 @@
 
 (define-public (query goal . extra)
   "Prove @goal using extra rules @extra."
-  (logic-prove (list goal) (map list extra) '()))
+  (logic-prove (list goal) (map list extra) '())
+) ;define-public
 
 (define-public-macro (logic-query . l)
-  (cons 'query (map (lambda (x) (list 'quote x)) l)))
+  (cons 'query (map (lambda (x) (list 'quote x)) l))
+) ;define-public-macro

--- a/TeXmacs/progs/kernel/logic/logic-rules.scm
+++ b/TeXmacs/progs/kernel/logic/logic-rules.scm
@@ -31,7 +31,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel logic logic-rules)
-  (:use (kernel logic logic-bind) (kernel logic logic-unify)))
+  (:use (kernel logic logic-bind) (kernel logic logic-unify))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inserting new rules
@@ -39,11 +40,14 @@
 
 (define (ahash-list-ref table key)
   (let ((val (ahash-ref table key)))
-    (if val val '())))
+    (if val val '())
+  ) ;let
+) ;define
 
 (define (ahash-list-add! table key val)
   "Add @value to list of values for @key in @table."
-  (ahash-set! table key (cons val (ahash-list-ref table key))))
+  (ahash-set! table key (cons val (ahash-list-ref table key)))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inserting new rules
@@ -52,27 +56,32 @@
 (define logic-rules-table (make-ahash-table))
 
 (define (logic-add-rule-advance table symb todo rule)
-  (if (not (ahash-ref table symb))
-      (ahash-set! table symb (make-ahash-table)))
-  (logic-add-rule-sub (ahash-ref table symb) todo rule))
+  (if (not (ahash-ref table symb)) (ahash-set! table symb (make-ahash-table)))
+  (logic-add-rule-sub (ahash-ref table symb) todo rule)
+) ;define
 
 (define (logic-add-rule-sub table todo rule)
   "Add @rule to @table with @todo yet to be 'read'."
   (ahash-list-add! table :all rule)
   (if (nnull? todo)
-      (let ((next (car todo)))
-	(cond ((npair? next)
-	       (logic-add-rule-advance table next (cdr todo) rule))
-	      ((free-variable? next)
-	       (ahash-list-add! table :free rule))
-	      (else (logic-add-rule-advance
-		     table :down
-		     (cons (car next) (cons (cdr next) (cdr todo)))
-		     rule))))))
+    (let ((next (car todo)))
+      (cond ((npair? next) (logic-add-rule-advance table next (cdr todo) rule))
+            ((free-variable? next) (ahash-list-add! table :free rule))
+            (else (logic-add-rule-advance table
+                    :down
+                    (cons (car next) (cons (cdr next) (cdr todo)))
+                    rule
+                  ) ;logic-add-rule-advance
+            ) ;else
+      ) ;cond
+    ) ;let
+  ) ;if
+) ;define
 
 (define (logic-add-rule rule)
   "Add the rule @rule to the global database."
-  (logic-add-rule-sub logic-rules-table (list (car rule)) rule))
+  (logic-add-rule-sub logic-rules-table (list (car rule)) rule)
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Getting filtered rules which may possibly be applied for proving a goal
@@ -80,27 +89,36 @@
 
 (define (logic-get-rules-advance table symb todo)
   (let ((next-table (ahash-ref table symb)))
-    (if next-table (logic-get-rules-sub next-table todo) '())))
+    (if next-table (logic-get-rules-sub next-table todo) '())
+  ) ;let
+) ;define
 
 (define (logic-get-rules-sub table todo)
   "Get rules for @todo from @table."
   (if (null? todo)
-      (ahash-list-ref table :all)
-      (let ((next (car todo)))
-	(cond ((npair? next)
-	       (append (ahash-list-ref table :free)
-		       (logic-get-rules-advance table next (cdr todo)))
-	       ;; FIXME: (difficult with present algorithm) messes up order
-	       )
-	      ((free-variable? next)
-	       (ahash-list-ref table :all))
-	      (else (logic-get-rules-advance
-		     table :down
-		     (cons (car next) (cons (cdr next) (cdr todo)))))))))
+    (ahash-list-ref table :all)
+    (let ((next (car todo)))
+      (cond ((npair? next)
+             (append (ahash-list-ref table :free)
+               (logic-get-rules-advance table next (cdr todo))
+             ) ;append
+             ;; FIXME: (difficult with present algorithm) messes up order
+            ) ;
+            ((free-variable? next) (ahash-list-ref table :all))
+            (else (logic-get-rules-advance table
+                    :down
+                    (cons (car next) (cons (cdr next) (cdr todo)))
+                  ) ;logic-get-rules-advance
+            ) ;else
+      ) ;cond
+    ) ;let
+  ) ;if
+) ;define
 
 (define-public (logic-get-rules goal)
   "Get all rules which may be applied to prove @goal."
-  (reverse (logic-get-rules-sub logic-rules-table (list goal))))
+  (reverse (logic-get-rules-sub logic-rules-table (list goal)))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
@@ -108,16 +126,17 @@
 
 (define-public (logic-rules-decls l extra)
   (cond ((npair? l) (noop))
-	((and (pair? (car l)) (== (caar l) 'assume))
-	 (logic-rules-decls (cdr l) (append (cdar l) extra)))
-	(else
-	 (logic-add-rule (cons (caar l) (append extra (cdar l))))
-	 (logic-rules-decls (cdr l) extra))))
+        ((and (pair? (car l)) (== (caar l) 'assume))
+         (logic-rules-decls (cdr l) (append (cdar l) extra))
+        ) ;
+        (else (logic-add-rule (cons (caar l) (append extra (cdar l))))
+          (logic-rules-decls (cdr l) extra)
+        ) ;else
+  ) ;cond
+) ;define-public
 
 (define-public-macro (logic-rules . l)
-  `(begin
-     (logic-rules-decls ,(list 'quasiquote l) '())
-     (display "")))
+  `(begin (logic-rules-decls ,(list 'quasiquote l) '()) (display ""))
+) ;define-public-macro
 
-(define-public-macro (logic-rule . l)
-  `(logic-rules ,l))
+(define-public-macro (logic-rule . l) `(logic-rules ,l))

--- a/TeXmacs/progs/kernel/logic/logic-unify.scm
+++ b/TeXmacs/progs/kernel/logic/logic-unify.scm
@@ -11,8 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel logic logic-unify)
-  (:use (kernel logic logic-bind)))
+(texmacs-module (kernel logic logic-unify) (:use (kernel logic logic-bind)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Unification
@@ -20,34 +19,42 @@
 
 (define-public (unify-any l expr bls)
   "Unifications for @l == @expr under any of the bindings in @bls."
-  (if (null? bls) '()
-      (append (unify l expr (car bls))
-	      (unify-any l expr (cdr bls)))))
+  (if (null? bls)
+    '()
+    (append (unify l expr (car bls)) (unify-any l expr (cdr bls)))
+  ) ;if
+) ;define-public
 
 (define (unify-priority expr)
   (cond ((null? expr) 4)
-	((nlist? expr) 3)
-	((nlist? (car expr)) 3)
-	((free-variable? (car expr)) 1)
-	(else 2)))
+        ((nlist? expr) 3)
+        ((nlist? (car expr)) 3)
+        ((free-variable? (car expr)) 1)
+        (else 2)
+  ) ;cond
+) ;define
 
 (define-public (unify l r bl)
   "Unifications for @l == @r under the bindings @bl."
-  (let ((lp (unify-priority l))
-	(rp (unify-priority r)))
+  (let ((lp (unify-priority l)) (rp (unify-priority r)))
     (cond ((< lp rp) (unify r l bl))
-	  ((= rp 4) ; r is the empty list (so that we must have l == r)
-	   (list bl))
-	  ((= rp 3) ; first element of r is not a list
-	   (cond ((null? l) '())
-		 ((!= (car l) (car r)) '())
-		 (else (unify (cdr l) (cdr r) bl))))
-	  ((= rp 2) ; first element of r is again a list
-	   (if (or (null? l) (nlist? (car l))) '()
-	       (unify-any (cdr l) (cdr r) (unify (car l) (car r) bl))))
-	  (else ; first element of r is a free variable
-	   (unify-any (cdr l) (cdr r)
-		      (bind-unify (cadar r) (car l) bl))))))
+          ((= rp 4) (list bl))
+          ((= rp 3)
+           (cond ((null? l) '())
+                 ((!= (car l) (car r)) '())
+                 (else (unify (cdr l) (cdr r) bl))
+           ) ;cond
+          ) ;
+          ((= rp 2)
+           (if (or (null? l) (nlist? (car l)))
+             '()
+             (unify-any (cdr l) (cdr r) (unify (car l) (car r) bl))
+           ) ;if
+          ) ;
+          (else (unify-any (cdr l) (cdr r) (bind-unify (cadar r) (car l) bl)))
+    ) ;cond
+  ) ;let
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; User interface
@@ -56,4 +63,6 @@
 (define-public (logic-unify expr1 expr2)
   "Compute unifications of expressions @expr1 and @expr2 with free variables."
   (let ((sols (unify (list expr1) (list expr2) '())))
-    (if (null? sols) #f sols)))
+    (if (null? sols) #f sols)
+  ) ;let
+) ;define-public

--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
@@ -234,33 +234,31 @@
 (define (recent-files-json-valid? recent-files)
   (njson-schema-valid? recent-files-schema-v1 recent-files))
 
-#|
-recent-files-remove-by-path
-按路径从最近文件缓存中删除对应条目。
-
-语法
-----
-(recent-files-remove-by-path path)
-
-参数
-----
-path : string
-    目标文件路径。用于在 `interactive-arg-recent-file-json` 的 `files`
-    列表中定位要移除的记录。
-
-返回值
-----
-unspecified
-- 函数通过副作用更新全局变量 `interactive-arg-recent-file-json`。
-- 若路径不存在，则不做任何修改。
-
-逻辑
-----
-1. 调用 `recent-files-index-by-path` 查找 `path` 在 `files` 中的索引。
-2. 若找到索引，调用 `njson-drop!` 删除该项。
-3. 将 `meta.total` 减一（不低于 0）。
-4. 将更新后的 JSON 结构回写到 `interactive-arg-recent-file-json`。
-|#
+;;recent-files-remove-by-path
+;;按路径从最近文件缓存中删除对应条目。
+;;
+;;语法
+;;----
+;;(recent-files-remove-by-path path)
+;;
+;;参数
+;;----
+;;path : string
+;;    目标文件路径。用于在 `interactive-arg-recent-file-json` 的 `files`
+;;    列表中定位要移除的记录。
+;;
+;;返回值
+;;----
+;;unspecified
+;;- 函数通过副作用更新全局变量 `interactive-arg-recent-file-json`。
+;;- 若路径不存在，则不做任何修改。
+;;
+;;逻辑
+;;----
+;;1. 调用 `recent-files-index-by-path` 查找 `path` 在 `files` 中的索引。
+;;2. 若找到索引，调用 `njson-drop!` 删除该项。
+;;3. 将 `meta.total` 减一（不低于 0）。
+;;4. 将更新后的 JSON 结构回写到 `interactive-arg-recent-file-json`。
 (define-public (recent-files-remove-by-path path)
   (let ((idx (recent-files-index-by-path interactive-arg-recent-file-json path)))
     (when idx
@@ -401,33 +399,31 @@ unspecified
       )))
 
 
-#|
-learned-interactive
-读取交互命令已学习的参数候选值。
-
-语法
-----
-(learned-interactive fun)
-
-参数
-----
-fun : procedure | symbol | string
-    目标命令。函数内部会先调用 `procedure-symbol-name` 归一化为符号。
-
-返回值
-----
-list
-- 当命令是 `recent-buffer` 时：返回最近文件路径列表，元素形如
-  `(("0" . 文件路径))`。
-- 其他命令：返回 `interactive-arg-json` 中为该命令记录的历史参数列表。
-- 若无记录，返回空列表 `()`。
-
-逻辑
-----
-1. 归一化：将 `fun` 转为符号名。
-2. 分支：`recent-buffer` 走最近文件 JSON 缓存分支。
-3. 默认：从 `interactive-arg-json` 读取命令历史，缺省为 `()`。
-|#
+;;learned-interactive
+;;读取交互命令已学习的参数候选值。
+;;
+;;语法
+;;----
+;;(learned-interactive fun)
+;;
+;;参数
+;;----
+;;fun : procedure | symbol | string
+;;    目标命令。函数内部会先调用 `procedure-symbol-name` 归一化为符号。
+;;
+;;返回值
+;;----
+;;list
+;;- 当命令是 `recent-buffer` 时：返回最近文件路径列表，元素形如
+;;  `(("0" . 文件路径))`。
+;;- 其他命令：返回 `interactive-arg-json` 中为该命令记录的历史参数列表。
+;;- 若无记录，返回空列表 `()`。
+;;
+;;逻辑
+;;----
+;;1. 归一化：将 `fun` 转为符号名。
+;;2. 分支：`recent-buffer` 走最近文件 JSON 缓存分支。
+;;3. 默认：从 `interactive-arg-json` 读取命令历史，缺省为 `()`。
 (define-public (learned-interactive fun)
   "Return learned list of interactive values for @fun"
   (set! fun (procedure-symbol-name fun))
@@ -443,33 +439,31 @@ list
 
 
 
-#|
-forget-interactive
-清除指定交互命令的已学习参数。
-
-语法
-----
-(forget-interactive fun)
-
-参数
-----
-fun : procedure | symbol | string
-    目标命令。函数内部会先调用 `procedure-symbol-name` 归一化为符号。
-
-返回值
-----
-unspecified
-- 通过副作用修改全局状态。
-- 若 `fun` 不能归一化为符号，则不执行清除操作。
-
-逻辑
-----
-1. 归一化：将 `fun` 转为符号名。
-2. 校验：仅当 `fun` 是符号时继续。
-3. 分支清理：
-   - `recent-buffer`：将最近文件列表重置为空向量 `#()`，并把计数清零。
-   - 其他命令：从 `interactive-arg-json` 中删除对应键。
-|#
+;;forget-interactive
+;;清除指定交互命令的已学习参数。
+;;
+;;语法
+;;----
+;;(forget-interactive fun)
+;;
+;;参数
+;;----
+;;fun : procedure | symbol | string
+;;    目标命令。函数内部会先调用 `procedure-symbol-name` 归一化为符号。
+;;
+;;返回值
+;;----
+;;unspecified
+;;- 通过副作用修改全局状态。
+;;- 若 `fun` 不能归一化为符号，则不执行清除操作。
+;;
+;;逻辑
+;;----
+;;1. 归一化：将 `fun` 转为符号名。
+;;2. 校验：仅当 `fun` 是符号时继续。
+;;3. 分支清理：
+;;   - `recent-buffer`：将最近文件列表重置为空向量 `#()`，并把计数清零。
+;;   - 其他命令：从 `interactive-arg-json` 中删除对应键。
 (define-public (forget-interactive fun)
   "Forget interactive values for @fun"
   (set! fun (procedure-symbol-name fun))

--- a/bin/format
+++ b/bin/format
@@ -33,3 +33,5 @@ clang-format -i 3rdparty/lolly/**/*.cpp
 clang-format -i 3rdparty/lolly/**/*.hpp
 
 gf fix TeXmacs/progs/kernel/boot
+gf fix TeXmacs/progs/kernel/library
+gf fix TeXmacs/progs/kernel/logic

--- a/devel/0102.md
+++ b/devel/0102.md
@@ -6,6 +6,8 @@
 ## 任务相关的代码文件
 - `bin/format`
 - `TeXmacs/progs/kernel/boot/*.scm`
+- `TeXmacs/progs/kernel/library/*.scm`
+- `TeXmacs/progs/kernel/logic/*.scm`
 
 ## 如何测试
 
@@ -17,6 +19,8 @@
 ### 非确定性测试（文档验证）
 ```bash
 gf fix TeXmacs/progs/kernel/boot
+gf fix TeXmacs/progs/kernel/library
+gf fix TeXmacs/progs/kernel/logic
 ```
 
 ## 如何提交
@@ -27,6 +31,9 @@ gf fix TeXmacs/progs/kernel/boot
 ./bin/format
 git diff
 ```
+
+## 工具版本
+- `gf` (Goldfish Scheme) 18.11.5
 
 ## What
 
@@ -41,10 +48,16 @@ git diff
 
 ## How
 
-在 `bin/format` 脚本末尾、所有 `clang-format` 调用之后，追加一行：
+在 `bin/format` 脚本末尾、所有 `clang-format` 调用之后，追加以下三行：
 
 ```
 gf fix TeXmacs/progs/kernel/boot
+gf fix TeXmacs/progs/kernel/library
+gf fix TeXmacs/progs/kernel/logic
 ```
 
 `gf`（Goldfish Scheme）的 `fix` 子命令会递归修正指定目录下所有 `.scm` 文件的括号格式。
+已完成的格式化：
+1. `TeXmacs/progs/kernel/boot` — 启动文件
+2. `TeXmacs/progs/kernel/library` — 基础库文件
+3. `TeXmacs/progs/kernel/logic` — 逻辑查询文件


### PR DESCRIPTION
## 摘要

- 将 `TeXmacs/progs/kernel/boot`、`library`、`logic` 三个目录纳入 `bin/format` 自动格式化流程
- 使用 `gf fix`（Goldfish Scheme 18.11.5）完成上述三个目录的 Scheme 文件格式化
- 将 kernel 目录下的多行注释统一改为双分号注释

## 变更内容

1. `bin/format`：追加 `gf fix TeXmacs/progs/kernel/library` 和 `gf fix TeXmacs/progs/kernel/logic`
2. `devel/0102.md`：更新任务文档，记录工具版本和已格式化的目录
3. `TeXmacs/progs/kernel/boot/*.scm`：gf fix 格式化
4. `TeXmacs/progs/kernel/library/*.scm`：gf fix 格式化
5. `TeXmacs/progs/kernel/logic/*.scm`：gf fix 格式化

## 测试

- [x] `./bin/format` 执行通过
- [x] `git diff` 确认格式化结果正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)