### PR TITLE
[0102] gf fix TeXmacs/progs/kernel 并更新 bin/format

### DIFF
--- a/TeXmacs/progs/kernel/boot/boot.scm
+++ b/TeXmacs/progs/kernel/boot/boot.scm
@@ -77,8 +77,8 @@
 (if (guile-a?)
   (define-macro (define-public-macro head . body)
     `(define-public ,(car head)
-       (*comment* " FIXME: why can't we use procedure->macro")
-       (*comment* " for a non-memoizing variant?")
+       ;; FIXME: why can't we use procedure->macro
+       ;; for a non-memoizing variant?
        (procedure->memoizing-macro (lambda (cmd env)
                                      (apply (lambda ,(cdr head) ,@body)
                                        (cdr cmd)))))

--- a/TeXmacs/progs/kernel/gui/gui-markup.scm
+++ b/TeXmacs/progs/kernel/gui/gui-markup.scm
@@ -11,8 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui gui-markup)
-  (:use (kernel regexp regexp-match)))
+(texmacs-module (kernel gui gui-markup) (:use (kernel regexp regexp-match)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Style constants
@@ -35,111 +34,130 @@
 (tm-define (gui-normalize l)
   (cond ((null? l) l)
         ((func? (car l) 'list)
-         (append (gui-normalize (cdar l)) (gui-normalize (cdr l))))
-        (else (cons (car l) (gui-normalize (cdr l))))))
+         (append (gui-normalize (cdar l)) (gui-normalize (cdr l)))
+        ) ;
+        (else (cons (car l) (gui-normalize (cdr l))))
+  ) ;cond
+) ;tm-define
 
 (tm-define-macro ($list . l)
   (:synopsis "Make widgets")
-  `(gui-normalize (list ,@l)))
+  `(gui-normalize (list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($begin . l)
   (:synopsis "Begin primitive for content generation")
-  `(cons* 'list ($list ,@l)))
+  `(cons* 'list ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($if pred? . l)
   (:synopsis "When primitive for content generation")
-  (cond ((== (length l) 1)
-         `(cons* 'list (if ,pred? ($list ,(car l)) '())))
+  (cond ((== (length l) 1) `(cons* 'list (if ,pred? ($list ,(car l)) '())))
         ((== (length l) 2)
-         `(cons* 'list (if ,pred? ($list ,(car l)) ($list ,(cadr l)))))
-        (else
-          (texmacs-error "$if" "invalid number of arguments"))))
+         `(cons* 'list (if ,pred? ($list ,(car l)) ($list ,(cadr l))))
+        ) ;
+        (else (texmacs-error "$if" "invalid number of arguments"))
+  ) ;cond
+) ;tm-define-macro
 
 (tm-define-macro ($when pred? . l)
   (:synopsis "When primitive for content generation")
-  `(cons* 'list (if ,pred? ($list ,@l) '())))
+  `(cons* 'list (if ,pred? ($list ,@l) '()))
+) ;tm-define-macro
 
 (tm-define-macro ($for* var-vals . l)
   (:synopsis "For primitive for content generation")
   `(list 'for
-         (lambda (,(car var-vals)) ($list ,@l))
-         (lambda () ,(cadr var-vals))))
+     (lambda (,(car var-vals)) ($list ,@l))
+     (lambda ,() ,(cadr var-vals)))
+) ;tm-define-macro
 
 (tm-define (cond$sub l)
-  (cond ((null? l)
-         (list `(else '())))
-        ((npair? (car l))
-         (texmacs-error "cond$sub" "syntax error ~S" l))
-        ((== (caar l) 'else)
-         (list `(else ($list ,@(cdar l)))))
-        (else (cons `(,(caar l) ($list ,@(cdar l)))
-                    (cond$sub (cdr l))))))
+  (cond ((null? l) (list '(else '())))
+        ((npair? (car l)) (texmacs-error "cond$sub" "syntax error ~S" l))
+        ((== (caar l) 'else) (list `(else ($list ,@(cdar l)))))
+        (else (cons `(,(caar l) ($list ,@(cdar l))) (cond$sub (cdr l))))
+  ) ;cond
+) ;tm-define
 
 (tm-define-macro ($cond . l)
   (:synopsis "Cond primitive for content generation")
-  `(cons* 'list (cond ,@(cond$sub l))))
+  `(cons* 'list (cond ,@(cond$sub l)))
+) ;tm-define-macro
 
 (tm-define-macro ($let decls . l)
   (:synopsis "Let* primitive for content generation")
-  `(let ,decls
-     (cons* 'list ($list ,@l))))
+  `(let ,decls (cons* 'list ($list ,@l)))
+) ;tm-define-macro
 
 (tm-define-macro ($let* decls . l)
   (:synopsis "Let* primitive for content generation")
-  `(let* ,decls
-     (cons* 'list ($list ,@l))))
+  `(let* ,decls (cons* 'list ($list ,@l)))
+) ;tm-define-macro
 
 (tm-define-macro ($with var val . l)
   (:synopsis "With primitive for content generation")
   (if (string? var)
-      ($quote `(with ,var ,val ($unquote ($inline ,@l))))
-      `(with ,var ,val
-         (cons* 'list ($list ,@l)))))
+    ($quote `(with ,var ,val ($unquote ($inline ,@l))))
+    `(with ,var ,val (cons* 'list ($list ,@l)))
+  ) ;if
+) ;tm-define-macro
 
 (tm-define-macro ($execute cmd . l)
   (:synopsis "Execute one command")
-  `(begin
-     ,cmd
-     (cons* 'list ($list ,@l))))
+  `(begin ,cmd (cons* 'list ($list ,@l)))
+) ;tm-define-macro
 
 (tm-define-macro ($for var-val . l)
   (:synopsis "For primitive for content generation")
   (when (nlist-2? var-val)
-    (texmacs-error "$for" "syntax error in ~S" var-val))
-  (with fun `(lambda (,(car var-val)) ($list ,@l))
-    `(cons* 'list (append-map ,fun ,(cadr var-val)))))
+    (texmacs-error "$for" "syntax error in ~S" var-val)
+  ) ;when
+  (with fun
+    `(lambda (,(car var-val)) ($list ,@l))
+    `(cons* 'list (append-map ,fun ,(cadr var-val)))
+  ) ;with
+) ;tm-define-macro
 
 (tm-define-macro ($dynamic w)
   (:synopsis "Make dynamic widgets")
-  `(cons* 'list ,w))
+  `(cons* 'list ,w)
+) ;tm-define-macro
 
 (tm-define-macro ($promise cmd)
   (:synopsis "Promise widgets")
-  `(list 'promise (lambda () ,cmd)))
+  `(list 'promise (lambda ,() ,cmd))
+) ;tm-define-macro
 
 (tm-define-macro ($menu-link w)
   (:synopsis "Make dynamic link to another widget")
-  `(list 'link ',w))
+  `(list 'link (quote ,w))
+) ;tm-define-macro
 
 (tm-define-macro ($delayed-when pred? . l)
   (:synopsis "Delayed when primitive for content generation")
-  `(cons* 'if (lambda () ,pred?) ($list ,@l)))
+  `(cons* 'if (lambda ,() ,pred?) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($assuming pred? . l)
   (:synopsis "Make possibly inert (whence greyed) widgets")
-  `(cons* 'when (lambda () ,pred?) ($list ,@l)))
+  `(cons* 'when (lambda ,() ,pred?) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($refresh s kind)
   (:synopsis "Make a refresh widget")
-  `(list 'refresh ',s ,kind))
+  `(list 'refresh (quote ,s) ,kind)
+) ;tm-define-macro
 
 (tm-define-macro ($refreshable kind . l)
   (:synopsis "Make a refreshable widget")
-  `(cons* 'refreshable (lambda () ,kind) ($list ,@l)))
+  `(cons* 'refreshable (lambda ,() ,kind) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($cached kind valid? . l)
   (:synopsis "Make a cached widget")
-  `(cons* 'cached (lambda () ,kind) (lambda () ,valid?) ($list ,@l)))
+  `(cons* 'cached (lambda ,() ,kind) (lambda ,() ,valid?) ($list ,@l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; General layout widgets
@@ -147,245 +165,293 @@
 
 (tm-define-macro ($glue hext? vext? minw minh)
   (:synopsis "Make extensible glue")
-  `(list 'glue ,hext? ,vext? ,minw ,minh))
+  `(list 'glue ,hext? ,vext? ,minw ,minh)
+) ;tm-define-macro
 
 (tm-define-macro ($colored-glue col hext? vext? minw minh)
   (:synopsis "Make extensible colored glue")
-  `(list 'color ,col ,hext? ,vext? ,minw ,minh))
+  `(list 'color ,col ,hext? ,vext? ,minw ,minh)
+) ;tm-define-macro
 
 (tm-define-macro ($hlist . l)
   (:synopsis "Horizontal layout of widgets")
-  `(cons* 'hlist ($list ,@l)))
+  `(cons* 'hlist ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($vlist . l)
   (:synopsis "Vertical layout of widgets")
-  `(cons* 'vlist ($list ,@l)))
+  `(cons* 'vlist ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($division name . l)
   (:synopsis "Widget with CSS style name")
-  `(cons* 'division (lambda () ,name) ($list ,@l)))
+  `(cons* 'division (lambda ,() ,name) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($class name . l)
   (:synopsis "Widget with CSS style name")
-  `(cons* 'class (lambda () ,name) ($list ,@l)))
+  `(cons* 'class (lambda ,() ,name) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($aligned . l)
   (:synopsis "Align two column table")
-  `(cons* 'aligned ($list ,@l)))
+  `(cons* 'aligned ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($aligned-item . l)
   (:synopsis "Item in an aligned list")
-  `(cons* 'aligned-item ($list ,@l)))
+  `(cons* 'aligned-item ($list ,@l))
+) ;tm-define-macro
 
-(tm-define-macro ($tabs . l)
-  (:synopsis "A tab bar")
-  `(cons* 'tabs ($list ,@l)))
+(tm-define-macro ($tabs . l) (:synopsis "A tab bar") `(cons* 'tabs ($list ,@l)))
 
 (tm-define-macro ($tab . l)
   (:synopsis "One tab of a tab bar")
-  `(cons* 'tab ($list ,@l)))
+  `(cons* 'tab ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($icon-tabs . l)
   (:synopsis "An icon tab bar")
-  `(cons* 'icon-tabs ($list ,@l)))
+  `(cons* 'icon-tabs ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($icon-tab . l)
   (:synopsis "One icon tab of an icon tab bar")
-  `(cons* 'icon-tab ($list ,@l)))
+  `(cons* 'icon-tab ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($horizontal . l)
   (:synopsis "Horizontal layout of widgets")
-  `(cons* 'horizontal ($list ,@l)))
+  `(cons* 'horizontal ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($vertical . l)
   (:synopsis "Vertical layout of widgets")
-  `(cons* 'vertical ($list ,@l)))
+  `(cons* 'vertical ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($tile columns . l)
   (:synopsis "Tile layout of widgets")
-  `(cons* 'tile ,columns ($list ,@l)))
+  `(cons* 'tile ,columns ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($scrollable . l)
   (:synopsis "Make a scrollable widget")
-  `(cons* 'scrollable ($list ,@l)))
+  `(cons* 'scrollable ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($resize w h . l)
   (:synopsis "Resize the widget")
-  `(cons* 'resize (lambda () ,w) (lambda () ,h) ($list ,@l)))
+  `(cons* 'resize (lambda ,() ,w) (lambda ,() ,h) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($hsplit l r)
   (:synopsis "Widget which is split horizontally into two parts")
-  `(list 'hsplit ,l ,r))
+  `(list 'hsplit ,l ,r)
+) ;tm-define-macro
 
 (tm-define-macro ($vsplit t b)
   (:synopsis "Widget which is split vertically into two parts")
-  `(list 'vsplit ,t ,b))
+  `(list 'vsplit ,t ,b)
+) ;tm-define-macro
 
-(tm-define $/
-  (:synopsis "Horizontal separator")
-  (string->symbol "|"))
+(tm-define $/ (:synopsis "Horizontal separator") (string->symbol "|"))
 
-(tm-define $---
-  (:synopsis "Vertical separator")
-  '---)
+(tm-define $--- (:synopsis "Vertical separator") '---)
 
 (tm-define-macro ($mini pred? . l)
   (:synopsis "Make mini widgets")
-  `(cons* 'mini (lambda () ,pred?) ($list ,@l)))
+  `(cons* 'mini (lambda ,() ,pred?) ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro (gui$minibar . l)
   (:synopsis "Make minibar")
-  `(cons* 'minibar ($list ,@l)))
+  `(cons* 'minibar ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($widget-style st . l)
   (:synopsis "Change the style of a widget")
-  `(cons* 'style ,st ($list ,@l)))
+  `(cons* 'style ,st ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($widget-extend w . l)
   (:synopsis "Extend the size of a widget")
-  `(cons* 'extend ,w ($list ,@l)))
+  `(cons* 'extend ,w ($list ,@l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu and widget elements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; Temporary hack:
 (tm-define all-translations (make-ahash-table))
 
 (define (process-translate x)
   (if (or (func? x 'concat) (func? x 'verbatim) (func? x 'replace))
-      `(list ',(car x) ,@(map process-translate (cdr x)))
-      x))
+    `(list (quote ,(car x)) ,@(map process-translate (cdr x)))
+    x
+  ) ;if
+) ;define
 
 (tm-define-macro ($-> text . l)
   (:synopsis "Make pullright button")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(cons* '-> ,text ($list ,@l)))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(cons* '-> ,text ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($=> text . l)
   (:synopsis "Make pulldown button")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(cons* '=> ,text ($list ,@l)))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(cons* '=> ,text ($list ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($> text . cmds)
   (:synopsis "Make button")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(list ,text (lambda () ,@cmds)))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(list ,text (lambda ,() ,@cmds))
+) ;tm-define-macro
 
 (tm-define-macro ($check text check pred?)
   (:synopsis "Make check")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(list 'check ,text ,check (lambda () ,pred?)))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(list 'check ,text ,check (lambda ,() ,pred?))
+) ;tm-define-macro
 
 (tm-define-macro ($shortcut* text sh)
   (:synopsis "Make shortcut")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(list 'shortcut ,text ,sh))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(list 'shortcut ,text ,sh)
+) ;tm-define-macro
 
 (tm-define-macro ($balloon text balloon)
   (:synopsis "Make balloon")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(list 'balloon ,text ,balloon))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(list 'balloon ,text ,balloon)
+) ;tm-define-macro
 
 (tm-define-macro ($concat-text . l)
   (:synopsis "Make text concatenation")
-  `(quote (concat ,@l)))
+  `(quote (concat ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($verbatim-text . l)
   (:synopsis "Make verbatim text")
-  `(quote (verbatim ,@l)))
+  `(quote (verbatim ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($replace-text str . x)
   (:synopsis "Make text to be translated with arguments")
-  (if developer-mode?
-      (ahash-set! all-translations (car x) #t))
-  `(quote (replace ,str ,@x)))
+  (if developer-mode? (ahash-set! all-translations (car x) #t))
+  `(quote (replace ,str ,@x))
+) ;tm-define-macro
 
-(tm-define-macro ($icon name)
-  (:synopsis "Make icon")
-  `(list 'icon ,name))
+(tm-define-macro ($icon name) (:synopsis "Make icon") `(list 'icon ,name))
 
 (tm-define-macro ($symbol sym . l)
   (:synopsis "Make a menu symbol")
-  (if (null? l)
-      `(list 'symbol ,sym)
-      `(list 'symbol ,sym (lambda () ,(car l)))))
+  (if (null? l) `(list 'symbol ,sym) `(list 'symbol ,sym (lambda ,() ,(car l))))
+) ;tm-define-macro
 
 (tm-define-macro ($menu-group text)
   (:synopsis "Make a menu group")
-  `(list 'group ,(process-translate text)))
+  `(list 'group ,(process-translate text))
+) ;tm-define-macro
 
 (tm-define-macro ($menu-text text)
   (:synopsis "Make text")
-  (if developer-mode?
-    (ahash-set! all-translations text #t))
-  `(list 'text ,(process-translate text)))
+  (if developer-mode? (ahash-set! all-translations text #t))
+  `(list 'text ,(process-translate text))
+) ;tm-define-macro
 
 (tm-define-macro ($menu-invisible text)
   (:synopsis "Make invisible")
-  `(list 'invisible ,text))
+  `(list 'invisible ,text)
+) ;tm-define-macro
 
 (tm-define-macro ($input cmd type proposals width)
   (:synopsis "Make input field")
-  `(list 'input (lambda (answer) ,cmd) ,type (lambda () ,proposals) ,width))
+  `(list 'input (lambda (answer) ,cmd) ,type (lambda ,() ,proposals) ,width)
+) ;tm-define-macro
 
 (tm-define-macro ($numeric-input cmd width unit min max step def)
   (:synopsis "Make numeric input field")
-  `(list 'numeric-input (lambda (answer) ,cmd) ,width ,unit ,min ,max ,step ,def))
+  `(list 'numeric-input
+     (lambda (answer) ,cmd)
+     ,width
+     ,unit
+     ,min
+     ,max
+     ,step
+     ,def)
+) ;tm-define-macro
 
 (tm-define-macro ($toggle cmd on)
   (:synopsis "Make input toggle")
-  `(list 'toggle (lambda (answer) ,cmd) (lambda () ,on)))
+  `(list 'toggle (lambda (answer) ,cmd) (lambda ,() ,on))
+) ;tm-define-macro
 
 (tm-define-macro ($enum cmd vals val width)
   (:synopsis "Make input enumeration field")
-  `(list 'enum (lambda (answer) ,cmd) (lambda () ,vals) (lambda () ,val)
-         ,width))
+  `(list 'enum
+     (lambda (answer) ,cmd)
+     (lambda ,() ,vals)
+     (lambda ,() ,val)
+     ,width)
+) ;tm-define-macro
 
 (tm-define-macro ($choice cmd vals val)
   (:synopsis "Make a choice list")
-  `(list 'choice (lambda (answer) ,cmd) (lambda () ,vals) (lambda () ,val)))
+  `(list 'choice (lambda (answer) ,cmd) (lambda ,() ,vals) (lambda ,() ,val))
+) ;tm-define-macro
 
 (tm-define-macro ($choices cmd vals mc)
   (:synopsis "Make a multiple choice list")
-  `(list 'choices (lambda (answer) ,cmd) (lambda () ,vals) (lambda () ,mc)))
+  `(list 'choices (lambda (answer) ,cmd) (lambda ,() ,vals) (lambda ,() ,mc))
+) ;tm-define-macro
 
 (tm-define-macro ($filtered-choice cmd vals val filterstr)
   (:synopsis "Make a scrollable choice list with a filter on top")
-  `(list 'filtered-choice (lambda (answer filter) ,cmd) (lambda () ,vals)
-                           (lambda () ,val) (lambda () ,filterstr)))
+  `(list 'filtered-choice
+     (lambda (answer filter) ,cmd)
+     (lambda ,() ,vals)
+     (lambda ,() ,val)
+     (lambda ,() ,filterstr))
+) ;tm-define-macro
 
 (tm-define-macro ($color-input cmd bg? proposals)
   (:synopsis "Make color picker")
-  `(list 'color-input (lambda (answer) ,cmd) ,bg? (lambda () ,proposals)))
+  `(list 'color-input (lambda (answer) ,cmd) ,bg? (lambda ,() ,proposals))
+) ;tm-define-macro
 
 (tm-define-macro ($tree-view cmd data roles)
   (:synopsis "Make a tree view of the data")
-  `(list 'tree-view (lambda x (apply ,cmd (reverse x)))
-                    (lambda () ,data) (lambda () ,roles)))
+  `(list 'tree-view
+     (lambda x (apply ,cmd (reverse x)))
+     (lambda ,() ,data)
+     (lambda ,() ,roles))
+) ;tm-define-macro
 
 (tm-define-macro ($texmacs-output doc tmstyle)
   (:synopsis "Make TeXmacs output field")
-  `(list 'texmacs-output (lambda () ,doc) (lambda () ,tmstyle)))
+  `(list 'texmacs-output (lambda ,() ,doc) (lambda ,() ,tmstyle))
+) ;tm-define-macro
 
 (tm-define-macro ($texmacs-input doc tmstyle name)
   (:synopsis "Make TeXmacs input field")
-  `(list 'texmacs-input (lambda () ,doc) (lambda () ,tmstyle)
-                        (lambda () ,name)))
+  `(list 'texmacs-input
+     (lambda ,() ,doc)
+     (lambda ,() ,tmstyle)
+     (lambda ,() ,name))
+) ;tm-define-macro
 
 (tm-define-macro ($ink cmd)
   (:synopsis "Make an ink widget")
-  `(list 'ink (lambda (answer) ,cmd)))
+  `(list 'ink (lambda (answer) ,cmd))
+) ;tm-define-macro
 
 (tm-define-macro ($tab-page url title button active?)
-  (:synopsis "Make a tab page") 
-  `(list 'tab-page ,url ,title ,button ,active?))
+  (:synopsis "Make a tab page")
+  `(list 'tab-page ,url ,title ,button ,active?)
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Forms
@@ -398,84 +464,84 @@
 
 (tm-define (form-named-set name field val)
   (if (and (pair? val) (pair? (cdr val)) (cadr val)) (set! val (car val)))
-  (ahash-set! form-last (list name field) val))
+  (ahash-set! form-last (list name field) val)
+) ;tm-define
 
 (tm-define (form-named-set-multiple name field val)
-  (ahash-set! form-last (list name field) val))
+  (ahash-set! form-last (list name field) val)
+) ;tm-define
 
-(tm-define (form-named-ref name field)
-  (ahash-ref form-last (list name field)))
+(tm-define (form-named-ref name field) (ahash-ref form-last (list name field)))
 
-(tm-define-macro (form-set field val)
-  `(form-named-set form-name ,field ,val))
+(tm-define-macro (form-set field val) `(form-named-set form-name ,field ,val))
 
-(tm-define-macro (form-ref field)
-  `(form-named-ref form-name ,field))
+(tm-define-macro (form-ref field) `(form-named-ref form-name ,field))
 
-(tm-define-macro (form-fields)
-  `form-entries)
+(tm-define-macro (form-fields) 'form-entries)
 
-(tm-define-macro (form-values)
-  `(map (lambda (x) (form-ref x)) (form-fields)))
+(tm-define-macro (form-values) '(map (lambda (x) (form-ref x)) (form-fields)))
 
 (tm-define-macro ($form name . l)
   (:synopsis "Make form")
-  `($let* ((form-name ,name)
-           (form-entries (list))
-           (form-text-entries (list)))
-     ,@l))
+  `($let* ((form-name ,name) (form-entries (list)) (form-text-entries (list)))
+     ,@l)
+) ;tm-define-macro
 
 (tm-define (form-proposals name field l)
   (if (nnull? l) (form-named-set name field (car l)))
-  l)
+  l
+) ;tm-define
 
 (tm-define (form-proposals-sel name field l selected)
-  (:synopsis "Inits the value of @field in form @name to the @selected value and returns the list @l unmodified")
+  (:synopsis "Inits the value of @field in form @name to the @selected value and returns the list @l unmodified"
+  ) ;:synopsis
   (if (nnull? l) (form-named-set name field selected))
-  l)
+  l
+) ;tm-define
 
 (tm-define-macro ($form-input field type proposals width)
   (:synopsis "Make a textual input field for the current form")
-  `($execute
-     (begin
-       (set! form-entries (append form-entries (list ,field)))
-       (set! form-text-entries (append form-text-entries (list ,field))))
+  `($execute (begin
+               (set! form-entries (append form-entries (list ,field)))
+               (set! form-text-entries (append form-text-entries (list ,field))))
      ($input (form-named-set form-name ,field answer)
-             (with nr (number->string (length form-text-entries))
-               (string-append ,field "#form-" form-name "-" nr ":" ,type))
-	     (form-proposals form-name ,field ,proposals) ,width)))
+       (with nr
+         (number->string (length form-text-entries))
+         (string-append ,field ,"#form-" form-name ,"-" nr ,":" ,type))
+       (form-proposals form-name ,field ,proposals)
+       ,width))
+) ;tm-define-macro
 
 (tm-define-macro ($form-enum field proposals selected width)
   (:synopsis "Make an enumeration field for the current form")
-  `($execute
-     (set! form-entries (append form-entries (list ,field)))
+  `($execute (set! form-entries (append form-entries (list ,field)))
      ($enum (form-named-set form-name ,field answer)
-            (form-proposals-sel form-name ,field ,proposals ,selected)
-            ,selected ,width)))
+       (form-proposals-sel form-name ,field ,proposals ,selected)
+       ,selected
+       ,width))
+) ;tm-define-macro
 
-(tm-define-macro ($form-choice field proposals selected) 
-  (:synopsis "Make a single choice field for the current form") 
-  `($execute
-     (set! form-entries (append form-entries (list ,field))) 
+(tm-define-macro ($form-choice field proposals selected)
+  (:synopsis "Make a single choice field for the current form")
+  `($execute (set! form-entries (append form-entries (list ,field)))
      ($choice (form-named-set form-name ,field answer)
-              (form-proposals-sel form-name ,field ,proposals ,selected)
-              ,selected)))
+       (form-proposals-sel form-name ,field ,proposals ,selected)
+       ,selected))
+) ;tm-define-macro
 
-(tm-define-macro ($form-choices field proposals selected) 
-  (:synopsis "Make a multiple choice field for the current form") 
-  `($execute
-     (set! form-entries (append form-entries (list ,field))) 
+(tm-define-macro ($form-choices field proposals selected)
+  (:synopsis "Make a multiple choice field for the current form")
+  `($execute (set! form-entries (append form-entries (list ,field)))
      ($choices (form-named-set-multiple form-name ,field answer)
-               (begin
-                 (form-named-set-multiple form-name ,field ,selected)
-                 ,proposals)
-               ,selected)))
+       (begin (form-named-set-multiple form-name ,field ,selected) ,proposals)
+       ,selected))
+) ;tm-define-macro
 
 (tm-define-macro ($form-toggle field on?)
-  (:synopsis "Make a toggle field for the current form") 
-  `($execute
-     (set! form-entries (append form-entries (list ,field))) 
-     ($toggle (form-named-set form-name ,field answer) ,on?)))
+  (:synopsis "Make a toggle field for the current form")
+  `($execute (set! form-entries (append form-entries (list ,field)))
+     ($toggle (form-named-set form-name ,field answer) ,on?))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic text markup
@@ -488,170 +554,198 @@
         ((symbol? x) (symbol->string x))
         ((== x #t) "true")
         ((== x #f) "false")
-        (else x)))
+        (else x)
+  ) ;cond
+) ;tm-define
 
 (tm-define (markup-build-concat l)
-  (with r (map markup-build-atom l)
+  (with r
+    (map markup-build-atom l)
     (cond ((null? r) "")
           ((list-1? r) (car r))
-          (else (cons 'concat r)))))
+          (else (cons 'concat r))
+    ) ;cond
+  ) ;with
+) ;tm-define
 
 (tm-define (markup-build-paragraphs l block?)
-  (with s (list-scatter l (lambda (x) (== x '$lf)) #f)
-    (with r (map markup-build-concat s)
+  (with s
+    (list-scatter l (lambda (x) (== x '$lf)) #f)
+    (with r
+      (map markup-build-concat s)
       (cond ((and (null? r) block?) '(document ""))
             ((null? r) "")
             ((and (list-1? r) (not block?)) (car r))
-            (else (cons 'document r))))))
+            (else (cons 'document r))
+      ) ;cond
+    ) ;with
+  ) ;with
+) ;tm-define
 
 (tm-define (markup-expand-document x)
   (if (tm-is? x 'document)
-      (append-map (lambda (x) (list x $lf)) (tm-cdr x))
-      (list x)))
+    (append-map (lambda (x) (list x $lf)) (tm-cdr x))
+    (list x)
+  ) ;if
+) ;tm-define
 
 (tm-define (markup-build-document l block?)
-  (with x (append-map markup-expand-document l)
-    (with y (if (and (nnull? x) (== (cAr x) $lf)) (cDr x) x)
-      (markup-build-paragraphs y block?))))
+  (with x
+    (append-map markup-expand-document l)
+    (with y
+      (if (and (nnull? x) (== (cAr x) $lf)) (cDr x) x)
+      (markup-build-paragraphs y block?)
+    ) ;with
+  ) ;with
+) ;tm-define
 
-(tm-define-macro ($textual . l)
-  `(markup-build-document ($list ,@l) #f))
+(tm-define-macro ($textual . l) `(markup-build-document ($list ,@l) ,#f))
 
-(tm-define-macro ($inline . l)
-  `(markup-build-document ($list ,@l) #f))
+(tm-define-macro ($inline . l) `(markup-build-document ($list ,@l) ,#f))
 
-(tm-define-macro ($block . l)
-  `(markup-build-document ($list ,@l) #t))
+(tm-define-macro ($block . l) `(markup-build-document ($list ,@l) ,#t))
 
 (define (replace-unquotes x)
   (cond ((npair? x) x)
         ((== (car x) '$unquote) (cons 'unquote (cdr x)))
-        (else (cons (replace-unquotes (car x)) (replace-unquotes (cdr x))))))
+        (else (cons (replace-unquotes (car x)) (replace-unquotes (cdr x))))
+  ) ;cond
+) ;define
 
-(tm-define ($quote x)
-  (list 'quasiquote (replace-unquotes x)))
+(tm-define ($quote x) (list 'quasiquote (replace-unquotes x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic markup
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define-macro ($para . l)
-  ($quote `(document ($unquote ($block ,@l)))))
+(tm-define-macro ($para . l) ($quote `(document ($unquote ($block ,@l)))))
 
 (tm-define-macro ($itemize . l)
-  ($quote `(document (itemize ($unquote ($block ,@l))))))
+  ($quote `(document (itemize ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($enumerate . l)
-  ($quote `(document (enumerate ($unquote ($block ,@l))))))
+  ($quote `(document (enumerate ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($description . l)
-  ($quote `(document (description ($unquote ($block ,@l))))))
+  ($quote `(document (description ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($description-aligned . l)
-  ($quote `(document (description-aligned ($unquote ($block ,@l))))))
+  ($quote `(document (description-aligned ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($description-long . l)
-  ($quote `(document (description-long ($unquote ($block ,@l))))))
+  ($quote `(document (description-long ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
-(tm-define-macro ($item)
-  ($quote `(item)))
+(tm-define-macro ($item) ($quote '(item)))
 
-(tm-define-macro ($item* . l)
-  ($quote `(item* ($unquote ($inline ,@l)))))
+(tm-define-macro ($item* . l) ($quote `(item* ($unquote ($inline ,@l)))))
 
-(tm-define-macro ($list-item . l)
-  `($begin ($item) ,@l $lf))
+(tm-define-macro ($list-item . l) `($begin ($item) ,@l $lf))
 
-(tm-define-macro ($describe-item key . l)
-  `($begin ($item* ,key) ,@l $lf))
+(tm-define-macro ($describe-item key . l) `($begin ($item* ,key) ,@l $lf))
 
-(tm-define-macro ($strong . l)
-  ($quote `(strong ($unquote ($inline ,@l)))))
+(tm-define-macro ($strong . l) ($quote `(strong ($unquote ($inline ,@l)))))
 
 (tm-define-macro ($ismall . l)
-  ($quote `(small (with "font-shape" "italic" ($unquote ($inline ,@l))))))
+  ($quote `(small (with ,"font-shape" ,"italic" ($unquote ($inline ,@l)))))
+) ;tm-define-macro
 
-(tm-define-macro ($verbatim . l)
-  ($quote `(verbatim ($unquote ($inline ,@l)))))
+(tm-define-macro ($verbatim . l) ($quote `(verbatim ($unquote ($inline ,@l)))))
 
 (tm-define-macro ($link dest . l)
-  ($quote `(hlink ($unquote ($inline ,@l)) ($unquote ($textual (utf8->cork ,dest))))))
+  ($quote `(hlink ($unquote ($inline ,@l))
+             ($unquote ($textual (utf8->cork ,dest))))
+  ) ;$quote
+) ;tm-define-macro
 
 (tm-define-macro ($color col . l)
-  ($quote `(with "color" ,col ($unquote ($inline ,@l)))))
+  ($quote `(with ,"color" ,col ($unquote ($inline ,@l))))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specific markup for TeXmacs documentation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define-macro ($generic . l)
-  ($quote
-   `(document
-      (TeXmacs ,(texmacs-version))
-      (style (tuple "generic"))
-      (body ($unquote ($block ,@l))))))
+  ($quote `(document (TeXmacs ,(texmacs-version))
+             (style (tuple "generic"))
+             (body ($unquote ($block ,@l))))
+  ) ;$quote
+) ;tm-define-macro
 
 (tm-define-macro ($tmdoc . l)
-  (with lan (get-output-language)
-    ($quote
-      `(document
-         (TeXmacs ,(texmacs-version))
-         (style (tuple "tmdoc" ,lan))
-         (body ($unquote ($block ,@l)))))))
+  (with lan
+    (get-output-language)
+    ($quote `(document (TeXmacs ,(texmacs-version))
+               (style (tuple ,"tmdoc" ,lan))
+               (body ($unquote ($block ,@l))))
+    ) ;$quote
+  ) ;with
+) ;tm-define-macro
 
-(tm-define-macro ($localize . l)
-  `(tree-translate ($inline ,@l)))
+(tm-define-macro ($localize . l) `(tree-translate ($inline ,@l)))
 
 (tm-define-macro ($tmdoc-title . l)
-  ($quote `(document (tmdoc-title ($unquote ($inline ,@l))))))
+  ($quote `(document (tmdoc-title ($unquote ($inline ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($tmfs-title . l)
-  ($quote `(document (tmfs-title ($unquote ($inline ,@l))))))
+  ($quote `(document (tmfs-title ($unquote ($inline ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($folded key . l)
-  ($quote `(document (folded ($unquote ($inline ,key))
-                             ($unquote ($block ,@l))))))
+  ($quote `(document (folded ($unquote ($inline ,key)) ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($unfolded key . l)
   ($quote `(document (unfolded ($unquote ($inline ,key))
-                               ($unquote ($block ,@l))))))
+                       ($unquote ($block ,@l))))
+  ) ;$quote
+) ;tm-define-macro
 
 (tm-define-macro ($folded-documentation key . l)
   ($quote `(document (folded-documentation ($unquote ($inline ,key))
-                                           ($unquote ($block ,@l))))))
+                       ($unquote ($block ,@l))))
+  ) ;$quote
+) ;tm-define-macro
 
 (tm-define-macro ($unfolded-documentation key . l)
   ($quote `(document (unfolded-documentation ($unquote ($inline ,key))
-                                             ($unquote ($block ,@l))))))
+                       ($unquote ($block ,@l))))
+  ) ;$quote
+) ;tm-define-macro
 
 (tm-define-macro ($explain key . l)
-  ($quote `(document (explain ($unquote ($inline ,key))
-                              ($unquote ($block ,@l))))))
+  ($quote `(document (explain ($unquote ($inline ,key)) ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
 (tm-define-macro ($tm-fragment . l)
-  ($quote `(document (tm-fragment ($unquote ($block ,@l))))))
+  ($quote `(document (tm-fragment ($unquote ($block ,@l)))))
+) ;tm-define-macro
 
-(tm-define-macro ($markup . l)
-  ($quote `(markup ($unquote ($inline ,@l)))))
+(tm-define-macro ($markup . l) ($quote `(markup ($unquote ($inline ,@l)))))
 
-(tm-define-macro ($tmstyle . l)
-  ($quote `(tmstyle ($unquote ($inline ,@l)))))
+(tm-define-macro ($tmstyle . l) ($quote `(tmstyle ($unquote ($inline ,@l)))))
 
 (tm-define-macro ($shortcut cmd)
-  ($quote `(shortcut ($unquote (object->string ',cmd)))))
+  ($quote `(shortcut ($unquote (object->string (quote ,cmd)))))
+) ;tm-define-macro
 
 (tm-define-macro ($tmdoc-link dest . l)
-  `(with s (string-append "$TEXMACS_DOC_PATH/" ,dest ".en.tm")
-     ($link s ,@l)))
+  `(with s (string-append ,"$TEXMACS_DOC_PATH/" ,dest ,".en.tm") ($link s ,@l))
+) ;tm-define-macro
 
-(tm-define-macro ($menu . l)
-  `(list 'menu ,@l))
+(tm-define-macro ($menu . l) `(list 'menu ,@l))
 
 (tm-define-macro ($tmdoc-icon dest)
-  ($quote `(icon ($unquote ($textual ,dest)))))
+  ($quote `(icon ($unquote ($textual ,dest))))
+) ;tm-define-macro
 
-(tm-define-macro ($src-arg s)
-  ($quote `(src-arg ($unquote ($textual ,s)))))
+(tm-define-macro ($src-arg s) ($quote `(src-arg ($unquote ($textual ,s)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Graphics
@@ -659,145 +753,170 @@
 
 (tm-define-macro ($geometry w h unit . l)
   `(list 'with
-         "gr-geometry" (list 'tuple "geometry" ,w ,h "center")
-         "gr-frame" (list 'tuple "scale" ,unit
-                          (list 'tuple "0.5gw" "0.5gh"))
-         ($inline ,@l)))
+     ,"gr-geometry"
+     (list 'tuple ,"geometry" ,w ,h ,"center")
+     ,"gr-frame"
+     (list 'tuple ,"scale" ,unit (list 'tuple "0.5gw" "0.5gh"))
+     ($inline ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($auto-crop . l)
-  `(list 'with
-         "gr-auto-crop" "true"
-         ($inline ,@l)))
+  `(list 'with ,"gr-auto-crop" ,"true" ($inline ,@l))
+) ;tm-define-macro
 
 (tm-define-macro ($grid unit . l)
   `(list 'with
-         "gr-grid" (list 'tuple "cartesian" (list 'point "0" "0")
-                         ,(markup-build-coordinate unit))
-         ($inline ,@l)))
+     ,"gr-grid"
+     (list 'tuple
+       ,"cartesian"
+       (list 'point "0" "0")
+       ,(markup-build-coordinate unit))
+     ($inline ,@l))
+) ;tm-define-macro
 
 (define (build-with w x)
-  (if (tm-func? x 'with)
-      `(with ,@w ,@(cdr x))
-      `(with ,@w ,x)))
+  (if (tm-func? x 'with) `(with ,@w ,@(cdr x)) `(with ,@w ,x))
+) ;define
 
 (tm-define (markup-build-graphics-items l)
   (cond ((null? l) (list))
         ((tm-func? (car l) 'concat)
          (append (markup-build-graphics-items (cdar l))
-                 (markup-build-graphics-items (cdr l))))
+           (markup-build-graphics-items (cdr l))
+         ) ;append
+        ) ;
         ((tm-func? (car l) 'with)
          (let* ((head (cDr (cdar l)))
                 (tail (cAr (car l)))
                 (sl (if (tm-func? tail 'concat) (cdr tail) (list tail)))
                 (sr (map markup-build-graphics-items sl))
                 (sr* (map (lambda (x) (build-with head x)) sr))
-                (r (markup-build-graphics-items (cdr l))))
-           (append sr* r)))
-        (else (cons (car l) (markup-build-graphics-items (cdr l))))))
+                (r (markup-build-graphics-items (cdr l)))
+               ) ;
+           (append sr* r)
+         ) ;let*
+        ) ;
+        (else (cons (car l) (markup-build-graphics-items (cdr l))))
+  ) ;cond
+) ;tm-define
 
 (tm-define (markup-build-graphics l)
-  (with x (append-map markup-expand-document l)
-    (cons 'graphics (markup-build-graphics-items x))))
+  (with x
+    (append-map markup-expand-document l)
+    (cons 'graphics (markup-build-graphics-items x))
+  ) ;with
+) ;tm-define
 
-(tm-define-macro ($graphics . l)
-  `(markup-build-graphics ($list ,@l)))
+(tm-define-macro ($graphics . l) `(markup-build-graphics ($list ,@l)))
 
 (tm-define (markup-build-coordinate x)
   (cond ((string? x) x)
         ((number? x)
-         (if (exact? x)
-             (number->string (exact->inexact x))
-             (number->string x)))
-        (else "0")))
+         (if (exact? x) (number->string (exact->inexact x)) (number->string x))
+        ) ;
+        (else "0")
+  ) ;cond
+) ;tm-define
 
 (tm-define (markup-build-point l)
-  (with x (append-map markup-expand-document l)
-    (cons 'point (map markup-build-coordinate x))))
+  (with x
+    (append-map markup-expand-document l)
+    (cons 'point (map markup-build-coordinate x))
+  ) ;with
+) ;tm-define
 
-(tm-define-macro ($point . l)
-  `(markup-build-point ($list ,@l)))
- 
-(tm-define-macro ($line . l)
-  `(cons 'line ($list ,@l)))
+(tm-define-macro ($point . l) `(markup-build-point ($list ,@l)))
 
-(tm-define-macro ($cline . l)
-  `(cons 'cline ($list ,@l)))
+(tm-define-macro ($line . l) `(cons 'line ($list ,@l)))
 
-(tm-define-macro ($spline . l)
-  `(cons 'spline ($list ,@l)))
+(tm-define-macro ($cline . l) `(cons 'cline ($list ,@l)))
 
-(tm-define-macro ($cspline . l)
-  `(cons 'cspline ($list ,@l)))
+(tm-define-macro ($spline . l) `(cons 'spline ($list ,@l)))
 
-(tm-define-macro ($arc . l)
-  `(cons 'arc ($list ,@l)))
+(tm-define-macro ($cspline . l) `(cons 'cspline ($list ,@l)))
 
-(tm-define-macro ($carc . l)
-  `(cons 'carc ($list ,@l)))
+(tm-define-macro ($arc . l) `(cons 'arc ($list ,@l)))
 
-(tm-define-macro ($ellipse . l)
-  `(cons 'ellipse ($list ,@l)))
+(tm-define-macro ($carc . l) `(cons 'carc ($list ,@l)))
+
+(tm-define-macro ($ellipse . l) `(cons 'ellipse ($list ,@l)))
 
 (tm-define-macro ($text-at p . l)
-  ($quote `(text-at ($unquote ($inline ,@l)) ($unquote ($inline ,p)))))
+  ($quote `(text-at ($unquote ($inline ,@l)) ($unquote ($inline ,p))))
+) ;tm-define-macro
 
 (tm-define-macro ($math-at p . l)
-  ($quote `(math-at ($unquote ($inline ,@l)) ($unquote ($inline ,p)))))
+  ($quote `(math-at ($unquote ($inline ,@l)) ($unquote ($inline ,p))))
+) ;tm-define-macro
 
 (tm-define (markup-build-graphical l)
-  (with x (append-map markup-expand-document l)
-    (if (== (length x) 1) (car x)
-        (cons 'gr-group x))))
+  (with x
+    (append-map markup-expand-document l)
+    (if (== (length x) 1) (car x) (cons 'gr-group x))
+  ) ;with
+) ;tm-define
 
-(tm-define-macro ($graphical . l)
-  `(markup-build-graphical ($list ,@l)))
+(tm-define-macro ($graphical . l) `(markup-build-graphical ($list ,@l)))
 
 (tm-define-macro ($line-width w . l)
-  ($quote `(with "line-width" ,w ($unquote ($graphical ,@l)))))
+  ($quote `(with ,"line-width" ,w ($unquote ($graphical ,@l))))
+) ;tm-define-macro
 
 (tm-define-macro ($pen-color col . l)
-  ($quote `(with "color" ,col ($unquote ($graphical ,@l)))))
+  ($quote `(with ,"color" ,col ($unquote ($graphical ,@l))))
+) ;tm-define-macro
 
 (tm-define-macro ($fill-color col . l)
-  ($quote `(with "fill-color" ,col ($unquote ($graphical ,@l)))))
+  ($quote `(with ,"fill-color" ,col ($unquote ($graphical ,@l))))
+) ;tm-define-macro
 
 (tm-define-macro ($text-align h v . l)
-  ($quote `(with "text-at-halign" ,h
-                 "text-at-valign" ,v
-                 ($unquote ($inline ,@l)))))
+  ($quote `(with ,"text-at-halign"
+             ,h
+             ,"text-at-valign"
+             ,v
+             ($unquote ($inline ,@l)))
+  ) ;$quote
+) ;tm-define-macro
 
 (tm-define-macro ($graph2d x1 x2 steps fun)
-  `($line
-     ($for (_k_ (.. 0 (+ ,steps 1)))
-       ($let* ((f ,fun)
-               (dx (/ (- ,x2 ,x1) ,steps))
-               (x (+ ,x1 (* _k_ dx)))
-               (y (f x)))
-         ($point x y)))))
+  `($line ($for (_k_ (.. ,0 (+ ,steps ,1)))
+            ($let* ((f ,fun)
+                    (dx (/ (- ,x2 ,x1) ,steps))
+                    (x (+ ,x1 (* _k_ dx)))
+                    (y (f x)))
+              ($point x y))))
+) ;tm-define-macro
 
 (tm-define-macro ($curve2d t1 t2 steps xt yt)
-  `($line
-     ($for (_k_ (.. 0 (+ ,steps 1)))
-       ($let* ((fx ,xt)
-               (fy ,yt)
-               (dt (/ (- ,t2 ,t1) ,steps))
-               (t (+ ,t1 (* _k_ dt)))
-               (x (fx t))
-               (y (fy t)))
-         ($point x y)))))
+  `($line ($for (_k_ (.. ,0 (+ ,steps ,1)))
+            ($let* ((fx ,xt)
+                    (fy ,yt)
+                    (dt (/ (- ,t2 ,t1) ,steps))
+                    (t (+ ,t1 (* _k_ dt)))
+                    (x (fx t))
+                    (y (fy t)))
+              ($point x y))))
+) ;tm-define-macro
 
 (tm-define (markup-build-animation duration l)
-  (with x (append-map markup-expand-document l)
-    (cons 'anim-compose
-          (map (lambda (f) `(anim-constant ,f ,duration)) x))))
+  (with x
+    (append-map markup-expand-document l)
+    (cons 'anim-compose (map (lambda (f) `(anim-constant ,f ,duration)) x))
+  ) ;with
+) ;tm-define
 
 (tm-define-macro ($animation duration . l)
-  `(markup-build-animation ,duration ($list ,@l)))
+  `(markup-build-animation ,duration ($list ,@l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; User interface for dynamic content generation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define-macro (tm-generate head . l)
-  (receive (opts body) (list-break l not-define-option?)
-    `(tm-define ,head ,@opts ($begin ,@body))))
+  (receive (opts body)
+    (list-break l not-define-option?)
+    `(tm-define ,head ,@opts ($begin ,@body))
+  ) ;receive
+) ;tm-define-macro

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -11,8 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui kbd-define)
-  (:use (kernel texmacs tm-define)))
+(texmacs-module (kernel gui kbd-define) (:use (kernel texmacs tm-define)))
 
 (import (liii hash-table))
 
@@ -24,41 +23,51 @@
 (tm-define lazy-keyboard-done (make-ahash-table))
 
 (tm-define (lazy-keyboard-do module mode*)
-  (with mode (texmacs-mode-mode mode*)
-    (set! lazy-keyboard-waiting (acons mode module lazy-keyboard-waiting))))
+  (with mode
+    (texmacs-mode-mode mode*)
+    (set! lazy-keyboard-waiting (acons mode module lazy-keyboard-waiting))
+  ) ;with
+) ;tm-define
 
 (tm-define-macro (lazy-keyboard module . modes)
   (for-each (lambda (mode) (lazy-keyboard-do module mode)) modes)
-  `(delayed
-     (:idle 250)
-     (ahash-set! lazy-keyboard-done ',module #t)
-     (module-provide ',module)))
+  `(delayed (:idle 250)
+     (ahash-set! lazy-keyboard-done (quote ,module) ,#t)
+     (module-provide (quote ,module)))
+) ;tm-define-macro
 
 (define lazy-force-all? #f)
+
 (define lazy-force-busy? #f)
 
 (define (lazy-keyboard-force-do l)
   (cond ((null? l) l)
-        ((ahash-ref lazy-keyboard-done (cdar l))
-         (lazy-keyboard-force-do (cdr l)))
+        ((ahash-ref lazy-keyboard-done (cdar l)) (lazy-keyboard-force-do (cdr l)))
         ((or lazy-force-all? (texmacs-in-mode? (caar l)))
          (module-provide (cdar l))
          (ahash-set! lazy-keyboard-done (cdar l) #t)
-         (lazy-keyboard-force-do (cdr l)))
-        (else (cons (car l) (lazy-keyboard-force-do (cdr l))))))
+         (lazy-keyboard-force-do (cdr l))
+        ) ;
+        (else (cons (car l) (lazy-keyboard-force-do (cdr l))))
+  ) ;cond
+) ;define
 
 (tm-define (lazy-keyboard-force . opt)
   (set! lazy-force-all? (or lazy-force-all? (nnull? opt)))
   (when (not lazy-force-busy?)
     (set! lazy-force-busy? #t)
-    (let* ((l1 (reverse lazy-keyboard-waiting))
-           (l2 (lazy-keyboard-force-do l1)))
+    (let* ((l1 (reverse lazy-keyboard-waiting)) (l2 (lazy-keyboard-force-do l1)))
       (set! lazy-keyboard-waiting (reverse l2))
       (set! lazy-force-busy? #f)
       (when (null? lazy-keyboard-waiting)
-        (set! lazy-force-all? #f))
+        (set! lazy-force-all? #f)
+      ) ;when
       (when (and lazy-force-all? (nnull? lazy-keyboard-waiting))
-        (lazy-keyboard-force #t)))))
+        (lazy-keyboard-force #t)
+      ) ;when
+    ) ;let*
+  ) ;when
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of keyboard wildcards
@@ -66,149 +75,203 @@
 
 (define (kbd-wildcards-sub l post)
   (if (nnull? l)
-      (let* ((w (car l))
-             (key (car w))
-             (im (cadr w))
-             (left (if (>= (length w) 3) (caddr w) #f))
-             (right (if (>= (length w) 4) (cadddr w) #t)))
-        (insert-kbd-wildcard key im post left right)
-        (kbd-wildcards-sub (cdr l) post))))
+    (let* ((w (car l))
+           (key (car w))
+           (im (cadr w))
+           (left (if (>= (length w) 3) (caddr w) #f))
+           (right (if (>= (length w) 4) (cadddr w) #t))
+          ) ;
+      (insert-kbd-wildcard key im post left right)
+      (kbd-wildcards-sub (cdr l) post)
+    ) ;let*
+  ) ;if
+) ;define
 
 (tm-define (kbd-wildcards-body l)
   (:synopsis "Helper routine for kbd-wildcards macro")
   (cond ((null? l) (noop))
         ((== (car l) 'pre) (kbd-wildcards-sub (cdr l) #f))
         ((== (car l) 'post) (kbd-wildcards-sub (cdr l) #t))
-        (else (kbd-wildcards-sub l #t))))
+        (else (kbd-wildcards-sub l #t))
+  ) ;cond
+) ;tm-define
 
 (tm-define-macro (kbd-wildcards . l)
   (:synopsis "Add entries in @l to the keyboard wildcard table")
-  `(kbd-wildcards-body ,(list 'quasiquote l)))
+  `(kbd-wildcards-body ,(list 'quasiquote l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Subroutines for the definition of keyboard shortcuts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define kbd-map-table (make-ahash-table))
+
 (define kbd-inv-table (make-ahash-table))
+
 (define kbd-rev-table (make-ahash-table))
-(define (kbd-set-map! key im) (ahash-set! kbd-map-table key im))
-(define (kbd-set-inv! key im) (ahash-set! kbd-inv-table key im))
-(define (kbd-set-rev! key im) (ahash-set! kbd-rev-table key im))
-(define (kbd-get-map key) (ahash-ref kbd-map-table key))
-(define (kbd-get-inv key) (ahash-ref kbd-inv-table key))
+
+(define (kbd-set-map! key im)
+  (ahash-set! kbd-map-table key im)
+) ;define
+
+(define (kbd-set-inv! key im)
+  (ahash-set! kbd-inv-table key im)
+) ;define
+
+(define (kbd-set-rev! key im)
+  (ahash-set! kbd-rev-table key im)
+) ;define
+
+(define (kbd-get-map key)
+  (ahash-ref kbd-map-table key)
+) ;define
+
+(define (kbd-get-inv key)
+  (ahash-ref kbd-inv-table key)
+) ;define
 (tm-define (kbd-get-rev key) (ahash-ref kbd-rev-table key))
-(define (kbd-remove-map! key) (ahash-remove! kbd-map-table key))
+
+(define (kbd-remove-map! key)
+  (ahash-remove! kbd-map-table key)
+) ;define
 
 (define (kbd-source cmd)
-  (if (procedure? cmd) (promise-source cmd) cmd))
+  (if (procedure? cmd) (promise-source cmd) cmd)
+) ;define
 
 (define (simple-insert l x)
-  (if (nlist? l) (list x)
-      (list-union (list x) l)))
+  (if (nlist? l) (list x) (list-union (list x) l))
+) ;define
 
 (define (simple-remove l x)
-  (if (nlist? l) (list)
-      (list-difference l (list x))))
+  (if (nlist? l) (list) (list-difference l (list x)))
+) ;define
 
 (define (kbd-insert-key-binding conds key im)
-  (let* ((com (kbd-source (car im)))
-         (cmd (if (string? com) com (object->string com))))
-    ;;(display* "Binding '" key "' when " conds " to " com "\n")
+  (let* ((com (kbd-source (car im))) (cmd (if (string? com) com (object->string com))))
+    ;; (display* "Binding '" key "' when " conds " to " com "\n")
     (kbd-delete-key-binding2 conds key)
     (kbd-set-map! key (ctx-insert (kbd-get-map key) im conds))
     (kbd-set-inv! com (ctx-insert (kbd-get-inv com) key conds))
     (kbd-set-rev! cmd (simple-insert (kbd-get-rev cmd) key))
-    ;;(display* key " > " (kbd-get-map key) "\n")
-    ;;(display* com " < " (kbd-get-inv com) "\n")
-    ;;(display* cmd " < " (kbd-get-rev cmd) "\n")
-    ))
+    ;; (display* key " > " (kbd-get-map key) "\n")
+    ;; (display* com " < " (kbd-get-inv com) "\n")
+    ;; (display* cmd " < " (kbd-get-rev cmd) "\n")
+  ) ;let*
+) ;define
 
 (tm-define (kbd-delete-key-binding2 conds key)
-  ;;(display* "Deleting binding '" key "' when " conds "\n")
-  (with im (ctx-find (kbd-get-map key) conds)
+  ;; (display* "Deleting binding '" key "' when " conds "\n")
+  (with im
+    (ctx-find (kbd-get-map key) conds)
     (if im
-        (let* ((com (kbd-source (car im)))
-               (cmd (object->string com)))
-          (kbd-set-map! key (ctx-remove (kbd-get-map key) conds))
-          (kbd-set-inv! com (ctx-remove (kbd-get-inv com) conds))
-          (kbd-set-rev! cmd (simple-remove (kbd-get-inv cmd) key))))))
+      (let* ((com (kbd-source (car im))) (cmd (object->string com)))
+        (kbd-set-map! key (ctx-remove (kbd-get-map key) conds))
+        (kbd-set-inv! com (ctx-remove (kbd-get-inv com) conds))
+        (kbd-set-rev! cmd (simple-remove (kbd-get-inv cmd) key))
+      ) ;let*
+    ) ;if
+  ) ;with
+) ;tm-define
 
 (tm-define (kbd-find-key-binding key)
   (:synopsis "Find the command associated to the keystroke @key")
-  ;;(display* "Find binding '" key "'\n")
+  ;; (display* "Find binding '" key "'\n")
   (lazy-keyboard-force)
-  (ctx-resolve (kbd-get-map key) #f))
+  (ctx-resolve (kbd-get-map key) #f)
+) ;tm-define
 
 (tm-define (kbd-find-inv-binding com)
   (:synopsis "Find keyboard binding for command @com")
-  ;;(display* "Find inverse binding '" com "'\n")
+  ;; (display* "Find inverse binding '" com "'\n")
   (lazy-keyboard-force)
-  (with r (ctx-resolve (kbd-get-inv com) #f)
-    (if r r "")))
+  (with r (ctx-resolve (kbd-get-inv com) #f) (if r r ""))
+) ;tm-define
 
 (tm-define (kbd-find-inv-system-binding com)
   (:synopsis "Find system keyboard binding for command @com")
-  (and-with b (tm->stree (kbd-system-rewrite (kbd-find-inv-binding com)))
-    (when (tm-is? b 'render-key) (set! b (tm-ref b 0)))
-    (when (tm-is? b 'with) (set! b (tm-ref b (- (tm-arity b) 1))))
-    (and (string? b) b)))
+  (and-with b
+    (tm->stree (kbd-system-rewrite (kbd-find-inv-binding com)))
+    (when (tm-is? b 'render-key)
+      (set! b (tm-ref b 0))
+    ) ;when
+    (when (tm-is? b 'with)
+      (set! b (tm-ref b (- (tm-arity b) 1)))
+    ) ;when
+    (and (string? b) b)
+  ) ;and-with
+) ;tm-define
 
 (tm-define (kbd-find-rev-binding cmd)
   (:synopsis "Find modeless keyboard binding for command @cmd")
-  ;;(display* "Find reverse binding '" com "'\n")
+  ;; (display* "Find reverse binding '" com "'\n")
   (lazy-keyboard-force)
-  (cond ((tree? cmd)
-         (kbd-find-rev-binding (tree->stree cmd)))
+  (cond ((tree? cmd) (kbd-find-rev-binding (tree->stree cmd)))
         ((string? cmd)
-         (with l (kbd-get-rev (object->string (string->object cmd)))
-           (and l (nnull? l) (string? (car l)) (string->tmstring (car l)))))
-        (else #f)))
+         (with l
+           (kbd-get-rev (object->string (string->object cmd)))
+           (and l (nnull? l) (string? (car l)) (string->tmstring (car l)))
+         ) ;with
+        ) ;
+        (else #f)
+  ) ;cond
+) ;tm-define
 
 (define (kbd-find-key-binding2 conds key)
-  ;;(display* "Find binding '" key "' when " conds "\n")
+  ;; (display* "Find binding '" key "' when " conds "\n")
   ;; FIXME: we really need an ctx-find which does mode inference
-  (or (ctx-find (kbd-get-map key) conds)
-      (ctx-find (kbd-get-map key) '())))
+  (or (ctx-find (kbd-get-map key) conds) (ctx-find (kbd-get-map key) '()))
+) ;define
 
 (tm-define (kbd-base-sequence comb)
-  (let loop ((s comb))
-    (if (string-ends? s " tab")
-        (loop (substring s 0 (- (string-length s) 4)))
-        s)))
+  (let loop
+    ((s comb))
+    (if (string-ends? s " tab") (loop (substring s 0 (- (string-length s) 4))) s)
+  ) ;let
+) ;tm-define
 
 (tm-define (kbd-find-prefix-tab-inner prefix)
-  (let* ((pairs (filter 
-                  (lambda (pair)
-                    (let* ((key (car pair))
-                           (val (cdr pair)))
-                      (and (string? key)
-                           (string-ends? key " tab")
-                           (let* ((base (kbd-base-sequence key))
-                                  (resolved (ctx-resolve val #f)))
-                             (and (string=? base prefix)
-                                  resolved)))))
-                  (ahash-table->list kbd-map-table)))
+  (let* ((pairs (filter (lambda (pair)
+                          (let* ((key (car pair)) (val (cdr pair)))
+                            (and (string? key)
+                              (string-ends? key " tab")
+                              (let* ((base (kbd-base-sequence key)) (resolved (ctx-resolve val #f)))
+                                (and (string=? base prefix) resolved)
+                              ) ;let*
+                            ) ;and
+                          ) ;let*
+                        ) ;lambda
+                  (ahash-table->list kbd-map-table)
+                ) ;filter
+         ) ;pairs
          ;; 将 (key . context-map) 转换为 (key . resolved-value)
-         (resolved-pairs (map (lambda (pair)
-                                (cons (car pair) (ctx-resolve (cdr pair) #f)))
-                              pairs)))
-    ; 按 tab 数量升序排序（少的在前）
+         (resolved-pairs (map (lambda (pair) (cons (car pair) (ctx-resolve (cdr pair) #f))) pairs)
+         ) ;resolved-pairs
+        ) ;
     (sort resolved-pairs
-          (lambda (x y)
-            (let ((len-x (string-length (car x)))
-                  (len-y (string-length (car y))))
-              (< len-x len-y))))))
+      (lambda (x y)
+        (let ((len-x (string-length (car x))) (len-y (string-length (car y))))
+          (< len-x len-y)
+        ) ;let
+      ) ;lambda
+    ) ;sort
+  ) ;let*
+) ;tm-define
 
 (define kbd-find-prefix-tab-cache (make-hash-table))
 
 (tm-define (kbd-find-prefix-tab prefix)
   (let ((cached (hash-table-ref/default kbd-find-prefix-tab-cache prefix #f)))
     (if cached
-        cached
-        (let ((result (kbd-find-prefix-tab-inner prefix)))
-          (hash-table-set! kbd-find-prefix-tab-cache prefix result)
-          result))))
+      cached
+      (let ((result (kbd-find-prefix-tab-inner prefix)))
+        (hash-table-set! kbd-find-prefix-tab-cache prefix result)
+        result
+      ) ;let
+    ) ;if
+  ) ;let
+) ;tm-define
 
 
 
@@ -220,88 +283,118 @@
   (let* ((s2 (string-replace s1 " " ""))
          (s3 (string-replace s2 "<" "<."))
          (s4 (string-replace s3 ">" "<gtr>"))
-         (s5 (string-replace s4 "<." "<less>")))
-    (string-append prefix s5)))
+         (s5 (string-replace s4 "<." "<less>"))
+        ) ;
+    (string-append prefix s5)
+  ) ;let*
+) ;define
 
 (define (kbd-sub-binding conds s prev-end end)
-  (let* ((this-ss (substring s 0 end))
-         (this (kbd-find-key-binding2 conds this-ss)))
+  (let* ((this-ss (substring s 0 end)) (this (kbd-find-key-binding2 conds this-ss)))
     (if (not this)
-        (let* ((prev-ss (substring s 0 prev-end))
-               (prev (kbd-find-key-binding2 conds prev-ss)))
-          (if (and (list? prev) (= (length prev) 2)) (set! prev (car prev)))
-          (if (or (not prev) (nstring? prev)) (set! prev prev-ss))
-          (with im (kbd-append prev (substring s prev-end end))
-            (kbd-insert-key-binding conds this-ss (list im "")))))))
+      (let* ((prev-ss (substring s 0 prev-end))
+             (prev (kbd-find-key-binding2 conds prev-ss))
+            ) ;
+        (if (and (list? prev) (= (length prev) 2)) (set! prev (car prev)))
+        (if (or (not prev) (nstring? prev)) (set! prev prev-ss))
+        (with im
+          (kbd-append prev (substring s prev-end end))
+          (kbd-insert-key-binding conds this-ss (list im ""))
+        ) ;with
+      ) ;let*
+    ) ;if
+  ) ;let*
+) ;define
 
 (define (kbd-sub-bindings-sub conds s prev-end end)
   (cond ((== end (string-length s)) (noop))
         ((== (string-ref s end) #\space)
          (kbd-sub-binding conds s prev-end end)
-         (kbd-sub-bindings-sub conds s end (+ end 1)))
-        (else (kbd-sub-bindings-sub conds s prev-end (+ end 1)))))
+         (kbd-sub-bindings-sub conds s end (+ end 1))
+        ) ;
+        (else (kbd-sub-bindings-sub conds s prev-end (+ end 1)))
+  ) ;cond
+) ;define
 
 (define (kbd-sub-bindings conds s)
-  (kbd-sub-bindings-sub conds s 0 0))
+  (kbd-sub-bindings-sub conds s 0 0)
+) ;define
 
 (tm-define (kbd-binding conds key2 cmd help)
   (:synopsis "Helper routine for kbd-map macro")
-  ;;(display* conds ", " key2 ", " cmd ", " help "\n")
-  (with key (kbd-pre-rewrite key2)
+  ;; (display* conds ", " key2 ", " cmd ", " help "\n")
+  (with key
+    (kbd-pre-rewrite key2)
     (kbd-sub-bindings conds key)
-    (kbd-insert-key-binding conds key (list cmd help))))
+    (kbd-insert-key-binding conds key (list cmd help))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of keyboard shortcuts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (kbd-add-condition conds opt)
-  ;;(display* "Add condition " opt "\n")
-  (cond ((== (car opt) :mode)
-         (ctx-add-condition conds 0 (cadr opt)))
-        ((== (car opt) :require)
-         (ctx-add-condition conds 0 `(lambda () ,(cadr opt))))
-        (else (texmacs-error "kbd-add-condition"
-                             "Bad keyboard option ~S" opt))))
+  ;; (display* "Add condition " opt "\n")
+  (cond ((== (car opt) :mode) (ctx-add-condition conds 0 (cadr opt)))
+        ((== (car opt) :require) (ctx-add-condition conds 0 `(lambda ,()
+                                                               ,(cadr opt))))
+        (else (texmacs-error "kbd-add-condition" "Bad keyboard option ~S" opt))
+  ) ;cond
+) ;define
 
 (define (kbd-map-one conds l)
   (if (not (and (pair? l) (string? (car l)) (pair? (cdr l))))
-      (texmacs-error "kbd-map-pre-one" "Bad keymap in: ~S" l))
-  (with (key action . opt) l
+    (texmacs-error "kbd-map-pre-one" "Bad keymap in: ~S" l)
+  ) ;if
+  (with (key action . opt)
+    l
     (if (string? action)
-        (with help (if (null? opt) "" (car opt))
-          `(kbd-binding (list ,@conds) ,key ,action ,help))
-        `(kbd-binding (list ,@conds) ,key (lambda () ,action ,@opt) ""))))
+      (with help
+        (if (null? opt) "" (car opt))
+        `(kbd-binding (list ,@conds) ,key ,action ,help)
+      ) ;with
+      `(kbd-binding (list ,@conds) ,key (lambda ,() ,action ,@opt) ,"")
+    ) ;if
+  ) ;with
+) ;define
 
 (define (kbd-map-body conds l)
   (cond ((null? l) '())
-        ((symbol? (car l))
-         (kbd-map-body (list 0 (car l)) (cdr l)))
+        ((symbol? (car l)) (kbd-map-body (list 0 (car l)) (cdr l)))
         ((and (pair? (car l)) (== (caar l) :profile))
-         (if (not (has-look-and-feel? (cdar l))) '((noop))
-             (kbd-map-body conds (cdr l))))
+         (if (not (has-look-and-feel? (cdar l))) '((noop)) (kbd-map-body conds (cdr l)))
+        ) ;
         ((and (pair? (car l)) (keyword? (caar l)))
-         (kbd-map-body (kbd-add-condition conds (car l)) (cdr l)))
-        (else (map (lambda (x) (kbd-map-one conds x)) l))))
+         (kbd-map-body (kbd-add-condition conds (car l)) (cdr l))
+        ) ;
+        (else (map (lambda (x) (kbd-map-one conds x)) l))
+  ) ;cond
+) ;define
 
 (tm-define-macro (kbd-map . l)
   (:synopsis "Add entries in @l to the keyboard mapping")
-  `(begin ,@(kbd-map-body '() l)))
+  `(begin ,@(kbd-map-body '() l))
+) ;tm-define-macro
 
 (define (kbd-remove-one conds key)
-  `(kbd-delete-key-binding2 (list ,@conds) ,key))
+  `(kbd-delete-key-binding2 (list ,@conds) ,key)
+) ;define
 
 (define (kbd-remove-body conds l)
   (cond ((null? l) '())
-        ((symbol? (car l))
-         (kbd-remove-body (list 0 (car l)) (cdr l)))
+        ((symbol? (car l)) (kbd-remove-body (list 0 (car l)) (cdr l)))
         ((and (pair? (car l)) (keyword? (caar l)))
-         (kbd-remove-body (kbd-add-condition conds (car l)) (cdr l)))
-        (else (map (lambda (x) (kbd-remove-one conds x)) l))))
+         (kbd-remove-body (kbd-add-condition conds (car l)) (cdr l))
+        ) ;
+        (else (map (lambda (x) (kbd-remove-one conds x)) l))
+  ) ;cond
+) ;define
 
 (tm-define-macro (kbd-unmap . l)
   (:synopsis "Remove entries in @l from keyboard mapping")
-  `(begin ,@(kbd-remove-body '() l)))
+  `(begin ,@(kbd-remove-body '() l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of keyboard (backslashed) commands
@@ -310,299 +403,336 @@
 (tm-define kbd-command-table (make-ahash-table))
 
 (define (kbd-set-command! key im)
-  (ahash-set! kbd-command-table key im))
+  (ahash-set! kbd-command-table key im)
+) ;define
 
 (tm-define (kbd-get-command key)
   (lazy-keyboard-force)
-  (ahash-ref kbd-command-table key))
+  (ahash-ref kbd-command-table key)
+) ;tm-define
 
 (tm-define (kbd-command-pre arg)
   (:synopsis "Helper routine for kbd-commands macro")
-  (with (cmd help . action) arg
-    (list cmd help (list 'unquote `(lambda () ,@action)))))
+  (with (cmd help . action)
+    arg
+    (list cmd help (list 'unquote `(lambda ,() ,@action)))
+  ) ;with
+) ;tm-define
 
 (tm-define (kbd-command arg)
   (:synopsis "Helper routine for kbd-commands macro")
-  (with (cmd help action) arg
-    (kbd-set-command! cmd (cons help action))))
+  (with (cmd help action) arg (kbd-set-command! cmd (cons help action)))
+) ;tm-define
 
 (tm-define-macro (kbd-commands . l)
   (:synopsis "Add backslashed commands in @l to keyboard mapping")
-  `(for-each kbd-command ,(list 'quasiquote (map kbd-command-pre l))))
+  `(for-each kbd-command ,(list 'quasiquote (map kbd-command-pre l)))
+) ;tm-define-macro
 
 (tm-define-macro (kbd-symbols . l)
   (:synopsis "Add symbols in @l to keyboard mapping")
   (define (fun s)
-    (list s (string-append "insert#<" s ">")
-          (list 'kbd-insert (string-append "<" s ">"))))
-  `(kbd-commands ,@(map fun l)))
+    (list s
+      (string-append "insert#<" s ">")
+      (list 'kbd-insert (string-append "<" s ">"))
+    ) ;list
+  ) ;define
+  `(kbd-commands ,@(map fun l))
+) ;tm-define-macro
 
-(tm-define (emulate-keyboard k)
-  (delayed (raw-emulate-keyboard k)))
+(tm-define (emulate-keyboard k) (delayed (raw-emulate-keyboard k)))
 
-;;extract-code-str
-;;从过程对象（Procedure）或列表中提取源码对象（S-Expression）。
-;;这是用于调试快捷键绑定的核心辅助函数，能够“透视”匿名 Lambda 函数的内部逻辑，
-;;并返回可供进一步程序处理的原始代码结构。
+;; extract-code-str
+;; 从过程对象（Procedure）或列表中提取源码对象（S-Expression）。
+;; 这是用于调试快捷键绑定的核心辅助函数，能够“透视”匿名 Lambda 函数的内部逻辑，
+;; 并返回可供进一步程序处理的原始代码结构。
 ;;
-;;语法
-;;----
-;;(extract-code-str proc)
+;; 语法
+;; ----
+;; (extract-code-str proc)
 ;;
-;;参数
-;;----
-;;proc : procedure | any
+;; 参数
+;; ----
+;; proc : procedure | any
 ;;    需要提取源码的目标对象。通常是 `kbd-get-map` 返回列表中的条件闭包或命令闭包。
 ;;    如果是 procedure，尝试获取其源码；如果是普通列表或其他数据，则按原样处理。
 ;;
-;;返回值
-;;----
-;;any (list | symbol)
-;;- 返回对象源码的原始 Scheme 结构（S-Expression）。
-;;- 如果输入是 `(lambda () (func))`，则返回列表 `(func)`（保留括号结构）。
-;;- 如果输入是 `(lambda () (func arg))`，则返回列表 `(func arg)`。
+;; 返回值
+;; ----
+;; any (list | symbol)
+;; - 返回对象源码的原始 Scheme 结构（S-Expression）。
+;; - 如果输入是 `(lambda () (func))`，则返回列表 `(func)`（保留括号结构）。
+;; - 如果输入是 `(lambda () (func arg))`，则返回列表 `(func arg)`。
 ;;
-;;逻辑
-;;----
-;;1. 源码获取：首先检查输入是否为过程，如果是则调用 `procedure-source` 获取源码列表。
-;;2. Lambda 识别：
+;; 逻辑
+;; ----
+;; 1. 源码获取：首先检查输入是否为过程，如果是则调用 `procedure-source` 获取源码列表。
+;; 2. Lambda 识别：
 ;;   - 检查源码是否为列表 (pair)。
 ;;   - 检查第一个元素是否为符号 `lambda`。
 ;;   - 检查列表长度是否足够包含函数体 (cddr)。
-;;3. 剥离外壳：
+;; 3. 剥离外壳：
 ;;   - 如果确认为 Lambda 结构，直接提取第三个元素 `(caddr src)` 作为函数体代码。
 ;;   - 注意：不进行额外的 `car` 拆包，完整保留函数体内的逻辑结构。
+
 (define (extract-code-str proc)
   (let* ((src (if (procedure? proc) (procedure-source proc) proc))
-         (code (if (and (pair? src) 
-                        (eq? (car src) 'lambda)
-                        (pair? (cddr src)))
-                   (caddr src)
-                   src)))
-    code))
+         (code (if (and (pair? src) (eq? (car src) 'lambda) (pair? (cddr src)))
+                 (caddr src)
+                 src
+               ) ;if
+         ) ;code
+        ) ;
+    code
+  ) ;let*
+) ;define
 
-;;get-kbd-bindings
-;;获取指定按键序列的所有绑定详情，并以结构化数据的形式返回。
-;;这是一个高层调试工具，用于查看某个快捷键在不同上下文（条件）下的行为定义。
+;; get-kbd-bindings
+;; 获取指定按键序列的所有绑定详情，并以结构化数据的形式返回。
+;; 这是一个高层调试工具，用于查看某个快捷键在不同上下文（条件）下的行为定义。
 ;;
-;;语法
-;;----
-;;(get-kbd-bindings key-str)
+;; 语法
+;; ----
+;; (get-kbd-bindings key-str)
 ;;
-;;参数
-;;----
-;;key-str : string
+;; 参数
+;; ----
+;; key-str : string
 ;;    按键序列字符串，例如 "return"、"C-x C-f" 或 "tab"。
 ;;
-;;返回值
-;;----
-;;list
-;;- 如果按键未定义：返回 `(not-bound)`。
-;;- 如果按键已定义：返回一个列表的列表，格式为：
+;; 返回值
+;; ----
+;; list
+;; - 如果按键未定义：返回 `(not-bound)`。
+;; - 如果按键已定义：返回一个列表的列表，格式为：
 ;;  `(( (条件代码列表...) 命令代码 "帮助文档" ) ...)`
 ;;  示例：`(( ((inside-replace-buffer?)) (replace-one ...) "" ) ...)`
 ;;  注意：这里的条件和命令是 Scheme 代码对象（List），而非字符串。
 ;;
-;;逻辑
-;;----
-;;1. 获取原始映射：调用 `kbd-get-map` 获取按键对应的原始关联列表 (Association List)。
-;;2. 空值检查：如果 `kbd-get-map` 返回 #f，则返回 `(not-bound)`。
-;;3. 遍历处理：使用 `map` 遍历原始列表中的每一项绑定：
+;; 逻辑
+;; ----
+;; 1. 获取原始映射：调用 `kbd-get-map` 获取按键对应的原始关联列表 (Association List)。
+;; 2. 空值检查：如果 `kbd-get-map` 返回 #f，则返回 `(not-bound)`。
+;; 3. 遍历处理：使用 `map` 遍历原始列表中的每一项绑定：
 ;;   - 条件处理：原始数据的 car 部分是条件闭包列表，对其中每个元素调用 `extract-code-str` 获取源码对象。
 ;;   - 命令处理：原始数据的 cadr 部分是命令闭包，对其调用 `extract-code-str` 获取源码对象。
 ;;   - 帮助文档：原始数据的 caddr 部分是字符串，保持原样。
-;;4. 结果组装：将处理后的条件代码列表、命令代码对象和帮助文档重新组装成一个新的列表返回。
+;; 4. 结果组装：将处理后的条件代码列表、命令代码对象和帮助文档重新组装成一个新的列表返回。
 ;;
-;;注意
-;;----
-;;1. 本函数使用 `tm-define` 定义，使其在 Mogan/TeXmacs 的模块系统中可见。
-;;2. 返回结果中的条件部分始终是一个列表（如 `((cond1) (cond2))`），
+;; 注意
+;; ----
+;; 1. 本函数使用 `tm-define` 定义，使其在 Mogan/TeXmacs 的模块系统中可见。
+;; 2. 返回结果中的条件部分始终是一个列表（如 `((cond1) (cond2))`），
 ;;   因为 Mogan 允许一个快捷键绑定同时依赖多个条件（逻辑与关系）。
 (tm-define (get-kbd-bindings key-str)
   (let ((raw-map (kbd-get-map key-str)))
     (if (not raw-map)
-        (list 'not-bound)
-        (map (lambda (item)
-               (let ((conds (car item))
-                     (cmd   (cadr item))
-                     (help  (caddr item)))
-                 (list 
-                   (map extract-code-str conds)
-                   (extract-code-str cmd)
-                   help)))
-             raw-map))))
+      (list 'not-bound)
+      (map (lambda (item)
+             (let ((conds (car item)) (cmd (cadr item)) (help (caddr item)))
+               (list (map extract-code-str conds) (extract-code-str cmd) help)
+             ) ;let
+           ) ;lambda
+        raw-map
+      ) ;map
+    ) ;if
+  ) ;let
+) ;tm-define
 
-;;get-bindings-by-command
-;;根据指定的命令代码，反向查找绑定了该命令的所有快捷键及其生效条件。
+;; get-bindings-by-command
+;; 根据指定的命令代码，反向查找绑定了该命令的所有快捷键及其生效条件。
 ;;
-;;语法
-;;----
-;;(get-bindings-by-command target-cmd)
+;; 语法
+;; ----
+;; (get-bindings-by-command target-cmd)
 ;;
-;;参数
-;;----
-;;target-cmd : list | symbol
+;; 参数
+;; ----
+;; target-cmd : list | symbol
 ;;    目标命令的源码结构。
 ;;    例如：
 ;;    - 查找特定调用：`'(search-next-match #t)`
 ;;    - 查找简单命令：`'(make 'select-region)`
 ;;
-;;返回值
-;;----
-;;list
-;;- 返回一个列表，其中每个元素结构为 `(按键字符串 (条件代码列表...))`。
-;;- 示例：`(("F3" ((inside-search-or-replace-buffer?))) ("return" (...)))`
+;; 返回值
+;; ----
+;; list
+;; - 返回一个列表，其中每个元素结构为 `(按键字符串 (条件代码列表...))`。
+;; - 示例：`(("F3" ((inside-search-or-replace-buffer?))) ("return" (...)))`
 ;;
-;;逻辑
-;;----
-;;1. 遍历：扫描 `kbd-map-table` 中的每一个按键定义。
-;;2. 提取：对每个绑定的命令闭包调用 `extract-code-str` 获取其源码对象。
-;;3. 比对：使用 `equal?` 将提取出的命令源码与 `target-cmd` 进行深度比对。
-;;4. 收集：如果匹配，将 `(Key Conditions)` 加入结果列表。
+;; 逻辑
+;; ----
+;; 1. 遍历：扫描 `kbd-map-table` 中的每一个按键定义。
+;; 2. 提取：对每个绑定的命令闭包调用 `extract-code-str` 获取其源码对象。
+;; 3. 比对：使用 `equal?` 将提取出的命令源码与 `target-cmd` 进行深度比对。
+;; 4. 收集：如果匹配，将 `(Key Conditions)` 加入结果列表。
 (tm-define (get-bindings-by-command target-cmd)
-  (let ((all-entries (ahash-table->list kbd-map-table))
-        (matches '()))
-    (for-each
-      (lambda (map-entry)
-        (let ((key (car map-entry))        ; 按键，如 "F3"
-              (ctx-list (cdr map-entry)))  ; 上下文列表
-          (for-each
-            (lambda (ctx-item)
-              (let* ((cmd-proc (cadr ctx-item))
-                     ;; 核心步骤：提取命令的源码进行比对
-                     (cmd-code (extract-code-str cmd-proc)))
-                (when (equal? cmd-code target-cmd)
-                  (let ((cond-codes (map extract-code-str (car ctx-item))))
-                    ;; 收集结果：(按键 (条件...))
-                    (set! matches (cons (list key cond-codes) matches))))))
-            ctx-list)))
-      all-entries)
-    (reverse matches)))
+  (let ((all-entries (ahash-table->list kbd-map-table)) (matches '()))
+    (for-each (lambda (map-entry)
+                (let ((key (car map-entry)) (ctx-list (cdr map-entry)))
+                  (for-each (lambda (ctx-item)
+                              (let* ((cmd-proc (cadr ctx-item))
+                                     ;; 核心步骤：提取命令的源码进行比对
+                                     (cmd-code (extract-code-str cmd-proc))
+                                    ) ;
+                                (when (equal? cmd-code target-cmd)
+                                  (let ((cond-codes (map extract-code-str (car ctx-item))))
+                                    ;; 收集结果：(按键 (条件...))
+                                    (set! matches (cons (list key cond-codes) matches))
+                                  ) ;let
+                                ) ;when
+                              ) ;let*
+                            ) ;lambda
+                    ctx-list
+                  ) ;for-each
+                ) ;let
+              ) ;lambda
+      all-entries
+    ) ;for-each
+    (reverse matches)
+  ) ;let
+) ;tm-define
 
 
 
-;;get-bindings-by-condition
-;;根据指定的条件列表，反向查找所有匹配的快捷键及其对应的命令代码。
-;;此函数用于回答“在某个特定环境（如表格中、数学模式中）下，定义了哪些快捷键？”
+;; get-bindings-by-condition
+;; 根据指定的条件列表，反向查找所有匹配的快捷键及其对应的命令代码。
+;; 此函数用于回答“在某个特定环境（如表格中、数学模式中）下，定义了哪些快捷键？”
 ;;
-;;语法
-;;----
-;;(get-bindings-by-condition target-conds)
+;; 语法
+;; ----
+;; (get-bindings-by-condition target-conds)
 ;;
-;;参数
-;;----
-;;target-conds : list
+;; 参数
+;; ----
+;; target-conds : list
 ;;    目标条件源码列表。这是一个由 Scheme 代码对象（S-expression）组成的列表。
 ;;    例如：
 ;;    - 查找无条件绑定：`()`
 ;;    - 查找数学模式绑定：`'((and (== (get-env "mode") "text") (not (in-graphics?))))` 或 `(list '(and (== (get-env "mode") "text") (not (in-graphics?))))`
 ;;    - 查找特定条件：`'((inside-replace-buffer?))`
 ;;
-;;返回值
-;;----
-;;list
-;;- 返回一个列表，其中每个元素也是一个列表，结构为 `(按键字符串 命令代码对象)`。
-;;- 示例：`(("return" (replace-one ...)) ("C-2" (insert ...)))`
+;; 返回值
+;; ----
+;; list
+;; - 返回一个列表，其中每个元素也是一个列表，结构为 `(按键字符串 命令代码对象)`。
+;; - 示例：`(("return" (replace-one ...)) ("C-2" (insert ...)))`
 ;;
-;;逻辑
-;;----
-;;1. 获取全集：调用 `ahash-table->list` 将 `kbd-map-table` 哈希表转换为遍历列表。
-;;2. 双层遍历：
+;; 逻辑
+;; ----
+;; 1. 获取全集：调用 `ahash-table->list` 将 `kbd-map-table` 哈希表转换为遍历列表。
+;; 2. 双层遍历：
 ;;   - 外层遍历每一个按键定义（Key Entry）。
 ;;   - 内层遍历该按键下的每一个上下文重载（Context Entry）。
-;;3. 源码比对：
+;; 3. 源码比对：
 ;;   - 使用 `extract-code-str` 提取当前上下文中的条件源码。
 ;;   - 使用 `equal?` 将提取出的条件与参数 `target-conds` 进行深度比对。
-;;4. 收集结果：
+;; 4. 收集结果：
 ;;   - 如果匹配成功，提取对应的命令源码，并将 `(Key Command)` 组合加入结果列表。
 (tm-define (get-bindings-by-condition target-conds)
-  (let ((all-entries (ahash-table->list kbd-map-table))
-        (matches '()))
-    (for-each
-      (lambda (map-entry)
-        (let ((key (car map-entry))        ; 按键字符串，如 "C-2"
-              (ctx-list (cdr map-entry)))  ; 上下文列表
-          ;; 遍历该按键的所有重载定义
-          (for-each
-            (lambda (ctx-item)
-              (let* ((cond-funcs (car ctx-item))
-                     ;; 提取源码用于比对
-                     (cond-codes (map extract-code-str cond-funcs)))
-                ;; 深度比对条件结构
-                (when (equal? cond-codes target-conds)
-                  (let ((cmd-code (extract-code-str (cadr ctx-item))))
-                    ;; 收集结果：(按键 命令)
-                    (set! matches (cons (list key cmd-code) matches))))))
-            ctx-list)))
-      all-entries)
+  (let ((all-entries (ahash-table->list kbd-map-table)) (matches '()))
+    (for-each (lambda (map-entry)
+                (let ((key (car map-entry)) (ctx-list (cdr map-entry)))
+                  ;; 遍历该按键的所有重载定义
+                  (for-each (lambda (ctx-item)
+                              (let* ((cond-funcs (car ctx-item))
+                                     ;; 提取源码用于比对
+                                     (cond-codes (map extract-code-str cond-funcs))
+                                    ) ;
+                                ;; 深度比对条件结构
+                                (when (equal? cond-codes target-conds)
+                                  (let ((cmd-code (extract-code-str (cadr ctx-item))))
+                                    ;; 收集结果：(按键 命令)
+                                    (set! matches (cons (list key cmd-code) matches))
+                                  ) ;let
+                                ) ;when
+                              ) ;let*
+                            ) ;lambda
+                    ctx-list
+                  ) ;for-each
+                ) ;let
+              ) ;lambda
+      all-entries
+    ) ;for-each
     ;; 返回结果（反转以保持发现顺序，虽不强求）
-    (reverse matches)))
+    (reverse matches)
+  ) ;let
+) ;tm-define
 
-;;kbd-conflict-query
-;;冲突查询函数
-;;检查在新按键序列（new-key）下，是否存在与给定条件（conds）完全一致的绑定。
+;; kbd-conflict-query
+;; 冲突查询函数
+;; 检查在新按键序列（new-key）下，是否存在与给定条件（conds）完全一致的绑定。
 ;;
-;;参数
-;;----
-;;conds   : list
+;; 参数
+;; ----
+;; conds   : list
 ;;    条件源码列表（S-Expression），例如 '((and (== (get-env "mode") "text") (not (in-graphics?)))) 或 '()。
-;;new-key : string
+;; new-key : string
 ;;    待检查的新按键序列，例如 "C-a"。
 ;;
-;;返回值
-;;----
-;;any | #f
-;;- 如果存在冲突：返回冲突绑定的命令源码（通常是一个列表）。
-;;- 如果无冲突：返回 #f。
+;; 返回值
+;; ----
+;; any | #f
+;; - 如果存在冲突：返回冲突绑定的命令源码（通常是一个列表）。
+;; - 如果无冲突：返回 #f。
 (tm-define (kbd-conflict-query conds new-key)
   (let ((raw-map (kbd-get-map new-key)))
     (if raw-map
-        (let loop ((entries raw-map))
-          (if (null? entries)
-              #f
-              (let* ((entry (car entries))
-                     (entry-conds (car entry))
-                     ;; 提取现有绑定的条件源码进行比对
-                     (entry-conds-src (map extract-code-str entry-conds)))
-                ;; 检查条件是否完全一致（精确匹配上下文）
-                (if (equal? entry-conds-src conds)
-                    ;; 发现冲突，返回占用该位置的命令源码
-                    (extract-code-str (cadr entry))
-                    ;; 继续检查下一个重载
-                    (loop (cdr entries))))))
-        #f)))
+      (let loop
+        ((entries raw-map))
+        (if (null? entries)
+          #f
+          (let* ((entry (car entries))
+                 (entry-conds (car entry))
+                 ;; 提取现有绑定的条件源码进行比对
+                 (entry-conds-src (map extract-code-str entry-conds))
+                ) ;
+            ;; 检查条件是否完全一致（精确匹配上下文）
+            (if (equal? entry-conds-src conds)
+              ;; 发现冲突，返回占用该位置的命令源码
+              (extract-code-str (cadr entry))
+              ;; 继续检查下一个重载
+              (loop (cdr entries))
+            ) ;if
+          ) ;let*
+        ) ;if
+      ) ;let
+      #f
+    ) ;if
+  ) ;let
+) ;tm-define
 
-;;kbd-execute-edit
-;;编辑执行函数
-;;根据给定的条件，删除旧按键绑定（如果存在），并创建新按键绑定。
+;; kbd-execute-edit
+;; 编辑执行函数
+;; 根据给定的条件，删除旧按键绑定（如果存在），并创建新按键绑定。
 ;;
-;;参数
-;;----
-;;conds   : list
+;; 参数
+;; ----
+;; conds   : list
 ;;    条件源码列表。
-;;cmd     : any
+;; cmd     : any
 ;;    命令源码（S-Expression），例如 '(insert "alpha")。
-;;old-key : string
+;; old-key : string
 ;;    旧按键序列。如果非空，函数将尝试移除该按键下匹配 conds 的绑定。
-;;new-key : string
+;; new-key : string
 ;;    新按键序列。如果非空，函数将在该按键下创建指向 cmd 的新绑定。
 ;;
-;;逻辑 (四种状态)
-;;--------------
-;;1. 清理旧绑定 (Old Key)：
+;; 逻辑 (四种状态)
+;; --------------
+;; 1. 清理旧绑定 (Old Key)：
 ;;   若 old-key 非空，遍历其映射表，寻找条件源码与 conds 完全匹配的条目。
 ;;   找到后，利用原始闭包对象将其从哈希表中移除。
 ;;
-;;2. 应用新绑定 (New Key)：
+;; 2. 应用新绑定 (New Key)：
 ;;   若 new-key 非空，将 conds 和 cmd 动态编译为闭包，插入到 new-key 的映射表中。
 ;;   **若 new-key 为空，则跳过此步。**
 ;;
-;;四种行为
-;;--------
-;;- 新增: old-key="", new-key="C-a" -> 旧的无动作，新增 C-a 绑定。
-;;- 修改: old-key="C-b", new-key="C-a"  -> 将绑定从 C-b 搬到 C-a。
-;;- 删除: old-key="C-b",  new-key="" -> C-b 被解绑，且没有新绑定生成。
-;;- 无效操作：都为空，直接返回。
+;; 四种行为
+;; --------
+;; - 新增: old-key="", new-key="C-a" -> 旧的无动作，新增 C-a 绑定。
+;; - 修改: old-key="C-b", new-key="C-a"  -> 将绑定从 C-b 搬到 C-a。
+;; - 删除: old-key="C-b",  new-key="" -> C-b 被解绑，且没有新绑定生成。
+;; - 无效操作：都为空，直接返回。
 (tm-define (kbd-execute-edit conds cmd old-key new-key)
   ;; 1. 如果提供了旧按键，则尝试删除旧绑定
   (when (and (string? old-key) (> (string-length old-key) 0))
@@ -611,22 +741,31 @@
         (for-each (lambda (entry)
                     (let* ((entry-conds (car entry))
                            (entry-conds-src (map extract-code-str entry-conds))
-                           (entry-cmd-src (extract-code-str (cadr entry))))
-                      
+                           (entry-cmd-src (extract-code-str (cadr entry)))
+                          ) ;
+
                       ;; 只有当 (条件匹配) 且 (命令也匹配) 时，才认为是同一个绑定进行删除
                       ;; 这样可以防止在交换快捷键时，误删刚刚绑定上去的新命令
-                      (when (and (equal? entry-conds-src conds)
-                                 (equal? entry-cmd-src cmd))
+                      (when (and (equal? entry-conds-src conds) (equal? entry-cmd-src cmd))
                         ;; 使用原始的条件闭包列表进行删除
-                        (kbd-delete-key-binding2 entry-conds old-key))))
-                  raw-map))))
+                        (kbd-delete-key-binding2 entry-conds old-key)
+                      ) ;when
+                    ) ;let*
+                  ) ;lambda
+          raw-map
+        ) ;for-each
+      ) ;when
+    ) ;let
+  ) ;when
 
   ;; 2. 如果提供了新按键，则插入新绑定
   (when (and (string? new-key) (> (string-length new-key) 0))
     ;; 将数据层面的源码 (S-Expression) 转换为可执行的闭包 (Procedure)
-    (let ((cond-funcs (map (lambda (c) 
-                             (eval `(lambda () ,c) (current-module))) 
-                           conds))
-          (cmd-func   (eval `(lambda () ,cmd) (current-module))))
+    (let ((cond-funcs (map (lambda (c) (eval `(lambda ,() ,c) (current-module))) conds))
+          (cmd-func (eval `(lambda ,() ,cmd) (current-module)))
+         ) ;
       ;; 插入新绑定，帮助文档暂留空字符串
-      (kbd-insert-key-binding cond-funcs new-key (list cmd-func "")))))
+      (kbd-insert-key-binding cond-funcs new-key (list cmd-func ""))
+    ) ;let
+  ) ;when
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/kbd-handlers.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-handlers.scm
@@ -11,45 +11,51 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui kbd-handlers)
-  (:use (kernel texmacs tm-define)))
+(texmacs-module (kernel gui kbd-handlers) (:use (kernel texmacs tm-define)))
 
-(tm-define ShiftMask     256)
-(tm-define LockMask      512)
-(tm-define ControlMask  1024)
-(tm-define Mod1Mask     2048)
-(tm-define Mod2Mask     4096)
-(tm-define Mod3Mask     8192)
-(tm-define Mod4Mask    16384)
-(tm-define Mod5Mask    32768)
+(tm-define ShiftMask 256)
+(tm-define LockMask 512)
+(tm-define ControlMask 1024)
+(tm-define Mod1Mask 2048)
+(tm-define Mod2Mask 4096)
+(tm-define Mod3Mask 8192)
+(tm-define Mod4Mask 16384)
+(tm-define Mod5Mask 32768)
 
-(tm-define (keyboard-press key time)
-  (key-press key))
+(tm-define (keyboard-press key time) (key-press key))
 
-(tm-define (keyboard-focus has-focus? time)
-  (noop))
+(tm-define (keyboard-focus has-focus? time) (noop))
 
 (tm-define (mouse-event key x y mods time data)
-  ;;(display* "mouse-event " key ", " x ", " y ", " mods ", " time ", " data "\n")
-  (mouse-any key x y mods (+ time 0.0) data))
+  ;; (display* "mouse-event " key ", " x ", " y ", " mods ", " time ", " data "\n")
+  (mouse-any key x y mods (+ time 0.0) data)
+) ;tm-define
 
 (tm-define (mouse-drop-event x y obj)
-  ;;(display* "mouse-drop-event " x ", " y ", " (tm->stree obj) "\n")
-  (insert obj))
+  ;; (display* "mouse-drop-event " x ", " y ", " (tm->stree obj) "\n")
+  (insert obj)
+) ;tm-define
 
-(tm-define (kbd-insert s)
-  (insert s))
+(tm-define (kbd-insert s) (insert s))
 
 (define delayed-keyboard-time #f)
 
 (tm-define (delayed-keyboard-press x t)
   (set! delayed-keyboard-time t)
-  (exec-delayed-pause
-   (lambda ()
-     (or (!= delayed-keyboard-time t)
-         (with left (- 100 (idle-time))
-           (if (> left 0) left
-               (begin
-                 (set! delayed-keyboard-time #f)
-                 (keyboard-press x t)
-                 #t)))))))
+  (exec-delayed-pause (lambda ()
+                        (or (!= delayed-keyboard-time t)
+                          (with left
+                            (- 100 (idle-time))
+                            (if (> left 0)
+                              left
+                              (begin
+                                (set! delayed-keyboard-time #f)
+                                (keyboard-press x t)
+                                #t
+                              ) ;begin
+                            ) ;if
+                          ) ;with
+                        ) ;or
+                      ) ;lambda
+  ) ;exec-delayed-pause
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/menu-convert.scm
+++ b/TeXmacs/progs/kernel/gui/menu-convert.scm
@@ -13,53 +13,94 @@
 ;; See menu-define.scm for the grammar of menus
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui menu-convert)
-  (:use (kernel gui menu-widget)))
+(texmacs-module (kernel gui menu-convert) (:use (kernel gui menu-widget)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper routines
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (mini?    style) (!= (logand style widget-style-mini) 0))
-(define (mono?    style) (!= (logand style widget-style-monospaced) 0))
-(define (greyed?  style) (!= (logand style widget-style-grey) 0))
-(define (pressed? style) (!= (logand style widget-style-pressed) 0))
-(define (active?  style) (== (logand style widget-style-inert) 0))
-(define (inert?   style) (!= (logand style widget-style-inert) 0))
-(define (button?  style) (!= (logand style widget-style-button) 0))
-(define (center?  style) (!= (logand style widget-style-centered) 0))
-(define (bold?    style) (!= (logand style widget-style-bold) 0))
-(define (verb?    style) (!= (logand style widget-style-verb) 0))
+(define (mini? style)
+  (!= (logand style widget-style-mini) 0)
+) ;define
+
+(define (mono? style)
+  (!= (logand style widget-style-monospaced) 0)
+) ;define
+
+(define (greyed? style)
+  (!= (logand style widget-style-grey) 0)
+) ;define
+
+(define (pressed? style)
+  (!= (logand style widget-style-pressed) 0)
+) ;define
+
+(define (active? style)
+  (== (logand style widget-style-inert) 0)
+) ;define
+
+(define (inert? style)
+  (!= (logand style widget-style-inert) 0)
+) ;define
+
+(define (button? style)
+  (!= (logand style widget-style-button) 0)
+) ;define
+
+(define (center? style)
+  (!= (logand style widget-style-centered) 0)
+) ;define
+
+(define (bold? style)
+  (!= (logand style widget-style-bold) 0)
+) ;define
+
+(define (verb? style)
+  (!= (logand style widget-style-verb) 0)
+) ;define
 
 (define global-command-table (make-ahash-table))
+
 (define global-command-counter 0)
 
 (define (command->mangle cmd)
   ;; FIXME: memory management
   (set! global-command-counter (+ global-command-counter 1))
   (ahash-set! global-command-table global-command-counter cmd)
-  global-command-counter)
+  global-command-counter
+) ;define
 
 (define (mangle->command nr)
-  (ahash-ref global-command-table nr))
+  (ahash-ref global-command-table nr)
+) ;define
 
 (define (nullary-mangled cmd)
-  (with nr (command->mangle cmd)
-    (string-append "(eval-nullary-mangled " (number->string nr) ")")))
+  (with nr
+    (command->mangle cmd)
+    (string-append "(eval-nullary-mangled " (number->string nr) ")")
+  ) ;with
+) ;define
 
 (tm-define (eval-nullary-mangled nr)
-  (:secure #t)  ;; FIXME: not that secure
-  ;;(display* "Eval " nr ", " (mangle->command nr) "\n")
-  (command-eval (mangle->command nr)))
+  (:secure #t)
+  ;; FIXME: not that secure
+  ;; (display* "Eval " nr ", " (mangle->command nr) "\n")
+  (command-eval (mangle->command nr))
+) ;tm-define
 
 (define (unary-mangled cmd)
-  (with nr (command->mangle cmd)
-    (string-append "(eval-unary-mangled " (number->string nr) " answer)")))
+  (with nr
+    (command->mangle cmd)
+    (string-append "(eval-unary-mangled " (number->string nr) " answer)")
+  ) ;with
+) ;define
 
 (tm-define (eval-unary-mangled nr answer)
-  (:secure #t)  ;; FIXME: not that secure
-  ;;(display* "Apply " nr ", " (mangle->command nr) ", " answer "\n")
-  (command-apply (mangle->command nr) (list answer)))
+  (:secure #t)
+  ;; FIXME: not that secure
+  ;; (display* "Apply " nr ", " (mangle->command nr) ", " answer "\n")
+  (command-apply (mangle->command nr) (list answer))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Widgets through markup
@@ -68,232 +109,286 @@
 (tm-define (markup-empty) "")
 
 (tm-define (markup-text text style col transparent?)
-  ;;(display* "Text " text ", " style ", " col ", " transparent? "\n")
+  ;; (display* "Text " text ", " style ", " col ", " transparent? "\n")
   (when (mini? style)
-    (set! text `(small ,text)))
+    (set! text `(small ,text))
+  ) ;when
   (when (or (greyed? style)
-            ;;(inert? style)
-            (== col (color "dark grey")))
-    (set! text `(greyed ,text)))    
-  (when (or (mono? style)
-            (verb? style))
-    (set! text `(verbatim ,text)))
+          ;; (inert? style)
+          (== col (color "dark grey"))
+        ) ;or
+    (set! text `(greyed ,text))
+  ) ;when
+  (when (or (mono? style) (verb? style))
+    (set! text `(verbatim ,text))
+  ) ;when
   (when (bold? style)
-    (set! text `(strong ,text)))
+    (set! text `(strong ,text))
+  ) ;when
   (when (not transparent?)
-    (set! text `(text-opaque ,text)))
+    (set! text `(text-opaque ,text))
+  ) ;when
   (when (center? style)
-    (set! text `(text-center ,text)))
-  `(inflate ,text))
+    (set! text `(text-center ,text))
+  ) ;when
+  `(inflate ,text)
+) ;tm-define
 
 (tm-define (markup-menu-group text style)
-  (markup-text text style (color "black") #t))
+  (markup-text text style (color "black") #t)
+) ;tm-define
 
 (tm-define (markup-box font text col transparent? ink?)
-  (markup-text text 0 col transparent?))
+  (markup-text text 0 col transparent?)
+) ;tm-define
 
 (tm-define (markup-balloon body balloon)
-  `(help-balloon ,body ,balloon "right" ""))
+  `(help-balloon ,body ,balloon ,"right" ,"")
+) ;tm-define
 
 (tm-define (markup-xpm u)
   (let* ((s (url->string u))
          (r (if (string-ends? s ".xpm") (string-drop-right s 4) s))
-         (i (string-append r "_x4.png")))
-    `(icon ,i)))
+         (i (string-append r "_x4.png"))
+        ) ;
+    `(icon ,i)
+  ) ;let*
+) ;tm-define
 
 (tm-define (markup-glue hext? vext? w h)
-  (let* ((ws  (string-append (number->string (quotient w 256)) "px"))
-         (hs  (string-append (number->string (quotient h 256)) "px")))
-    `(glue ,(if hext? "true" "false")
-           ,(if vext? "true" "false")
-           ,ws ,hs)))
+  (let* ((ws (string-append (number->string (quotient w 256)) "px"))
+         (hs (string-append (number->string (quotient h 256)) "px"))
+        ) ;
+    `(glue ,(if hext? "true" "false") ,(if vext? "true" "false") ,ws ,hs)
+  ) ;let*
+) ;tm-define
 
 (tm-define (markup-color col hext? vext? w h)
-  (let* ((ws  (string-append (number->string w) "px"))
-         (hs  (string-append (number->string h) "px")))
-    `(monochrome ,ws ,hs ,col)))
+  (let* ((ws (string-append (number->string w) "px"))
+         (hs (string-append (number->string h) "px"))
+        ) ;
+    `(monochrome ,ws ,hs ,col)
+  ) ;let*
+) ;tm-define
 
-(tm-define (markup-separator vertical?)
-  "")
+(tm-define (markup-separator vertical?) "")
 
 (define (listify tag l)
   (set! l (list-filter l (cut != <> "")))
   (set! l (append-map (lambda (x) (if (func? x tag) (cdr x) (list x))) l))
   (cond ((null? l) "")
         ((null? (cdr l)) (car l))
-        (else `(,tag ,@l))))
+        (else `(,tag ,@l))
+  ) ;cond
+) ;define
 
-(tm-define (markup-hlist l)
-  (listify 'hlist l))
+(tm-define (markup-hlist l) (listify 'hlist l))
 
-(tm-define (markup-vlist l)
-  (listify 'vlist l))
+(tm-define (markup-vlist l) (listify 'vlist l))
 
-(tm-define (markup-hsplit l r)
-  `(hlist ,l ,r))
+(tm-define (markup-hsplit l r) `(hlist ,l ,r))
 
-(tm-define (markup-vsplit t b)
-  `(vlist ,t ,b))
+(tm-define (markup-vsplit t b) `(vlist ,t ,b))
 
-(tm-define (markup-hmenu l)
-  (listify 'hlist l))
+(tm-define (markup-hmenu l) (listify 'hlist l))
 
-(tm-define (markup-vmenu l)
-  (listify 'vlist l))
+(tm-define (markup-vmenu l) (listify 'vlist l))
 
 (tm-define (markup-minibar-menu l)
   ;; TODO: minibar style?
-  (listify 'hlist l))
+  (listify 'hlist l)
+) ;tm-define
 
 (tm-define (markup-tmenu items columns)
-  `(tiled ,(number->string columns) ,@items))
+  `(tiled ,(number->string columns) ,@items)
+) ;tm-define
 
 (define (alternate l r)
-  (if (or (null? l) (null? r)) (list)
-      (cons* (car l) (car r) (alternate (cdr l) (cdr r)))))
+  (if (or (null? l) (null? r))
+    (list)
+    (cons* (car l) (car r) (alternate (cdr l) (cdr r)))
+  ) ;if
+) ;define
 
 (tm-define (markup-aligned l-list r-list)
-  `(align-tiled "2" ,@(alternate l-list r-list)))
+  `(align-tiled ,"2" ,@(alternate l-list r-list))
+) ;tm-define
 
 (tm-define (markup-menu-button text cmd check shortcut style)
   ;; TODO: handle 'shortcut'
   ;; TODO: handle inert style
   (let* ((body (markup-text text style (color "black") #t))
-         (but `(menu-button ,body ,(nullary-mangled cmd))))
-    (cond ((button?  style) `(with-explicit-buttons ,but))
+         (but `(menu-button ,body ,(nullary-mangled cmd)))
+        ) ;
+    (cond ((button? style) `(with-explicit-buttons ,but))
           ((pressed? style) `(with-pressed-buttons ,but))
-          (else but))))
+          (else but)
+    ) ;cond
+  ) ;let*
+) ;tm-define
 
 (tm-define (markup-toggle cmd* on? style)
   ;; TODO: handle inert style
-  (with cmd (unary-mangled cmd*)
-    `(toggle-button ,(if on? "true" "false") ,cmd)))
+  (with cmd (unary-mangled cmd*) `(toggle-button ,(if on? "true" "false") ,cmd))
+) ;tm-define
 
 (tm-define (markup-tabs names bodies)
-  `(tabs (tabs-bar
-          (active-tab ,(car names))
-          ,@(map (lambda (x) `(passive-tab ,x)) (cdr names)))
-         (tabs-body
-          (shown ,(car bodies))
-          ,@(map (lambda (x) `(hidden ,x)) (cdr bodies)))))
+  `(tabs (tabs-bar (active-tab ,(car names))
+           ,@(map (lambda (x) `(passive-tab ,x)) (cdr names)))
+     (tabs-body (shown ,(car bodies))
+       ,@(map (lambda (x) `(hidden ,x)) (cdr bodies))))
+) ;tm-define
 
 (define (attach-icon icon name)
-  `(concat ,(markup-xpm icon) " " ,name))
+  `(concat ,(markup-xpm icon) ," " ,name)
+) ;define
 
 (tm-define (markup-icon-tabs icons names bodies)
-  (with combined (map attach-icon icons names)
-    (markup-tabs combined bodies)))
+  (with combined (map attach-icon icons names) (markup-tabs combined bodies))
+) ;tm-define
 
 (tm-define (markup-input cmd* type props style width)
   ;; TODO: handle inert style
-  (with cmd (unary-mangled cmd*)
-    (cond ((null? props)
-           `(input-field ,type ,cmd ,width ""))
-          ((null? (cdr props))
-           `(input-field ,type ,cmd ,width ,(car props)))
-          (else
-           `(input-popup ,type ,cmd ,width ,(car props)
-                         (choice-list ,cmd ,(car props) ,@props))))))
+  (with cmd
+    (unary-mangled cmd*)
+    (cond ((null? props) `(input-field ,type ,cmd ,width ,""))
+          ((null? (cdr props)) `(input-field ,type ,cmd ,width ,(car props)))
+          (else `(input-popup ,type
+                   ,cmd
+                   ,width
+                   ,(car props)
+                   (choice-list ,cmd ,(car props) ,@props))
+          ) ;else
+    ) ;cond
+  ) ;with
+) ;tm-define
 
 (tm-define (markup-numeric-input cmd* width unit min max step def)
-  (with cmd (unary-mangled cmd*)
-    `(numeric-input ,cmd ,width ,unit ,min ,max ,step ,def)))
+  (with cmd
+    (unary-mangled cmd*)
+    `(numeric-input ,cmd ,width ,unit ,min ,max ,step ,def)
+  ) ;with
+) ;tm-define
 
 (tm-define (markup-enum cmd* props val style width)
   ;; TODO: handle inert style
-  (with cmd (unary-mangled cmd*)
-    (cond ((null? props)
-           `(input-field "generic" ,cmd ,width ,val))
+  (with cmd
+    (unary-mangled cmd*)
+    (cond ((null? props) `(input-field ,"generic" ,cmd ,width ,val))
           ((== (cAr props) "")
-           `(input-popup "generic" ,cmd ,width ,val
-                         (choice-list ,cmd ,val ,@(cDr props))))
-          (else
-           `(input-list  "generic" ,cmd ,width ,val
-                         (choice-list ,cmd ,val ,@props))))))
+           `(input-popup ,"generic"
+              ,cmd
+              ,width
+              ,val
+              (choice-list ,cmd ,val ,@(cDr props)))
+          ) ;
+          (else `(input-list ,"generic"
+                   ,cmd
+                   ,width
+                   ,val
+                   (choice-list ,cmd ,val ,@props)))
+    ) ;cond
+  ) ;with
+) ;tm-define
 
 (tm-define (markup-choice cmd* proposals selected)
   (when (null? proposals)
-    (set! proposals (list "")))
-  (with cmd (unary-mangled cmd*)
-    `(choice-list ,cmd ,selected ,@proposals)))
+    (set! proposals (list ""))
+  ) ;when
+  (with cmd (unary-mangled cmd*) `(choice-list ,cmd ,selected ,@proposals))
+) ;tm-define
 
 (tm-define (markup-choices cmd* proposals selected)
   (when (null? proposals)
-    (set! proposals (list "")))
-  (with cmd (unary-mangled cmd*)
-    `(check-list ,cmd (tuple ,@selected) ,@proposals)))
+    (set! proposals (list ""))
+  ) ;when
+  (with cmd
+    (unary-mangled cmd*)
+    `(check-list ,cmd (tuple ,@selected) ,@proposals)
+  ) ;with
+) ;tm-define
 
 (tm-define (markup-filtered-choice cmd proposals selected filter)
   ;; TODO: do not ignore the filter
   (when (null? proposals)
-    (set! proposals (list "")))
-  (markup-choice cmd proposals selected))
+    (set! proposals (list ""))
+  ) ;when
+  (markup-choice cmd proposals selected)
+) ;tm-define
 
 (tm-define (object->promise-markup obj) obj)
 
 (tm-define (markup-pulldown-button button popup*)
-  (with popup (popup*)
-    `(popup-balloon ,button ,popup "left" "Bottom")))
+  (with popup (popup*) `(popup-balloon ,button ,popup ,"left" ,"Bottom"))
+) ;tm-define
 
 (tm-define (markup-pullright-button button popup*)
-  (with popup (popup*)
-    `(popup-balloon ,button ,popup "Right" "top")))
+  (with popup (popup*) `(popup-balloon ,button ,popup ,"Right" ,"top"))
+) ;tm-define
 
 (define (make-division tag body)
-  (cond ((and (tm-in? body '(hlist vlist))
-              (in? tag '(plain-style discrete-style)))
-         `(,(tm-car body)
-           ,@(map (cut make-division tag <>) (tm-children body))))
+  (cond ((and (tm-in? body '(hlist vlist)) (in? tag '(plain-style discrete-style)))
+         `(,(tm-car body) ,@(map (cut make-division tag <>) (tm-children body)))
+        ) ;
         ((tm-is? body 'glue) body)
-        (else `(,tag ,body))))
+        (else `(,tag ,body))
+  ) ;cond
+) ;define
 
 (tm-define (markup-division type body)
-  (if (in? type (list "title" "section" "subsection" "section-tabs"
-                      "plain" "discrete"))
-      (make-division (string->symbol (string-append type "-style")) body)
-      body))
+  (if (in? type
+        (list "title" "section" "subsection" "section-tabs" "plain" "discrete")
+      ) ;in?
+    (make-division (string->symbol (string-append type "-style")) body)
+    body
+  ) ;if
+) ;tm-define
 
 (tm-define (markup-refresh wid kind)
   (lazy-initialize-force)
-  (with x `(vertical (link ,(string->symbol wid)))
-    (build-menu-widget x 0)))
+  (with x `(vertical (link ,(string->symbol wid))) (build-menu-widget x 0))
+) ;tm-define
 
-(tm-define (markup-refreshable body-promise kind)
-  (body-promise))
+(tm-define (markup-refreshable body-promise kind) (body-promise))
 
 (tm-define (markup-resize body style w1 h1 w2 h2 w3 h3 hpos vpos)
   (let* ((ww w2)
          (hh (if (string? h2) (string-append "-" h2) `(minus ,h2)))
-         ;;(cv (lambda (x) `(minipar* ,x ,w2 ,h2)))
-         (cv (lambda (x) `(canvas "0px" ,hh ,ww "0px" "0%" "0%" ,x))))
-    (if (tm-func? body 'input-area 1)
-        `(input-area ,(cv (tm-ref body 0)))
-        (cv body))))
+         ;; (cv (lambda (x) `(minipar* ,x ,w2 ,h2)))
+         (cv (lambda (x) `(canvas ,"0px" ,hh ,ww ,"0px" ,"0%" ,"0%" ,x)))
+        ) ;
+    (if (tm-func? body 'input-area 1) `(input-area ,(cv (tm-ref body 0))) (cv body))
+  ) ;let*
+) ;tm-define
 
-(tm-define (markup-extend body items)
-  body)
+(tm-define (markup-extend body items) body)
 
-(tm-define (markup-scrollable body scroll-style)
-  body)
+(tm-define (markup-scrollable body scroll-style) body)
 
 (define (decode-packages style)
   (cond ((string? style) (list style))
         ((func? style 'style) (append-map decode-packages (cdr style)))
         ((func? style 'tuple) (append-map decode-packages (cdr style)))
-        (else (list))))
+        (else (list))
+  ) ;cond
+) ;define
 
 (define (markup-with-packages packs body)
   ;; TODO: check absence of conflicts due to double loading
-  (if (null? packs) body
-      `(with-package ,(car packs)
-                     ,(markup-with-packages (cdr packs) body))))
+  (if (null? packs)
+    body
+    `(with-package ,(car packs) ,(markup-with-packages (cdr packs) body))
+  ) ;if
+) ;define
 
 (tm-define (markup-texmacs-output body style)
-  (markup-with-packages (decode-packages style) body))
+  (markup-with-packages (decode-packages style) body)
+) ;tm-define
 
 (tm-define (markup-texmacs-input body style u)
   ;; TODO: url mirroring according to 'u'
-  `(input-area ,(markup-with-packages (decode-packages style) body)))
+  `(input-area ,(markup-with-packages (decode-packages style) body))
+) ;tm-define
 
 (tm-define (markup-color-picker cmd background? proposals) "Color picker")
 (tm-define (markup-tree-view cmd data data-roles) "Tree view")
@@ -305,32 +400,39 @@
 
 (define (build-menu-error . args)
   (apply tm-display-error args)
-  (markup-text "Error" 0 (color "black") #t))
+  (markup-text "Error" 0 (color "black") #t)
+) ;define
 
 (define (build-menu-bad-format p style)
-  (build-menu-error "menu has bad format in " (object->string p)))
+  (build-menu-error "menu has bad format in " (object->string p))
+) ;define
 
-(define (build-menu-empty) (markup-hmenu '()))
+(define (build-menu-empty)
+  (markup-hmenu '())
+) ;define
 
 (define (delay-command cmd)
-  (object->command (lambda () (exec-delayed cmd))))
+  (object->command (lambda () (exec-delayed cmd)))
+) ;define
 
 (define-macro (build-menu-command cmd)
-  `(delay-command (lambda () (protected-call (lambda () ,cmd)))))
+  `(delay-command (lambda ,() (protected-call (lambda ,() ,cmd))))
+) ;define-macro
 
 (define (menu-protect cmd)
-  (lambda x
-    (exec-delayed
-      (lambda ()
-        (protected-call (lambda () (apply cmd x)))))))
+  (lambda x (exec-delayed (lambda () (protected-call (lambda () (apply cmd x))))))
+) ;define
 
 (define (kbd-system shortcut menu-flag?)
   (cond ((nstring? shortcut) "")
         ((and (qt-gui?) menu-flag?) shortcut)
-        (else (translate (kbd-system-rewrite shortcut)))))
+        (else (translate (kbd-system-rewrite shortcut)))
+  ) ;cond
+) ;define
 
 (define (kbd-find-shortcut what menu-flag?)
-  (with r (kbd-find-inv-binding what)
+  (with r
+    (kbd-find-inv-binding what)
     (when (string-contains? r "accent:")
       (set! r (string-replace r "accent:deadhat" "^"))
       (set! r (string-replace r "accent:tilde" "~"))
@@ -340,40 +442,52 @@
       (set! r (string-replace r "accent:abovedot" "."))
       (set! r (string-replace r "accent:breve" "U"))
       (set! r (string-replace r "accent:invbreve" "A"))
-      (set! r (string-replace r "accent:check" "C")))
-    ;;(when (!= r "")
+      (set! r (string-replace r "accent:check" "C"))
+    ) ;when
+    ;; (when (!= r "")
     ;;  (display* what " -> " r " -> " (kbd-system r menu-flag?) "\n"))
-    (kbd-system r menu-flag?)))
+    (kbd-system r menu-flag?)
+  ) ;with
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu labels
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (translatable? s)
-  (or (string? s) (func? s 'concat) (func? s 'verbatim) (func? s 'replace)))
+  (or (string? s) (func? s 'concat) (func? s 'verbatim) (func? s 'replace))
+) ;define
 
 (define (recursive-occurs? w t)
   (cond ((string? t) (string-occurs? w t))
         ((list? t) (list-or (map (cut recursive-occurs? w <>) t)))
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define
 
 (define (recursive-replace t w b)
   (cond ((string? t) (string-replace t w b))
         ((list? t) (map (cut recursive-replace <> w b) t))
-        (else t)))
+        (else t)
+  ) ;cond
+) ;define
 
 (define (adjust-translation s t)
-  (cond ((not (and (qt-gui?) (os-macos?)
-                   (in? (get-preference "language")
-                        (list "english" "british"))))
-         t)
+  (cond ((not (and (qt-gui?)
+                (os-macos?)
+                (in? (get-preference "language") (list "english" "british"))
+              ) ;and
+         ) ;not
+         t
+        ) ;
         ((recursive-occurs? "reference" s)
-	 (recursive-replace (recursive-replace t "c" "<#441>") "e" "<#435>"))
-        ((recursive-occurs? "onfigur" s)
-	 (recursive-replace t "o" "<#43E>"))
-        ((in? s (list "Help" "Edit" "View"))
-	 (recursive-replace t "e" "<#435>"))
-        (else t)))
+         (recursive-replace (recursive-replace t "c" "<#441>") "e" "<#435>")
+        ) ;
+        ((recursive-occurs? "onfigur" s) (recursive-replace t "o" "<#43E>"))
+        ((in? s (list "Help" "Edit" "View")) (recursive-replace t "e" "<#435>"))
+        (else t)
+  ) ;cond
+) ;define
 
 (define (build-menu-label p style . opt)
   "Make widget for menu label @p."
@@ -390,26 +504,38 @@
   ;;   <label> :: (icon <string>)
   ;;     Pixmap menu label, the <string> is the name of the pixmap.
   (let ((tt? (and (nnull? opt) (car opt)))
-        (col (color (if (greyed? style) "dark grey" "black"))))
-    (cond ((translatable? p)            ; "text"
-           (markup-text (adjust-translation p (translate p)) style col #t))
-          ((tuple? p 'balloon 2)        ; (balloon <label> "balloon text")
-           (build-menu-label (cadr p) style tt?))
-          ((tuple? p 'extend)           ; (extend <label> . ws)
-           (with l (build-menu-items (cddr p) style tt?)
-             (markup-extend (build-menu-label (cadr p) style tt?) l)))
-          ((tuple? p 'style 2)          ; (style st <label>)
+        (col (color (if (greyed? style) "dark grey" "black")))
+       ) ;
+    (cond ((translatable? p)
+           (markup-text (adjust-translation p (translate p)) style col #t)
+          ) ;
+          ((tuple? p 'balloon 2) (build-menu-label (cadr p) style tt?))
+          ((tuple? p 'extend)
+           (with l
+             (build-menu-items (cddr p) style tt?)
+             (markup-extend (build-menu-label (cadr p) style tt?) l)
+           ) ;with
+          ) ;
+          ((tuple? p 'style 2)
            (let* ((x (cadr p))
-                  (new-style (if (> x 0) (logior style x)
-                                 (logand style (lognot (- x))))))
-             (build-menu-label (caddr p) new-style tt?)))
-          ((tuple? p 'text 2)           ; (text <font desc> "text")
-           (markup-box (cadr p) (caddr p) col #t #t))
-          ((tuple? p 'icon 1)           ; (icon "name.xpm")
-           (markup-xpm (cadr p)))
-          ((tuple? p 'color 5)          ; (color col hext? vext? minw minh)
-           (markup-color (second p) (third p) (fourth p)
-                         (* (fifth p) 256) (* (sixth p) 256))))))
+                  (new-style (if (> x 0) (logior style x) (logand style (lognot (- x)))))
+                 ) ;
+             (build-menu-label (caddr p) new-style tt?)
+           ) ;let*
+          ) ;
+          ((tuple? p 'text 2) (markup-box (cadr p) (caddr p) col #t #t))
+          ((tuple? p 'icon 1) (markup-xpm (cadr p)))
+          ((tuple? p 'color 5)
+           (markup-color (second p)
+             (third p)
+             (fourth p)
+             (* (fifth p) 256)
+             (* (sixth p) 256)
+           ) ;markup-color
+          ) ;
+    ) ;cond
+  ) ;let
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elementary menu items
@@ -417,98 +543,143 @@
 
 (define (build-menu-hsep)
   "Make @--- menu item."
-  (markup-separator #f))
+  (markup-separator #f)
+) ;define
 
 (define (build-menu-vsep)
   "Make @| menu item."
-  (markup-separator #t))
+  (markup-separator #t)
+) ;define
 
 (define (build-menu-glue hext? vext? minw minh)
   "Make @(glue :boolean? :boolean? :integer? :integer?) menu item."
-  (markup-glue hext? vext? (* minw 256) (* minh 256)))
+  (markup-glue hext? vext? (* minw 256) (* minh 256))
+) ;define
 
 (define (build-menu-color col hext? vext? minw minh)
   "Make @(glue :1% :boolean? :boolean? :integer? :integer?) menu item."
-  (markup-color col hext? vext? (* minw 256) (* minh 256)))
+  (markup-color col hext? vext? (* minw 256) (* minh 256))
+) ;define
 
 (define (build-menu-group s style)
   "Make @(group :string?) menu item."
-  (markup-menu-group (adjust-translation s (translate s)) style))
+  (markup-menu-group (adjust-translation s (translate s)) style)
+) ;define
 
 (define (build-menu-text s style)
   "Make @(text :string?) menu item."
-  ;;(markup-text s style (color "black") #t)
-  (markup-text (translate s) style (color "black") #f))
+  ;; (markup-text s style (color "black") #t)
+  (markup-text (translate s) style (color "black") #f)
+) ;define
 
 (define (build-texmacs-output p style)
   "Make @(texmacs-output :%2) item."
-  (with (tag t tmstyle) p
-    (markup-texmacs-output (t) (tmstyle))))
+  (with (tag t tmstyle) p (markup-texmacs-output (t) (tmstyle)))
+) ;define
 
 (define (build-texmacs-input p style)
   "Make @(texmacs-input :%3) item."
-  (with (tag t tmstyle name) p
-    (markup-texmacs-input (t) (tmstyle) (or (name) (url-none)))))
+  (with (tag t tmstyle name)
+    p
+    (markup-texmacs-input (t) (tmstyle) (or (name) (url-none)))
+  ) ;with
+) ;define
 
 (define (build-menu-input p style)
   "Make @(input :%1 :string? :%1 :string?) menu item."
-  (with (tag cmd type props width) p
-    (markup-input (object->command (menu-protect cmd)) type (props)
-                  style width)))
+  (with (tag cmd type props width)
+    p
+    (markup-input (object->command (menu-protect cmd)) type (props) style width)
+  ) ;with
+) ;define
 
 (define (build-numeric-input p style)
   "Make @(numeric-input :%7) menu item."
-  (with (tag cmd width unit min max step def) p
-    (markup-numeric-input (object->command (menu-protect cmd)) width unit min max
-                          step def)))
+  (with (tag cmd width unit min max step def)
+    p
+    (markup-numeric-input (object->command (menu-protect cmd))
+      width
+      unit
+      min
+      max
+      step
+      def
+    ) ;markup-numeric-input
+  ) ;with
+) ;define
 
 (define (build-enum p style)
   "Make @(enum :%3 :string?) item."
-  (with (tag cmd vals val width) p
+  (with (tag cmd vals val width)
+    p
     (let* ((translate* (if (verb? style) identity translate))
            (xval (val))
            (xvals (vals))
            (nvals (if (and (nnull? xvals) (== (cAr xvals) ""))
-                      `(,@(cDr xvals) ,xval "") `(,@xvals ,xval)))
+                    `(,@(cDr xvals) ,xval ,"")
+                    `(,@xvals ,xval)
+                  ) ;if
+           ) ;nvals
            (xvals* (list-remove-duplicates nvals))
            (tval (translate* xval))
            (tvals (map translate* xvals*))
            (dec (map (lambda (v) (cons (translate* v) v)) xvals*))
-           (cmd* (lambda (r) (cmd (or (assoc-ref dec r) r)))))
-      (markup-enum (object->command (menu-protect cmd*))
-                   tvals tval style width))))
+           (cmd* (lambda (r) (cmd (or (assoc-ref dec r) r))))
+          ) ;
+      (markup-enum (object->command (menu-protect cmd*)) tvals tval style width)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (build-choice p style)
   "Make @(choice :%3) item."
-  (with (tag cmd vals val) p
-    (markup-choice (object->command (menu-protect cmd)) (vals) (val))))
+  (with (tag cmd vals val)
+    p
+    (markup-choice (object->command (menu-protect cmd)) (vals) (val))
+  ) ;with
+) ;define
 
 (define (build-choices p style)
   "Make @(choices :%3) item."
-  (with (tag cmd vals mc) p
-    (markup-choices (object->command (menu-protect cmd)) (vals) (mc))))
+  (with (tag cmd vals mc)
+    p
+    (markup-choices (object->command (menu-protect cmd)) (vals) (mc))
+  ) ;with
+) ;define
 
 (define (build-filtered-choice p style)
   "Make @(filtered-choice :%4) item."
-  (with (tag cmd vals val filterstr) p
-    (markup-filtered-choice (object->command (menu-protect cmd)) (vals) (val)
-                            (filterstr))))
+  (with (tag cmd vals val filterstr)
+    p
+    (markup-filtered-choice (object->command (menu-protect cmd))
+      (vals)
+      (val)
+      (filterstr)
+    ) ;markup-filtered-choice
+  ) ;with
+) ;define
 
 (define (build-color-input p style)
   "Make @(color-input :%3) menu item."
-  (with (tag cmd bg? props) p
-    (markup-color-picker (object->command (menu-protect cmd)) bg? (props))))
+  (with (tag cmd bg? props)
+    p
+    (markup-color-picker (object->command (menu-protect cmd)) bg? (props))
+  ) ;with
+) ;define
 
 (define (build-tree-view p style)
   "Make @(tree-view :%3) item."
-  (with (tag cmd data roles) p
-    (markup-tree-view (object->command (menu-protect cmd)) (data) (roles))))
+  (with (tag cmd data roles)
+    p
+    (markup-tree-view (object->command (menu-protect cmd)) (data) (roles))
+  ) ;with
+) ;define
 
 
 (define (build-toggle p style)
   "Make @(toggle :%2) item."
-  (with (tag cmd on) p
-    (markup-toggle (object->command cmd) (on) style)))
+  (with (tag cmd on) p (markup-toggle (object->command cmd) (on) style))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu entries
@@ -516,150 +687,228 @@
 
 (define (synopsis-substitute synopsis source)
   (if (string-occurs? "@" synopsis)
-      #f ;; not yet implemented
-      synopsis))
+    #f
+    ;; not yet implemented
+    synopsis
+  ) ;if
+) ;define
 
 (define (search-balloon-help action)
-  (and-with source (promise-source action)
+  (and-with source
+    (promise-source action)
     (and (pair? source)
-         (or (and-with prop (property (car source) :balloon)
-               (with txt (apply (car prop) (cdr source))
-                 (and (string? txt) txt)))
-             (and-with prop (property (car source) :synopsis)
-               (and (pair? prop) (string? (car prop))
-                    (with txt (synopsis-substitute (car prop) source)
-                      (and (string? txt) txt))))))))
+      (or (and-with prop
+            (property (car source) :balloon)
+            (with txt (apply (car prop) (cdr source)) (and (string? txt) txt))
+          ) ;and-with
+        (and-with prop
+          (property (car source) :synopsis)
+          (and (pair? prop)
+            (string? (car prop))
+            (with txt (synopsis-substitute (car prop) source) (and (string? txt) txt))
+          ) ;and
+        ) ;and-with
+      ) ;or
+    ) ;and
+  ) ;and-with
+) ;define
 
 (define (add-menu-entry-balloon but style action)
-  (with txt (search-balloon-help action)
-    (if (not txt) but
-        (with bal (markup-text txt style (color "black") #t)
-          (markup-balloon but bal)))))
+  (with txt
+    (search-balloon-help action)
+    (if (not txt)
+      but
+      (with bal (markup-text txt style (color "black") #t) (markup-balloon but bal))
+    ) ;if
+  ) ;with
+) ;define
 
 (define (build-menu-entry-button style bar? bal? check label short action)
   (let* ((command (build-menu-command (if (active? style) (apply action '()))))
          (l (build-menu-label label style))
          (pressed? (and bar? (!= check "")))
-         (new-style (logior style (if pressed? widget-style-pressed 0))))
-    (with but (if bar?
-                  (markup-menu-button l command "" "" new-style)
-                  (markup-menu-button l command check short style))
-      (if bal? but (add-menu-entry-balloon but style action)))))
+         (new-style (logior style (if pressed? widget-style-pressed 0)))
+        ) ;
+    (with but
+      (if bar?
+        (markup-menu-button l command "" "" new-style)
+        (markup-menu-button l command check short style)
+      ) ;if
+      (if bal? but (add-menu-entry-balloon but style action))
+    ) ;with
+  ) ;let*
+) ;define
 
 (define (build-menu-entry-shortcut label action opt-key)
   (cond (opt-key (kbd-system opt-key #t))
         ((pair? label) "")
-        (else (with source (promise-source action)
-                (if source (kbd-find-shortcut source #t) "")))))
+        (else (with source
+                (promise-source action)
+                (if source (kbd-find-shortcut source #t) "")
+              ) ;with
+        ) ;else
+  ) ;cond
+) ;define
 
 (define (build-menu-entry-check-sub result propose)
   (cond ((string? result) result)
         (result propose)
-        (else "")))
+        (else "")
+  ) ;cond
+) ;define
 
 (define (build-menu-entry-check opt-check action)
   (if opt-check
-      (build-menu-entry-check-sub ((cadr opt-check)) (car opt-check))
-      (with source (promise-source action)
-        (cond ((not (and source (pair? source))) "")
-              (else (with prop (property (car source) :check-mark)
-                      (build-menu-entry-check-sub
-                       (and prop (apply (cadr prop) (cdr source)))
-                       (and prop (car prop)))))))))
+    (build-menu-entry-check-sub ((cadr opt-check)) (car opt-check))
+    (with source
+      (promise-source action)
+      (cond ((not (and source (pair? source))) "")
+            (else (with prop
+                    (property (car source) :check-mark)
+                    (build-menu-entry-check-sub (and prop (apply (cadr prop) (cdr source)))
+                      (and prop (car prop))
+                    ) ;build-menu-entry-check-sub
+                  ) ;with
+            ) ;else
+      ) ;cond
+    ) ;with
+  ) ;if
+) ;define
 
 (define (menu-label-add-dots l)
   (cond ((match? l ':string?) (string-append l "..."))
-        ((match? l '(concat :*))
-         `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
-        ((match? l '(verbatim :*))
-         `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
+        ((match? l '(concat :*)) `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
+        ((match? l '(verbatim :*)) `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
         ((match? l '(text :tuple? :string?))
-         `(text ,(cadr l) ,(string-append (caddr l) "...")))
+         `(text ,(cadr l) ,(string-append (caddr l) "..."))
+        ) ;
         ((match? l '(icon :string?)) l)
-        (else `(,(car l) ,(menu-label-add-dots (cadr l)) ,(caddr l)))))
+        (else `(,(car l) ,(menu-label-add-dots (cadr l)) ,(caddr l)))
+  ) ;cond
+) ;define
 
 (define (build-menu-entry-dots label action)
-  (with source (promise-source action)
+  (with source
+    (promise-source action)
     (if (and source (pair? source) (property (car source) :interactive))
-        (menu-label-add-dots label)
-        label)))
+      (menu-label-add-dots label)
+      label
+    ) ;if
+  ) ;with
+) ;define
 
 (define (build-menu-entry-style style action)
-  (with source (promise-source action)
-    (if (not (pair? source)) style
-	(with prop (property (car source) :applicable)
-	  (if (or (not prop) (apply (car prop) (list)))
-	      style
-	      (logior style (+ widget-style-inert widget-style-grey)))))))
+  (with source
+    (promise-source action)
+    (if (not (pair? source))
+      style
+      (with prop
+        (property (car source) :applicable)
+        (if (or (not prop) (apply (car prop) (list)))
+          style
+          (logior style (+ widget-style-inert widget-style-grey))
+        ) ;if
+      ) ;with
+    ) ;if
+  ) ;with
+) ;define
 
 (define (build-menu-entry-attrs label action opt-key opt-check)
   (cond ((match? label '(check :%1 :string? :%1))
-         (build-menu-entry-attrs (cadr label) action opt-key (cddr label)))
+         (build-menu-entry-attrs (cadr label) action opt-key (cddr label))
+        ) ;
         ((match? label '(shortcut :%1 :string?))
-         (build-menu-entry-attrs (cadr label) action (caddr label) opt-check))
-        (else (values label action opt-key opt-check))))
+         (build-menu-entry-attrs (cadr label) action (caddr label) opt-check)
+        ) ;
+        (else (values label action opt-key opt-check))
+  ) ;cond
+) ;define
 
 (define (build-menu-entry-sub p style bar?)
-  (receive
-      (label action opt-key opt-check)
-      (build-menu-entry-attrs (car p) (cAr p) #f #f)
-    (build-menu-entry-button
-     (build-menu-entry-style style action)
-     bar?
-     (tuple? (car p) 'balloon 2)
-     (build-menu-entry-check opt-check action)
-     (build-menu-entry-dots label action)
-     (build-menu-entry-shortcut label action opt-key)
-     action)))
+  (receive (label action opt-key opt-check)
+    (build-menu-entry-attrs (car p) (cAr p) #f #f)
+    (build-menu-entry-button (build-menu-entry-style style action)
+      bar?
+      (tuple? (car p) 'balloon 2)
+      (build-menu-entry-check opt-check action)
+      (build-menu-entry-dots label action)
+      (build-menu-entry-shortcut label action opt-key)
+      action
+    ) ;build-menu-entry-button
+  ) ;receive
+) ;define
 
 (define (build-menu-entry p style bar?)
   "Make @:menu-wide-item menu item."
-  (let ((but (build-menu-entry-sub p style bar?))
-        (label (car p)))
+  (let ((but (build-menu-entry-sub p style bar?)) (label (car p)))
     (if (tuple? label 'balloon 2)
-        (let* ((text (caddr label))
-               (cmd (and (nnull? (cdr p)) (procedure? (cadr p)) (cadr p)))
-               (src (and cmd (promise-source cmd)))
-               (sh (and src (kbd-find-shortcut src #f)))
-               (txt (if (or (not sh) (== sh "")) text
-                        (if (string? text) 
-                            (string-append text " (" sh ")")
-                            text)))
-               (ftxt (translate txt))
-               (twid (markup-text ftxt style (color "black") #t)))
-          (markup-balloon but twid))
-        but)))
+      (let* ((text (caddr label))
+             (cmd (and (nnull? (cdr p)) (procedure? (cadr p)) (cadr p)))
+             (src (and cmd (promise-source cmd)))
+             (sh (and src (kbd-find-shortcut src #f)))
+             (txt (if (or (not sh) (== sh ""))
+                    text
+                    (if (string? text) (string-append text " (" sh ")") text)
+                  ) ;if
+             ) ;txt
+             (ftxt (translate txt))
+             (twid (markup-text ftxt style (color "black") #t))
+            ) ;
+        (markup-balloon but twid)
+      ) ;let*
+      but
+    ) ;if
+  ) ;let
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbol fields
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (build-menu-symbol-button style sym opt-cmd)
-  (with col (color (if (greyed? style) "dark grey" "black"))
+  (with col
+    (color (if (greyed? style) "dark grey" "black"))
     (if opt-cmd
-        (markup-menu-button (markup-box '() sym col #t #f)
-                            (build-menu-command (apply opt-cmd '()))
-                            "" "" style)
-        (markup-menu-button (markup-box '() sym col #t #f)
-                            (build-menu-command (insert sym))
-                            "" "" style))))
+      (markup-menu-button (markup-box '() sym col #t #f)
+        (build-menu-command (apply opt-cmd '()))
+        ""
+        ""
+        style
+      ) ;markup-menu-button
+      (markup-menu-button (markup-box '() sym col #t #f)
+        (build-menu-command (insert sym))
+        ""
+        ""
+        style
+      ) ;markup-menu-button
+    ) ;if
+  ) ;with
+) ;define
 
 (define (build-menu-symbol p style)
   "Make @(symbol :string? :*) menu item."
   ;; Possibilities for p:
   ;;   <menu-symbol> :: (symbol <symbol-string> [<cmd>])
-  (with (tag symstring . opt) p
-    (with opt-cmd (and (nnull? opt) (car opt))
+  (with (tag symstring . opt)
+    p
+    (with opt-cmd
+      (and (nnull? opt) (car opt))
       (if (and opt-cmd (not (procedure? opt-cmd)))
-          (build-menu-error "invalid symbol command in " p)
-          (let* ((source (and opt-cmd (promise-source opt-cmd)))
-                 (sh (kbd-find-shortcut (if source source symstring) #f)))
-            (if (== sh "")
-                (build-menu-symbol-button style symstring opt-cmd)
-                (markup-balloon
-                 (build-menu-symbol-button style symstring opt-cmd)
-                 (build-menu-label (string-append "Keyboard equivalent: " sh)
-                                  style))))))))
+        (build-menu-error "invalid symbol command in " p)
+        (let* ((source (and opt-cmd (promise-source opt-cmd)))
+               (sh (kbd-find-shortcut (if source source symstring) #f))
+              ) ;
+          (if (== sh "")
+            (build-menu-symbol-button style symstring opt-cmd)
+            (markup-balloon (build-menu-symbol-button style symstring opt-cmd)
+              (build-menu-label (string-append "Keyboard equivalent: " sh) style)
+            ) ;markup-balloon
+          ) ;if
+        ) ;let*
+      ) ;if
+    ) ;with
+  ) ;with
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Composite menus and submenus
@@ -667,155 +916,223 @@
 
 (define (build-menu-horizontal p style)
   "Make @(horizontal :menu-item-list) menu item."
-  (markup-hmenu (build-menu-items (cdr p) style #t)))
+  (markup-hmenu (build-menu-items (cdr p) style #t))
+) ;define
 
 (define (build-menu-vertical p style)
   "Make @(vertical :menu-item-list) menu item."
-  (markup-vmenu (build-menu-items (cdr p) style #f)))
+  (markup-vmenu (build-menu-items (cdr p) style #f))
+) ;define
 
 (define (build-menu-hlist p style)
   "Make @(hlist :menu-item-list) menu item."
-  (markup-hlist (build-menu-items (cdr p) style #t)))
+  (markup-hlist (build-menu-items (cdr p) style #t))
+) ;define
 
 (define (build-menu-vlist p style)
   "Make @(vlist :menu-item-list) menu item."
-  (markup-vlist (build-menu-items (cdr p) style #f)))
+  (markup-vlist (build-menu-items (cdr p) style #f))
+) ;define
 
 (define (build-menu-division p style)
   "Make @(division :%1 :menu-item-list) item."
-  (with (tag name . items) p
-    (with inner (build-menu-items (list (cons 'vertical items)) style #f)
-      (markup-division (name) (car inner)))))
+  (with (tag name . items)
+    p
+    (with inner
+      (build-menu-items (list (cons 'vertical items)) style #f)
+      (markup-division (name) (car inner))
+    ) ;with
+  ) ;with
+) ;define
 
 (define (build-menu-class p style)
   "Make @(class :%1 :menu-item-list) item."
-  (with (tag name . items) p
-    (with inner (build-menu-items (list (cons 'horizontal items)) style #f)
-      (markup-division (name) (car inner)))))
+  (with (tag name . items)
+    p
+    (with inner
+      (build-menu-items (list (cons 'horizontal items)) style #f)
+      (markup-division (name) (car inner))
+    ) ;with
+  ) ;with
+) ;define
 
 (define (build-aligned p style)
   "Make @(aligned :menu-item-list) item."
   (markup-aligned (build-menu-items (map cadr (cdr p)) style #f)
-                  (build-menu-items (map caddr (cdr p)) style #f)))
+    (build-menu-items (map caddr (cdr p)) style #f)
+  ) ;markup-aligned
+) ;define
 
 (define (build-aligned-item p style)
   "Make @(aligned-item :%2) item."
   (display* "Error 'build-aligned-item', " p ", " style "\n")
-  (list 'vlist))
+  (list 'vlist)
+) ;define
 
 (define (tab-key x)
-  (cadr x))
+  (cadr x)
+) ;define
 
 (define (tab-value x)
-  (list 'vlist (cddr x)))
+  (list 'vlist (cddr x))
+) ;define
 
 (define (build-menu-tabs p style)
   "Make @(tabs :menu-item-list) menu item."
   (markup-tabs (build-menu-items (map tab-key (cdr p)) style #f)
-               (build-menu-items (map tab-value (cdr p)) style #f)))
+    (build-menu-items (map tab-value (cdr p)) style #f)
+  ) ;markup-tabs
+) ;define
 
 (define (build-menu-tab p style)
   "Make @(tab :menu-item-list) menu item."
   (display* "Error 'build-menu-tab', " p ", " style "\n")
-  (list 'vlist))
+  (list 'vlist)
+) ;define
 
 (define (icon-tab-icon x)
-  (string->url (cadr x)))
+  (string->url (cadr x))
+) ;define
 
 (define (icon-tab-key x)
-  (caddr x))
+  (caddr x)
+) ;define
 
 (define (icon-tab-value x)
-  (list 'vlist (cdddr x)))
+  (list 'vlist (cdddr x))
+) ;define
 
 (define (build-menu-icon-tabs p style)
   "Make @(icon-tabs :menu-item-list) menu item."
-  (with style* (logior style widget-style-mini)
+  (with style*
+    (logior style widget-style-mini)
     (markup-icon-tabs (map icon-tab-icon (cdr p))
-                      (build-menu-items (map icon-tab-key (cdr p)) style* #f)
-                      (build-menu-items (map icon-tab-value (cdr p)) style #f))))
+      (build-menu-items (map icon-tab-key (cdr p)) style* #f)
+      (build-menu-items (map icon-tab-value (cdr p)) style #f)
+    ) ;markup-icon-tabs
+  ) ;with
+) ;define
 
 (define (build-menu-icon-tab p style)
   "Make @(icon-tab :menu-item-list) menu item."
   (display* "Error 'build-menu-icon-tab', " p ", " style "\n")
-  (list 'vlist))
+  (list 'vlist)
+) ;define
 
 (define (build-menu-extend p style bar?)
   "Make @(extend :menu-item :menu-item-list) menu item."
-  (with l (build-menu-items (cdr p) style bar?)
-    (markup-extend (car l) (cdr l))))
+  (with l (build-menu-items (cdr p) style bar?) (markup-extend (car l) (cdr l)))
+) ;define
 
 (define (build-menu-style p style bar?)
   "Make @(extend :integer? :menu-item-list) menu item."
   (let* ((x (cadr p))
-         (new-style (if (> x 0) (logior style x)
-                        (logand style (lognot (- x))))))
-    (build-menu-items-list (cddr p) new-style bar?)))
+         (new-style (if (> x 0) (logior style x) (logand style (lognot (- x)))))
+        ) ;
+    (build-menu-items-list (cddr p) new-style bar?)
+  ) ;let*
+) ;define
 
 (define (build-menu-minibar p style)
   "Make @(minibar :menu-item-list) menu items."
-  (with new-style (logior style widget-style-mini)
-    (markup-minibar-menu (build-menu-items (cdr p) new-style #t))))
+  (with new-style
+    (logior style widget-style-mini)
+    (markup-minibar-menu (build-menu-items (cdr p) new-style #t))
+  ) ;with
+) ;define
 
 (define (build-menu-submenu p style)
   "Make @((:or -> =>) :menu-label :menu-item-list) menu item."
-  (with (tag label . items) p
-    (let ((button
-           ((cond ((== tag '=>) markup-pulldown-button)
-                  ((== tag '->) markup-pullright-button))
-            (build-menu-label label style)
-            (object->promise-markup
-             (lambda () (build-menu-widget (list 'vertical items) style))))))
+  (with (tag label . items)
+    p
+    (let ((button ((cond ((== tag '=>) markup-pulldown-button)
+                         ((== tag '->) markup-pullright-button)
+                   ) ;cond
+                   (build-menu-label label style)
+                   (object->promise-markup (lambda () (build-menu-widget (list 'vertical items) style))
+                   ) ;object->promise-markup
+                  ) ;
+          ) ;button
+         ) ;
       (if (tuple? label 'balloon 2)
-          (let* ((text (caddr label))
-                 (ftxt (translate text))
-                 (twid (markup-text ftxt style (color "black") #t)))
-            (markup-balloon button twid))
-          button))))
+        (let* ((text (caddr label))
+               (ftxt (translate text))
+               (twid (markup-text ftxt style (color "black") #t))
+              ) ;
+          (markup-balloon button twid)
+        ) ;let*
+        button
+      ) ;if
+    ) ;let
+  ) ;with
+) ;define
 
 (define (build-menu-tile p style)
   "Make @(tile :integer? :menu-item-list) menu item."
-  (with (tag width . items) p
-    (markup-tmenu (build-menu-items items style #f) width)))
+  (with (tag width . items)
+    p
+    (markup-tmenu (build-menu-items items style #f) width)
+  ) ;with
+) ;define
 
 (define (build-scrollable p style)
   "Make @(scrollable :menu-item-list) item."
-  (with (tag . items) p
-    (with inner (build-menu-items (list (cons 'vertical items)) style #f)
-      (markup-scrollable (car inner) style))))
+  (with (tag . items)
+    p
+    (with inner
+      (build-menu-items (list (cons 'vertical items)) style #f)
+      (markup-scrollable (car inner) style)
+    ) ;with
+  ) ;with
+) ;define
 
 (define (decode-resize x default)
   (cond ((string? x) (list x x x default))
         ((list-3? x) (append x (list default)))
         ((list-4? x) x)
-        (else (build-menu-error "bad length in " (object->string x)))))
+        (else (build-menu-error "bad length in " (object->string x)))
+  ) ;cond
+) ;define
 
 (define (build-resize p style)
   "Make @(resize :%2 :menu-item-list) item."
-  (with (tag w-cmd h-cmd . items) p
-    (let ((w (w-cmd))
-          (h (h-cmd)))
-      (with inner (build-menu-items (list (cons 'vertical items)) style #f)
-        (with (w1 w2 w3 hpos) (decode-resize w "left")
-          (with (h1 h2 h3 vpos) (decode-resize h "top")
-            (markup-resize (car inner) style w1 h1 w2 h2 w3 h3 hpos vpos)))))))
+  (with (tag w-cmd h-cmd . items)
+    p
+    (let ((w (w-cmd)) (h (h-cmd)))
+      (with inner
+        (build-menu-items (list (cons 'vertical items)) style #f)
+        (with (w1 w2 w3 hpos)
+          (decode-resize w "left")
+          (with (h1 h2 h3 vpos)
+            (decode-resize h "top")
+            (markup-resize (car inner) style w1 h1 w2 h2 w3 h3 hpos vpos)
+          ) ;with
+        ) ;with
+      ) ;with
+    ) ;let
+  ) ;with
+) ;define
 
 (define (build-hsplit p style)
   "Make @(hsplit :menu-item :menu-item) item."
-  (with (tag . items) p
-    (with l (build-menu-items items style #f)
-      (markup-hsplit (car l) (cadr l)))))
+  (with (tag . items)
+    p
+    (with l (build-menu-items items style #f) (markup-hsplit (car l) (cadr l)))
+  ) ;with
+) ;define
 
 (define (build-vsplit p style)
   "Make @(vsplit :menu-item :menu-item) item."
-  (with (tag . items) p
-    (with l (build-menu-items items style #f)
-      (markup-vsplit (car l) (cadr l)))))
+  (with (tag . items)
+    p
+    (with l (build-menu-items items style #f) (markup-vsplit (car l) (cadr l)))
+  ) ;with
+) ;define
 
 (define (build-ink p style)
   "Make @(ink) item."
-  (with (tag cmd) p
-    (markup-ink (object->command cmd))))
+  (with (tag cmd) p (markup-ink (object->command cmd)))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dynamic menus
@@ -823,82 +1140,128 @@
 
 (define (build-menu-if p style bar?)
   "Make @(if :%1 :menu-item-list) menu items."
-  (with (tag pred? . items) p
-    (if (pred?) (build-menu-items-list items style bar?) '())))
+  (with (tag pred? . items)
+    p
+    (if (pred?) (build-menu-items-list items style bar?) '())
+  ) ;with
+) ;define
 
 (define (build-menu-when p style bar?)
   "Make @(when :%1 :menu-item-list) menu items."
-  (with (tag pred? . items) p
+  (with (tag pred? . items)
+    p
     (let* ((old-active? (== (logand style widget-style-inert) 0))
            (new-active? (and old-active? (pred?)))
-           (new-style (logior style
-                              (if new-active? 0
-                                  (+ widget-style-inert widget-style-grey)))))
-      (build-menu-items-list items new-style bar?))))
+           (new-style (logior style (if new-active? 0 (+ widget-style-inert widget-style-grey)))
+           ) ;new-style
+          ) ;
+      (build-menu-items-list items new-style bar?)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (build-menu-for p style bar?)
   "Make @(for :%1 :%1) menu items."
-  (with (tag gen-func vals-promise) p
-    (let* ((vals (vals-promise))
-           (items (append-map gen-func vals)))
-      (build-menu-items-list items style bar?))))
+  (with (tag gen-func vals-promise)
+    p
+    (let* ((vals (vals-promise)) (items (append-map gen-func vals)))
+      (build-menu-items-list items style bar?)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (build-menu-mini p style bar?)
   "Make @(mini :%1 :menu-item-list) menu items."
-  (with (tag pred? . items) p
+  (with (tag pred? . items)
+    p
     (let* ((style-maxi (logand style (lognot widget-style-mini)))
            (style-mini (logior style-maxi widget-style-mini))
-           (new-style (if (pred?) style-mini style-maxi)))
-      (build-menu-items-list items new-style bar?))))
+           (new-style (if (pred?) style-mini style-maxi))
+          ) ;
+      (build-menu-items-list items new-style bar?)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (build-menu-link p style bar?)
   "Make @(link :%1) menu items."
-  (with linked ((eval (cadr p)))
-    (if linked (build-menu-items linked style bar?)
-        (build-menu-error "bad link: " (object->string (cadr p))))))
+  (with linked
+   ((eval (cadr p)))
+   (if linked
+     (build-menu-items linked style bar?)
+     (build-menu-error "bad link: " (object->string (cadr p)))
+   ) ;if
+  ) ;with
+) ;define
 
 (define (build-menu-dynamic p style bar?)
   "Make @(dynamic :%1) menu items."
-  (with dyn (eval (cadr p))
-    (if dyn (build-menu-items dyn style bar?)
-        (build-menu-error "bad link: " (object->string (cadr p))))))
+  (with dyn
+    (eval (cadr p))
+    (if dyn
+      (build-menu-items dyn style bar?)
+      (build-menu-error "bad link: " (object->string (cadr p)))
+    ) ;if
+  ) ;with
+) ;define
 
 (define (build-menu-promise p style bar?)
   "Make @(promise :%1) menu items."
-  (with value ((cadr p))
-    ;;(build-menu-items value style bar?)
-    (if (match? value ':menu-item) (build-menu-items value style bar?)
-        (build-menu-error "promise did not yield a menu: " value))))
+  (with value
+   ((cadr p))
+   ;; (build-menu-items value style bar?)
+   (if (match? value ':menu-item)
+     (build-menu-items value style bar?)
+     (build-menu-error "promise did not yield a menu: " value)
+   ) ;if
+  ) ;with
+) ;define
 
 (define (build-refresh p style bar?)
   "Make @(refresh :%1 :string?) widget."
-  (with (tag s kind) p
-    (list (markup-refresh (if (string? s) s (symbol->string s)) kind))))
+  (with (tag s kind)
+    p
+    (list (markup-refresh (if (string? s) s (symbol->string s)) kind))
+  ) ;with
+) ;define
 
 (define (build-refreshable p style bar?)
   "Make @(refreshable :%1 :menu-item-list) menu items."
-  (with (tag kind . items) p
-    (list (markup-refreshable
-            (lambda () (markup-vmenu (build-menu-items-list items style bar?)))
-            (kind)))))
+  (with (tag kind . items)
+    p
+    (list (markup-refreshable (lambda () (markup-vmenu (build-menu-items-list items style bar?)))
+            (kind)
+          ) ;markup-refreshable
+    ) ;list
+  ) ;with
+) ;define
 
 (define cached-widgets (make-ahash-table))
 
 (define (build-cached p style bar?)
   "Make @(cached :%1 :menu-item-list) menu items."
-  (with (tag kind valid? . items) p
+  (with (tag kind valid? . items)
+    p
     (let* ((kind* (kind))
            (fun (lambda ()
                   (or (and (valid?) (ahash-ref cached-widgets kind*))
-                      (let* ((l (build-menu-items-list items style bar?))
-                             (w (markup-vmenu l)))
-                        (ahash-set! cached-widgets kind* w)
-                        w)))))
-      (list (markup-refreshable fun kind*)))))
+                    (let* ((l (build-menu-items-list items style bar?)) (w (markup-vmenu l)))
+                      (ahash-set! cached-widgets kind* w)
+                      w
+                    ) ;let*
+                  ) ;or
+                ) ;lambda
+           ) ;fun
+          ) ;
+      (list (markup-refreshable fun kind*))
+    ) ;let*
+  ) ;with
+) ;define
 
 (tm-define (invalidate-now kind)
   (ahash-remove! cached-widgets kind)
-  (refresh-now kind))
+  (refresh-now kind)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main routines for making menu items
@@ -906,135 +1269,123 @@
 
 (define (build-menu-items-list l style bar?)
   "Make menu items for each element in @l and append results."
-  (append-map (lambda (p) (build-menu-items p style bar?)) l))
+  (append-map (lambda (p) (build-menu-items p style bar?)) l)
+) ;define
 
 (define (build-menu-items p style bar?)
   "Make menu items @p. The items are on a bar if @bar? and of a given @style."
-  ;;(display* "Make items " p ", " style "\n")
+  ;; (display* "Make items " p ", " style "\n")
   (if (pair? p)
-      (cond ((match? p '(input :%1 :string? :%1 :string?))
-             (list (build-menu-input p style)))
-            ((translatable? (car p))
-             (list (build-menu-entry p style bar?)))
-            ((symbol? (car p))
-             (with result (ahash-ref build-menu-items-table (car p))
-               (if (or (not result) (not (match? (cdr p) (car result))))
-                   (build-menu-items-list p style bar?)
-                   ((cadr result) p style bar?))))
-            ((match? (car p) ':menu-wide-label)
-             (list (build-menu-entry p style bar?)))
-            (else
-             (build-menu-items-list p style bar?)))
-      (cond ((== p '---) (list (build-menu-hsep)))
-            ((== p '|) (list (build-menu-vsep))) ;; '|
-            ((== p '()) p)
-            (else (list (build-menu-bad-format p style))))))
+    (cond ((match? p '(input :%1 :string? :%1 :string?))
+           (list (build-menu-input p style))
+          ) ;
+          ((translatable? (car p)) (list (build-menu-entry p style bar?)))
+          ((symbol? (car p))
+           (with result
+             (ahash-ref build-menu-items-table (car p))
+             (if (or (not result) (not (match? (cdr p) (car result))))
+               (build-menu-items-list p style bar?)
+               ((cadr result) p style bar?)
+             ) ;if
+           ) ;with
+          ) ;
+          ((match? (car p) ':menu-wide-label) (list (build-menu-entry p style bar?)))
+          (else (build-menu-items-list p style bar?))
+    ) ;cond
+    (cond ((== p '---) (list (build-menu-hsep)))
+          ((== p '|) (list (build-menu-vsep)))
+          ;; '|
+          ((== p '()) p)
+          (else (list (build-menu-bad-format p style)))
+    ) ;cond
+  ) ;if
+) ;define
 
 (define-table build-menu-items-table
   (glue (:boolean? :boolean? :integer? :integer?)
-        ,(lambda (p style bar?)
-           (list (build-menu-glue (second p) (third p)
-                                 (fourth p) (fifth p)))))
+    ,(lambda (p style bar?)
+       (list (build-menu-glue (second p) (third p) (fourth p) (fifth p))))
+  ) ;glue
   (color (:%1 :boolean? :boolean? :integer? :integer?)
-         ,(lambda (p style bar?)
-            (list (build-menu-color (second p) (third p)
-                                   (fourth p) (fifth p) (sixth p)))))
-  (group (:%1)
-         ,(lambda (p style bar?) (list (build-menu-group (cadr p) style))))
-  (text (:%1)
-         ,(lambda (p style bar?) (list (build-menu-text (cadr p) style))))
-  (invisible (:%1)
-             ,(lambda (p style bar?) (list)))
+    ,(lambda (p style bar?)
+       (list (build-menu-color (second p)
+               (third p)
+               (fourth p)
+               (fifth p)
+               (sixth p))))
+  ) ;color
+  (group (:%1) ,(lambda (p style bar?) (list (build-menu-group (cadr p) style))))
+  (text (:%1) ,(lambda (p style bar?) (list (build-menu-text (cadr p) style))))
+  (invisible (:%1) ,(lambda (p style bar?) (list)))
   (symbol (:string? :*)
-          ,(lambda (p style bar?) (list (build-menu-symbol p style))))
+    ,(lambda (p style bar?) (list (build-menu-symbol p style)))
+  ) ;symbol
   (texmacs-output (:%2)
-    ,(lambda (p style bar?) (list (build-texmacs-output p style))))
+    ,(lambda (p style bar?) (list (build-texmacs-output p style)))
+  ) ;texmacs-output
   (texmacs-input (:%3)
-    ,(lambda (p style bar?) (list (build-texmacs-input p style))))
+    ,(lambda (p style bar?) (list (build-texmacs-input p style)))
+  ) ;texmacs-input
   (input (:%1 :string? :%1 :string?)
-         ,(lambda (p style bar?) (list (build-menu-input p style))))
+    ,(lambda (p style bar?) (list (build-menu-input p style)))
+  ) ;input
   (numeric-input (:%1 :string? :string? :integer? :integer? :integer? :integer?)
-         ,(lambda (p style bar?) (list (build-numeric-input p style))))
-  (enum (:%3 :string?)
-        ,(lambda (p style bar?) (list (build-enum p style))))
-  (choice (:%3)
-          ,(lambda (p style bar?) (list (build-choice p style))))
-  (choices (:%3)
-           ,(lambda (p style bar?) (list (build-choices p style))))
+    ,(lambda (p style bar?) (list (build-numeric-input p style)))
+  ) ;numeric-input
+  (enum (:%3 :string?) ,(lambda (p style bar?) (list (build-enum p style))))
+  (choice (:%3) ,(lambda (p style bar?) (list (build-choice p style))))
+  (choices (:%3) ,(lambda (p style bar?) (list (build-choices p style))))
   (filtered-choice (:%4)
-           ,(lambda (p style bar?) (list (build-filtered-choice p style))))
-  (color-input (:%3)
-         ,(lambda (p style bar?) (list (build-color-input p style))))
-  (tree-view (:%3)
-             ,(lambda (p style bar?) (list (build-tree-view p style))))
-  (toggle (:%2)
-          ,(lambda (p style bar?) (list (build-toggle p style))))
-  (link (:%1)
-        ,(lambda (p style bar?) (build-menu-link p style bar?)))
-  (dynamic (:%1)
-           ,(lambda (p style bar?) (build-menu-dynamic p style bar?)))
+    ,(lambda (p style bar?) (list (build-filtered-choice p style)))
+  ) ;filtered-choice
+  (color-input (:%3) ,(lambda (p style bar?) (list (build-color-input p style))))
+  (tree-view (:%3) ,(lambda (p style bar?) (list (build-tree-view p style))))
+  (toggle (:%2) ,(lambda (p style bar?) (list (build-toggle p style))))
+  (link (:%1) ,(lambda (p style bar?) (build-menu-link p style bar?)))
+  (dynamic (:%1) ,(lambda (p style bar?) (build-menu-dynamic p style bar?)))
   (horizontal (:*)
-              ,(lambda (p style bar?) (list (build-menu-horizontal p style))))
-  (vertical (:*)
-            ,(lambda (p style bar?) (list (build-menu-vertical p style))))
-  (hlist (:*)
-         ,(lambda (p style bar?) (list (build-menu-hlist p style))))
-  (vlist (:*)
-         ,(lambda (p style bar?) (list (build-menu-vlist p style))))
+    ,(lambda (p style bar?) (list (build-menu-horizontal p style)))
+  ) ;horizontal
+  (vertical (:*) ,(lambda (p style bar?) (list (build-menu-vertical p style))))
+  (hlist (:*) ,(lambda (p style bar?) (list (build-menu-hlist p style))))
+  (vlist (:*) ,(lambda (p style bar?) (list (build-menu-vlist p style))))
   (division (:%1 :*)
-            ,(lambda (p style bar?) (list (build-menu-division p style))))
-  (class (:%1 :*)
-            ,(lambda (p style bar?) (list (build-menu-class p style))))
-  (aligned (:*)
-         ,(lambda (p style bar?) (list (build-aligned p style))))
+    ,(lambda (p style bar?) (list (build-menu-division p style)))
+  ) ;division
+  (class (:%1 :*) ,(lambda (p style bar?) (list (build-menu-class p style))))
+  (aligned (:*) ,(lambda (p style bar?) (list (build-aligned p style))))
   (aligned-item (:%2)
-                ,(lambda (p style bar?) (list (build-aligned-item p style))))
-  (tabs (:*)
-        ,(lambda (p style bar?) (list (build-menu-tabs p style))))
-  (tab (:*)
-        ,(lambda (p style bar?) (list (build-menu-tab p style))))
-  (icon-tabs (:*)
-        ,(lambda (p style bar?) (list (build-menu-icon-tabs p style))))
-  (icon-tab (:*)
-        ,(lambda (p style bar?) (list (build-menu-icon-tab p style))))
-  (minibar (:*)
-            ,(lambda (p style bar?) (list (build-menu-minibar p style))))
+    ,(lambda (p style bar?) (list (build-aligned-item p style)))
+  ) ;aligned-item
+  (tabs (:*) ,(lambda (p style bar?) (list (build-menu-tabs p style))))
+  (tab (:*) ,(lambda (p style bar?) (list (build-menu-tab p style))))
+  (icon-tabs (:*) ,(lambda (p style bar?) (list (build-menu-icon-tabs p style))))
+  (icon-tab (:*) ,(lambda (p style bar?) (list (build-menu-icon-tab p style))))
+  (minibar (:*) ,(lambda (p style bar?) (list (build-menu-minibar p style))))
   (extend (:%1 :*)
-          ,(lambda (p style bar?) (list (build-menu-extend p style bar?))))
-  (style (:%1 :*)
-         ,(lambda (p style bar?) (build-menu-style p style bar?)))
-  (-> (:%1 :*)
-      ,(lambda (p style bar?) (list (build-menu-submenu p style))))
-  (=> (:%1 :*)
-      ,(lambda (p style bar?) (list (build-menu-submenu p style))))
-  (tile (:integer? :*)
-        ,(lambda (p style bar?) (list (build-menu-tile p style))))
-  (scrollable (:*)
-              ,(lambda (p style bar?) (list (build-scrollable p style))))
-  (resize (:%2 :*)
-      ,(lambda (p style bar?) (list (build-resize p style))))
-  (hsplit (:%2)
-          ,(lambda (p style bar?) (list (build-hsplit p style))))
-  (vsplit (:%2)
-          ,(lambda (p style bar?) (list (build-vsplit p style))))
-  (ink (:%1)
-       ,(lambda (p style bar?) (list (build-ink p style))))
-  (if (:%1 :*)
-      ,(lambda (p style bar?) (build-menu-if p style bar?)))
+    ,(lambda (p style bar?) (list (build-menu-extend p style bar?)))
+  ) ;extend
+  (style (:%1 :*) ,(lambda (p style bar?) (build-menu-style p style bar?)))
+  (-> (:%1 :*) ,(lambda (p style bar?) (list (build-menu-submenu p style))))
+  (=> (:%1 :*) ,(lambda (p style bar?) (list (build-menu-submenu p style))))
+  (tile (:integer? :*) ,(lambda (p style bar?) (list (build-menu-tile p style))))
+  (scrollable (:*) ,(lambda (p style bar?) (list (build-scrollable p style))))
+  (resize (:%2 :*) ,(lambda (p style bar?) (list (build-resize p style))))
+  (hsplit (:%2) ,(lambda (p style bar?) (list (build-hsplit p style))))
+  (vsplit (:%2) ,(lambda (p style bar?) (list (build-vsplit p style))))
+  (ink (:%1) ,(lambda (p style bar?) (list (build-ink p style))))
+  (if (:%1 :*) ,(lambda (p style bar?) (build-menu-if p style bar?)))
   (when (:%1 :*)
-        ,(lambda (p style bar?) (build-menu-when p style bar?)))
-  (for (:%1 :%1)
-        ,(lambda (p style bar?) (build-menu-for p style bar?)))
-  (mini (:%1 :*)
-        ,(lambda (p style bar?) (build-menu-mini p style bar?)))
-  (promise (:%1)
-           ,(lambda (p style bar?) (build-menu-promise p style bar?)))
-  (refresh (:%1 :string?)
-           ,(lambda (p style bar?) (build-refresh p style bar?)))
-  (refreshable (:%1 :*)
-               ,(lambda (p style bar?) (build-refreshable p style bar?)))
-  (cached (:%1 :%1 :*)
-               ,(lambda (p style bar?) (build-cached p style bar?))))
+    ,(lambda (p style bar?) (build-menu-when p style bar?))
+  ) ;when
+  (for (:%1 :%1) ,(lambda (p style bar?) (build-menu-for p style bar?)))
+  (mini (:%1 :*) ,(lambda (p style bar?) (build-menu-mini p style bar?)))
+  (promise (:%1) ,(lambda (p style bar?) (build-menu-promise p style bar?)))
+  (refresh (:%1 :string?) ,(lambda (p style bar?) (build-refresh p style bar?)))
+  (refreshable (:%1 :*) ,(lambda (p style bar?)
+                           (build-refreshable p style bar?)))
+  (cached (:%1 :%1 :*) ,(lambda (p style bar?) (build-cached p style bar?)))
+) ;define-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
@@ -1042,22 +1393,31 @@
 
 (define (build-menu-main p style)
   "Transform the menu @p into a widget."
-  (with l (build-menu-items p style #f)
+  (with l
+    (build-menu-items p style #f)
     (cond ((null? l) (build-menu-empty))
           ((and (list? l) (null? (cdr l))) (car l))
-          (else (build-menu-bad-format p style)))))
+          (else (build-menu-bad-format p style))
+    ) ;cond
+  ) ;with
+) ;define
 
 (tm-define (build-menu-widget p style)
   (:synopsis "Transform a menu into a widget")
   (:argument p "a scheme object which represents the menu")
   (:argument style "menu style")
-  ((wrap-catch build-menu-main) p style))
+  ((wrap-catch build-menu-main) p style)
+) ;tm-define
 
 (define (get-gui-style)
-  (with theme (get-preference "gui theme")
+  (with theme
+    (get-preference "gui theme")
     (cond ((== theme "light") "gui-bright")
           ((== theme "dark") "gui-dark")
-          (else "gui-button"))))
+          (else "gui-button")
+    ) ;cond
+  ) ;with
+) ;define
 
 (tm-define (make-menu-widget** p style . opt-size)
   (let* ((cur (current-buffer))
@@ -1067,15 +1427,20 @@
          (h* (if (nlist>1? opt-size) 600 (quotient (* 1 (cadr opt-size)) 1)))
          (w (string-append (number->string w*) "px"))
          (h (string-append (number->string h*) "px"))
-         (sty `(style (tuple ,"generic" ,(get-gui-style)
-                             ,@(if (null? opt-size) '() '("side-tools")))))
-         (tmo `(texmacs-output ,(lambda () `(top-widget ,doc))
-                               ,(lambda () sty)))
+         (sty `(style (tuple ,"generic"
+                        ,(get-gui-style)
+                        ,@(if (null? opt-size) '() '("side-tools"))))
+         ) ;sty
+         (tmo `(texmacs-output ,(lambda () `(top-widget ,doc)) ,(lambda () sty)))
          (tmi `(texmacs-input ,(lambda () `(top-widget ,doc))
-                              ,(lambda () sty)
-                              ,(lambda () u)))
+                 ,(lambda () sty)
+                 ,(lambda () u))
+         ) ;tmi
          (rsz `(resize ,(lambda () w) ,(lambda () h) ,tmi))
-         (wid (list 'vertical (list rsz) `(glue #f #t 0 0))))
-    ;;(display* "doc = " doc "\n")
+         (wid (list 'vertical (list rsz) '(glue #f #t 0 0)))
+        ) ;
+    ;; (display* "doc = " doc "\n")
     (buffer-set-master u cur)
-    (make-menu-widget wid style)))
+    (make-menu-widget wid style)
+  ) ;let*
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/menu-define.scm
+++ b/TeXmacs/progs/kernel/gui/menu-define.scm
@@ -11,8 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui menu-define)
-  (:use (kernel gui gui-markup)))
+(texmacs-module (kernel gui menu-define) (:use (kernel gui gui-markup)))
 
 (define use-minibars? (== (cpp-get-preference "use minibars" "off") "on"))
 
@@ -22,372 +21,457 @@
 
 (define (require-format x pattern)
   (if (not (match? x pattern))
-    (texmacs-error "gui-make" "invalid menu item ~S" x)))
+    (texmacs-error "gui-make" "invalid menu item ~S" x)
+  ) ;if
+) ;define
 
 (define (gui-make-eval x)
   (require-format x '(eval :%1))
-  (cadr x))
+  (cadr x)
+) ;define
 
 (define (gui-make-dynamic x)
   (require-format x '(dynamic :%1))
-  `($dynamic ,(cadr x)))
+  `($dynamic ,(cadr x))
+) ;define
 
 (define (gui-make-former x)
   (require-format x '(former :*))
-  `($dynamic ,x))
+  `($dynamic ,x)
+) ;define
 
 (define (gui-make-link x)
   (require-format x '(link :%1))
-  `($menu-link ,(cadr x)))
+  `($menu-link ,(cadr x))
+) ;define
 
 (define (gui-make-let x)
   (require-format x '(:%1 :%1 :*))
-  `(,(car x) ,(cadr x) (menu-dynamic ,@(cddr x))))
+  `(,(car x) ,(cadr x) (menu-dynamic ,@(cddr x)))
+) ;define
 
 (define (gui-make-with x)
   (require-format x '(:%1 :%2 :*))
-  `(,(car x) ,(cadr x) ,(caddr x) (menu-dynamic ,@(cdddr x))))
+  `(,(car x) ,(cadr x) ,(caddr x) (menu-dynamic ,@(cdddr x)))
+) ;define
 
 (define (gui-make-push-focus x)
   (require-format x '(push-focus :%1 :*))
-  `(with pushed-tree ,(cadr x)
-     (with pushed-focus (tree->fingerprint pushed-tree)
-       (menu-dynamic
-         (invisible (tree->path pushed-tree))
-         ,@(cddr x)))))
+  `(with pushed-tree
+     ,(cadr x)
+     (with pushed-focus
+       (tree->fingerprint pushed-tree)
+       (menu-dynamic (invisible (tree->path pushed-tree)) ,@(cddr x))))
+) ;define
 
 (define (gui-make-cond x)
   (require-format x '(cond :*))
-  (with fun (lambda (x)
-              (with (pred? . body) x
-                (list pred? (cons* 'menu-dynamic body))))
-    `(cond ,@(map fun (cdr x)))))
+  (with fun
+    (lambda (x) (with (pred? . body) x (list pred? (cons* 'menu-dynamic body))))
+    `(cond ,@(map fun (cdr x)))
+  ) ;with
+) ;define
 
 (define (gui-make-loop x)
   (require-format x '(loop (:%1 :%1) :*))
-  (with fun `(lambda (,(caadr x)) (menu-dynamic ,@(cddr x)))
-    `($dynamic (append-map ,fun ,(cadadr x)))))
+  (with fun
+    `(lambda (,(caadr x)) (menu-dynamic ,@(cddr x)))
+    `($dynamic (append-map ,fun ,(cadadr x)))
+  ) ;with
+) ;define
 
 (define (gui-make-refresh x)
   (require-format x '(refresh :%1 :*))
-  (with opts (cddr x)
+  (with opts
+    (cddr x)
     (when (and (null? opts) (symbol? (cadr x)))
-      (set! opts (list (cadr x))))
+      (set! opts (list (cadr x)))
+    ) ;when
     (when (not (symbol? (car opts)))
-      (texmacs-error "gui-make-refresh" "invalid menu item ~S" x))
-    `($refresh ,(cadr x) ,(symbol->string (car opts)))))
+      (texmacs-error "gui-make-refresh" "invalid menu item ~S" x)
+    ) ;when
+    `($refresh ,(cadr x) ,(symbol->string (car opts)))
+  ) ;with
+) ;define
 
 (define (gui-make-refreshable x)
   (require-format x '(refreshable :%1 :*))
-  `($refreshable ,(cadr x) ,@(map gui-make (cddr x))))
+  `($refreshable ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-cached x)
   (require-format x '(cached :%1 :%1 :*))
-  `($cached ,(cadr x) ,(caddr x) ,@(map gui-make (cdddr x))))
+  `($cached ,(cadr x) ,(caddr x) ,@(map gui-make (cdddr x)))
+) ;define
 
 (define (gui-make-group x)
   (require-format x '(group :%1))
-  `($menu-group ,(cadr x)))
+  `($menu-group ,(cadr x))
+) ;define
 
 (define (gui-make-text x)
   (require-format x '(text :%1))
-  `($menu-text ,(cadr x)))
+  `($menu-text ,(cadr x))
+) ;define
 
 (define (gui-make-invisible x)
   (require-format x '(invisible :%1))
-  `($menu-invisible ,(cadr x)))
+  `($menu-invisible ,(cadr x))
+) ;define
 
 (define (gui-make-glue x)
   (require-format x '(glue :%4))
-  `($glue ,(second x) ,(third x) ,(fourth x) ,(fifth x)))
+  `($glue ,(second x) ,(third x) ,(fourth x) ,(fifth x))
+) ;define
 
 (define (gui-make-color x)
   (require-format x '(color :%5))
-  `($colored-glue ,(second x) ,(third x) ,(fourth x) ,(fifth x) ,(sixth x)))
+  `($colored-glue ,(second x) ,(third x) ,(fourth x) ,(fifth x) ,(sixth x))
+) ;define
 
 (define (gui-make-texmacs-output x)
   (require-format x '(texmacs-output :%2))
-  `($texmacs-output ,@(cdr x)))
+  `($texmacs-output ,@(cdr x))
+) ;define
 
 (define (gui-make-texmacs-input x)
   (require-format x '(texmacs-input :%3))
-  `($texmacs-input ,@(cdr x)))
+  `($texmacs-input ,@(cdr x))
+) ;define
 
 (define (gui-make-input x)
   (require-format x '(input :%4))
-  `($input ,@(cdr x)))
+  `($input ,@(cdr x))
+) ;define
 
 (define (gui-make-numeric-input x)
   (require-format x '(numeric-input :%7))
-  `($numeric-input ,@(cdr x)))
+  `($numeric-input ,@(cdr x))
+) ;define
 
 (define (gui-make-enum x)
   (require-format x '(enum :%4))
-  `($enum ,@(cdr x)))
+  `($enum ,@(cdr x))
+) ;define
 
 (define (gui-make-choice x)
   (require-format x '(choice :%3))
-  `($choice ,@(cdr x)))
+  `($choice ,@(cdr x))
+) ;define
 
 (define (gui-make-choices x)
   (require-format x '(choices :%3))
-  `($choices ,@(cdr x)))
+  `($choices ,@(cdr x))
+) ;define
 
 (define (gui-make-filtered-choice x)
   (require-format x '(filtered-choice :%4))
-  `($filtered-choice ,@(cdr x)))
+  `($filtered-choice ,@(cdr x))
+) ;define
 
 (define (gui-make-color-input x)
   (require-format x '(color-input :%3))
-  `($color-input ,@(cdr x)))
+  `($color-input ,@(cdr x))
+) ;define
 
 (define (gui-make-tree-view x)
   (require-format x '(tree-view :%3))
-  `($tree-view ,@(cdr x)))
+  `($tree-view ,@(cdr x))
+) ;define
 
 (define (gui-make-toggle x)
   (require-format x '(toggle :%2))
-  `($toggle ,@(cdr x)))
+  `($toggle ,@(cdr x))
+) ;define
 
 (define (gui-make-icon x)
   (require-format x '(icon :%1))
-  `($icon ,(cadr x)))
+  `($icon ,(cadr x))
+) ;define
 
 (define (gui-make-replace x)
   (require-format x '(replace :%1 :*))
-  `($replace-text ,(cadr x) ,@(cddr x)))
+  `($replace-text ,(cadr x) ,@(cddr x))
+) ;define
 
 (define (gui-make-concat x)
   (require-format x '(concat :*))
-  `($concat-text ,@(cdr x)))
+  `($concat-text ,@(cdr x))
+) ;define
 
 (define (gui-make-verbatim x)
   (require-format x '(verbatim :*))
-  `($verbatim-text ,@(cdr x)))
+  `($verbatim-text ,@(cdr x))
+) ;define
 
 (define (gui-make-check x)
   (require-format x '(check :%3))
-  `($check ,(gui-make (cadr x)) ,(caddr x) ,(cadddr x)))
+  `($check ,(gui-make (cadr x)) ,(caddr x) ,(cadddr x))
+) ;define
 
 (define (gui-make-shortcut x)
   (require-format x '(shortcut :%2))
-  `($shortcut* ,(gui-make (cadr x)) ,(caddr x)))
+  `($shortcut* ,(gui-make (cadr x)) ,(caddr x))
+) ;define
 
 (define (gui-make-balloon x)
   (require-format x '(balloon :%2))
-  `($balloon ,(gui-make (cadr x)) ,(gui-make (caddr x))))
+  `($balloon ,(gui-make (cadr x)) ,(gui-make (caddr x)))
+) ;define
 
 (define (gui-make-submenu x)
   (require-format x '(-> :%1 :*))
-  `($-> ,@(map gui-make (cdr x))))
+  `($-> ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-top-submenu x)
   (require-format x '(=> :%1 :*))
-  `($=> ,@(map gui-make (cdr x))))
+  `($=> ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-horizontal x)
   (require-format x '(horizontal :*))
-  `($horizontal ,@(map gui-make (cdr x))))
+  `($horizontal ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-vertical x)
   (require-format x '(vertical :*))
-  `($vertical ,@(map gui-make (cdr x))))
+  `($vertical ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-hlist x)
   (require-format x '(hlist :*))
-  `($hlist ,@(map gui-make (cdr x))))
+  `($hlist ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-vlist x)
   (require-format x '(vlist :*))
-  `($vlist ,@(map gui-make (cdr x))))
+  `($vlist ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-division x)
   (require-format x '(division :%1 :*))
-  `($division ,(cadr x) ,@(map gui-make (cddr x))))
+  `($division ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-class x)
   (require-format x '(class :%1 :*))
-  `($class ,(cadr x) ,@(map gui-make (cddr x))))
+  `($class ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-aligned x)
   (require-format x '(aligned :*))
-  `($aligned ,@(map gui-make (cdr x))))
+  `($aligned ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-item x)
   (require-format x '(item :%2))
-  `($aligned-item ,@(map gui-make (cdr x))))
+  `($aligned-item ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-meti x)
   (require-format x '(meti :%2))
-  `($aligned-item ,@(map gui-make (reverse (cdr x)))))
+  `($aligned-item ,@(map gui-make (reverse (cdr x))))
+) ;define
 
 (define (gui-make-tabs x)
   (require-format x '(tabs :*))
-  `($tabs ,@(map gui-make (cdr x))))
+  `($tabs ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-tab x)
   (require-format x '(tab :%1 :*))
-  `($tab ,@(map gui-make (cdr x))))
+  `($tab ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-icon-tabs x)
   (require-format x '(icon-tabs :*))
-  `($icon-tabs ,@(map gui-make (cdr x))))
+  `($icon-tabs ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-icon-tab x)
   (require-format x '(icon-tab :%2 :*))
-  `($icon-tab ,@(map gui-make (cdr x))))
+  `($icon-tab ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-plain-style x)
   (require-format x '(plain-style :*))
-  `($widget-style 0 ,@(map gui-make (cdr x))))
+  `($widget-style ,0 ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-inert x)
   (require-format x '(inert :*))
-  `($widget-style ,widget-style-inert ,@(map gui-make (cdr x))))
+  `($widget-style ,widget-style-inert ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-explicit-buttons x)
   (require-format x '(explicit-buttons :*))
-  `($widget-style ,widget-style-button ,@(map gui-make (cdr x))))
+  `($widget-style ,widget-style-button ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-bold x)
   (require-format x '(bold :*))
-  `($widget-style ,widget-style-bold ,@(map gui-make (cdr x))))
+  `($widget-style ,widget-style-bold ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-grey x)
   (require-format x '(grey :*))
-  `($widget-style ,widget-style-grey ,@(map gui-make (cdr x))))
+  `($widget-style ,widget-style-grey ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-monospaced x)
   (require-format x '(mono :*))
-  `($widget-style ,widget-style-monospaced ,@(map gui-make (cdr x))))
+  `($widget-style ,widget-style-monospaced ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-verb x)
   (require-format x '(verb :*))
-  `($widget-style ,widget-style-verb ,@(map gui-make (cdr x))))
+  `($widget-style ,widget-style-verb ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-tile x)
   (require-format x '(tile :integer? :*))
-  `($tile ,(cadr x) ,@(map gui-make (cddr x))))
+  `($tile ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-scrollable x)
   (require-format x '(scrollable :*))
-  `($scrollable ,@(map gui-make (cdr x))))
+  `($scrollable ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-resize x)
   (require-format x '(resize :%2 :*))
-  `($resize ,(cadr x) ,(caddr x) ,@(map gui-make (cdddr x))))
+  `($resize ,(cadr x) ,(caddr x) ,@(map gui-make (cdddr x)))
+) ;define
 
 (define (gui-make-hsplit x)
   (require-format x '(hsplit :%2))
-  `($hsplit ,@(map gui-make (cdr x))))
+  `($hsplit ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-vsplit x)
   (require-format x '(vsplit :%2))
-  `($vsplit ,@(map gui-make (cdr x))))
+  `($vsplit ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-minibar x)
   (require-format x '(minibar :*))
   (if use-minibars?
-      `(gui$minibar ,@(map gui-make (cdr x)))
-      `($when #t ,@(map gui-make (cdr x)))))
+    `(gui$minibar ,@(map gui-make (cdr x)))
+    `($when ,#t ,@(map gui-make (cdr x)))
+  ) ;if
+) ;define
 
 (define (gui-make-extend x)
   (require-format x '(extend :%1 :*))
-  `($widget-extend ,@(map gui-make (cdr x))))
+  `($widget-extend ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-padded x)
   (require-format x '(padded :*))
-  `($vlist
-     ($glue #f #f 0 10)
-     ($hlist
-       ($glue #f #f 25 0)
+  `($vlist ($glue #f #f 0 10)
+     ($hlist ($glue #f #f 25 0)
        ($vlist ,@(map gui-make (cdr x)))
        ($glue #f #f 25 0))
-     ($glue #f #f 0 10)))
+     ($glue #f #f 0 10))
+) ;define
 
 (define (gui-make-centered x)
   (require-format x '(centered :*))
-  `($vlist
-     ($glue #f #f 0 10)
-     ($hlist
-       ($glue #t #f 25 0)
+  `($vlist ($glue #f #f 0 10)
+     ($hlist ($glue #t #f 25 0)
        ($vlist ,@(map gui-make (cdr x)))
        ($glue #t #f 25 0))
-     ($glue #f #f 0 10)))
+     ($glue #f #f 0 10))
+) ;define
 
 (define (gui-make-bottom-buttons x)
   (require-format x '(bottom-buttons :*))
-  `($vlist
-     $---
+  `($vlist $---
      ($glue #f #f 0 5)
-     ($hlist
-       ($glue #f #f 5 0)
-       ($widget-style ,widget-style-button
-         ,@(map gui-make (cdr x)))
+     ($hlist ($glue #f #f 5 0)
+       ($widget-style ,widget-style-button ,@(map gui-make (cdr x)))
        ($glue #f #f 5 0))
-     ($glue #f #f 0 5)))
+     ($glue #f #f 0 5))
+) ;define
 
 (define (gui-make-assuming x)
   (require-format x '(assuming :%1 :*))
-  `($when ,(cadr x) ,@(map gui-make (cddr x))))
+  `($when ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-if x)
   (require-format x '(if :%1 :*))
-  `($delayed-when ,(cadr x) ,@(map gui-make (cddr x))))
+  `($delayed-when ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-when x)
   (require-format x '(when :%1 :*))
-  `($assuming ,(cadr x) ,@(map gui-make (cddr x))))
+  `($assuming ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-for x)
   (require-format x '(for (:%1 :%1) :*))
-  `($for* ,(cadr x) ,@(map gui-make (cddr x))))
+  `($for* ,(cadr x) ,@(map gui-make (cddr x)))
+) ;define
 
 (define (gui-make-mini x)
   (require-format x '(mini :%1 :*))
   (if use-minibars?
-      `($mini ,(cadr x) ,@(map gui-make (cddr x)))
-      `($when #t ,@(map gui-make (cddr x)))))
+    `($mini ,(cadr x) ,@(map gui-make (cddr x)))
+    `($when ,#t ,@(map gui-make (cddr x)))
+  ) ;if
+) ;define
 
 (define (gui-make-symbol x)
   (require-format x '(symbol :string? :*))
-  `($symbol ,@(cdr x)))
+  `($symbol ,@(cdr x))
+) ;define
 
 (define (gui-make-promise x)
   (require-format x '(promise :%1))
-  `($promise ,(cadr x)))
+  `($promise ,(cadr x))
+) ;define
 
 (define (gui-make-ink x)
   (require-format x '(ink :%1))
-  `($ink ,(cadr x)))
+  `($ink ,(cadr x))
+) ;define
 
 (define (gui-make-form x)
   (require-format x '(form :%1 :*))
-  `($form ,@(map gui-make (cdr x))))
+  `($form ,@(map gui-make (cdr x)))
+) ;define
 
 (define (gui-make-form-input x)
   (require-format x '(form-input :%4))
-  `($form-input ,@(cdr x)))
+  `($form-input ,@(cdr x))
+) ;define
 
 (define (gui-make-form-enum x)
   (require-format x '(form-enum :%4))
-  `($form-enum ,@(cdr x)))
+  `($form-enum ,@(cdr x))
+) ;define
 
 (define (gui-make-form-choice x)
   (require-format x '(form-choice :%3))
-  `($form-choice ,@(cdr x)))
+  `($form-choice ,@(cdr x))
+) ;define
 
 (define (gui-make-form-choices x)
   (require-format x '(form-choices :%3))
-  `($form-choices ,@(cdr x)))
+  `($form-choices ,@(cdr x))
+) ;define
 
 (define (gui-make-form-toggle x)
   (require-format x '(form-toggle :%2))
-  `($form-toggle ,@(cdr x)))
+  `($form-toggle ,@(cdr x))
+) ;define
 
 (define (gui-make-tab-page x)
-  (require-format x '(tab-page :%4)) ; :%4 means requiring 4 parameters
-  `($tab-page ,@(map gui-make (cdr x))))
+  (require-format x '(tab-page :%4))
+  `($tab-page ,@(map gui-make (cdr x)))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Table with Gui primitives and dispatching
@@ -398,12 +482,15 @@
   (dynamic ,gui-make-dynamic)
   (former ,gui-make-former)
   (link ,gui-make-link)
-  (let ,gui-make-let)
-  (let* ,gui-make-let)
+  (let ,gui-make-let
+  ) ;let
+  (let* ,gui-make-let
+  ) ;let*
   (with ,gui-make-with)
   (push-focus ,gui-make-push-focus)
   (receive ,gui-make-with)
-  (cond ,gui-make-cond)
+  (cond ,gui-make-cond
+  ) ;cond
   (loop ,gui-make-loop)
   (refresh ,gui-make-refresh)
   (refreshable ,gui-make-refreshable)
@@ -465,7 +552,8 @@
   (bottom-buttons ,gui-make-bottom-buttons)
   (assuming ,gui-make-assuming)
   (if ,gui-make-if)
-  (when ,gui-make-when)
+  (when ,gui-make-when
+  ) ;when
   (for ,gui-make-for)
   (mini ,gui-make-mini)
   (symbol ,gui-make-symbol)
@@ -477,10 +565,11 @@
   (form-choice ,gui-make-form-choice)
   (form-choices ,gui-make-form-choices)
   (form-toggle ,gui-make-form-toggle)
-  (tab-page ,gui-make-tab-page))
+  (tab-page ,gui-make-tab-page)
+) ;define-table
 
 (tm-define (gui-make x)
-  ;;(display* "x= " x "\n")
+  ;; (display* "x= " x "\n")
   (cond ((symbol? x)
          (cond ((== x '---) '$---)
                ((== x '===) (gui-make '(glue #f #f 0 5)))
@@ -491,48 +580,61 @@
                ((== x '>>) (gui-make '(glue #t #f 5 0)))
                ((== x '>>>) (gui-make '(glue #t #f 15 0)))
                ((== x (string->symbol "|")) '$/)
-               (else
-                 (texmacs-error "gui-make" "invalid menu item ~S" x))))
+               (else (texmacs-error "gui-make" "invalid menu item ~S" x))
+         ) ;cond
+        ) ;
         ((string? x) x)
         ((and (pair? x) (ahash-ref gui-make-table (car x)))
-         (apply (car (ahash-ref gui-make-table (car x))) (list x)))
+         (apply (car (ahash-ref gui-make-table (car x))) (list x))
+        ) ;
         ((and (pair? x) (or (string? (car x)) (pair? (car x))))
-         `($> ,(gui-make (car x)) ,@(cdr x)))
-        (else
-          (texmacs-error "gui-make" "invalid menu item ~S" x))))
+         `($> ,(gui-make (car x)) ,@(cdr x))
+        ) ;
+        (else (texmacs-error "gui-make" "invalid menu item ~S" x))
+  ) ;cond
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; User interface for dynamic menu definitions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define-macro (menu-dynamic . l)
-  `($list ,@(map gui-make l)))
+(tm-define-macro (menu-dynamic . l) `($list ,@(map gui-make l)))
 
 (tm-define-macro (define-menu head . body)
-  `(define ,head (menu-dynamic ,@body)))
+  `(define ,head (menu-dynamic ,@body))
+) ;tm-define-macro
 
 (tm-define-macro (define-widget head . body)
-  `(define ,head (menu-dynamic ,@body)))
+  `(define ,head (menu-dynamic ,@body))
+) ;tm-define-macro
 
 (tm-define-macro (tm-menu head . l)
-  (receive (opts body) (list-break l not-define-option?)
-    `(tm-define ,head ,@opts (menu-dynamic ,@body))))
+  (receive (opts body)
+    (list-break l not-define-option?)
+    `(tm-define ,head ,@opts (menu-dynamic ,@body))
+  ) ;receive
+) ;tm-define-macro
 
 (tm-define-macro (tm-widget head . l)
-  (receive (opts body) (list-break l not-define-option?)
-    `(tm-define ,head ,@opts (menu-dynamic ,@body))))
+  (receive (opts body)
+    (list-break l not-define-option?)
+    `(tm-define ,head ,@opts (menu-dynamic ,@body))
+  ) ;receive
+) ;tm-define-macro
 
 (tm-define-macro (menu-bind name . l)
-  ;;(display* name " --> " l "\n")
-  (receive (opts body) (list-break l not-define-option?)
-    `(tm-define (,name) ,@opts (menu-dynamic ,@body))))
+  ;; (display* name " --> " l "\n")
+  (receive (opts body)
+    (list-break l not-define-option?)
+    `(tm-define (,name) ,@opts (menu-dynamic ,@body))
+  ) ;receive
+) ;tm-define-macro
 
 (define-public-macro (lazy-menu module . menus)
   `(begin
      (lazy-define ,module ,@menus)
-     (delayed
-       (:idle 500)
-       (module-provide ',module))))
+     (delayed (:idle 500) (module-provide (quote ,module))))
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Section tabs
@@ -541,116 +643,176 @@
 (define section-tab-table (make-ahash-table))
 
 (tm-define (section-tab-ref name key)
-  (or (ahash-ref section-tab-table (list name key)) 0))
+  (or (ahash-ref section-tab-table (list name key)) 0)
+) ;tm-define
 
 (tm-define (section-tab-set name key val)
   (ahash-set! section-tab-table (list name key) val)
   (refresh-now name)
-  (keyboard-focus-on "canvas"))
+  (keyboard-focus-on "canvas")
+) ;tm-define
 
 (define (make-section-tab* name key ts i j)
-  (let* ((t (list-ref ts j))
-         (title (cadr t)))
+  (let* ((t (list-ref ts j)) (title (cadr t)))
     (if (== i j)
-        `(class "section-active-tab" (,title (noop)))
-        `(,title (section-tab-set ,name ,key ,j)))))
+      `(class ,"section-active-tab" (,title (noop)))
+      `(,title (section-tab-set ,name ,key ,j))
+    ) ;if
+  ) ;let*
+) ;define
 
 (define (make-section-tab name key ts i)
-  (with t (list-ref ts i)
+  (with t
+    (list-ref ts i)
     (require-format t '(section-tab :%1 :*))
     `(assuming (== (section-tab-ref ,name ,key) ,i)
-       (division "section-tabs"
+       (division ,"section-tabs"
          ===
-         (hlist
-           ,@(map (lambda (j) (make-section-tab* name key ts i j))
-                  (.. 0 (length ts)))
+         (hlist ,@(map (lambda (j) (make-section-tab* name key ts i j))
+                    (.. 0 (length ts)))
            >>>))
-       ,@(cddr t))))
+       ,@(cddr t))
+  ) ;with
+) ;define
 
 (define (gui-make-section-tabs x)
   (require-format x '(section-tabs :%2 :*))
-  (with (tag name key . ts) x
-    `(menu-dynamic
-       (refreshable ,name
-         ,@(map (lambda (i) (make-section-tab name key ts i))
-                (.. 0 (length ts)))))))
+  (with (tag name key . ts)
+    x
+    `(menu-dynamic (refreshable ,name
+                     ,@(map (lambda (i) (make-section-tab name key ts i))
+                         (.. 0 (length ts)))))
+  ) ;with
+) ;define
 
-(extend-table gui-make-table
-  (section-tabs ,gui-make-section-tabs))
+(extend-table gui-make-table (section-tabs ,gui-make-section-tabs))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic color pickers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (standard-color-list)
-  '("dark red" "dark magenta" "dark blue" "dark cyan"
-    "dark green" "dark yellow" "dark orange" "dark brown"
-    "red" "magenta" "blue" "cyan"
-    "green" "yellow" "orange" "brown"
-    "#faa" "#faf" "#aaf" "#aff"
-    "#afa" "#ffa" "#fa6" "#a66"
-    "pastel red" "pastel magenta" "pastel blue" "pastel cyan"
-    "pastel green" "pastel yellow" "pastel orange" "pastel brown"))
+  '("dark red"
+    "dark magenta"
+    "dark blue"
+    "dark cyan"
+    "dark green"
+    "dark yellow"
+    "dark orange"
+    "dark brown"
+    "red"
+    "magenta"
+    "blue"
+    "cyan"
+    "green"
+    "yellow"
+    "orange"
+    "brown"
+    "#faa"
+    "#faf"
+    "#aaf"
+    "#aff"
+    "#afa"
+    "#ffa"
+    "#fa6"
+    "#a66"
+    "pastel red"
+    "pastel magenta"
+    "pastel blue"
+    "pastel cyan"
+    "pastel green"
+    "pastel yellow"
+    "pastel orange"
+    "pastel brown")
+) ;define
 
 (define (standard-grey-list)
-  '("black" "darker grey" "dark grey" "#a0a0a0"
-    "light grey" "pastel grey" "#f0f0f0" "white"))
+  '("black"
+    "darker grey"
+    "dark grey"
+    "#a0a0a0"
+    "light grey"
+    "pastel grey"
+    "#f0f0f0"
+    "white")
+) ;define
 
 (tm-menu (standard-color-menu cmd)
   (tile 8
     (for (col (append (standard-color-list) (standard-grey-list)))
-      (explicit-buttons
-        ((color col #f #f 32 24)
-         (cmd col))))))
+      (explicit-buttons ((color col #f #f 32 24) (cmd col)))
+    ) ;for
+  ) ;tile
+) ;tm-menu
 
 (define (gui-make-pick-color x)
-  `(menu-dynamic
-     (dynamic (standard-color-menu (lambda (answer) ,@(cdr x))))))
+  `(menu-dynamic (dynamic (standard-color-menu (lambda (answer) ,@(cdr x)))))
+) ;define
 
-(extend-table gui-make-table
-  (pick-color ,gui-make-pick-color))
+(extend-table gui-make-table (pick-color ,gui-make-pick-color))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic pattern picker
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (get-preferred-list type nr)
-  (with l (get-preference type)
-    (when (string? l) (set! l (string->object l)))
+  (with l
+    (get-preference type)
+    (when (string? l)
+      (set! l (string->object l))
+    ) ;when
     (cond ((nlist? l) (list))
           ((> (length l) nr) (sublist l 0 nr))
-          (else l))))
+          (else l)
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (insert-preferred-list type what nr)
   (let* ((l (get-preferred-list type nr))
          (i (list-find-index l (cut == <> what)))
-         (r l))
-    (if i (set! r (append (sublist r 0 i)
-                          (sublist r (+ i 1) (length r)))))
+         (r l)
+        ) ;
+    (if i (set! r (append (sublist r 0 i) (sublist r (+ i 1) (length r)))))
     (set! r (cons what r))
     (when (> (length r) nr)
-      (set! r (sublist r 0 nr)))
+      (set! r (sublist r 0 nr))
+    ) ;when
     (when (!= r l)
-      (set-preference type r))))
+      (set-preference type r)
+    ) ;when
+  ) ;let*
+) ;define-public
 
 (define-public (tm-pattern name . args)
   (cond ((url-exists? (url-append "$TEXMACS_PATTERN_PATH" (url-tail name)))
-         `(pattern ,(url->unix (url-tail name)) ,@args))
+         `(pattern ,(url->unix (url-tail name)) ,@args)
+        ) ;
         ((and-let* ((delta-unix (url->delta-unix name)))
-           (string-starts? (url->unix delta-unix) "../"))
-         (when (url? name) (set! name (url->system name)))
-         `(pattern ,name ,@args))
-        (else
-         `(pattern ,(url->system name) ,@args))))
+           (string-starts? (url->unix delta-unix) "../")
+         ) ;and-let*
+         (when (url? name)
+           (set! name (url->system name))
+         ) ;when
+         `(pattern ,name ,@args)
+        ) ;
+        (else `(pattern ,(url->system name) ,@args))
+  ) ;cond
+) ;define-public
 
 (tm-menu (my-pattern-menu cmd)
   (tile 8
     (for (col (get-preferred-list "my patterns" 32))
-      (with args (cons* (cadr col) "100%" "100@" (cddddr col))
-        (with col2 (apply tm-pattern args)
-          (explicit-buttons
-            ((color col2 #f #f 32 32)
-             (cmd col))))))))
+      (with args
+        (cons* (cadr col) "100%" "100@" (cddddr col))
+        (with col2
+          (apply tm-pattern args)
+          (explicit-buttons ((color col2 #f #f 32 32) (cmd col)))
+        ) ;with
+      ) ;with
+    ) ;for
+  ) ;tile
+) ;tm-menu
 
 (define (standard-pattern-list dir scale)
   (let* ((l1 (url-read-directory dir "*.png"))
@@ -658,51 +820,60 @@
          (l3 (url-read-directory dir "*.gif"))
          (l (append l1 l2 l3))
          (d (map (cut url-delta (string-append dir "/x") <>) l))
-         (f (map (lambda (x) (string-append dir "/" (url->unix x))) d)))
-    (map (lambda (x) (tm-pattern x scale "")) f)))
+         (f (map (lambda (x) (string-append dir "/" (url->unix x))) d))
+        ) ;
+    (map (lambda (x) (tm-pattern x scale "")) f)
+  ) ;let*
+) ;define
 
 (tm-menu (standard-pattern-menu cmd dir scale)
   (tile 8
     (for (col (standard-pattern-list dir scale))
-      (with col2 (tm-pattern (cadr col) "100%" "100@")
-        (explicit-buttons
-          ((color col2 #f #f 32 32)
-           (cmd col)))))))
+      (with col2
+        (tm-pattern (cadr col) "100%" "100@")
+        (explicit-buttons ((color col2 #f #f 32 32) (cmd col)))
+      ) ;with
+    ) ;for
+  ) ;tile
+) ;tm-menu
 
 (tm-menu (big-pattern-menu cmd dir scale)
   (tile 6
     (for (col (standard-pattern-list dir scale))
-      (with col2 (tm-pattern (cadr col) "100%" "100@")
-        (explicit-buttons
-          ((color col2 #f #f 90 90)
-           (cmd col)))))))
+      (with col2
+        (tm-pattern (cadr col) "100%" "100@")
+        (explicit-buttons ((color col2 #f #f 90 90) (cmd col)))
+      ) ;with
+    ) ;for
+  ) ;tile
+) ;tm-menu
 
 (define-public (clipart-list)
-  (list-filter
-   (list (list "Dot hatches" "$TEXMACS_PATH/misc/patterns/dots-hatches")
-         (list "Line hatches" "$TEXMACS_PATH/misc/patterns/lines-default")
-         (list "Artistic hatches" "$TEXMACS_PATH/misc/patterns/lines-artistic")
-         (list "Textile" "$TEXMACS_PATH/misc/patterns/textile")
-         (list "Hatch" "/opt/local/share/openclipart/special/patterns")
-         (list "Personal" "~/patterns")
-         (list "Simple" "~/simple-tiles"))
-   (lambda (p) (url-exists? (cadr p)))))
+  (list-filter (list (list "Dot hatches" "$TEXMACS_PATH/misc/patterns/dots-hatches")
+                 (list "Line hatches" "$TEXMACS_PATH/misc/patterns/lines-default")
+                 (list "Artistic hatches" "$TEXMACS_PATH/misc/patterns/lines-artistic")
+                 (list "Textile" "$TEXMACS_PATH/misc/patterns/textile")
+                 (list "Hatch" "/opt/local/share/openclipart/special/patterns")
+                 (list "Personal" "~/patterns")
+                 (list "Simple" "~/simple-tiles")
+               ) ;list
+    (lambda (p) (url-exists? (cadr p)))
+  ) ;list-filter
+) ;define-public
 
 (tm-menu (clipart-pattern-menu cmd scale)
   (for (p (clipart-list))
-    (-> (eval (car p))
-        (dynamic (big-pattern-menu cmd (cadr p) scale)))))
+    (-> (eval (car p)) (dynamic (big-pattern-menu cmd (cadr p) scale)))
+  ) ;for
+) ;tm-menu
 
 (define (gui-make-pick-background x)
-  `(menu-dynamic
-     (dynamic (standard-color-menu (lambda (answer) ,@(cddr x))))
-     ))
+  `(menu-dynamic (dynamic (standard-color-menu (lambda (answer) ,@(cddr x)))))
+) ;define
 
-(extend-table gui-make-table
-  (pick-background ,gui-make-pick-background))
+(extend-table gui-make-table (pick-background ,gui-make-pick-background))
 
-(tm-define (allow-pattern-colors?)
-  (qt-gui?))
+(tm-define (allow-pattern-colors?) (qt-gui?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra RGB color picker
@@ -712,7 +883,9 @@
   (string-append "#"
     (integer->padded-hexadecimal r 2)
     (integer->padded-hexadecimal g 2)
-    (integer->padded-hexadecimal b 2)))
+    (integer->padded-hexadecimal b 2)
+  ) ;string-append
+) ;define
 
 (tm-menu (rgb-palette cmd r1 r2 g1 g2 b1 b2 n)
   (for (rr (.. r1 r2))
@@ -721,24 +894,26 @@
         (let* ((r (/ (* 255 rr) (- n 1)))
                (g (/ (* 255 gg) (- n 1)))
                (b (/ (* 255 bb) (- n 1)))
-               (col (rgb-color-name r g b)))
-          (explicit-buttons
-            ((color col #f #f 24 24)
-             (cmd col))))))))
+               (col (rgb-color-name r g b))
+              ) ;
+          (explicit-buttons ((color col #f #f 24 24) (cmd col)))
+        ) ;let*
+      ) ;for
+    ) ;for
+  ) ;for
+) ;tm-menu
 
 (tm-menu (rgb-color-picker cmd)
-  (tile 18
-    (dynamic (rgb-palette cmd 0 6 0 3 0 6 6)))
-  (tile 18
-    (dynamic (rgb-palette cmd 0 6 3 6 0 6 6)))
+  (tile 18 (dynamic (rgb-palette cmd 0 6 0 3 0 6 6)))
+  (tile 18 (dynamic (rgb-palette cmd 0 6 3 6 0 6 6)))
   ---
   (glue #f #f 0 3)
-  (hlist
-    (glue #t #f 0 17)
-    (explicit-buttons
-      ("Cancel" (cmd #f)))
-    (glue #f #f 3 0))
-  (glue #f #f 0 3))
+  (hlist (glue #t #f 0 17)
+    (explicit-buttons ("Cancel" (cmd #f)))
+    (glue #f #f 3 0)
+  ) ;hlist
+  (glue #f #f 0 3)
+) ;tm-menu
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Deprecated functionality
@@ -746,5 +921,8 @@
 
 (tm-define-macro (menu-extend name . l)
   (deprecated-function "menu-extend" "tm-menu" "former")
-  (receive (opts body) (list-break l not-define-option?)
-    `(tm-define (,name) ,@opts (menu-dynamic (former) ,@body))))
+  (receive (opts body)
+    (list-break l not-define-option?)
+    `(tm-define (,name) ,@opts (menu-dynamic (former) ,@body))
+  ) ;receive
+) ;tm-define-macro

--- a/TeXmacs/progs/kernel/gui/menu-test.scm
+++ b/TeXmacs/progs/kernel/gui/menu-test.scm
@@ -13,187 +13,215 @@
 ;; See menu-define.scm for the grammar of menus
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui menu-test)
-  (:use (kernel gui menu-widget)))
+(texmacs-module (kernel gui menu-test) (:use (kernel gui menu-widget)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Some test widgets
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-widget (widget1)
-  (centered
-    (aligned
-      (item (text "First:")
-        (toggle (display* "First " answer "\n") #f))
-      (item (text "Second:")
-        (toggle (display* "Second " answer "\n") #f)))))
+  (centered (aligned (item (text "First:") (toggle (display* "First " answer "\n") #f))
+              (item (text "Second:") (toggle (display* "Second " answer "\n") #f))
+            ) ;aligned
+  ) ;centered
+) ;tm-widget
 
 (tm-widget (widget2)
-  (tabs
-    (tab (text "General")
-      (centered
-        (aligned
-          (item (text "First:")
-            (toggle (display* "First " answer "\n") #f))
-          (item (text "Second:")
-            (toggle (display* "Second " answer "\n") #f)))))
+  (tabs (tab (text "General")
+          (centered (aligned (item (text "First:") (toggle (display* "First " answer "\n") #f))
+                      (item (text "Second:") (toggle (display* "Second " answer "\n") #f))
+                    ) ;aligned
+          ) ;centered
+        ) ;tab
     (tab (text "Extra")
-      (centered
-        (aligned
-          (item (text "First:")
-            (toggle (display* "First " answer "\n") #f))
-          (item (text "Second:")
-            (toggle (display* "Second " answer "\n") #f))))
-      (bottom-buttons
-        ("Cancel" (display "Cancel\n")) >> ("Ok" (display "Ok\n"))))
+      (centered (aligned (item (text "First:") (toggle (display* "First " answer "\n") #f))
+                  (item (text "Second:") (toggle (display* "Second " answer "\n") #f))
+                ) ;aligned
+      ) ;centered
+      (bottom-buttons ("Cancel" (display "Cancel\n")) >> ("Ok" (display "Ok\n")))
+    ) ;tab
     (tab (text "Settings")
-      (centered
-        (aligned
-          (item (text "First:")
-            (enum (display* "First " answer "\n")
-                  '("gnu" "gnat" "zebra")
-                  "zebra" "10em"))
-          (item (text "Second:")
-            (enum (display* "Second " answer "\n")
-                  '("fun" "foo" "bar")
-                  "fun" "10em"))))
-      (bottom-buttons
-        >> ("Ok" (display "Ok\n"))))))
+      (centered (aligned (item (text "First:")
+                           (enum (display* "First " answer "\n") '("gnu"
+                                                                   "gnat"
+                                                                   "zebra") "zebra" "10em")
+                         ) ;item
+                  (item (text "Second:")
+                    (enum (display* "Second " answer "\n") '("fun" "foo" "bar") "fun" "10em")
+                  ) ;item
+                ) ;aligned
+      ) ;centered
+      (bottom-buttons >> ("Ok" (display "Ok\n")))
+    ) ;tab
+  ) ;tabs
+) ;tm-widget
 
 (tm-widget (widget3)
-  (centered
-    (resize "200px" "100px"
-      (scrollable
-        (aligned
-          (item (text "First:")
-            (toggle (display* "First " answer "\n") #f))
-          (item (text "Second:")
-            (toggle (display* "Second " answer "\n") #f))
-          (item (text "Third:")
-            (toggle (display* "Third " answer "\n") #f))
-          (item (text "Fourth:")
-            (toggle (display* "Fourth " answer "\n") #f))
-          (item (text "Fifth:")
-            (toggle (display* "Fifth " answer "\n") #f))
-          (item (text "Sixth:")
-            (toggle (display* "Sixth " answer "\n") #f))
-          (item (text "Seventh:")
-            (toggle (display* "Seventh " answer "\n") #f))
-          (item (text "Eighth:")
-            (toggle (display* "Eighth " answer "\n") #f)))))))
+  (centered (resize "200px"
+              "100px"
+              (scrollable (aligned (item (text "First:") (toggle (display* "First " answer "\n") #f))
+                            (item (text "Second:") (toggle (display* "Second " answer "\n") #f))
+                            (item (text "Third:") (toggle (display* "Third " answer "\n") #f))
+                            (item (text "Fourth:") (toggle (display* "Fourth " answer "\n") #f))
+                            (item (text "Fifth:") (toggle (display* "Fifth " answer "\n") #f))
+                            (item (text "Sixth:") (toggle (display* "Sixth " answer "\n") #f))
+                            (item (text "Seventh:") (toggle (display* "Seventh " answer "\n") #f))
+                            (item (text "Eighth:") (toggle (display* "Eighth " answer "\n") #f))
+                          ) ;aligned
+              ) ;scrollable
+            ) ;resize
+  ) ;centered
+) ;tm-widget
 
 (tm-widget (widget4)
-  (centered
-    (resize "200px" "50px"
-      (scrollable
-        (choice (display* answer "\n")
-                '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
-                "Third")))
+  (centered (resize "200px"
+              "50px"
+              (scrollable (choice (display* answer "\n")
+                            '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
+                            "Third"
+                          ) ;choice
+              ) ;scrollable
+            ) ;resize
     ======
-    (resize "200px" "150px"
+    (resize "200px"
+      "150px"
       (choices (display* answer "\n")
-               '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
-               '("Third" "Fifth")))))
+        '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
+        '("Third" "Fifth")
+      ) ;choices
+    ) ;resize
+  ) ;centered
+) ;tm-widget
 
 (tm-widget (widget5)
   ===
-  (hlist
+  (hlist //
+    (hsplit (resize '("100px" "200px" "400px")
+              '("50px" "100px" "150px")
+              (scrollable (choice (display* answer "\n")
+                            '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
+                            "Third"
+                          ) ;choice
+              ) ;scrollable
+            ) ;resize
+      (resize '("100px" "200px" "400px")
+        '("50px" "100px" "150px")
+        (scrollable (choices (display* answer "\n")
+                      '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
+                      '("Third" "Fifth")
+                    ) ;choices
+        ) ;scrollable
+      ) ;resize
+    ) ;hsplit
     //
-    (hsplit
-      (resize '("100px" "200px" "400px") '("50px" "100px" "150px")
-        (scrollable
-          (choice (display* answer "\n")
-                  '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
-                  "Third")))
-      (resize '("100px" "200px" "400px") '("50px" "100px" "150px")
-        (scrollable
-          (choices (display* answer "\n")
-                   '("First" "Second" "Third" "Fourth" "Fifth" "Sixth")
-                   '("Third" "Fifth")))))
-    //)
-  ===)
+  ) ;hlist
+  ===
+) ;tm-widget
 
 (tm-widget (widget6)
-  (centered
-    (resize "500px" "50px"
-      (texmacs-output
-        '(document (theorem (document "This is true.")))
-        '(style "generic")))
+  (centered (resize "500px"
+              "50px"
+              (texmacs-output '(document (theorem (document "This is true.")))
+                '(style "generic")
+              ) ;texmacs-output
+            ) ;resize
     ======
-    (resize "500px" "300px"
-      (texmacs-input
-        '(with "bg-color" "#fcfcf8"
-           (document (proof (document "Trivial."
-                                      "But you may add more details."))))
-        '(style "generic") #f))))
+    (resize "500px"
+      "300px"
+      (texmacs-input '(with "bg-color"
+                        "#fcfcf8"
+                        (document (proof (document "Trivial."
+                                           "But you may add more details."))))
+        '(style "generic")
+        #f
+      ) ;texmacs-input
+    ) ;resize
+  ) ;centered
+) ;tm-widget
 
 (tm-widget (widget7)
   (padded
-    ;;(ink (display* answer "\n"))))
-    (ink (noop))))
+    ;; (ink (display* answer "\n"))))
+    (ink (noop))
+  ) ;padded
+) ;tm-widget
 
 (tm-define widget8-list '("First" "Second"))
 
-(menu-bind widget8-sub
-  (for (x widget8-list)
-    ((eval x) (display* x "\n"))))
+(menu-bind widget8-sub (for (x widget8-list) ((eval x) (display* x "\n"))))
 
 (tm-widget (widget8)
-  (padded
-    (with l '("First" "Second")
-      (input (if answer (set! widget8-list (cons answer widget8-list)))
-             "string" '() "1w")
-      ===
-      (refresh widget8-sub auto))))
+  (padded (with l
+            '("First" "Second")
+            (input (if answer (set! widget8-list (cons answer widget8-list)))
+              "string"
+              '()
+              "1w"
+            ) ;input
+            ===
+            (refresh widget8-sub auto)
+          ) ;with
+  ) ;padded
+) ;tm-widget
 
 (tm-widget (widget9)
-  (padded
-    (with flag? #f
-      (refreshable "test"
-        (if (not flag?) (text "Flag is off"))
-        (if flag? (text "Flag is on")))
-      ===
-      (hlist
-        (toggle (begin (set! flag? answer) (refresh-now "test")) flag?)
-        ///
-        (text "Toggle here")))))
+  (padded (with flag?
+            #f
+            (refreshable "test"
+              (if (not flag?) (text "Flag is off"))
+              (if flag? (text "Flag is on"))
+            ) ;refreshable
+            ===
+            (hlist (toggle (begin (set! flag? answer) (refresh-now "test")) flag?)
+              ///
+              (text "Toggle here")
+            ) ;hlist
+          ) ;with
+  ) ;padded
+) ;tm-widget
 
 (tm-widget (widget10)
-  (resize '("150px" "400px" "9000px") '("300px" "600px" "9000px")
-    (vertical
-      (bold (text "Testing tree-view"))
+  (resize '("150px" "400px" "9000px")
+    '("300px" "600px" "9000px")
+    (vertical (bold (text "Testing tree-view"))
       ===
-      (tree-view noop (buffer-tree) (stree->tree '(dummy))))))
+      (tree-view noop (buffer-tree) (stree->tree '(dummy)))
+    ) ;vertical
+  ) ;resize
+) ;tm-widget
 
 (tm-widget ((widget11 . l))
-  (padded
-    (aligned
-      (for (x l)
-	(item (toggle (display* x ": " answer "\n") #f)
-	  (text x))))))
+  (padded (aligned (for (x l) (item (toggle (display* x ": " answer "\n") #f) (text x))))
+  ) ;padded
+) ;tm-widget
 
-(tm-define (show-widget11)
-  (show (widget11 "hop" "hola" "plok")))
+(tm-define (show-widget11) (show (widget11 "hop" "hola" "plok")))
 
 (define widget11-switch? #f)
 
 (tm-widget (widget11)
-  (padded
-    (refreshable "toggle"
-      (if (not widget11-switch?)
-          (hlist
-            (text "Toggle off") // // //
-            (explicit-buttons
-              ("Turn on" (begin
-                           (set! widget11-switch? #t)
-                           (refresh-now "toggle"))))))
-      (if widget11-switch?
-          (hlist
-            (text "Toggle on") // // //
-            (explicit-buttons
-              ("Turn off" (begin
-                            (set! widget11-switch? #f)
-                            (refresh-now "toggle")))))))))
+  (padded (refreshable "toggle"
+            (if (not widget11-switch?)
+              (hlist (text "Toggle off")
+                //
+                //
+                //
+                (explicit-buttons ("Turn on" (begin (set! widget11-switch? #t) (refresh-now "toggle")))
+                ) ;explicit-buttons
+              ) ;hlist
+            ) ;if
+            (if widget11-switch?
+              (hlist (text "Toggle on")
+                //
+                //
+                //
+                (explicit-buttons ("Turn off" (begin (set! widget11-switch? #f) (refresh-now "toggle")))
+                ) ;explicit-buttons
+              ) ;hlist
+            ) ;if
+          ) ;refreshable
+  ) ;padded
+) ;tm-widget
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Some test forms
@@ -201,56 +229,56 @@
 
 (tm-widget (form1 cmd)
   (form "Test"
-    (centered
-      (aligned
-        (item (text "First:")
-          (form-input "First" "string" '("gnu") "1w"))
-        (item (text "Second:")
-          (form-input "Second" "string" '("gnat") "1w"))))
-    (bottom-buttons
-      ("Cancel" (cmd "Cancel")) >>
-      ("Ok"
-       (display* (form-fields) " -> " (form-values) "\n")
-       (cmd "Ok")))))
+    (centered (aligned (item (text "First:") (form-input "First" "string" '("gnu") "1w"))
+                (item (text "Second:") (form-input "Second" "string" '("gnat") "1w"))
+              ) ;aligned
+    ) ;centered
+    (bottom-buttons ("Cancel" (cmd "Cancel"))
+      >>
+      ("Ok" (display* (form-fields) " -> " (form-values) "\n") (cmd "Ok"))
+    ) ;bottom-buttons
+  ) ;form
+) ;tm-widget
 
 (tm-widget (form2 cmd)
-  (centered
-    (aligned
-      (item (text "First:")
-        (toggle (display* "First " answer "\n") #f))
-      (item (text "Second:")
-        (toggle (display* "Second " answer "\n") #f))))
-  (bottom-buttons >> ("Ok" (cmd "Ok"))))
+  (centered (aligned (item (text "First:") (toggle (display* "First " answer "\n") #f))
+              (item (text "Second:") (toggle (display* "Second " answer "\n") #f))
+            ) ;aligned
+  ) ;centered
+  (bottom-buttons >> ("Ok" (cmd "Ok")))
+) ;tm-widget
 
 (tm-widget (form3 cmd)
-  (resize "500px" "500px"
-    (padded
-      (form "Test"
-        (aligned
-          (item (text "Input:")
-            (form-input "fieldname1" "string" '("one") "1w"))
-          (item === ===)
-          (item (text "Enum:")
-            (form-enum "fieldname2" '("one" "two" "three") "two" "1w"))
-          (item === ===)
-          (item (text "Choice:")
-            (form-choice "fieldname3" '("one" "two" "three") "one"))
-          (item === ===)
-          (item (text "Choices:")
-            (form-choices "fieldname4" 
-                          '("one" "two" "three") 
-                          '("one" "two")))
-          (item === ===)
-          (item (text "Password:")
-            (form-input "fieldname5" "password" '() "1w"))
-          (item === ===)
-          (item (text "Toggle:")
-            (form-toggle "fieldname6" #f)))
-        (bottom-buttons
-          ("Cancel" (cmd "cancel")) >>
-          ("Ok"
-           (display* (form-fields) " -> " (form-values) "\n")
-           (cmd "ok")))))))
+  (resize "500px"
+    "500px"
+    (padded (form "Test"
+              (aligned (item (text "Input:") (form-input "fieldname1" "string" '("one") "1w"))
+                (item === ===)
+                (item (text "Enum:") (form-enum "fieldname2" '("one"
+                                                               "two"
+                                                               "three") "two" "1w"))
+                (item === ===)
+                (item (text "Choice:") (form-choice "fieldname3" '("one"
+                                                                   "two"
+                                                                   "three") "one"))
+                (item === ===)
+                (item (text "Choices:")
+                  (form-choices "fieldname4" '("one" "two" "three") '("one"
+                                                                      "two"))
+                ) ;item
+                (item === ===)
+                (item (text "Password:") (form-input "fieldname5" "password" '() "1w"))
+                (item === ===)
+                (item (text "Toggle:") (form-toggle "fieldname6" #f))
+              ) ;aligned
+              (bottom-buttons ("Cancel" (cmd "cancel"))
+                >>
+                ("Ok" (display* (form-fields) " -> " (form-values) "\n") (cmd "ok"))
+              ) ;bottom-buttons
+            ) ;form
+    ) ;padded
+  ) ;resize
+) ;tm-widget
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for showing widgets and forms
@@ -258,11 +286,13 @@
 
 (tm-define (show w)
   ;; Example: execute (show widget1) in a Scheme session
-  (top-window w "Simple widget"))
+  (top-window w "Simple widget")
+) ;tm-define
 
 (tm-define (show-form w)
   ;; Example: execute (show-form form1) in a Scheme session
-  (dialogue-window w (lambda (x) (display* x "\n")) "Simple form"))
+  (dialogue-window w (lambda (x) (display* x "\n")) "Simple form")
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Regtest routines for menu widgets
@@ -270,56 +300,31 @@
 
 (define (regtest-menu-widgets)
   ;; Basic test to ensure menu module loads without errors
-  (regression-test-group
-   "menu" "widgets"
-   values values
-   (test "module loaded successfully" 
-     #t 
-     #t)
-   (test "tm-widget macro available" 
-     (defined? 'tm-widget) 
-     #t)
-   (test "show function available" 
-     (defined? 'show) 
-     #t)
-   (test "show-form function available" 
-     (defined? 'show-form) 
-     #t)
-   (test "tm-define macro available" 
-     (defined? 'tm-define) 
-     #t)
-   (test "menu-bind macro available" 
-     (defined? 'menu-bind) 
-     #t)
-   (test "display* function available" 
-     (defined? 'display*) 
-     #t)
-   (test "noop function available" 
-     (defined? 'noop) 
-     #t)
-   (test "refresh-now function available" 
-     (defined? 'refresh-now) 
-     #t)
-   (test "stree->tree function available" 
-     (defined? 'stree->tree) 
-     #t)
-   (test "buffer-tree function available" 
-     (defined? 'buffer-tree) 
-     #t)
-   (test "widget-hmenu function available" 
-     (defined? 'widget-hmenu) 
-     #t)
-   (test "widget-text function available" 
-     (defined? 'widget-text) 
-     #t)
-   (test "widget-vlist function available" 
-     (defined? 'widget-vlist) 
-     #t)
-   (test "widget-hlist function available" 
-     (defined? 'widget-hlist) 
-     #t)))
+  (regression-test-group "menu"
+    "widgets"
+    values
+    values
+    (test "module loaded successfully" #t #t)
+    (test "tm-widget macro available" (defined? 'tm-widget) #t)
+    (test "show function available" (defined? 'show) #t)
+    (test "show-form function available" (defined? 'show-form) #t)
+    (test "tm-define macro available" (defined? 'tm-define) #t)
+    (test "menu-bind macro available" (defined? 'menu-bind) #t)
+    (test "display* function available" (defined? 'display*) #t)
+    (test "noop function available" (defined? 'noop) #t)
+    (test "refresh-now function available" (defined? 'refresh-now) #t)
+    (test "stree->tree function available" (defined? 'stree->tree) #t)
+    (test "buffer-tree function available" (defined? 'buffer-tree) #t)
+    (test "widget-hmenu function available" (defined? 'widget-hmenu) #t)
+    (test "widget-text function available" (defined? 'widget-text) #t)
+    (test "widget-vlist function available" (defined? 'widget-vlist) #t)
+    (test "widget-hlist function available" (defined? 'widget-hlist) #t)
+  ) ;regression-test-group
+) ;define
 
 (tm-define (regtest-menu)
   (let ((n (regtest-menu-widgets)))
     (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-menu: ok\n")))
+    (display "Test suite of regtest-menu: ok\n")
+  ) ;let
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/menu-widget.scm
+++ b/TeXmacs/progs/kernel/gui/menu-widget.scm
@@ -16,86 +16,93 @@
 (import (liii hashlib))
 
 (texmacs-module (kernel gui menu-widget)
-  (:use (kernel gui menu-define) (kernel gui kbd-define)))
+  (:use (kernel gui menu-define) (kernel gui kbd-define))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu grammar
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-regexp-grammar
-  (:translatable? (:or
-    :string?
-    (concat :*)
-    (verbatim :%1)
-    (text :tuple? :string?)
-    (replace :string? :translatable?)))
-  (:menu-label (:or
-    :translatable?
-    (color :%5)
-    (icon :string?)
-    (extend :menu-label :*)
-    (style :integer? :menu-label)
-    (balloon :menu-label :translatable?)))
-  (:menu-wide-label (:or
-    :menu-label
-    (check :menu-wide-label :string? :%1)
-    (shortcut :menu-wide-label :string?)))
-  (:menu-item (:or
-    ---
-    | ;; |
-    (group :%1)
-    (text :%1)
-    (invisible :%1)
-    (glue :boolean? :boolean? :integer? :integer?)
-    (color :%1 :boolean? :boolean? :integer? :integer?)
-    (:menu-wide-label :%1)
-    (symbol :string? :*)
-    (texmacs-output :%2)
-    (texmacs-input :%3)
-    (input :%1 :string? :%1 :string?)
-    (enum :%3 :string?)
-    (choice :%3)
-    (choices :%3)
-    (filtered-choice :%4)
-    (color-input :%3)
-    (tree-view :%3)
-    (toggle :%2)
-    (horizontal :menu-item-list)
-    (vertical :menu-item-list)
-    (hlist :menu-item-list)
-    (vlist :menu-item-list)
-    (division :%1 :menu-item-list)
-    (class :%1 :menu-item-list)
-    (aligned :menu-item-list)
-    (aligned-item :%2)
-    (tabs :menu-item-list)
-    (tab :menu-item-list)
-    (icon-tabs :menu-item-list)
-    (icon-tab :menu-item-list)
-    (minibar :menu-item-list)
-    (extend :menu-item :menu-item-list)
-    (style :integer? :menu-item-list)
-    (-> :menu-label :menu-item-list)
-    (=> :menu-label :menu-item-list)
-    (tile :integer? :menu-item-list)
-    (scrollable :menu-item-list)
-    (resize :%2 :menu-item-list)
-    (hsplit :menu-item :menu-item)
-    (vsplit :menu-item :menu-item)
-    (refresh :%1 :string?)
-    (refreshable :%1 :menu-item-list)
-    (cached :%1 :%1 :menu-item-list)
-    (if :%1 :menu-item-list)
-    (when :%1 :menu-item-list)
-    (for :%1 :%1)
-    (mini :%1 :menu-item-list)
-    (link :%1)
-    (promise :%1)
-    (ink :%1)
-    (:menu-item-list)))
+(define-regexp-grammar (:translatable? (:or :string?
+                                         (concat :*)
+                                         (verbatim :%1)
+                                         (text :tuple? :string?)
+                                         (replace :string? :translatable?)
+                                       ) ;:or
+                       ) ;:translatable?
+  (:menu-label (:or :translatable?
+                 (color :%5)
+                 (icon :string?)
+                 (extend :menu-label :*)
+                 (style :integer? :menu-label)
+                 (balloon :menu-label :translatable?)
+               ) ;:or
+  ) ;:menu-label
+  (:menu-wide-label (:or :menu-label
+                      (check :menu-wide-label :string? :%1)
+                      (shortcut :menu-wide-label :string?)
+                    ) ;:or
+  ) ;:menu-wide-label
+  (:menu-item (:or ---
+                |
+                ;; |
+                (group :%1)
+                (text :%1)
+                (invisible :%1)
+                (glue :boolean? :boolean? :integer? :integer?)
+                (color :%1 :boolean? :boolean? :integer? :integer?)
+                (:menu-wide-label :%1)
+                (symbol :string? :*)
+                (texmacs-output :%2)
+                (texmacs-input :%3)
+                (input :%1 :string? :%1 :string?)
+                (enum :%3 :string?)
+                (choice :%3)
+                (choices :%3)
+                (filtered-choice :%4)
+                (color-input :%3)
+                (tree-view :%3)
+                (toggle :%2)
+                (horizontal :menu-item-list)
+                (vertical :menu-item-list)
+                (hlist :menu-item-list)
+                (vlist :menu-item-list)
+                (division :%1 :menu-item-list)
+                (class :%1 :menu-item-list)
+                (aligned :menu-item-list)
+                (aligned-item :%2)
+                (tabs :menu-item-list)
+                (tab :menu-item-list)
+                (icon-tabs :menu-item-list)
+                (icon-tab :menu-item-list)
+                (minibar :menu-item-list)
+                (extend :menu-item :menu-item-list)
+                (style :integer? :menu-item-list)
+                (-> :menu-label :menu-item-list)
+                (=> :menu-label :menu-item-list)
+                (tile :integer? :menu-item-list)
+                (scrollable :menu-item-list)
+                (resize :%2 :menu-item-list)
+                (hsplit :menu-item :menu-item)
+                (vsplit :menu-item :menu-item)
+                (refresh :%1 :string?)
+                (refreshable :%1 :menu-item-list)
+                (cached :%1 :%1 :menu-item-list)
+                (if :%1 :menu-item-list)
+                (when :%1
+                  :menu-item-list
+                ) ;when
+                (for :%1 :%1)
+                (mini :%1 :menu-item-list)
+                (link :%1)
+                (promise :%1)
+                (ink :%1)
+                (:menu-item-list)
+              ) ;:or
+  ) ;:menu-item
   (:menu-item-list (:repeat :menu-item))
-  (:tab-page (tab-page :%4)) ; :%4 means requiring 4 parameters
-)
+  (:tab-page (tab-page :%4))
+) ;define-regexp-grammar
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu utilities
@@ -103,39 +110,43 @@
 
 (define (make-menu-error . args)
   (apply tm-display-error args)
-  (widget-text "Error" 0 (color "black") #t))
+  (widget-text "Error" 0 (color "black") #t)
+) ;define
 
 (define (make-menu-bad-format p style)
-  (make-menu-error "menu has bad format in " (object->string p)))
+  (make-menu-error "menu has bad format in " (object->string p))
+) ;define
 
-(define (make-menu-empty) (widget-hmenu '()))
+(define (make-menu-empty)
+  (widget-hmenu '())
+) ;define
 
 (define (delay-command cmd)
-  (object->command (lambda () (exec-delayed cmd))))
+  (object->command (lambda () (exec-delayed cmd)))
+) ;define
 
 (define-macro (make-menu-command cmd)
-  `(delay-command (lambda () (protected-call (lambda () ,cmd)))))
+  `(delay-command (lambda ,() (protected-call (lambda ,() ,cmd))))
+) ;define-macro
 
 (define (menu-protect cmd)
-  (lambda x
-    (exec-delayed
-      (lambda ()
-        (protected-call (lambda () (apply cmd x)))))))
+  (lambda x (exec-delayed (lambda () (protected-call (lambda () (apply cmd x))))))
+) ;define
 
 (define (kbd-system shortcut menu-flag?)
   (cond ((nstring? shortcut) "")
         ((and (qt-gui?) menu-flag?) shortcut)
-        (else (translate (kbd-system-rewrite shortcut)))))
+        (else (translate (kbd-system-rewrite shortcut)))
+  ) ;cond
+) ;define
 
 (define (kbd-find-shortcut what menu-flag?)
-  ; eg. (pull-focus t (numbered-toggle t)) -> (numbered-toggle (focus-tree))
-  ; eg. (pull-focus t (alternate-toggle t)) -> (alternate-toggle (focus-tree))
   (define (pull-focus-transform src)
-    (if (tuple? src 'pull-focus 2)
-        `(,(caaddr src) (focus-tree))
-        src))
+    (if (tuple? src 'pull-focus 2) `(,(caaddr src) (focus-tree)) src)
+  ) ;define
 
-  (with r (kbd-find-inv-binding (pull-focus-transform what))
+  (with r
+    (kbd-find-inv-binding (pull-focus-transform what))
     (when (string-contains? r "accent:")
       (set! r (string-replace r "accent:deadhat" "^"))
       (set! r (string-replace r "accent:tilde" "~"))
@@ -145,53 +156,69 @@
       (set! r (string-replace r "accent:abovedot" "."))
       (set! r (string-replace r "accent:breve" "U"))
       (set! r (string-replace r "accent:invbreve" "A"))
-      (set! r (string-replace r "accent:check" "C")))
-    ;;(when (!= r "")
+      (set! r (string-replace r "accent:check" "C"))
+    ) ;when
+    ;; (when (!= r "")
     ;;  (display* what " -> " r " -> " (kbd-system r menu-flag?) "\n"))
-    (kbd-system r menu-flag?)))
+    (kbd-system r menu-flag?)
+  ) ;with
+) ;define
 
 (tm-define (kbd-find-shortcut-export what)
   (:synopsis "Find display shortcut string for command @what")
-  (kbd-find-shortcut what #f))
+  (kbd-find-shortcut what #f)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu labels
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (translatable? s)
-  (or (string? s) (func? s 'concat) (func? s 'verbatim) (func? s 'replace)))
+  (or (string? s) (func? s 'concat) (func? s 'verbatim) (func? s 'replace))
+) ;define
 
 (define (active? style)
-  (== (logand style widget-style-inert) 0))
+  (== (logand style widget-style-inert) 0)
+) ;define
 
 (define (greyed? style)
-  (!= (logand style widget-style-grey) 0))
+  (!= (logand style widget-style-grey) 0)
+) ;define
 
 (define (verb? style)
-  (!= (logand style widget-style-verb) 0))
+  (!= (logand style widget-style-verb) 0)
+) ;define
 
 (define (recursive-occurs? w t)
   (cond ((string? t) (string-occurs? w t))
         ((list? t) (list-or (map (cut recursive-occurs? w <>) t)))
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define
 
 (define (recursive-replace t w b)
   (cond ((string? t) (string-replace t w b))
         ((list? t) (map (cut recursive-replace <> w b) t))
-        (else t)))
+        (else t)
+  ) ;cond
+) ;define
 
 (define (adjust-translation s t)
-  (cond ((not (and (qt-gui?) (os-macos?)
-                   (in? (get-preference "language")
-                        (list "english" "british"))))
-         t)
+  (cond ((not (and (qt-gui?)
+                (os-macos?)
+                (in? (get-preference "language") (list "english" "british"))
+              ) ;and
+         ) ;not
+         t
+        ) ;
         ((recursive-occurs? "reference" s)
-	 (recursive-replace (recursive-replace t "c" "<#441>") "e" "<#435>"))
-        ((recursive-occurs? "onfigur" s)
-	 (recursive-replace t "o" "<#43E>"))
-        ((in? s (list "Help" "Edit" "View"))
-	 (recursive-replace t "e" "<#435>"))
-        (else t)))
+         (recursive-replace (recursive-replace t "c" "<#441>") "e" "<#435>")
+        ) ;
+        ((recursive-occurs? "onfigur" s) (recursive-replace t "o" "<#43E>"))
+        ((in? s (list "Help" "Edit" "View")) (recursive-replace t "e" "<#435>"))
+        (else t)
+  ) ;cond
+) ;define
 
 (define (make-menu-label p style . opt)
   "Make widget for menu label @p."
@@ -208,28 +235,39 @@
   ;;   <label> :: (icon <string>)
   ;;     Pixmap menu label, the <string> is the name of the pixmap.
   (let ((tt? (and (nnull? opt) (car opt)))
-        (col (color (if (greyed? style) "dark grey" "black"))))
-    (cond ((and (list? p) (== (car p) 'verbatim)) ; (verbatim "text")
-           (widget-text (cadr p) style col #t))
-          ((translatable? p)            ; "text"
-           (widget-text (adjust-translation p (translate p)) style col #t))
-          ((tuple? p 'balloon 2)        ; (balloon <label> "balloon text")
-           (make-menu-label (cadr p) style tt?))
-          ((tuple? p 'extend)           ; (extend <label> . ws)
-           (with l (make-menu-items (cddr p) style tt?)
-             (widget-extend (make-menu-label (cadr p) style tt?) l)))
-          ((tuple? p 'style 2)          ; (style st <label>)
+        (col (color (if (greyed? style) "dark grey" "black")))
+       ) ;
+    (cond ((and (list? p) (== (car p) 'verbatim)) (widget-text (cadr p) style col #t))
+          ((translatable? p)
+           (widget-text (adjust-translation p (translate p)) style col #t)
+          ) ;
+          ((tuple? p 'balloon 2) (make-menu-label (cadr p) style tt?))
+          ((tuple? p 'extend)
+           (with l
+             (make-menu-items (cddr p) style tt?)
+             (widget-extend (make-menu-label (cadr p) style tt?) l)
+           ) ;with
+          ) ;
+          ((tuple? p 'style 2)
            (let* ((x (cadr p))
-                  (new-style (if (> x 0) (logior style x)
-                                 (logand style (lognot (- x))))))
-             (make-menu-label (caddr p) new-style tt?)))
-          ((tuple? p 'text 2)           ; (text <font desc> "text")
-           (widget-box (cadr p) (caddr p) col #t #t))
-          ((tuple? p 'icon 1)           ; (icon "name.xpm")
-           (widget-xpm (cadr p)))
-          ((tuple? p 'color 5)          ; (color col hext? vext? minw minh)
-           (widget-color (second p) (third p) (fourth p)
-                         (* (fifth p) 256) (* (sixth p) 256))))))
+                  (new-style (if (> x 0) (logior style x) (logand style (lognot (- x)))))
+                 ) ;
+             (make-menu-label (caddr p) new-style tt?)
+           ) ;let*
+          ) ;
+          ((tuple? p 'text 2) (widget-box (cadr p) (caddr p) col #t #t))
+          ((tuple? p 'icon 1) (widget-xpm (cadr p)))
+          ((tuple? p 'color 5)
+           (widget-color (second p)
+             (third p)
+             (fourth p)
+             (* (fifth p) 256)
+             (* (sixth p) 256)
+           ) ;widget-color
+          ) ;
+    ) ;cond
+  ) ;let
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elementary menu items
@@ -237,119 +275,185 @@
 
 (define (make-menu-hsep)
   "Make @--- menu item."
-  (widget-separator #f))
+  (widget-separator #f)
+) ;define
 
 (define (make-menu-vsep)
   "Make @| menu item."
-  (widget-separator #t))
+  (widget-separator #t)
+) ;define
 
 (define (make-menu-glue hext? vext? minw minh)
   "Make @(glue :boolean? :boolean? :integer? :integer?) menu item."
-  (widget-glue hext? vext? (* minw 256) (* minh 256)))
+  (widget-glue hext? vext? (* minw 256) (* minh 256))
+) ;define
 
 (define (make-menu-color col hext? vext? minw minh)
   "Make @(glue :1% :boolean? :boolean? :integer? :integer?) menu item."
-  (widget-color col hext? vext? (* minw 256) (* minh 256)))
+  (widget-color col hext? vext? (* minw 256) (* minh 256))
+) ;define
 
 (define (make-menu-group s style)
   "Make @(group :string?) menu item."
-  (widget-menu-group (adjust-translation s (translate s)) style))
+  (widget-menu-group (adjust-translation s (translate s)) style)
+) ;define
 
 (define (make-menu-text s style)
   "Make @(text :string?) menu item."
-  ;;(widget-text s style (color "black") #t)
-  (widget-text (translate s) style (color "black") #f))
+  ;; (widget-text s style (color "black") #t)
+  (widget-text (translate s) style (color "black") #f)
+) ;define
 
 (define (attach-resize t)
-  (if (not global-resize) t
-      (with (w1 w2 w3 wpos h1 h2 h3 hpos) global-resize
-        (with attrs (list "page-medium" "papyrus"
-                          "page-type" "user"
-                          "page-width" w2
-                          "page-height" h2
-                          "page-odd" "4px"
-                          "page-even" "4px"
-                          "page-right" "4px"
-                          "page-top" "2px"
-                          "page-bot" "2px"
-                          "page-screen-left" "4px"
-                          "page-screen-right" "4px"
-                          "page-screen-top" "2px"
-                          "page-screen-bot" "2px")
-          (if (tm-is? t 'with)
-              `(with ,@attrs ,@(cDr (tm-children t)) ,(cAr (tm-children t)))
-              `(with ,@attrs ,t))))))
+  (if (not global-resize)
+    t
+    (with (w1 w2 w3 wpos h1 h2 h3 hpos)
+      global-resize
+      (with attrs
+        (list "page-medium"
+          "papyrus"
+          "page-type"
+          "user"
+          "page-width"
+          w2
+          "page-height"
+          h2
+          "page-odd"
+          "4px"
+          "page-even"
+          "4px"
+          "page-right"
+          "4px"
+          "page-top"
+          "2px"
+          "page-bot"
+          "2px"
+          "page-screen-left"
+          "4px"
+          "page-screen-right"
+          "4px"
+          "page-screen-top"
+          "2px"
+          "page-screen-bot"
+          "2px"
+        ) ;list
+        (if (tm-is? t 'with)
+          `(with ,@attrs ,@(cDr (tm-children t)) ,(cAr (tm-children t)))
+          `(with ,@attrs ,t)
+        ) ;if
+      ) ;with
+    ) ;with
+  ) ;if
+) ;define
 
 (define (make-texmacs-output p style)
   "Make @(texmacs-output :%2) item."
-  (with (tag t tmstyle) p
-    (widget-texmacs-output (attach-resize (t)) (tmstyle))))
+  (with (tag t tmstyle) p (widget-texmacs-output (attach-resize (t)) (tmstyle)))
+) ;define
 
 (define (make-texmacs-input p style)
   "Make @(texmacs-input :%3) item."
-  (with (tag t tmstyle name) p
-    (widget-texmacs-input (attach-resize (t)) (tmstyle)
-                          (or (name) (url-none)))))
+  (with (tag t tmstyle name)
+    p
+    (widget-texmacs-input (attach-resize (t)) (tmstyle) (or (name) (url-none)))
+  ) ;with
+) ;define
 
 (define (make-menu-input p style)
   "Make @(input :%1 :string? :%1 :string?) menu item."
-  (with (tag cmd type props width) p
-    (widget-input (object->command (menu-protect cmd)) type (props)
-                  style width)))
+  (with (tag cmd type props width)
+    p
+    (widget-input (object->command (menu-protect cmd)) type (props) style width)
+  ) ;with
+) ;define
 
 (define (make-numeric-input p style)
   "Make @(numeric-input :%7) menu item."
-  (with (tag cmd width unit min max step def) p
-    (widget-numeric-input (object->command (menu-protect cmd)) width unit min max
-                          step def)))
+  (with (tag cmd width unit min max step def)
+    p
+    (widget-numeric-input (object->command (menu-protect cmd))
+      width
+      unit
+      min
+      max
+      step
+      def
+    ) ;widget-numeric-input
+  ) ;with
+) ;define
 
 (define (make-enum p style)
   "Make @(enum :%3 :string?) item."
-  (with (tag cmd vals val width) p
+  (with (tag cmd vals val width)
+    p
     (let* ((translate* (if (verb? style) identity translate))
            (xval (val))
            (xvals (vals))
            (nvals (if (and (nnull? xvals) (== (cAr xvals) ""))
-                      `(,@(cDr xvals) ,xval "") `(,@xvals ,xval)))
+                    `(,@(cDr xvals) ,xval ,"")
+                    `(,@xvals ,xval)
+                  ) ;if
+           ) ;nvals
            (xvals* (list-remove-duplicates nvals))
            (tval (translate* xval))
            (tvals (map translate* xvals*))
            (dec (map (lambda (v) (cons (translate* v) v)) xvals*))
-           (cmd* (lambda (r) (cmd (or (assoc-ref dec r) r)))))
-      (widget-enum (object->command (menu-protect cmd*))
-                   tvals tval style width))))
+           (cmd* (lambda (r) (cmd (or (assoc-ref dec r) r))))
+          ) ;
+      (widget-enum (object->command (menu-protect cmd*)) tvals tval style width)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (make-choice p style)
   "Make @(choice :%3) item."
-  (with (tag cmd vals val) p
-    (widget-choice (object->command (menu-protect cmd)) (vals) (val))))
+  (with (tag cmd vals val)
+    p
+    (widget-choice (object->command (menu-protect cmd)) (vals) (val))
+  ) ;with
+) ;define
 
 (define (make-choices p style)
   "Make @(choices :%3) item."
-  (with (tag cmd vals mc) p
-    (widget-choices (object->command (menu-protect cmd)) (vals) (mc))))
+  (with (tag cmd vals mc)
+    p
+    (widget-choices (object->command (menu-protect cmd)) (vals) (mc))
+  ) ;with
+) ;define
 
 (define (make-filtered-choice p style)
   "Make @(filtered-choice :%4) item."
-  (with (tag cmd vals val filterstr) p
-    (widget-filtered-choice (object->command (menu-protect cmd)) (vals) (val)
-                            (filterstr))))
+  (with (tag cmd vals val filterstr)
+    p
+    (widget-filtered-choice (object->command (menu-protect cmd))
+      (vals)
+      (val)
+      (filterstr)
+    ) ;widget-filtered-choice
+  ) ;with
+) ;define
 
 (define (make-color-input p style)
   "Make @(color-input :%3) menu item."
-  (with (tag cmd bg? props) p
-    (widget-color-picker (object->command (menu-protect cmd)) bg? (props))))
+  (with (tag cmd bg? props)
+    p
+    (widget-color-picker (object->command (menu-protect cmd)) bg? (props))
+  ) ;with
+) ;define
 
 (define (make-tree-view p style)
   "Make @(tree-view :%3) item."
-  (with (tag cmd data roles) p
-    (widget-tree-view (object->command (menu-protect cmd)) (data) (roles))))
+  (with (tag cmd data roles)
+    p
+    (widget-tree-view (object->command (menu-protect cmd)) (data) (roles))
+  ) ;with
+) ;define
 
 
 (define (make-toggle p style)
   "Make @(toggle :%2) item."
-  (with (tag cmd on) p
-    (widget-toggle (object->command cmd) (on) style)))
+  (with (tag cmd on) p (widget-toggle (object->command cmd) (on) style))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu entries
@@ -357,208 +461,283 @@
 
 (define (synopsis-substitute synopsis source)
   (if (string-occurs? "@" synopsis)
-      #f ;; not yet implemented
-      synopsis))
+    #f
+    ;; not yet implemented
+    synopsis
+  ) ;if
+) ;define
 
 (define (search-balloon-help action)
-  (and-with source (promise-source action)
+  (and-with source
+    (promise-source action)
     (and (pair? source)
-         (or (and-with prop (property (car source) :balloon)
-               (with txt (apply (car prop) (cdr source))
-                 (and (string? txt) txt)))
-             (and-with prop (property (car source) :synopsis)
-               (and (pair? prop) (string? (car prop))
-                    (with txt (synopsis-substitute (car prop) source)
-                      (and (string? txt) txt))))))))
+      (or (and-with prop
+            (property (car source) :balloon)
+            (with txt (apply (car prop) (cdr source)) (and (string? txt) txt))
+          ) ;and-with
+        (and-with prop
+          (property (car source) :synopsis)
+          (and (pair? prop)
+            (string? (car prop))
+            (with txt (synopsis-substitute (car prop) source) (and (string? txt) txt))
+          ) ;and
+        ) ;and-with
+      ) ;or
+    ) ;and
+  ) ;and-with
+) ;define
 
 (define (add-menu-entry-balloon but style action)
-  (with txt (search-balloon-help action)
+  (with txt
+    (search-balloon-help action)
     (if (not txt)
-        but
-        (with bal (widget-text (translate txt) style (color "black") #t)
-          (widget-balloon but bal)))))
+      but
+      (with bal
+        (widget-text (translate txt) style (color "black") #t)
+        (widget-balloon but bal)
+      ) ;with
+    ) ;if
+  ) ;with
+) ;define
 
 (define (make-menu-entry-button style bar? bal? check label short action)
   (let* ((command (make-menu-command (if (active? style) (apply action '()))))
          (l (make-menu-label label style))
          (pressed? (and bar? (!= check "")))
-         (new-style (logior style (if pressed? widget-style-pressed 0))))
-    (with but (if bar?
-                  (widget-menu-button l command "" "" new-style)
-                  (widget-menu-button l command check short style))
-      (if bal? but (add-menu-entry-balloon but style action)))))
+         (new-style (logior style (if pressed? widget-style-pressed 0)))
+        ) ;
+    (with but
+      (if bar?
+        (widget-menu-button l command "" "" new-style)
+        (widget-menu-button l command check short style)
+      ) ;if
+      (if bal? but (add-menu-entry-balloon but style action))
+    ) ;with
+  ) ;let*
+) ;define
 
 (define-public (promise-source action)
   "Helper routines for menu-widget and kbd-define"
   (and (procedure? action)
-       (with source (procedure-source action)
-         (and (== (car source) 'lambda)
-              (== (cadr source) '())
-              (null? (cdddr source))
-              (caddr source)))))
+    (with source
+      (procedure-source action)
+      (and (== (car source) 'lambda)
+        (== (cadr source) '())
+        (null? (cdddr source))
+        (caddr source)
+      ) ;and
+    ) ;with
+  ) ;and
+) ;define-public
 
 (define (make-menu-entry-shortcut label action opt-key)
   (cond (opt-key (kbd-system opt-key #t))
         ((pair? label) "")
-        (else (with source (promise-source action)
-                (if source (kbd-find-shortcut source #t) "")))))
+        (else (with source
+                (promise-source action)
+                (if source (kbd-find-shortcut source #t) "")
+              ) ;with
+        ) ;else
+  ) ;cond
+) ;define
 
 (define (make-menu-entry-check-sub result propose)
   (cond ((string? result) result)
         (result propose)
-        (else "")))
+        (else "")
+  ) ;cond
+) ;define
 
 (define (make-menu-entry-check opt-check action)
   (if opt-check
-      (make-menu-entry-check-sub ((cadr opt-check)) (car opt-check))
-      (with source (promise-source action)
-        (cond ((not (and source (pair? source))) "")
-              (else (with prop (property (car source) :check-mark)
-                      (make-menu-entry-check-sub
-                       (and prop (apply (cadr prop) (cdr source)))
-                       (and prop (car prop)))))))))
+    (make-menu-entry-check-sub ((cadr opt-check)) (car opt-check))
+    (with source
+      (promise-source action)
+      (cond ((not (and source (pair? source))) "")
+            (else (with prop
+                    (property (car source) :check-mark)
+                    (make-menu-entry-check-sub (and prop (apply (cadr prop) (cdr source)))
+                      (and prop (car prop))
+                    ) ;make-menu-entry-check-sub
+                  ) ;with
+            ) ;else
+      ) ;cond
+    ) ;with
+  ) ;if
+) ;define
 
 (define (menu-label-add-dots l)
   (cond ((match? l ':string?) (string-append l "..."))
-        ((match? l '(concat :*))
-         `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
-        ((match? l '(verbatim :*))
-         `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
+        ((match? l '(concat :*)) `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
+        ((match? l '(verbatim :*)) `(,@(cDr l) ,(menu-label-add-dots (cAr l))))
         ((match? l '(text :tuple? :string?))
-         `(text ,(cadr l) ,(string-append (caddr l) "...")))
+         `(text ,(cadr l) ,(string-append (caddr l) "..."))
+        ) ;
         ((match? l '(icon :string?)) l)
-        (else `(,(car l) ,(menu-label-add-dots (cadr l)) ,(caddr l)))))
+        (else `(,(car l) ,(menu-label-add-dots (cadr l)) ,(caddr l)))
+  ) ;cond
+) ;define
 
 (define (make-menu-entry-dots label action)
-  (with source (promise-source action)
+  (with source
+    (promise-source action)
     (if (and source (pair? source) (property (car source) :interactive))
-        (menu-label-add-dots label)
-        label)))
+      (menu-label-add-dots label)
+      label
+    ) ;if
+  ) ;with
+) ;define
 
 (define (make-menu-entry-style style action)
-  (with source (promise-source action)
-    (if (not (pair? source)) style
-	(with prop (property (car source) :applicable)
-	  (if (or (not prop) (apply (car prop) (list)))
-	      style
-	      (logior style (+ widget-style-inert widget-style-grey)))))))
+  (with source
+    (promise-source action)
+    (if (not (pair? source))
+      style
+      (with prop
+        (property (car source) :applicable)
+        (if (or (not prop) (apply (car prop) (list)))
+          style
+          (logior style (+ widget-style-inert widget-style-grey))
+        ) ;if
+      ) ;with
+    ) ;if
+  ) ;with
+) ;define
 
 (define (make-menu-entry-attrs label action opt-key opt-check)
   (cond ((match? label '(check :%1 :string? :%1))
-         (make-menu-entry-attrs (cadr label) action opt-key (cddr label)))
+         (make-menu-entry-attrs (cadr label) action opt-key (cddr label))
+        ) ;
         ((match? label '(shortcut :%1 :string?))
-         (make-menu-entry-attrs (cadr label) action (caddr label) opt-check))
-        (else (values label action opt-key opt-check))))
+         (make-menu-entry-attrs (cadr label) action (caddr label) opt-check)
+        ) ;
+        (else (values label action opt-key opt-check))
+  ) ;cond
+) ;define
 
 (define (make-menu-entry-sub p style bar?)
-  (receive
-   (label action opt-key opt-check)
-   (make-menu-entry-attrs (car p) (cAr p) #f #f)
-   (make-menu-entry-button
-     (make-menu-entry-style style action)
-     bar?
-     (tuple? (car p) 'balloon 2)
-     (make-menu-entry-check opt-check action)
-     (make-menu-entry-dots label action)
-     (make-menu-entry-shortcut label action opt-key)
-     action)))
+  (receive (label action opt-key opt-check)
+    (make-menu-entry-attrs (car p) (cAr p) #f #f)
+    (make-menu-entry-button (make-menu-entry-style style action)
+      bar?
+      (tuple? (car p) 'balloon 2)
+      (make-menu-entry-check opt-check action)
+      (make-menu-entry-dots label action)
+      (make-menu-entry-shortcut label action opt-key)
+      action
+    ) ;make-menu-entry-button
+  ) ;receive
+) ;define
 
 (define (make-menu-entry p style bar?)
   "Make @:menu-wide-item menu item."
 
   (define (retrieve-shortcut p)
-   (let* ((cmd (and (nnull? (cdr p)) (procedure? (cadr p)) (cadr p)))
-          (source (and cmd (promise-source cmd))))
-     (and source (kbd-find-shortcut source #f))))
+    (let* ((cmd (and (nnull? (cdr p)) (procedure? (cadr p)) (cadr p)))
+           (source (and cmd (promise-source cmd)))
+          ) ;
+      (and source (kbd-find-shortcut source #f))
+    ) ;let*
+  ) ;define
 
   (define (create-text-widget text shortcut style)
     (let* ((txt (if (or (not shortcut) (== shortcut ""))
-                    text
-                    (if (string? text)
-                        (string-append text " (" shortcut ")")
-                        text)))
-           (ftxt (translate txt)))
-      (widget-text ftxt style (color "black") #t)))
+                  text
+                  (if (string? text) (string-append text " (" shortcut ")") text)
+                ) ;if
+           ) ;txt
+           (ftxt (translate txt))
+          ) ;
+      (widget-text ftxt style (color "black") #t)
+    ) ;let*
+  ) ;define
 
-  (let ((but (make-menu-entry-sub p style bar?))
-        (label (car p)))
-    (cond
-     ; eg. label is (balloon (icon "tm_focus_help.xpm") "Describe tag")
-     ((tuple? label 'balloon 2)
-      (let* ((text (caddr label))
-             (shortcut (retrieve-shortcut p))
-             (twid (create-text-widget text shortcut style)))
-        (widget-balloon but twid)))
-     ; eg. label is (check
-     ;               (balloon (icon "tm_numbered.xpm") "Toggle numbering")
-     ;               "v" #<lambda ()>)
-     ; eg. label is (check
-     ;               (balloon "Prefix by section number"
-     ;                        "Prefix numbered environments by section number")
-     ;               "v" #<lambda ()>)
-     ((and (tuple? label 'check 3)
-           (tuple? (cadr label) 'balloon 2))
-      (let* ((text (caddr (cadr label)))
-             (shortcut (retrieve-shortcut p))
-             (twid (create-text-widget text shortcut style)))
-        (widget-balloon but twid)))
-     (else but))))
+  (let ((but (make-menu-entry-sub p style bar?)) (label (car p)))
+    (cond ((tuple? label 'balloon 2)
+           (let* ((text (caddr label))
+                  (shortcut (retrieve-shortcut p))
+                  (twid (create-text-widget text shortcut style))
+                 ) ;
+             (widget-balloon but twid)
+           ) ;let*
+          ) ;
+          ((and (tuple? label 'check 3) (tuple? (cadr label) 'balloon 2))
+           (let* ((text (caddr (cadr label)))
+                  (shortcut (retrieve-shortcut p))
+                  (twid (create-text-widget text shortcut style))
+                 ) ;
+             (widget-balloon but twid)
+           ) ;let*
+          ) ;
+          (else but)
+    ) ;cond
+  ) ;let
+) ;define
 
 (define (make-tab-page entry-data style bar?)
-  ; eg. 
-  ; entry-data is ((tab-page
-  ;                  <url>
-  ;                  ((balloon "doc-title" "doc-path") #<lambda ()>)
-  ;                  ((balloon (icon "tm_cancel.xpm") "Close") #<lambda ()>)
-  ;                  #t
-  ;               ))
-  ; style is 0, an integer value indicates theme or color style
-  ; bar? is #t, a bool value indicates whether the item is placed in the menu bar
 
-  ; (display* "make-tab-page: " entry-data "\n" style "\n" bar? "\n")
-  (let* ((args  (cdar entry-data))
-         (url   (first args))      ; url
-         (title (second args))     ; widget
-         (close-btn (third args))  ; widget
-         (active?   (fourth args)) ; bool
-        )
-    (widget-tab-page
-      url
+  (let* ((args (cdar entry-data))
+         (url (first args))
+         (title (second args))
+         (close-btn (third args))
+         (active? (fourth args))
+        ) ;
+    (widget-tab-page url
       (car (make-menu-items title style bar?))
       (car (make-menu-items close-btn style bar?))
       active?
-    )))
+    ) ;widget-tab-page
+  ) ;let*
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbol fields
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (make-menu-symbol-button style font sym opt-cmd clr)
-  (with col (if (greyed? style) (color "dark grey") clr)
+  (with col
+    (if (greyed? style) (color "dark grey") clr)
     (if opt-cmd
-        (widget-menu-button (widget-box font sym col #t #t)
-                            (make-menu-command (apply opt-cmd '()))
-                            "" "" style)
-        (widget-menu-button (widget-box font sym col #t #t)
-                            (make-menu-command (insert sym))
-                            "" "" style))))
+      (widget-menu-button (widget-box font sym col #t #t)
+        (make-menu-command (apply opt-cmd '()))
+        ""
+        ""
+        style
+      ) ;widget-menu-button
+      (widget-menu-button (widget-box font sym col #t #t)
+        (make-menu-command (insert sym))
+        ""
+        ""
+        style
+      ) ;widget-menu-button
+    ) ;if
+  ) ;with
+) ;define
 
 (define (make-menu-symbol p style font col)
   "Make @(symbol :string? :*) menu item."
   ;; Possibilities for p:
   ;;   <menu-symbol> :: (symbol <symbol-string> [<cmd>])
-  (with (tag symstring . opt) p
-    (with opt-cmd (and (nnull? opt) (car opt))
+  (with (tag symstring . opt)
+    p
+    (with opt-cmd
+      (and (nnull? opt) (car opt))
       (if (and opt-cmd (not (procedure? opt-cmd)))
-          (make-menu-error "invalid symbol command in " p)
-          (let* ((source (and opt-cmd (promise-source opt-cmd)))
-                 (sh (kbd-find-shortcut (if source source symstring) #f)))
-            (if (== sh "")
-                (make-menu-symbol-button style font symstring opt-cmd col)
-                (widget-balloon
-                 (make-menu-symbol-button style font symstring opt-cmd col)
-                 (make-menu-label (string-append "Keyboard equivalent: " sh)
-                                  style))))))))
+        (make-menu-error "invalid symbol command in " p)
+        (let* ((source (and opt-cmd (promise-source opt-cmd)))
+               (sh (kbd-find-shortcut (if source source symstring) #f))
+              ) ;
+          (if (== sh "")
+            (make-menu-symbol-button style font symstring opt-cmd col)
+            (widget-balloon (make-menu-symbol-button style font symstring opt-cmd col)
+              (make-menu-label (string-append "Keyboard equivalent: " sh) style)
+            ) ;widget-balloon
+          ) ;if
+        ) ;let*
+      ) ;if
+    ) ;with
+  ) ;with
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Composite menus and submenus
@@ -566,159 +745,228 @@
 
 (define (make-menu-horizontal p style)
   "Make @(horizontal :menu-item-list) menu item."
-  (widget-hmenu (make-menu-items (cdr p) style #t)))
+  (widget-hmenu (make-menu-items (cdr p) style #t))
+) ;define
 
 (define (make-menu-vertical p style)
   "Make @(vertical :menu-item-list) menu item."
-  (widget-vmenu (make-menu-items (cdr p) style #f)))
+  (widget-vmenu (make-menu-items (cdr p) style #f))
+) ;define
 
 (define (make-menu-hlist p style)
   "Make @(hlist :menu-item-list) menu item."
-  (widget-hlist (make-menu-items (cdr p) style #t)))
+  (widget-hlist (make-menu-items (cdr p) style #t))
+) ;define
 
 (define (make-menu-vlist p style)
   "Make @(vlist :menu-item-list) menu item."
-  (widget-vlist (make-menu-items (cdr p) style #f)))
+  (widget-vlist (make-menu-items (cdr p) style #f))
+) ;define
 
 (define (make-menu-division p style)
   "Make @(division :%1 :menu-item-list) item."
-  (with (tag name . items) p
-    (with inner (make-menu-items (list (cons 'vertical items)) style #f)
-      (widget-division (name) (car inner)))))
+  (with (tag name . items)
+    p
+    (with inner
+      (make-menu-items (list (cons 'vertical items)) style #f)
+      (widget-division (name) (car inner))
+    ) ;with
+  ) ;with
+) ;define
 
 (define (make-menu-class p style)
   "Make @(class :%1 :menu-item-list) item."
-  (with (tag name . items) p
-    (with inner (make-menu-items (list (cons 'horizontal items)) style #f)
-      (widget-division (name) (car inner)))))
+  (with (tag name . items)
+    p
+    (with inner
+      (make-menu-items (list (cons 'horizontal items)) style #f)
+      (widget-division (name) (car inner))
+    ) ;with
+  ) ;with
+) ;define
 
 (define (make-aligned p style)
   "Make @(aligned :menu-item-list) item."
   (widget-aligned (make-menu-items (map cadr (cdr p)) style #f)
-                  (make-menu-items (map caddr (cdr p)) style #f)))
+    (make-menu-items (map caddr (cdr p)) style #f)
+  ) ;widget-aligned
+) ;define
 
 (define (make-aligned-item p style)
   "Make @(aligned-item :%2) item."
   (display* "Error 'make-aligned-item', " p ", " style "\n")
-  (list 'vlist))
+  (list 'vlist)
+) ;define
 
 (define (tab-key x)
-  (cadr x))
+  (cadr x)
+) ;define
 
 (define (tab-value x)
-  (list 'vlist (cddr x)))
+  (list 'vlist (cddr x))
+) ;define
 
 (define (make-menu-tabs p style)
   "Make @(tabs :menu-item-list) menu item."
   (widget-tabs (make-menu-items (map tab-key (cdr p)) style #f)
-               (make-menu-items (map tab-value (cdr p)) style #f)))
+    (make-menu-items (map tab-value (cdr p)) style #f)
+  ) ;widget-tabs
+) ;define
 
 (define (make-menu-tab p style)
   "Make @(tab :menu-item-list) menu item."
   (display* "Error 'make-menu-tab', " p ", " style "\n")
-  (list 'vlist))
+  (list 'vlist)
+) ;define
 
 (define (icon-tab-icon x)
-  (string->url (cadr x)))
+  (string->url (cadr x))
+) ;define
 
 (define (icon-tab-key x)
-  (caddr x))
+  (caddr x)
+) ;define
 
 (define (icon-tab-value x)
-  (list 'vlist (cdddr x)))
+  (list 'vlist (cdddr x))
+) ;define
 
 (define (make-menu-icon-tabs p style)
   "Make @(icon-tabs :menu-item-list) menu item."
-  (with style* (logior style widget-style-mini)
+  (with style*
+    (logior style widget-style-mini)
     (widget-icon-tabs (map icon-tab-icon (cdr p))
-                      (make-menu-items (map icon-tab-key (cdr p)) style* #f)
-                      (make-menu-items (map icon-tab-value (cdr p)) style #f))))
+      (make-menu-items (map icon-tab-key (cdr p)) style* #f)
+      (make-menu-items (map icon-tab-value (cdr p)) style #f)
+    ) ;widget-icon-tabs
+  ) ;with
+) ;define
 
 (define (make-menu-icon-tab p style)
   "Make @(icon-tab :menu-item-list) menu item."
   (display* "Error 'make-menu-icon-tab', " p ", " style "\n")
-  (list 'vlist))
+  (list 'vlist)
+) ;define
 
 (define (make-menu-extend p style bar?)
   "Make @(extend :menu-item :menu-item-list) menu item."
-  (with l (make-menu-items (cdr p) style bar?)
-    (widget-extend (car l) (cdr l))))
+  (with l (make-menu-items (cdr p) style bar?) (widget-extend (car l) (cdr l)))
+) ;define
 
 (define (make-menu-style p style bar?)
   "Make @(extend :integer? :menu-item-list) menu item."
   (let* ((x (cadr p))
-         (new-style (if (> x 0) (logior style x)
-                        (logand style (lognot (- x))))))
-    (make-menu-items-list (cddr p) new-style bar?)))
+         (new-style (if (> x 0) (logior style x) (logand style (lognot (- x)))))
+        ) ;
+    (make-menu-items-list (cddr p) new-style bar?)
+  ) ;let*
+) ;define
 
 (define (make-menu-minibar p style)
   "Make @(minibar :menu-item-list) menu items."
-  (with new-style (logior style widget-style-mini)
-    (widget-minibar-menu (make-menu-items (cdr p) new-style #t))))
+  (with new-style
+    (logior style widget-style-mini)
+    (widget-minibar-menu (make-menu-items (cdr p) new-style #t))
+  ) ;with
+) ;define
 
 (define (make-menu-submenu p style)
   "Make @((:or -> =>) :menu-label :menu-item-list) menu item."
-  (with (tag label . items) p
-    (let ((button
-           ((cond ((== tag '=>) widget-pulldown-button)
-                  ((== tag '->) widget-pullright-button))
-            (make-menu-label label style)
-            (object->promise-widget
-             (lambda () (make-menu-widget (list 'vertical items) style))))))
+  (with (tag label . items)
+    p
+    (let ((button ((cond ((== tag '=>) widget-pulldown-button)
+                         ((== tag '->) widget-pullright-button)
+                   ) ;cond
+                   (make-menu-label label style)
+                   (object->promise-widget (lambda () (make-menu-widget (list 'vertical items) style))
+                   ) ;object->promise-widget
+                  ) ;
+          ) ;button
+         ) ;
       (if (tuple? label 'balloon 2)
-          (let* ((text (caddr label))
-                 (ftxt (translate text))
-                 (twid (widget-text ftxt style (color "black") #t)))
-            (widget-balloon button twid))
-          button))))
+        (let* ((text (caddr label))
+               (ftxt (translate text))
+               (twid (widget-text ftxt style (color "black") #t))
+              ) ;
+          (widget-balloon button twid)
+        ) ;let*
+        button
+      ) ;if
+    ) ;let
+  ) ;with
+) ;define
 
 (define (make-menu-tile p style)
   "Make @(tile :integer? :menu-item-list) menu item."
-  (with (tag width . items) p
-    (widget-tmenu (make-menu-items items style #f) width)))
+  (with (tag width . items)
+    p
+    (widget-tmenu (make-menu-items items style #f) width)
+  ) ;with
+) ;define
 
 (define (make-scrollable p style)
   "Make @(scrollable :menu-item-list) item."
-  (with (tag . items) p
-    (with inner (make-menu-items (list (cons 'vertical items)) style #f)
-      (widget-scrollable (car inner) style))))
+  (with (tag . items)
+    p
+    (with inner
+      (make-menu-items (list (cons 'vertical items)) style #f)
+      (widget-scrollable (car inner) style)
+    ) ;with
+  ) ;with
+) ;define
 
 (define (decode-resize x default)
   (cond ((string? x) (list x x x default))
         ((list-3? x) (append x (list default)))
         ((list-4? x) x)
-        (else (make-menu-error "bad length in " (object->string x)))))
+        (else (make-menu-error "bad length in " (object->string x)))
+  ) ;cond
+) ;define
 
 (define global-resize #f)
 
 (define (make-resize p style)
   "Make @(resize :%2 :menu-item-list) item."
-  (with (tag w-cmd h-cmd . items) p
-    (let ((w (w-cmd))
-          (h (h-cmd)))
-      (with (w1 w2 w3 hpos) (decode-resize w "left")
-        (with (h1 h2 h3 vpos) (decode-resize h "top")
-          (with-global global-resize (list w1 w2 w3 hpos h1 h2 h3 hpos)
-            (with inner (make-menu-items (list (cons 'vertical items)) style #f)
-              (widget-resize (car inner) style
-                             w1 h1 w2 h2 w3 h3 hpos vpos))))))))
+  (with (tag w-cmd h-cmd . items)
+    p
+    (let ((w (w-cmd)) (h (h-cmd)))
+      (with (w1 w2 w3 hpos)
+        (decode-resize w "left")
+        (with (h1 h2 h3 vpos)
+          (decode-resize h "top")
+          (with-global global-resize
+            (list w1 w2 w3 hpos h1 h2 h3 hpos)
+            (with inner
+              (make-menu-items (list (cons 'vertical items)) style #f)
+              (widget-resize (car inner) style w1 h1 w2 h2 w3 h3 hpos vpos)
+            ) ;with
+          ) ;with-global
+        ) ;with
+      ) ;with
+    ) ;let
+  ) ;with
+) ;define
 
 (define (make-hsplit p style)
   "Make @(hsplit :menu-item :menu-item) item."
-  (with (tag . items) p
-    (with l (make-menu-items items style #f)
-      (widget-hsplit (car l) (cadr l)))))
+  (with (tag . items)
+    p
+    (with l (make-menu-items items style #f) (widget-hsplit (car l) (cadr l)))
+  ) ;with
+) ;define
 
 (define (make-vsplit p style)
   "Make @(vsplit :menu-item :menu-item) item."
-  (with (tag . items) p
-    (with l (make-menu-items items style #f)
-      (widget-vsplit (car l) (cadr l)))))
+  (with (tag . items)
+    p
+    (with l (make-menu-items items style #f) (widget-vsplit (car l) (cadr l)))
+  ) ;with
+) ;define
 
 (define (make-ink p style)
   "Make @(ink) item."
-  (with (tag cmd) p
-    (widget-ink (object->command cmd))))
+  (with (tag cmd) p (widget-ink (object->command cmd)))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dynamic menus
@@ -726,82 +974,128 @@
 
 (define (make-menu-if p style bar?)
   "Make @(if :%1 :menu-item-list) menu items."
-  (with (tag pred? . items) p
-    (if (pred?) (make-menu-items-list items style bar?) '())))
+  (with (tag pred? . items)
+    p
+    (if (pred?) (make-menu-items-list items style bar?) '())
+  ) ;with
+) ;define
 
 (define (make-menu-when p style bar?)
   "Make @(when :%1 :menu-item-list) menu items."
-  (with (tag pred? . items) p
+  (with (tag pred? . items)
+    p
     (let* ((old-active? (== (logand style widget-style-inert) 0))
            (new-active? (and old-active? (pred?)))
-           (new-style (logior style
-                              (if new-active? 0
-                                  (+ widget-style-inert widget-style-grey)))))
-      (make-menu-items-list items new-style bar?))))
+           (new-style (logior style (if new-active? 0 (+ widget-style-inert widget-style-grey)))
+           ) ;new-style
+          ) ;
+      (make-menu-items-list items new-style bar?)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (make-menu-for p style bar?)
   "Make @(for :%1 :%1) menu items."
-  (with (tag gen-func vals-promise) p
-    (let* ((vals (vals-promise))
-           (items (append-map gen-func vals)))
-      (make-menu-items-list items style bar?))))
+  (with (tag gen-func vals-promise)
+    p
+    (let* ((vals (vals-promise)) (items (append-map gen-func vals)))
+      (make-menu-items-list items style bar?)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (make-menu-mini p style bar?)
   "Make @(mini :%1 :menu-item-list) menu items."
-  (with (tag pred? . items) p
+  (with (tag pred? . items)
+    p
     (let* ((style-maxi (logand style (lognot widget-style-mini)))
            (style-mini (logior style-maxi widget-style-mini))
-           (new-style (if (pred?) style-mini style-maxi)))
-      (make-menu-items-list items new-style bar?))))
+           (new-style (if (pred?) style-mini style-maxi))
+          ) ;
+      (make-menu-items-list items new-style bar?)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (make-menu-link p style bar?)
   "Make @(link :%1) menu items."
-  (with linked ((eval (cadr p)))
-    (if linked (make-menu-items linked style bar?)
-        (make-menu-error "bad link: " (object->string (cadr p))))))
+  (with linked
+   ((eval (cadr p)))
+   (if linked
+     (make-menu-items linked style bar?)
+     (make-menu-error "bad link: " (object->string (cadr p)))
+   ) ;if
+  ) ;with
+) ;define
 
 (define (make-menu-dynamic p style bar?)
   "Make @(dynamic :%1) menu items."
-  (with dyn (eval (cadr p))
-    (if dyn (make-menu-items dyn style bar?)
-        (make-menu-error "bad link: " (object->string (cadr p))))))
+  (with dyn
+    (eval (cadr p))
+    (if dyn
+      (make-menu-items dyn style bar?)
+      (make-menu-error "bad link: " (object->string (cadr p)))
+    ) ;if
+  ) ;with
+) ;define
 
 (define (make-menu-promise p style bar?)
   "Make @(promise :%1) menu items."
-  (with value ((cadr p))
-    ;;(make-menu-items value style bar?)
-    (if (match? value ':menu-item) (make-menu-items value style bar?)
-        (make-menu-error "promise did not yield a menu: " value))))
+  (with value
+   ((cadr p))
+   ;; (make-menu-items value style bar?)
+   (if (match? value ':menu-item)
+     (make-menu-items value style bar?)
+     (make-menu-error "promise did not yield a menu: " value)
+   ) ;if
+  ) ;with
+) ;define
 
 (define (make-refresh p style bar?)
   "Make @(refresh :%1 :string?) widget."
-  (with (tag s kind) p
-    (list (widget-refresh (if (string? s) s (symbol->string s)) kind))))
+  (with (tag s kind)
+    p
+    (list (widget-refresh (if (string? s) s (symbol->string s)) kind))
+  ) ;with
+) ;define
 
 (define (make-refreshable p style bar?)
   "Make @(refreshable :%1 :menu-item-list) menu items."
-  (with (tag kind . items) p
-    (list (widget-refreshable
-            (lambda () (widget-vmenu (make-menu-items-list items style bar?)))
-            (kind)))))
+  (with (tag kind . items)
+    p
+    (list (widget-refreshable (lambda () (widget-vmenu (make-menu-items-list items style bar?)))
+            (kind)
+          ) ;widget-refreshable
+    ) ;list
+  ) ;with
+) ;define
 
 (define cached-widgets (make-ahash-table))
 
 (define (make-cached p style bar?)
   "Make @(cached :%1 :menu-item-list) menu items."
-  (with (tag kind valid? . items) p
+  (with (tag kind valid? . items)
+    p
     (let* ((kind* (kind))
            (fun (lambda ()
                   (or (and (valid?) (ahash-ref cached-widgets kind*))
-                      (let* ((l (make-menu-items-list items style bar?))
-                             (w (widget-vmenu l)))
-                        (ahash-set! cached-widgets kind* w)
-                        w)))))
-      (list (widget-refreshable fun kind*)))))
+                    (let* ((l (make-menu-items-list items style bar?)) (w (widget-vmenu l)))
+                      (ahash-set! cached-widgets kind* w)
+                      w
+                    ) ;let*
+                  ) ;or
+                ) ;lambda
+           ) ;fun
+          ) ;
+      (list (widget-refreshable fun kind*))
+    ) ;let*
+  ) ;with
+) ;define
 
 (tm-define (invalidate-now kind)
   (ahash-remove! cached-widgets kind)
-  (refresh-now kind))
+  (refresh-now kind)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main routines for making menu items
@@ -809,147 +1103,142 @@
 
 (define (make-menu-items-list l style bar?)
   "Make menu items for each element in @l and append results."
-  (append-map (lambda (p) (make-menu-items p style bar?)) l))
+  (append-map (lambda (p) (make-menu-items p style bar?)) l)
+) ;define
 
 (define (make-menu-items p style bar?)
   "Make menu items @p. The items are on a bar if @bar? and of a given @style."
-  ;;(display* "Make items " p ", " style "\n")
+  ;; (display* "Make items " p ", " style "\n")
   (if (pair? p)
-      (cond ((match? p '(input :%1 :string? :%1 :string?))
-             (list (make-menu-input p style)))
-            ((translatable? (car p))
-             (list (make-menu-entry p style bar?)))
-            ((symbol? (car p))
-             (with result (ahash-ref make-menu-items-table (car p))
-               (if (or (not result) (not (match? (cdr p) (car result))))
-                   (make-menu-items-list p style bar?)
-                   ((cadr result) p style bar?))))
-            ((match? (car p) ':menu-wide-label)
-             (list (make-menu-entry p style bar?)))
-            ((match? (car p) ':tab-page)
-             (list (make-tab-page p style bar?)))
-            (else
-             (make-menu-items-list p style bar?)))
-      (cond ((== p '---) (list (make-menu-hsep)))
-            ((== p '|) (list (make-menu-vsep))) ;; '|
-            ((== p '()) p)
-            (else (list (make-menu-bad-format p style))))))
+    (cond ((match? p '(input :%1 :string? :%1 :string?)) (list (make-menu-input p style)))
+          ((translatable? (car p)) (list (make-menu-entry p style bar?)))
+          ((symbol? (car p))
+           (with result
+             (ahash-ref make-menu-items-table (car p))
+             (if (or (not result) (not (match? (cdr p) (car result))))
+               (make-menu-items-list p style bar?)
+               ((cadr result) p style bar?)
+             ) ;if
+           ) ;with
+          ) ;
+          ((match? (car p) ':menu-wide-label) (list (make-menu-entry p style bar?)))
+          ((match? (car p) ':tab-page) (list (make-tab-page p style bar?)))
+          (else (make-menu-items-list p style bar?))
+    ) ;cond
+    (cond ((== p '---) (list (make-menu-hsep)))
+          ((== p '|) (list (make-menu-vsep)))
+          ;; '|
+          ((== p '()) p)
+          (else (list (make-menu-bad-format p style)))
+    ) ;cond
+  ) ;if
+) ;define
 
 (define-table make-menu-items-table
   (glue (:boolean? :boolean? :integer? :integer?)
-        ,(lambda (p style bar?)
-           (list (make-menu-glue (second p) (third p)
-                                 (fourth p) (fifth p)))))
+    ,(lambda (p style bar?)
+       (list (make-menu-glue (second p) (third p) (fourth p) (fifth p))))
+  ) ;glue
   (color (:%1 :boolean? :boolean? :integer? :integer?)
-         ,(lambda (p style bar?)
-            (list (make-menu-color (second p) (third p)
-                                   (fourth p) (fifth p) (sixth p)))))
-  (group (:%1)
-         ,(lambda (p style bar?) (list (make-menu-group (cadr p) style))))
-  (text (:%1)
-         ,(lambda (p style bar?) (list (make-menu-text (cadr p) style))))
-  (invisible (:%1)
-             ,(lambda (p style bar?) (list)))
+    ,(lambda (p style bar?)
+       (list (make-menu-color (second p)
+               (third p)
+               (fourth p)
+               (fifth p)
+               (sixth p))))
+  ) ;color
+  (group (:%1) ,(lambda (p style bar?) (list (make-menu-group (cadr p) style))))
+  (text (:%1) ,(lambda (p style bar?) (list (make-menu-text (cadr p) style))))
+  (invisible (:%1) ,(lambda (p style bar?) (list)))
   (symbol (:string? :*)
-          ,(lambda (p style bar?)
-             (let ((symbol-color (if (== (get-preference "gui theme") "liii-night") "white" "black")))
-               (list (make-menu-symbol p style '() (color symbol-color))))))
+    ,(lambda (p style bar?)
+       (let ((symbol-color (if (== (get-preference "gui theme") "liii-night")
+                             "white"
+                             "black")))
+         (list (make-menu-symbol p style '() (color symbol-color)))))
+  ) ;symbol
   (symbol-completion (:string? :*)
-          ,(lambda (p style bar?)
-             (let ((symbol-color (if (== (get-preference "gui theme") "liii-night") "white" "black")))
-               (list (make-menu-symbol p style '(roman mr medium normal 10 600 0) (color symbol-color))))))
+    ,(lambda (p style bar?)
+       (let ((symbol-color (if (== (get-preference "gui theme") "liii-night")
+                             "white"
+                             "black")))
+         (list (make-menu-symbol p
+                 style
+                 '(roman mr medium normal 10 600 0)
+                 (color symbol-color)))))
+  ) ;symbol-completion
   (symbol-completion* (:string? :*)
-          ,(lambda (p style bar?)
-             (let ((symbol-color (if (== (get-preference "gui theme") "liii-night") "#ff6666" "red")))
-               (list (make-menu-symbol p style '(roman mr medium normal 10 600 -2) (color symbol-color))))))
+    ,(lambda (p style bar?)
+       (let ((symbol-color (if (== (get-preference "gui theme") "liii-night")
+                             "#ff6666"
+                             "red")))
+         (list (make-menu-symbol p
+                 style
+                 '(roman mr medium normal 10 600 -2)
+                 (color symbol-color)))))
+  ) ;symbol-completion*
   (texmacs-output (:%2)
-    ,(lambda (p style bar?) (list (make-texmacs-output p style))))
+    ,(lambda (p style bar?) (list (make-texmacs-output p style)))
+  ) ;texmacs-output
   (texmacs-input (:%3)
-    ,(lambda (p style bar?) (list (make-texmacs-input p style))))
+    ,(lambda (p style bar?) (list (make-texmacs-input p style)))
+  ) ;texmacs-input
   (input (:%1 :string? :%1 :string?)
-         ,(lambda (p style bar?) (list (make-menu-input p style))))
+    ,(lambda (p style bar?) (list (make-menu-input p style)))
+  ) ;input
   (numeric-input (:%1 :string? :string? :integer? :integer? :integer? :integer?)
-         ,(lambda (p style bar?) (list (make-numeric-input p style))))
-  (enum (:%3 :string?)
-        ,(lambda (p style bar?) (list (make-enum p style))))
-  (choice (:%3)
-          ,(lambda (p style bar?) (list (make-choice p style))))
-  (choices (:%3)
-           ,(lambda (p style bar?) (list (make-choices p style))))
+    ,(lambda (p style bar?) (list (make-numeric-input p style)))
+  ) ;numeric-input
+  (enum (:%3 :string?) ,(lambda (p style bar?) (list (make-enum p style))))
+  (choice (:%3) ,(lambda (p style bar?) (list (make-choice p style))))
+  (choices (:%3) ,(lambda (p style bar?) (list (make-choices p style))))
   (filtered-choice (:%4)
-           ,(lambda (p style bar?) (list (make-filtered-choice p style))))
-  (color-input (:%3)
-         ,(lambda (p style bar?) (list (make-color-input p style))))
-  (tree-view (:%3)
-             ,(lambda (p style bar?) (list (make-tree-view p style))))
-  (toggle (:%2)
-          ,(lambda (p style bar?) (list (make-toggle p style))))
-  (link (:%1)
-        ,(lambda (p style bar?) (make-menu-link p style bar?)))
-  (dynamic (:%1)
-           ,(lambda (p style bar?) (make-menu-dynamic p style bar?)))
-  (horizontal (:*)
-              ,(lambda (p style bar?) (list (make-menu-horizontal p style))))
-  (vertical (:*)
-            ,(lambda (p style bar?) (list (make-menu-vertical p style))))
-  (hlist (:*)
-         ,(lambda (p style bar?) (list (make-menu-hlist p style))))
-  (vlist (:*)
-         ,(lambda (p style bar?) (list (make-menu-vlist p style))))
-  (division (:%1 :*)
-            ,(lambda (p style bar?) (list (make-menu-division p style))))
-  (class (:%1 :*)
-            ,(lambda (p style bar?) (list (make-menu-class p style))))
-  (aligned (:*)
-         ,(lambda (p style bar?) (list (make-aligned p style))))
-  (aligned-item (:%2)
-                ,(lambda (p style bar?) (list (make-aligned-item p style))))
-  (tabs (:*)
-        ,(lambda (p style bar?) (list (make-menu-tabs p style))))
-  (tab (:*)
-        ,(lambda (p style bar?) (list (make-menu-tab p style))))
-  (icon-tabs (:*)
-        ,(lambda (p style bar?) (list (make-menu-icon-tabs p style))))
-  (icon-tab (:*)
-        ,(lambda (p style bar?) (list (make-menu-icon-tab p style))))
-  (minibar (:*)
-            ,(lambda (p style bar?) (list (make-menu-minibar p style))))
+    ,(lambda (p style bar?) (list (make-filtered-choice p style)))
+  ) ;filtered-choice
+  (color-input (:%3) ,(lambda (p style bar?) (list (make-color-input p style))))
+  (tree-view (:%3) ,(lambda (p style bar?) (list (make-tree-view p style))))
+  (toggle (:%2) ,(lambda (p style bar?) (list (make-toggle p style))))
+  (link (:%1) ,(lambda (p style bar?) (make-menu-link p style bar?)))
+  (dynamic (:%1) ,(lambda (p style bar?) (make-menu-dynamic p style bar?)))
+  (horizontal (:*) ,(lambda (p style bar?)
+                      (list (make-menu-horizontal p style))))
+  (vertical (:*) ,(lambda (p style bar?) (list (make-menu-vertical p style))))
+  (hlist (:*) ,(lambda (p style bar?) (list (make-menu-hlist p style))))
+  (vlist (:*) ,(lambda (p style bar?) (list (make-menu-vlist p style))))
+  (division (:%1 :*) ,(lambda (p style bar?)
+                        (list (make-menu-division p style))))
+  (class (:%1 :*) ,(lambda (p style bar?) (list (make-menu-class p style))))
+  (aligned (:*) ,(lambda (p style bar?) (list (make-aligned p style))))
+  (aligned-item (:%2) ,(lambda (p style bar?)
+                         (list (make-aligned-item p style))))
+  (tabs (:*) ,(lambda (p style bar?) (list (make-menu-tabs p style))))
+  (tab (:*) ,(lambda (p style bar?) (list (make-menu-tab p style))))
+  (icon-tabs (:*) ,(lambda (p style bar?) (list (make-menu-icon-tabs p style))))
+  (icon-tab (:*) ,(lambda (p style bar?) (list (make-menu-icon-tab p style))))
+  (minibar (:*) ,(lambda (p style bar?) (list (make-menu-minibar p style))))
   (extend (:%1 :*)
-          ,(lambda (p style bar?) (list (make-menu-extend p style bar?))))
-  (style (:%1 :*)
-         ,(lambda (p style bar?) (make-menu-style p style bar?)))
-  (-> (:%1 :*)
-      ,(lambda (p style bar?) (list (make-menu-submenu p style))))
-  (=> (:%1 :*)
-      ,(lambda (p style bar?) (list (make-menu-submenu p style))))
-  (tile (:integer? :*)
-        ,(lambda (p style bar?) (list (make-menu-tile p style))))
-  (scrollable (:*)
-              ,(lambda (p style bar?) (list (make-scrollable p style))))
-  (resize (:%2 :*)
-      ,(lambda (p style bar?) (list (make-resize p style))))
-  (hsplit (:%2)
-          ,(lambda (p style bar?) (list (make-hsplit p style))))
-  (vsplit (:%2)
-          ,(lambda (p style bar?) (list (make-vsplit p style))))
-  (ink (:%1)
-       ,(lambda (p style bar?) (list (make-ink p style))))
-  (if (:%1 :*)
-      ,(lambda (p style bar?) (make-menu-if p style bar?)))
+    ,(lambda (p style bar?) (list (make-menu-extend p style bar?)))
+  ) ;extend
+  (style (:%1 :*) ,(lambda (p style bar?) (make-menu-style p style bar?)))
+  (-> (:%1 :*) ,(lambda (p style bar?) (list (make-menu-submenu p style))))
+  (=> (:%1 :*) ,(lambda (p style bar?) (list (make-menu-submenu p style))))
+  (tile (:integer? :*) ,(lambda (p style bar?) (list (make-menu-tile p style))))
+  (scrollable (:*) ,(lambda (p style bar?) (list (make-scrollable p style))))
+  (resize (:%2 :*) ,(lambda (p style bar?) (list (make-resize p style))))
+  (hsplit (:%2) ,(lambda (p style bar?) (list (make-hsplit p style))))
+  (vsplit (:%2) ,(lambda (p style bar?) (list (make-vsplit p style))))
+  (ink (:%1) ,(lambda (p style bar?) (list (make-ink p style))))
+  (if (:%1 :*) ,(lambda (p style bar?) (make-menu-if p style bar?)))
   (when (:%1 :*)
-        ,(lambda (p style bar?) (make-menu-when p style bar?)))
-  (for (:%1 :%1)
-        ,(lambda (p style bar?) (make-menu-for p style bar?)))
-  (mini (:%1 :*)
-        ,(lambda (p style bar?) (make-menu-mini p style bar?)))
-  (promise (:%1)
-           ,(lambda (p style bar?) (make-menu-promise p style bar?)))
-  (refresh (:%1 :string?)
-           ,(lambda (p style bar?) (make-refresh p style bar?)))
-  (refreshable (:%1 :*)
-               ,(lambda (p style bar?) (make-refreshable p style bar?)))
-  (cached (:%1 :%1 :*)
-               ,(lambda (p style bar?) (make-cached p style bar?))))
+    ,(lambda (p style bar?) (make-menu-when p style bar?))
+  ) ;when
+  (for (:%1 :%1) ,(lambda (p style bar?) (make-menu-for p style bar?)))
+  (mini (:%1 :*) ,(lambda (p style bar?) (make-menu-mini p style bar?)))
+  (promise (:%1) ,(lambda (p style bar?) (make-menu-promise p style bar?)))
+  (refresh (:%1 :string?) ,(lambda (p style bar?) (make-refresh p style bar?)))
+  (refreshable (:%1 :*) ,(lambda (p style bar?) (make-refreshable p style bar?)))
+  (cached (:%1 :%1 :*) ,(lambda (p style bar?) (make-cached p style bar?)))
+) ;define-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Menu expansion
@@ -957,154 +1246,183 @@
 
 (define (menu-expand-link p)
   "Expand menu link @p."
-  (with linked ((eval (cadr p)))
-    (if linked (menu-expand linked) p)))
+  (with linked ((eval (cadr p))) (if linked (menu-expand linked) p))
+) ;define
 
 (define (menu-expand-dynamic p)
   "Expand menu link @p."
-  (with dyn (eval (cadr p))
-    (if dyn (menu-expand dyn) p)))
+  (with dyn (eval (cadr p)) (if dyn (menu-expand dyn) p))
+) ;define
 
 (define (menu-expand-resize p)
   "Expand resize menu @p."
-  (with (tag h-cmd v-cmd . items) p
-    (cons* 'resize (h-cmd) (v-cmd) (menu-expand-list items))))
+  (with (tag h-cmd v-cmd . items)
+    p
+    (cons* 'resize (h-cmd) (v-cmd) (menu-expand-list items))
+  ) ;with
+) ;define
 
 (define (menu-expand-if p)
   "Expand conditional menu @p."
-  (with (tag pred? . items) p
-    (if (pred?) (menu-expand-list items) '())))
+  (with (tag pred? . items) p (if (pred?) (menu-expand-list items) '()))
+) ;define
 
 (define (menu-expand-when p)
   "Expand potentially greyed menu @p."
-  (with (tag pred? . items) p
+  (with (tag pred? . items)
+    p
     (if (pred?)
-        (cons* 'when #t (menu-expand-list items))
-        (cons* 'when #f (replace-procedures items)))))
+      (cons* 'when #t (menu-expand-list items))
+      (cons* 'when #f (replace-procedures items))
+    ) ;if
+  ) ;with
+) ;define
 
 (define (menu-expand-for p)
   "Expand menu @p generated using for loop."
-  (with (tag gen-func vals-promise) p
-    (let* ((vals (vals-promise))
-           (items (append-map gen-func vals)))
-      (menu-expand-list items))))
+  (with (tag gen-func vals-promise)
+    p
+    (let* ((vals (vals-promise)) (items (append-map gen-func vals)))
+      (menu-expand-list items)
+    ) ;let*
+  ) ;with
+) ;define
 
 (define (menu-expand-mini p)
   "Expand mini menu @p."
-  (with (tag pred? . items) p
-    (cons* 'mini (pred?) (menu-expand-list items))))
+  (with (tag pred? . items) p (cons* 'mini (pred?) (menu-expand-list items)))
+) ;define
 
 (define (menu-expand-promise p)
   "Expand promised menu @p."
-  (with value ((cadr p))
-    ;;(menu-expand value)
-    (if (match? value ':menu-item) (menu-expand value) p)))
+  (with value
+   ((cadr p))
+   ;; (menu-expand value)
+   (if (match? value ':menu-item) (menu-expand value) p)
+  ) ;with
+) ;define
 
 (define (menu-expand-texmacs-input p)
   "Expand texmacs-input item @p."
   `(texmacs-input ,(replace-procedures (cadr p))
-                  ,(replace-procedures (caddr p))
-                  ,(replace-procedures (cadddr p))))
+     ,(replace-procedures (caddr p))
+     ,(replace-procedures (cadddr p)))
+) ;define
 
 (define (menu-expand-texmacs-output p)
   "Expand output menu item @p."
-  (with (tag doc tmstyle) p
-    `(texmacs-output ',(doc) ',(tmstyle))))
+  (with (tag doc tmstyle) p `(texmacs-output (quote ,(doc)) (quote ,(tmstyle))))
+) ;define
 
 (define (menu-expand-input p)
   "Expand input menu item @p."
   `(input ,(replace-procedures (cadr p))
-          ,(caddr p)
-          ,(with r ((cadddr p))
-             (if (pair? r) (car r) (replace-procedures (cadddr p))))
-          ,(fifth p)))
+     ,(caddr p)
+     ,(with r
+        ((cadddr p))
+        (if (pair? r) (car r) (replace-procedures (cadddr p))))
+     ,(fifth p))
+) ;define
 
 (define (menu-expand-enum p)
   "Expand enum item @p."
   `(enum ,(replace-procedures (cadr p))
-         ,(replace-procedures (caddr p))
-         ,((cadddr p))
-         ,(fifth p)))
+     ,(replace-procedures (caddr p))
+     ,((cadddr p))
+     ,(fifth p))
+) ;define
 
 (define (menu-expand-choice p)
   "Expand choice item @p."
-  `(,(car p) ,(replace-procedures (cadr p))
-             ,((caddr p))
-             ,((cadddr p))))
+  `(,(car p) ,(replace-procedures (cadr p)) ,((caddr p)) ,((cadddr p)))
+) ;define
 
 (define (menu-expand-filtered-choice p)
   "Expand filtered choice item @p."
-  `(,(car p) ,(replace-procedures (cadr p))
-             :proposals ;; ,((caddr p))
-             ,((cadddr p))
-             ,(replace-procedures (car (cddddr p)))))
+  `(,(car p)
+    ,(replace-procedures (cadr p))
+    ,:proposals
+    ;; ,((caddr p))
+    ,((cadddr p))
+    ,(replace-procedures (car (cddddr p))))
+) ;define
 
 (define (menu-expand-color-input p)
   "Expand color-input menu item @p."
   `(input ,(replace-procedures (cadr p))
-          ,(caddr p)
-          ,(with r ((cadddr p))
-             (if (pair? r) (car r) (replace-procedures (cadddr p))))))
+     ,(caddr p)
+     ,(with r
+        ((cadddr p))
+        (if (pair? r) (car r) (replace-procedures (cadddr p)))))
+) ;define
 
 (define (menu-expand-tree-view p)
   "Expand tree-view item @p."
   (display* "menu-expand-tree-view\n")
-  `(,(car p) ,(replace-procedures (cadr p))
-             ,(caddr p)
-             ,(cadddr p)))
+  `(,(car p) ,(replace-procedures (cadr p)) ,(caddr p) ,(cadddr p))
+) ;define
 
 (define (menu-expand-toggle p)
   "Expand toggle item @p."
-  `(toggle ,(replace-procedures (cadr p))
-           ,((caddr p))))
+  `(toggle ,(replace-procedures (cadr p)) ,((caddr p)))
+) ;define
 
 (define (menu-expand-list l)
   "Expand links and conditional menus in list of menus @l."
-  (map menu-expand l))
+  (map menu-expand l)
+) ;define
 
-(define must-eval-list
-  '(input enum choice filtered-choice toggle))
+(define must-eval-list '(input enum choice filtered-choice toggle))
 
 (define (replace-procedures x)
   (cond ((procedure? x) (procedure-source x))
         ((and (pair? x) (in? (car x) must-eval-list)) (menu-expand x))
         ((list? x) (map replace-procedures x))
-        (else x)))
+        (else x)
+  ) ;cond
+) ;define
 
 (tm-define (menu-expand p)
   (:type (-> object object))
   (:synopsis "Expand links and conditional menus in menu @p")
-  ;;(display* "Expand " p "\n")
+  ;; (display* "Expand " p "\n")
   (cond ((npair? p) (replace-procedures p))
         ((string? (car p)) (list (car p)))
         ((symbol? (car p))
-         (with result (ahash-ref menu-expand-table (car p))
-           (if result ((car result) p) p)))
+         (with result
+           (ahash-ref menu-expand-table (car p))
+           (if result ((car result) p) p)
+         ) ;with
+        ) ;
         ((match? (car p) '(check :menu-wide-label :string? :%1))
-         (with a (cdar p)
-           (list (list 'check
-                       (menu-expand (car a))
-                       (cadr a)
-                       ((caddr a)))
-                 (replace-procedures (cadr p)))))
+         (with a
+           (cdar p)
+           (list (list 'check (menu-expand (car a)) (cadr a) ((caddr a)))
+             (replace-procedures (cadr p))
+           ) ;list
+         ) ;with
+        ) ;
         ((match? (car p) '(shortcut :menu-wide-label :string?))
-         (with a (cdar p)
-           (list (list 'shortcut
-                       (menu-expand (car a))
-                       (cadr a))
-                 (replace-procedures (cadr p)))))
-        ((match? (car p) ':menu-wide-label)
-         (replace-procedures p))
-        (else (menu-expand-list p))))
+         (with a
+           (cdar p)
+           (list (list 'shortcut (menu-expand (car a)) (cadr a))
+             (replace-procedures (cadr p))
+           ) ;list
+         ) ;with
+        ) ;
+        ((match? (car p) ':menu-wide-label) (replace-procedures p))
+        (else (menu-expand-list p))
+  ) ;cond
+) ;tm-define
 
 (tm-define (cache-menu? r)
   (:type (-> object bool))
   (:synopsis "Cache expanded menu @r")
   (cond ((symbol? r) (!= r 'input))
-        ((pair? r)
-         (and (cache-menu? (car r))
-              (cache-menu? (cdr r))))
-        (else #t)))
+        ((pair? r) (and (cache-menu? (car r)) (cache-menu? (cdr r))))
+        (else #t)
+  ) ;cond
+) ;tm-define
 
 (define-table menu-expand-table
   (--- ,(lambda (p) `(--- ,@(menu-expand-list (cdr p)))))
@@ -1151,13 +1469,15 @@
   (vsplit ,(lambda (p) `(vsplit ,@(menu-expand-list (cdr p)))))
   (ink ,replace-procedures)
   (if ,menu-expand-if)
-  (when ,menu-expand-when)
+  (when ,menu-expand-when
+  ) ;when
   (for ,menu-expand-for)
   (mini ,menu-expand-mini)
   (promise ,menu-expand-promise)
   (refresh ,replace-procedures)
   (refreshable ,replace-procedures)
-  (cached ,replace-procedures))
+  (cached ,replace-procedures)
+) ;define-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
@@ -1165,71 +1485,94 @@
 
 (define (make-menu-main p style)
   "Transform the menu @p into a widget."
-  (with l (make-menu-items p style #f)
+  (with l
+    (make-menu-items p style #f)
     (cond ((null? l) (make-menu-empty))
           ((and (list? l) (null? (cdr l))) (car l))
-          (else (make-menu-bad-format p style)))))
+          (else (make-menu-bad-format p style))
+    ) ;cond
+  ) ;with
+) ;define
 
 (tm-define (make-menu-widget p style)
   (:synopsis "Transform a menu into a widget")
   (:argument p "a scheme object which represents the menu")
   (:argument style "menu style")
-  ((wrap-catch make-menu-main) p style))
+  ((wrap-catch make-menu-main) p style)
+) ;tm-define
 
 (tm-define (make-menu-widget* p style . opt-size)
   (set! global-resize #f)
   (if (has-markup-gui?)
-      (apply make-menu-widget** (cons* p style opt-size))
-      (make-menu-widget p style)))
+    (apply make-menu-widget** (cons* p style opt-size))
+    (make-menu-widget p style)
+  ) ;if
+) ;tm-define
 
 (define (decode-options opts)
-  (let* ((bufs (list))
-         (qcmd noop))
+  (let* ((bufs (list)) (qcmd noop))
     (while (and (pair? opts) (url? (car opts)))
       (set! bufs (cons (car opts) bufs))
-      (set! opts (cdr opts)))
+      (set! opts (cdr opts))
+    ) ;while
     (when (pair? opts)
       (set! qcmd (car opts))
-      (set! opts (cdr opts)))
-    (list bufs qcmd)))
+      (set! opts (cdr opts))
+    ) ;when
+    (list bufs qcmd)
+  ) ;let*
+) ;define
 
 (define window-deleters (make-ahash-table))
 
 (define (make-window-deleter win bufs)
-  (for-each (lambda (buf)
-              (and-with old-del (ahash-ref window-deleters buf) (old-del)))
-            bufs)
+  (for-each (lambda (buf) (and-with old-del (ahash-ref window-deleters buf) (old-del)))
+    bufs
+  ) ;for-each
   (with del
-      (lambda ()
-        (for-each (lambda (buf) (ahash-remove! window-deleters buf)) bufs)
-        (alt-window-delete win))
+    (lambda ()
+      (for-each (lambda (buf) (ahash-remove! window-deleters buf)) bufs)
+      (alt-window-delete win)
+    ) ;lambda
     (for-each (lambda (buf) (ahash-set! window-deleters buf del)) bufs)
-    del))
+    del
+  ) ;with
+) ;define
 
 (tm-define (top-window menu-promise name . opts)
   (:interactive #t)
-  (with (bufs qqq) (decode-options opts)
+  (with (bufs qqq)
+    (decode-options opts)
     (let* ((win (alt-window-handle))
            (del (make-window-deleter win bufs))
            (qui (object->command (lambda () (qqq) (del))))
            (men (menu-promise))
            (scm (list 'vertical men))
-           (wid (make-menu-widget* scm 0)))
+           (wid (make-menu-widget* scm 0))
+          ) ;
       (alt-window-create-quit win wid (translate name) qui)
-      (alt-window-show win))))
+      (alt-window-show win)
+    ) ;let*
+  ) ;with
+) ;tm-define
 
 (tm-define (dialogue-window menu-promise cmd name . opts)
   (:interactive #t)
-  (with (bufs qqq) (decode-options opts)
+  (with (bufs qqq)
+    (decode-options opts)
     (let* ((win (alt-window-handle))
            (del (make-window-deleter win bufs))
            (qui (object->command (lambda () (qqq) (del))))
            (lbd (lambda x (apply cmd x) (del)))
            (men (menu-promise lbd))
            (scm (list 'vertical men))
-           (wid (make-menu-widget* scm 0)))
+           (wid (make-menu-widget* scm 0))
+          ) ;
       (alt-window-create-quit win wid (translate name) qui)
-      (alt-window-show win))))
+      (alt-window-show win)
+    ) ;let*
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Other top-level windows
@@ -1240,104 +1583,121 @@
   (let* ((win (alt-window-handle))
          (lbd (lambda x (apply cmd x) (alt-window-delete win)))
          (com (object->command (menu-protect lbd)))
-         (wid (wid-promise com)))
+         (wid (wid-promise com))
+        ) ;
     (alt-window-create-plain win wid (translate name))
-    (alt-window-show win)))
+    (alt-window-show win)
+  ) ;let*
+) ;tm-define
 
 (tm-define (interactive-print done u)
   (:interactive #t)
-  (with p (lambda (com) (widget-printer com u))
-    (interactive-window p done "Print document")))
+  (with p
+    (lambda (com) (widget-printer com u))
+    (interactive-window p done "Print document")
+  ) ;with
+) ;tm-define
 
 (tm-define (interactive-rgb-picker cmd l)
   (:interactive #t)
-  (with cmd* (lambda (col) (when col (cmd col)))
-    (dialogue-window rgb-color-picker cmd* "Choose color")))
+  (with cmd*
+    (lambda (col) (when col (cmd col)))
+    (dialogue-window rgb-color-picker cmd* "Choose color")
+  ) ;with
+) ;tm-define
 
 (tm-define (interactive-color cmd proposals)
   (:interactive #t)
   (set! proposals (map tm->tree proposals))
   (if (not (qt-gui?))
-      (interactive-rgb-picker cmd proposals)
-      (with p (lambda (com) (widget-color-picker com #f proposals))
-        (with cmd* (lambda (t) (when t (cmd (tm->stree t))))
-          (interactive-window p cmd* "Choose color")))))
+    (interactive-rgb-picker cmd proposals)
+    (with p
+      (lambda (com) (widget-color-picker com #f proposals))
+      (with cmd*
+        (lambda (t) (when t (cmd (tm->stree t))))
+        (interactive-window p cmd* "Choose color")
+      ) ;with
+    ) ;with
+  ) ;if
+) ;tm-define
 
 (tm-define (interactive-background cmd proposals)
   (:interactive #t)
   (set! proposals (map tm->tree proposals))
   (if (not (qt-gui?))
-      (interactive-rgb-picker cmd proposals)
-      ;;(with p (lambda (com) (widget-color-picker com #t proposals))
-      (with p (lambda (com) (widget-color-picker com #f proposals))
-        (with cmd* (lambda (t) (when t (cmd (tm->stree t))))
-          (interactive-window p cmd* "Choose background")))))
+    (interactive-rgb-picker cmd proposals)
+    ;; (with p (lambda (com) (widget-color-picker com #t proposals))
+    (with p
+      (lambda (com) (widget-color-picker com #f proposals))
+      (with cmd*
+        (lambda (t) (when t (cmd (tm->stree t))))
+        (interactive-window p cmd* "Choose background")
+      ) ;with
+    ) ;with
+  ) ;if
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Reporting errors of system commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-widget ((system-error-widget cmd out err) done)
-  (padded
-    (resize '("300px" "600px" "1200px") '("275px" "400px" "600px")
-      (centered (bold (text "Input command")))  
-      (scrollable
-	(for (x (string-decompose cmd "\n"))
-	  (hlist // (text x) >>)))
-      ===
-      (centered (bold (text "Standard Output")))
-      (scrollable
-	(for (x (string-decompose out "\n"))
-	  (hlist // (text x) >>)))
-      ===
-      (centered (bold (text "Error output")))
-      (scrollable
-	(for (x (string-decompose err "\n"))
-	  (hlist // (text x) >>)))
-      ===
-      (bottom-buttons >> ("Ok" (done))))))
+  (padded (resize '("300px" "600px" "1200px")
+            '("275px" "400px" "600px")
+            (centered (bold (text "Input command")))
+            (scrollable (for (x (string-decompose cmd "\n")) (hlist // (text x) >>)))
+            ===
+            (centered (bold (text "Standard Output")))
+            (scrollable (for (x (string-decompose out "\n")) (hlist // (text x) >>)))
+            ===
+            (centered (bold (text "Error output")))
+            (scrollable (for (x (string-decompose err "\n")) (hlist // (text x) >>)))
+            ===
+            (bottom-buttons >> ("Ok" (done)))
+          ) ;resize
+  ) ;padded
+) ;tm-widget
 
 (tm-define (report-system-error win-name cmd out err)
   (:synopsis "Display command @cmd with its standard outputs @out and @err")
-  (when (list? cmd) (set! cmd (string-recompose cmd " ")))
+  (when (list? cmd)
+    (set! cmd (string-recompose cmd " "))
+  ) ;when
   (set! out (utf8->cork out))
   (set! err (utf8->cork err))
   (dialogue-window (system-error-widget cmd out err) noop win-name)
-  #f)
+  #f
+) ;tm-define
 
 (tm-widget ((message-widget msg) done)
-  (padded
-    (centered (text msg))
-    ===
-    (centered
-      (explicit-buttons
-        ("Ok" (done))))))
+  (padded (centered (text msg)) === (centered (explicit-buttons ("Ok" (done)))))
+) ;tm-widget
 
 (tm-define (show-message msg title)
   (:interactive #t)
-  (dialogue-window (message-widget msg) noop title))
+  (dialogue-window (message-widget msg) noop title)
+) ;tm-define
 
 (tm-define (restart-message)
   (:interactive #t)
   (show-message "Restart TeXmacs in order to let changes take effect"
-                "Notification"))
+    "Notification"
+  ) ;show-message
+) ;tm-define
 
 (tm-widget ((notify-dialogue message) cmd)
-  (padded
-    (text message)
-    ===
-    (bottom-buttons
-      >>
-      ("Ok" (cmd "Ok"))
-      >>)))
+  (padded (text message) === (bottom-buttons >> ("Ok" (cmd "Ok")) >>))
+) ;tm-widget
 
 (tm-define (notify-now message)
-  (delayed
-    (:idle 1)
-    (dialogue-window (notify-dialogue message) noop "Notification")))
+  (delayed (:idle 1)
+    (dialogue-window (notify-dialogue message) noop "Notification")
+  ) ;delayed
+) ;tm-define
 
 (tm-define (notify-restart . args)
-  (notify-now "Restart TeXmacs in order to let changes take effect"))
+  (notify-now "Restart TeXmacs in order to let changes take effect")
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Attaching global information to widgets and tools
@@ -1345,11 +1705,11 @@
 
 (define global-key-table (make-ahash-table))
 
-(tm-define (global-ref . key)
-  (ahash-ref global-key-table key))
+(tm-define (global-ref . key) (ahash-ref global-key-table key))
 
 (tm-define (global-set . key-val)
-  (ahash-set! global-key-table (cDr key-val) (cAr key-val)))
+  (ahash-set! global-key-table (cDr key-val) (cAr key-val))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Attaching side tools to windows
@@ -1359,151 +1719,222 @@
 (tm-define lazy-tool-table (make-ahash-table))
 
 (define-public-macro (lazy-tool module . tools)
-  `(for (tool ',tools)
+  `(for (tool (quote ,tools))
      (if (pair? tool) (set! tool (car tool)))
-     ;;(display* "Lazy tool " tool ", " ',module "\n")
-     (ahash-set! lazy-tool-table tool ',module)))
+     ;; (display* "Lazy tool " tool ", " ',module "\n")
+     (ahash-set! lazy-tool-table tool (quote ,module)))
+) ;define-public-macro
 
 (define (lazy-tool-force . tools)
   (for (tool tools)
     (if (pair? tool) (set! tool (car tool)))
-    ;;(display* "Loading tool " tool "\n")
-    (and-with module (ahash-ref lazy-tool-table tool)
-      (eval `(use-modules ,module)))
-    (ahash-remove! lazy-tool-table tool)))
+    ;; (display* "Loading tool " tool "\n")
+    (and-with module (ahash-ref lazy-tool-table tool) (eval `(use-modules ,module)))
+    (ahash-remove! lazy-tool-table tool)
+  ) ;for
+) ;define
 
 (tm-define (window->tools win . pos-l)
-  (if (null? pos-l) (list)
-      (with (pos . pos-r) pos-l
-        (with tools (ahash-ref window-tools-table (list win pos))
-          (or (and tools (nnull? tools) tools)
-              (apply window->tools (cons win pos-r)))))))
+  (if (null? pos-l)
+    (list)
+    (with (pos . pos-r)
+      pos-l
+      (with tools
+        (ahash-ref window-tools-table (list win pos))
+        (or (and tools (nnull? tools) tools) (apply window->tools (cons win pos-r)))
+      ) ;with
+    ) ;with
+  ) ;if
+) ;tm-define
 
 (define (find-positions tool win l)
-  (if (null? l) l
-      (with r (find-positions tool win (cdr l))
-        (with (x . t) l
-          (with (key val) (if (list-2? x) x (list "" ""))
-            (with (key-win key-pos) (if (list-2? key) key (list "" ""))
-              (if (and (== key-win win) (== val tool))
-                  (cons key-pos r)
-                  r)))))))
+  (if (null? l)
+    l
+    (with r
+      (find-positions tool win (cdr l))
+      (with (x . t)
+        l
+        (with (key val)
+          (if (list-2? x) x (list "" ""))
+          (with (key-win key-pos)
+            (if (list-2? key) key (list "" ""))
+            (if (and (== key-win win) (== val tool)) (cons key-pos r) r)
+          ) ;with
+        ) ;with
+      ) ;with
+    ) ;with
+  ) ;if
+) ;define
 
 (tm-define (tool->positions tool win)
-  (with l (ahash-table->list window-tools-table)
-    (find-positions tool win l)))
+  (with l (ahash-table->list window-tools-table) (find-positions tool win l))
+) ;tm-define
 
 (tm-define (tool-bottom? tool win)
-  (with l (tool->positions tool win)
-    (or (in? :transient-bottom l)
-        (in? :bottom l))))
+  (with l
+    (tool->positions tool win)
+    (or (in? :transient-bottom l) (in? :bottom l))
+  ) ;with
+) ;tm-define
 
-(tm-define (tool-side? tool win)
-  (not (tool-bottom? tool win)))
+(tm-define (tool-side? tool win) (not (tool-bottom? tool win)))
 
 (define (notify-side-tools n show?)
   (when (!= show? (visible-side-tools? n))
-    (show-side-tools n show?)))
+    (show-side-tools n show?)
+  ) ;when
+) ;define
 
 (define (notify-bottom-tools n show?)
   (when (!= show? (visible-bottom-tools? n))
-    (show-bottom-tools n show?)))
+    (show-bottom-tools n show?)
+  ) ;when
+) ;define
 
 (tm-define (extra-bottom-tools?) #f)
 
 (tm-define (has-bottom-tools? . opt-win)
-  (with win (if (null? opt-win) (current-window) (car opt-win))
-    (with l (window->tools win :transient-bottom :bottom)
-      (or (== (get-preference "keyboard tool") "on")
-          (extra-bottom-tools?)
-          (nnull? l)))))
+  (with win
+    (if (null? opt-win) (current-window) (car opt-win))
+    (with l
+      (window->tools win :transient-bottom :bottom)
+      (or (== (get-preference "keyboard tool") "on") (extra-bottom-tools?) (nnull? l))
+    ) ;with
+  ) ;with
+) ;tm-define
 
 (tm-define (update-bottom-tools . opt-win)
   (show-bottom-tools 0 (apply has-bottom-tools? opt-win))
   (when (not (extra-bottom-tools?))
-    (keyboard-focus-on "canvas")))
+    (keyboard-focus-on "canvas")
+  ) ;when
+) ;tm-define
 
 (tm-define (set-window-tools win pos l)
   (apply lazy-tool-force l)
   (ahash-set! window-tools-table (list win pos) l)
   (let* ((l0 (window->tools win :transient-right :right :bottom-right))
-         (l1 (window->tools win :transient-left :left :bottom-left)))
+         (l1 (window->tools win :transient-left :left :bottom-left))
+        ) ;
     (notify-side-tools 0 (nnull? l0))
     (notify-side-tools 1 (nnull? l1))
     (notify-bottom-tools 0 (has-bottom-tools? win))
-    (keyboard-focus-on "canvas")))
+    (keyboard-focus-on "canvas")
+  ) ;let*
+) ;tm-define
 
 (tm-define (set-window-tool win pos tool)
-  (set-window-tools win pos (list tool)))
+  (set-window-tools win pos (list tool))
+) ;tm-define
 
 (tm-define (tool-active? pos tool . opt-win)
   (when (func? tool 'quote)
-    (set! tool (cadr tool)))
+    (set! tool (cadr tool))
+  ) ;when
   (when (string? tool)
-    (set! tool (string->symbol tool)))
+    (set! tool (string->symbol tool))
+  ) ;when
   (when (symbol? tool)
-    (set! tool (list tool)))
-  (with win (if (null? opt-win) (current-window) (car opt-win))
-    (and-with l (window->tools win pos)
-      (in? tool l))))
+    (set! tool (list tool))
+  ) ;when
+  (with win
+    (if (null? opt-win) (current-window) (car opt-win))
+    (and-with l (window->tools win pos) (in? tool l))
+  ) ;with
+) ;tm-define
 
 (tm-define (tool-select pos tool . opt-win)
   (:check-mark "v" tool-active?)
   (when (string? tool)
-    (set! tool (string->symbol tool)))
+    (set! tool (string->symbol tool))
+  ) ;when
   (when (symbol? tool)
-    (set! tool (list tool)))
-  (with win (if (null? opt-win) (current-window) (car opt-win))
-    (set-window-tool win pos tool)))
+    (set! tool (list tool))
+  ) ;when
+  (with win
+    (if (null? opt-win) (current-window) (car opt-win))
+    (set-window-tool win pos tool)
+  ) ;with
+) ;tm-define
 
 (tm-define (tool-focus pos tool u)
   (:check-mark "v" tool-active?)
   (if (tool-active? pos tool)
-      (buffer-focus* u #f)
-      (begin
-        (tool-select pos tool)
-        (delayed
-          (:pause 250)
-          (buffer-focus* u #f)))))
+    (buffer-focus* u #f)
+    (begin
+      (tool-select pos tool)
+      (delayed (:pause 250) (buffer-focus* u #f))
+    ) ;begin
+  ) ;if
+) ;tm-define
 
 (tm-define (tool-toggle pos tool . opt-win)
   (:check-mark "v" tool-active?)
   (when (string? tool)
-    (set! tool (string->symbol tool)))
+    (set! tool (string->symbol tool))
+  ) ;when
   (when (symbol? tool)
-    (set! tool (list tool)))
-  (with win (if (null? opt-win) (current-window) (car opt-win))
-    (with l (window->tools win pos)
+    (set! tool (list tool))
+  ) ;when
+  (with win
+    (if (null? opt-win) (current-window) (car opt-win))
+    (with l
+      (window->tools win pos)
       (if (in? tool l)
-          (set-window-tools win pos (list-remove l tool))
-          (set-window-tools win pos (cons tool l))))))
+        (set-window-tools win pos (list-remove l tool))
+        (set-window-tools win pos (cons tool l))
+      ) ;if
+    ) ;with
+  ) ;with
+) ;tm-define
 
 (tm-define (tool-close pos tool quit . opt-win)
   (if (== pos :any)
-      (for (pos* (list :transient-right :right :bottom-right
-                       :transient-left :left :bottom-left
-                       :transient-bottom :bottom))
-        (apply tool-close (cons* pos* tool quit opt-win)))
-      (let* ((win (if (null? opt-win) (current-window) (car opt-win)))
-             (l (window->tools win pos))
-             (f (list-filter l (lambda (t) (!= (car t) tool)))))
-        (when (!= f l)
-          (when quit (quit))
-          (buffer-focus (window->buffer win) #f)
-          (set-window-tools win pos f)))))
+    (for (pos* (list :transient-right
+                 :right
+                 :bottom-right
+                 :transient-left
+                 :left
+                 :bottom-left
+                 :transient-bottom
+                 :bottom
+               ) ;list
+         ) ;pos*
+      (apply tool-close (cons* pos* tool quit opt-win))
+    ) ;for
+    (let* ((win (if (null? opt-win) (current-window) (car opt-win)))
+           (l (window->tools win pos))
+           (f (list-filter l (lambda (t) (!= (car t) tool))))
+          ) ;
+      (when (!= f l)
+        (when quit
+          (quit)
+        ) ;when
+        (buffer-focus (window->buffer win) #f)
+        (set-window-tools win pos f)
+      ) ;when
+    ) ;let*
+  ) ;if
+) ;tm-define
 
 (tm-define ((tool-quit tool quit . opt-win) . args)
-  (apply tool-close (cons* :any tool quit opt-win)))
+  (apply tool-close (cons* :any tool quit opt-win))
+) ;tm-define
 
 (tm-define (no-active-tools? pos . opt-win)
-  (with win (if (null? opt-win) (current-window) (car opt-win))
-    (with l (window->tools win pos)
-      (null? l))))
+  (with win
+    (if (null? opt-win) (current-window) (car opt-win))
+    (with l (window->tools win pos) (null? l))
+  ) ;with
+) ;tm-define
 
 (tm-define (close-tools pos . opt-win)
   (:check-mark "v" no-active-tools?)
-  (with win (if (null? opt-win) (current-window) (car opt-win))
-    (set-window-tools win pos (list))))
+  (with win
+    (if (null? opt-win) (current-window) (car opt-win))
+    (set-window-tools win pos (list))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining side tools
@@ -1511,103 +1942,136 @@
 
 (tm-widget (texmacs-side-tool win tool . opts)
   (division "title"
-    (text (string-append "Missing '" (object->string (car tool)) "' tool"))))
+    (text (string-append "Missing '" (object->string (car tool)) "' tool"))
+  ) ;division
+) ;tm-widget
 
 (define (get-name-tool tool body)
   (cond ((null? body) #f)
         ((keyword? (car body)) (get-name-tool tool (cdr body)))
         ((and (func? (car body) :name 1) (null? (cddr tool))) (cadar body))
         ((func? (car body) :name 1)
-         ;;(display* "Name = "
+         ;; (display* "Name = "
          ;;          `(with (,@(cddr tool)) (cdr tool) ,(cadar body)) "\n")
-         `(with (,@(cddr tool)) (cdr tool) ,(cadar body)))
+         `(with (,@(cddr tool)) (cdr tool) ,(cadar body))
+        ) ;
         ((not (and (pair? (car body)) (keyword? (caar body)))) #f)
-        (else (get-name-tool tool (cdr body)))))
+        (else (get-name-tool tool (cdr body)))
+  ) ;cond
+) ;define
 
 (define (get-quit-tool tool body)
   (cond ((null? body) #f)
         ((keyword? (car body)) (get-quit-tool tool (cdr body)))
         ((func? (car body) :quit 1)
-         `(with (,@(cddr tool)) (cdr tool)
-            (lambda () ,(cadar body))))
+         `(with (,@(cddr tool)) (cdr tool) (lambda ,() ,(cadar body)))
+        ) ;
         ((not (and (pair? (car body)) (keyword? (caar body)))) #f)
-        (else (get-quit-tool tool (cdr body)))))
+        (else (get-quit-tool tool (cdr body)))
+  ) ;cond
+) ;define
 
 (define (finalize-tool body pos)
   (cond ((null? body) (lambda (x) x))
         ((and (== (car body) :side-centered) (== pos :side))
-         (with finalize (finalize-tool (cdr body) pos)
-           (lambda (x) `(centered ,(finalize x)))))
+         (with finalize
+           (finalize-tool (cdr body) pos)
+           (lambda (x) `(centered ,(finalize x)))
+         ) ;with
+        ) ;
         ((and (== (car body) :bottom-indent) (== pos :bottom))
-         (with finalize (finalize-tool (cdr body) pos)
-           (lambda (x) `(hlist (glue #f #f 7 0)
-                               (vlist === ,(finalize x) ===)
-                               (glue #f #f 7 0)))))
-        ((or (keyword? (car body))
-             (and (pair? (car body)) (keyword? (caar body))))
-         (finalize-tool (cdr body) pos))
-        (else (lambda (x) x))))
+         (with finalize
+           (finalize-tool (cdr body) pos)
+           (lambda (x)
+             `(hlist (glue #f #f 7 0)
+                (vlist === ,(finalize x) ===)
+                (glue #f #f 7 0))
+           ) ;lambda
+         ) ;with
+        ) ;
+        ((or (keyword? (car body)) (and (pair? (car body)) (keyword? (caar body))))
+         (finalize-tool (cdr body) pos)
+        ) ;
+        (else (lambda (x) x))
+  ) ;cond
+) ;define
 
 (define (preprocess-tool body)
   (cond ((null? body) body)
-        ((or (keyword? (car body))
-             (and (pair? (car body)) (keyword? (caar body))))
-         (preprocess-tool (cdr body)))
-        (else body)))
+        ((or (keyword? (car body)) (and (pair? (car body)) (keyword? (caar body))))
+         (preprocess-tool (cdr body))
+        ) ;
+        (else body)
+  ) ;cond
+) ;define
 
 (tm-define-macro (tm-tool* tool . obody)
   (let* ((name (get-name-tool tool obody))
          (quit (get-quit-tool tool obody))
          (finalize-side (finalize-tool obody :side))
          (finalize-bottom (finalize-tool obody :bottom))
-         (body (preprocess-tool obody)))
-    ;;(display* "body = " body "\n")
+         (body (preprocess-tool obody))
+        ) ;
+    ;; (display* "body = " body "\n")
     `(begin
        (tm-widget ,tool ,@body)
        (tm-widget (texmacs-side-tool ,(cadr tool) tool . opts)
-         (:require (== (car tool) ',(car tool)))
+         (,:require (== (car tool) (quote ,(car tool))))
          (if (and (in? :title opts) ,name)
-             (division "title"
-               (hlist
-                 (text ,name)
-                 >>
-                 (division "plain"
-                   ("x" (tool-close :any ',(car tool) ,quit ,(cadr tool)))))))
+           (division ,"title"
+             (hlist (text ,name)
+               >>
+               (division ,"plain"
+                 (,"x"
+                  (tool-close ,:any (quote ,(car tool)) ,quit ,(cadr tool)))))))
          (assuming (tool-side? tool win)
-           ,(finalize-side
-             `(dynamic (,(car tool) ,(cadr tool)
-                        ,@(map (lambda (i) `(list-ref tool ,(- i 1)))
-                               (.. 2 (length tool)))))))
+           ,(finalize-side `(dynamic (,(car tool)
+                                      ,(cadr tool)
+                                      ,@(map (lambda (i)
+                                               `(list-ref tool ,(- i 1)))
+                                          (.. 2 (length tool)))))))
          (assuming (tool-bottom? tool win)
-           ,(finalize-bottom
-             `(dynamic (,(car tool) ,(cadr tool)
-                        ,@(map (lambda (i) `(list-ref tool ,(- i 1)))
-                               (.. 2 (length tool)))))))))))
+           ,(finalize-bottom `(dynamic (,(car tool)
+                                        ,(cadr tool)
+                                        ,@(map (lambda (i)
+                                                 `(list-ref tool ,(- i 1)))
+                                            (.. 2 (length tool)))))))))
+  ) ;let*
+) ;tm-define-macro
 
 (tm-define-macro (tm-tool tool . body)
-  `(tm-tool* ,tool :side-centered :bottom-indent ,@body))
+  `(tm-tool* ,tool ,:side-centered ,:bottom-indent ,@body)
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Auxiliary Widget
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 全局哈希表，存储辅助窗口状态
+
 (define auxiliary-widget-table (make-ahash-table))
 
 ;; widget-type到action的映射表
+
 (define widget-type->action (make-ahash-table))
 
 ;; 注册widget类型和对应的action函数
 (tm-define (register-auxiliary-widget-type widget-type action-func)
-  (ahash-set! widget-type->action widget-type action-func))
+  (ahash-set! widget-type->action widget-type action-func)
+) ;tm-define
 
 ;; 设置辅助窗口状态
 (tm-define (set-auxiliary-widget-state opened? widget-type)
-  (ahash-set! auxiliary-widget-table (current-view-url) (list opened? widget-type)))
+  (ahash-set! auxiliary-widget-table
+    (current-view-url)
+    (list opened? widget-type)
+  ) ;ahash-set!
+) ;tm-define
 
 ;; 获取辅助窗口状态
 (tm-define (get-auxiliary-widget-state)
-  (ahash-ref auxiliary-widget-table (current-view-url)))
+  (ahash-ref auxiliary-widget-table (current-view-url))
+) ;tm-define
 
 ;; 关闭辅助窗口
 (tm-define (close-auxiliary-widget)
@@ -1617,32 +2081,47 @@
       (show-auxiliary-widget #f)
       (let ((actions (ahash-ref widget-type->action (cadr state))))
         (when (and (pair? actions) (pair? (cdr actions)))
-          (with close-action (second actions)
-            (close-action)))))))
-          
+          (with close-action (second actions) (close-action))
+        ) ;when
+      ) ;let
+    ) ;when
+  ) ;let
+) ;tm-define
+
 ;; 刷新辅助窗口
 (tm-define (refresh-auxiliary-widget)
   (let ((state (get-auxiliary-widget-state)))
-    (cond ((not state)
-           (show-auxiliary-widget #f))   ;; 状态为空，隐藏辅助窗口
-          ((not (car state))
-           (show-auxiliary-widget #f))   ;; 第一个是#f，隐藏辅助窗口
-          (else
-           (let* ((widget-type (cadr state))
-                  (action-list (ahash-ref widget-type->action widget-type)))
-             (if (and action-list (pair? action-list))
-                 (with open-action (car action-list)
-                  (open-action))
-                 (show-auxiliary-widget #f))))))) ;; 列表为空或未找到，隐藏窗口
+    (cond ((not state) (show-auxiliary-widget #f))
+          ;; 状态为空，隐藏辅助窗口
+          ((not (car state)) (show-auxiliary-widget #f))
+          ;; 第一个是#f，隐藏辅助窗口
+          (else (let* ((widget-type (cadr state))
+                       (action-list (ahash-ref widget-type->action widget-type))
+                      ) ;
+                  (if (and action-list (pair? action-list))
+                    (with open-action (car action-list) (open-action))
+                    (show-auxiliary-widget #f)
+                  ) ;if
+                ) ;let*
+          ) ;else
+    ) ;cond
+  ) ;let
+) ;tm-define
+;; 列表为空或未找到，隐藏窗口
 
 (tm-define (auxiliary-widget menu-promise cmd name . opts)
   (:interactive #t)
-  (with (bufs qqq) (decode-options opts)
+  (with (bufs qqq)
+    (decode-options opts)
     (let* ((del (lambda () (show-auxiliary-widget #f)))
            (qui (object->command (lambda () (qqq) (del))))
            (lbd (lambda x (apply cmd x) (del)))
            (men (menu-promise lbd))
            (scm (list 'vertical men))
-           (wid (make-menu-widget* scm 0)))
+           (wid (make-menu-widget* scm 0))
+          ) ;
       (set-auxiliary-widget wid name)
-      (show-auxiliary-widget #t))))
+      (show-auxiliary-widget #t)
+    ) ;let*
+  ) ;with
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/speech-define.scm
+++ b/TeXmacs/progs/kernel/gui/speech-define.scm
@@ -11,8 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel gui speech-define)
-  (:use (kernel gui kbd-define)))
+(texmacs-module (kernel gui speech-define) (:use (kernel gui kbd-define)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of speech commands
@@ -21,41 +20,57 @@
 (define speech-map-table (make-ahash-table))
 
 (tm-define (speech-map-set lan mode key im)
-  (ahash-set! speech-map-table (list lan mode key) im))
+  (ahash-set! speech-map-table (list lan mode key) im)
+) ;tm-define
 
 (tm-define (speech-map-ref lan mode key)
-  (ahash-ref speech-map-table (list lan mode key)))
+  (ahash-ref speech-map-table (list lan mode key))
+) ;tm-define
 
 (define (speech-map-line lan mode line)
   (if (and (pair? line) (string? (car line)))
-      (with (key . l) line
-        (speech-accepts lan mode (utf8->cork key))
-        (set! key (speech-pre-sanitize lan (utf8->cork key)))
-        (speech-map-set lan mode key l)
-        (speech-accepts lan mode key)
-        (with key* (string-append (symbol->string lan) ":" (locase-all key))
-          (list (cons* key* '(noop) l))))
-      (list line)))
+    (with (key . l)
+      line
+      (speech-accepts lan mode (utf8->cork key))
+      (set! key (speech-pre-sanitize lan (utf8->cork key)))
+      (speech-map-set lan mode key l)
+      (speech-accepts lan mode key)
+      (with key*
+        (string-append (symbol->string lan) ":" (locase-all key))
+        (list (cons* key* '(noop) l))
+      ) ;with
+    ) ;with
+    (list line)
+  ) ;if
+) ;define
 
 (tm-define-macro (speech-map lan mode . l)
   (:synopsis "Add entries in @l to the keyboard speech mapping")
-  `(kbd-map
-     ,@(if (== mode 'any) (list) `((:mode ,(symbol-append 'in- mode '?))))
-     ,@(append-map (cut speech-map-line lan mode <>) l)))
+  `(kbd-map ,@(if (== mode 'any)
+                (list)
+                `((,:mode ,(symbol-append 'in- mode '?))))
+     ,@(append-map (cut speech-map-line lan mode <>) l))
+) ;tm-define-macro
 
 (define (speech-subst-wildcard x w)
   (cond ((string? x) (string-replace x "*" w))
         ((list? x) (map (cut speech-subst-wildcard <> w) x))
-        (else x)))
+        (else x)
+  ) ;cond
+) ;define
 
 (define (speech-expand-wildcards l)
-  (if (null? l) l
-      (append (map (cut speech-subst-wildcard (car l) <>) roman-letters)
-              (speech-expand-wildcards (cdr l)))))
+  (if (null? l)
+    l
+    (append (map (cut speech-subst-wildcard (car l) <>) roman-letters)
+      (speech-expand-wildcards (cdr l))
+    ) ;append
+  ) ;if
+) ;define
 
 (tm-define-macro (speech-map-wildcard lan mode . l)
-  `(speech-map ,lan ,mode
-     ,@(speech-expand-wildcards l)))
+  `(speech-map ,lan ,mode ,@(speech-expand-wildcards l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definition of speech ajustments
@@ -66,30 +81,39 @@
 (define speech-adjust-table (make-ahash-table))
 
 (tm-define (speech-adjust-set lan mode key im)
-  (ahash-set! speech-adjust-table (list lan mode key) im))
+  (ahash-set! speech-adjust-table (list lan mode key) im)
+) ;tm-define
 
 (tm-define (speech-adjust-ref lan mode key)
-  (ahash-ref speech-adjust-table (list lan mode key)))
+  (ahash-ref speech-adjust-table (list lan mode key))
+) ;tm-define
 
 (define (speech-adjust-line lan mode line)
-  (with *lan (if (symbol-ends? lan '*) (symbol-drop-right lan 1) lan)
+  (with *lan
+    (if (symbol-ends? lan '*) (symbol-drop-right lan 1) lan)
     (if (and (list-2? line) (string? (car line)))
-	(with (key im) line
-          (speech-accepts lan mode (utf8->cork key))
-	  (set! key (speech-pre-sanitize *lan (utf8->cork key)))
-	  (set! im  (speech-pre-sanitize *lan (utf8->cork im )))
-	  (speech-accepts lan mode key)
-	  `(speech-adjust-set ',lan ',mode ,key ,im))
-	`(noop))))
+      (with (key im)
+        line
+        (speech-accepts lan mode (utf8->cork key))
+        (set! key (speech-pre-sanitize *lan (utf8->cork key)))
+        (set! im (speech-pre-sanitize *lan (utf8->cork im)))
+        (speech-accepts lan mode key)
+        `(speech-adjust-set (quote ,lan) (quote ,mode) ,key ,im)
+      ) ;with
+      '(noop)
+    ) ;if
+  ) ;with
+) ;define
 
 (tm-define-macro (speech-adjust lan mode . l)
   (:synopsis "Add entries in @l to the keyboard speech adjustment table")
-  `(begin
-     ,@(map (cut speech-adjust-line lan mode <>) l)))
+  `(begin ,@(map (cut speech-adjust-line lan mode <>) l))
+) ;tm-define-macro
 
 (tm-define-macro (speech-reduce lan mode . l)
   (:synopsis "Add entries in @l to the keyboard speech reduction table")
-  `(speech-adjust ,(symbol-append lan '*) ,mode ,@l))
+  `(speech-adjust ,(symbol-append lan '*) ,mode ,@l)
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Collections of language specific words
@@ -99,69 +123,178 @@
 
 (tm-define (speech-collection-set name lan elem)
   (set! elem (speech-pre-sanitize lan (utf8->cork elem)))
-  (ahash-set! speech-collection-table (list name lan elem) #t))
+  (ahash-set! speech-collection-table (list name lan elem) #t)
+) ;tm-define
 
 (tm-define (speech-has? lan name elem)
-  (ahash-ref speech-collection-table (list name lan elem)))
+  (ahash-ref speech-collection-table (list name lan elem))
+) ;tm-define
 
 (define (speech-collection-add name lan elem)
-  `(speech-collection-set ',name ',lan ,elem))
+  `(speech-collection-set (quote ,name) (quote ,lan) ,elem)
+) ;define
 
 (tm-define-macro (speech-collection name lan . l)
   (:synopsis "Add entries in @l to the speech collection tables")
-  `(begin
-     ,@(map (cut speech-collection-add name lan <>) l)))
+  `(begin ,@(map (cut speech-collection-add name lan <>) l))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Mathematical symbols
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (string-list-2? line)
-  (and (list-2? line) (string? (car line)) (string? (cadr line))))
+  (and (list-2? line) (string? (car line)) (string? (cadr line)))
+) ;define
 
 (tm-define roman-letters
-  (list "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m"
-        "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z"))
+  (list "a"
+    "b"
+    "c"
+    "d"
+    "e"
+    "f"
+    "g"
+    "h"
+    "i"
+    "j"
+    "k"
+    "l"
+    "m"
+    "n"
+    "o"
+    "p"
+    "q"
+    "r"
+    "s"
+    "t"
+    "u"
+    "v"
+    "w"
+    "x"
+    "y"
+    "z"
+  ) ;list
+) ;tm-define
 
 (tm-define greek-letters
-  (list "<alpha>" "<beta>" "<gamma>" "<delta>" "<epsilon>" "<zeta>" "<eta>"
-        "<theta>" "<iota>" "<kappa>" "<lambda>" "<mu>" "<nu>" "<xi>"
-        "<omicron>" "<pi>" "<rho>" "<sigma>" "<tau>" "<upsilon>"
-        "<phi>" "<psi>" "<chi>" "<omega>"))
+  (list "<alpha>"
+    "<beta>"
+    "<gamma>"
+    "<delta>"
+    "<epsilon>"
+    "<zeta>"
+    "<eta>"
+    "<theta>"
+    "<iota>"
+    "<kappa>"
+    "<lambda>"
+    "<mu>"
+    "<nu>"
+    "<xi>"
+    "<omicron>"
+    "<pi>"
+    "<rho>"
+    "<sigma>"
+    "<tau>"
+    "<upsilon>"
+    "<phi>"
+    "<psi>"
+    "<chi>"
+    "<omega>"
+  ) ;list
+) ;tm-define
 
-(tm-define punctuation-symbols
-  (list "." "," ":" ";" "!" "?"))
+(tm-define punctuation-symbols (list "." "," ":" ";" "!" "?"))
 
 (tm-define standard-operators
-  (list "arc" "arc cos" "arc sin" "arc tan" "arccos" "arcsin" "arctan"
-        "arg" "cos" "cosh" "cot" "coth" "csc" "deg" "det" "dim" "exp" "gcd"
-        "hom" "inf" "ker" "lg" "lim" "liminf" "limsup" "lim inf" "lim sup"
-        "ln" "log" "max" "min" "Pr" "sec" "sin" "sinh" "sup" "tan" "tanh"))
+  (list "arc"
+    "arc cos"
+    "arc sin"
+    "arc tan"
+    "arccos"
+    "arcsin"
+    "arctan"
+    "arg"
+    "cos"
+    "cosh"
+    "cot"
+    "coth"
+    "csc"
+    "deg"
+    "det"
+    "dim"
+    "exp"
+    "gcd"
+    "hom"
+    "inf"
+    "ker"
+    "lg"
+    "lim"
+    "liminf"
+    "limsup"
+    "lim inf"
+    "lim sup"
+    "ln"
+    "log"
+    "max"
+    "min"
+    "Pr"
+    "sec"
+    "sin"
+    "sinh"
+    "sup"
+    "tan"
+    "tanh"
+  ) ;list
+) ;tm-define
 
-(tm-define lowercase-letters
-  (append roman-letters greek-letters))
+(tm-define lowercase-letters (append roman-letters greek-letters))
 
-(define (number-cadr? x) (string-number? (cadr x)))
-(define (roman-cadr? x) (in? (cadr x) roman-letters))
-(define (greek-cadr? x) (in? (cadr x) greek-letters))
+(define (number-cadr? x)
+  (string-number? (cadr x))
+) ;define
+
+(define (roman-cadr? x)
+  (in? (cadr x) roman-letters)
+) ;define
+
+(define (greek-cadr? x)
+  (in? (cadr x) greek-letters)
+) ;define
 
 (define (ordinary-cadr? x)
   (and (== (math-symbol-type (cadr x)) "symbol")
-       (nin? (cadr x) roman-letters)
-       (nin? (cadr x) greek-letters)))
+    (nin? (cadr x) roman-letters)
+    (nin? (cadr x) greek-letters)
+  ) ;and
+) ;define
 
-(define (infix-cadr? x) (== (math-symbol-type (cadr x)) "infix"))
-(define (prefix-cadr? x) (== (math-symbol-type (cadr x)) "prefix"))
-(define (postfix-cadr? x) (== (math-symbol-type (cadr x)) "postfix"))
-(define (prefix-infix-cadr? x) (== (math-symbol-type (cadr x)) "prefix-infix"))
-(define (separator-cadr? x) (== (math-symbol-type (cadr x)) "separator"))
+(define (infix-cadr? x)
+  (== (math-symbol-type (cadr x)) "infix")
+) ;define
 
-(tm-define (speech-insert-symbol sym)
-  (insert sym))
+(define (prefix-cadr? x)
+  (== (math-symbol-type (cadr x)) "prefix")
+) ;define
+
+(define (postfix-cadr? x)
+  (== (math-symbol-type (cadr x)) "postfix")
+) ;define
+
+(define (prefix-infix-cadr? x)
+  (== (math-symbol-type (cadr x)) "prefix-infix")
+) ;define
+
+(define (separator-cadr? x)
+  (== (math-symbol-type (cadr x)) "separator")
+) ;define
+
+(tm-define (speech-insert-symbol sym) (insert sym))
 
 (define (speech-map-symbol line)
-  (with (key im) line
-    `(,key (speech-insert-symbol ,im))))
+  (with (key im) line `(,key (speech-insert-symbol ,im)))
+) ;define
 
 (tm-define-macro (speech-symbols lan . l)
   (:synopsis "Add entries in @l to the keyboard speech adjustment table")
@@ -174,10 +307,10 @@
          (prefix (filter infix-cadr? l))
          (postfix (filter infix-cadr? l))
          (prefix-infix (filter prefix-infix-cadr? l))
-         (separator (filter separator-cadr? l)))
+         (separator (filter separator-cadr? l))
+        ) ;
     `(begin
-       (speech-map ,lan math
-         ,@(map speech-map-symbol l))
+       (speech-map ,lan math ,@(map speech-map-symbol l))
        (speech-collection number ,lan ,@(map car number))
        (speech-collection roman ,lan ,@(map car roman))
        (speech-collection greek ,lan ,@(map car greek))
@@ -186,47 +319,62 @@
        (speech-collection infix ,lan ,@(map car infix))
        (speech-collection postfix ,lan ,@(map car postfix))
        (speech-collection prefix-infix ,lan ,@(map car prefix-infix))
-       (speech-collection separator ,lan ,@(map car separator)))))
+       (speech-collection separator ,lan ,@(map car separator)))
+  ) ;let*
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Sanitizing speech commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (string-locase? s)
-  (and (string? s) (string-alpha? s) (== s (locase-all s))))
+  (and (string? s) (string-alpha? s) (== s (locase-all s)))
+) ;tm-define
 
 (tm-define (string-upcase? s)
-  (and (string? s) (string-alpha? s) (== s (upcase-all s))))
+  (and (string? s) (string-alpha? s) (== s (upcase-all s)))
+) ;tm-define
 
 (tm-define (spaced-quotes s)
-  (cond ((string-starts? s "'")
-         (string-append "'" (spaced-quotes (string-drop s 1))))
+  (cond ((string-starts? s "'") (string-append "'" (spaced-quotes (string-drop s 1))))
         ((string-ends? s "'")
-         (string-append (spaced-quotes (string-drop-right s 1)) "'"))
-        (else (string-replace (string-replace s "'" "' ") "'  " "' "))))
+         (string-append (spaced-quotes (string-drop-right s 1)) "'")
+        ) ;
+        (else (string-replace (string-replace s "'" "' ") "'  " "' "))
+  ) ;cond
+) ;tm-define
 
 (tm-define (clean-letter-digit l)
   (cond ((or (null? l) (null? (cdr l))) l)
         ((and (string-alpha? (car l)) (string-number? (cadr l)))
-         (cons* (car l) " " (clean-letter-digit (cdr l))))
+         (cons* (car l) " " (clean-letter-digit (cdr l)))
+        ) ;
         ((and (string-number? (car l)) (string-alpha? (cadr l)))
-         (cons* (car l) " " (clean-letter-digit (cdr l))))
+         (cons* (car l) " " (clean-letter-digit (cdr l)))
+        ) ;
         ((and (string-locase? (car l)) (string-upcase? (cadr l)))
-         (cons* (car l) " " (clean-letter-digit (cdr l))))
-        (else (cons (car l) (clean-letter-digit (cdr l))))))
+         (cons* (car l) " " (clean-letter-digit (cdr l)))
+        ) ;
+        (else (cons (car l) (clean-letter-digit (cdr l))))
+  ) ;cond
+) ;tm-define
 
 (define (string-replace-trailing-one s what by)
-  (let* ((l (string-length what))
-         (n (string-length s)))
-    (if (and (>= n l) (>= n 2)
-             (not (string-occurs? what (substring s 1 (- n 1)))))
-        (string-replace s what by)
-        s)))
+  (let* ((l (string-length what)) (n (string-length s)))
+    (if (and (>= n l) (>= n 2) (not (string-occurs? what (substring s 1 (- n 1)))))
+      (string-replace s what by)
+      s
+    ) ;if
+  ) ;let*
+) ;define
 
 (tm-define (string-replace-trailing s what by)
   (let* ((l (string-decompose s " "))
-         (r (map (cut string-replace-trailing-one <> what by) l)))
-    (string-recompose r " ")))
+         (r (map (cut string-replace-trailing-one <> what by) l))
+        ) ;
+    (string-recompose r " ")
+  ) ;let*
+) ;tm-define
 
 (tm-define (speech-pre-sanitize lan s) s)
 (tm-define (speech-sanitize lan mode s) s)
@@ -238,186 +386,255 @@
 (tm-define (speech-current-mode) 'any)
 
 (define (speech-rewrite*** lan mode h t)
-  (with key (locase-all (string-recompose h " "))
+  (with key
+    (locase-all (string-recompose h " "))
     (if (null? h)
-        (if (null? t) t
-            (cons (car t) (speech-rewrite*** lan mode (cdr t) (list))))
-        (or (and-with im (speech-adjust-ref lan mode key)
-              ;;(display* "  Rewrote " key " ~> " im "\n")
-              (with im* (string-decompose im " ")
-                (append im* t)))
-            (speech-rewrite*** lan mode (cDr h) (cons (cAr h) t))))))
+      (if (null? t) t (cons (car t) (speech-rewrite*** lan mode (cdr t) (list))))
+      (or (and-with im
+            (speech-adjust-ref lan mode key)
+            ;; (display* "  Rewrote " key " ~> " im "\n")
+            (with im* (string-decompose im " ") (append im* t))
+          ) ;and-with
+        (speech-rewrite*** lan mode (cDr h) (cons (cAr h) t))
+      ) ;or
+    ) ;if
+  ) ;with
+) ;define
 
 (define (speech-rewrite** lan mode l depth)
-  ;;(display* "Rewrite " l ", " lan ", " mode ", " depth "\n")
-  (with r (speech-rewrite*** lan mode l (list))
-    (if (or (<= depth 0) (== r l)) r
-        (speech-rewrite** lan mode r (- depth 1)))))
+  ;; (display* "Rewrite " l ", " lan ", " mode ", " depth "\n")
+  (with r
+    (speech-rewrite*** lan mode l (list))
+    (if (or (<= depth 0) (== r l)) r (speech-rewrite** lan mode r (- depth 1)))
+  ) ;with
+) ;define
 
 (define (speech-rewrite* lan mode l)
-  (with r (speech-rewrite** lan mode l 100)
-    (speech-rewrite** (symbol-append lan '*) mode r 100)))
+  (with r
+    (speech-rewrite** lan mode l 100)
+    (speech-rewrite** (symbol-append lan '*) mode r 100)
+  ) ;with
+) ;define
 
 (tm-define (speech-rewrite lan mode s)
   (set! s (speech-sanitize lan mode s))
-  ;;(display* "Sanitized " (cork->utf8 s) "\n")
-  (let* ((l (string-decompose s " "))
-         (r (speech-rewrite* lan mode l)))
-    (string-recompose r " ")))
+  ;; (display* "Sanitized " (cork->utf8 s) "\n")
+  (let* ((l (string-decompose s " ")) (r (speech-rewrite* lan mode l)))
+    (string-recompose r " ")
+  ) ;let*
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check whether commands are recognized in a given mode
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define speech-accepts-table (make-ahash-table))
+
 (define speech-recognizes-table (make-ahash-table))
 
 (tm-define (speech-accepts lan mode s)
-  (with ls (locase-all s)
-    (ahash-set! speech-recognizes-table (list lan mode ls) #t))
-  (with l (string-decompose s " ")
-    (for (ss l)
-      (ahash-set! speech-accepts-table (list lan mode ss) #t))))
+  (with ls
+    (locase-all s)
+    (ahash-set! speech-recognizes-table (list lan mode ls) #t)
+  ) ;with
+  (with l
+    (string-decompose s " ")
+    (for (ss l) (ahash-set! speech-accepts-table (list lan mode ss) #t))
+  ) ;with
+) ;tm-define
 
 (tm-define (raw-speech-accepts? lan mode s)
-  (with lan* (symbol-append lan '*)
+  (with lan*
+    (symbol-append lan '*)
     (or (nnot (string->number s))
-        (ahash-ref speech-accepts-table (list lan mode s))
-        (ahash-ref speech-accepts-table (list lan* mode s)))))
+      (ahash-ref speech-accepts-table (list lan mode s))
+      (ahash-ref speech-accepts-table (list lan* mode s))
+    ) ;or
+  ) ;with
+) ;tm-define
 
 (tm-define (speech-accepts? lan mode s)
   (set! s (speech-sanitize lan mode s))
-  (forall? (cut raw-speech-accepts? lan mode <>)
-           (string-decompose s " ")))
+  (forall? (cut raw-speech-accepts? lan mode <>) (string-decompose s " "))
+) ;tm-define
 
 (tm-define (speech-border-accepts? lan mode s)
   (set! s (speech-sanitize lan mode s))
-  (with lan* (symbol-append lan '*)
+  (with lan*
+    (symbol-append lan '*)
     (or (nnot (string->number s))
-        (ahash-ref speech-recognizes-table (list lan mode s))
-        (ahash-ref speech-recognizes-table (list lan* mode s)))))
+      (ahash-ref speech-recognizes-table (list lan mode s))
+      (ahash-ref speech-recognizes-table (list lan* mode s))
+    ) ;or
+  ) ;with
+) ;tm-define
 
 (define (speech-recognizes-list? lan mode h t)
-  ;;(display* "    checking " h ", " t "\n")
-  (with key (locase-all (string-recompose h " "))
-    (if (null? h) (null? t)
-        (or (and (or (string->number key)
-                     (ahash-ref speech-recognizes-table (list lan mode key))
-                     (ahash-ref speech-recognizes-table (list lan 'any key)))
-                 (speech-recognizes-list? lan mode t (list)))
-            (speech-recognizes-list? lan mode (cDr h) (cons (cAr h) t))))))
+  ;; (display* "    checking " h ", " t "\n")
+  (with key
+    (locase-all (string-recompose h " "))
+    (if (null? h)
+      (null? t)
+      (or (and (or (string->number key)
+                 (ahash-ref speech-recognizes-table (list lan mode key))
+                 (ahash-ref speech-recognizes-table (list lan 'any key))
+               ) ;or
+            (speech-recognizes-list? lan mode t (list))
+          ) ;and
+        (speech-recognizes-list? lan mode (cDr h) (cons (cAr h) t))
+      ) ;or
+    ) ;if
+  ) ;with
+) ;define
 
 (tm-define (speech-recognizes? lan mode s)
-  ;;(display* "    checking " (speech-sanitize lan mode s) "\n")
+  ;; (display* "    checking " (speech-sanitize lan mode s) "\n")
   (and (speech-accepts? lan mode s)
-       (let* ((r (speech-rewrite lan mode s))
-              (l (string-decompose r " ")))
-         (speech-recognizes-list? lan mode l (list)))))
+    (let* ((r (speech-rewrite lan mode s)) (l (string-decompose r " ")))
+      (speech-recognizes-list? lan mode l (list))
+    ) ;let*
+  ) ;and
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Execution of speech commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (speech-language)
-  (with lan (string->symbol (get-preference "speech"))
-    (if (== lan 'off) 'english lan)))
+  (with lan
+    (string->symbol (get-preference "speech"))
+    (if (== lan 'off) 'english lan)
+  ) ;with
+) ;tm-define
 
-(tm-define (speech-insert-number nr)
-  (insert nr))
+(tm-define (speech-insert-number nr) (insert nr))
 
 (tm-define (speech-exec-hook l) #f)
 
 (define (speech-exec-list lan h t)
   (let* ((key* (locase-all (string-recompose h " ")))
-         (key (string-append (symbol->string lan) ":" key*)))
-    ;;(display* "  Try " key* " -> " (kbd-find-key-binding key) "\n")
+         (key (string-append (symbol->string lan) ":" key*))
+        ) ;
+    ;; (display* "  Try " key* " -> " (kbd-find-key-binding key) "\n")
     (cond ((and (null? h) (null? t)) (noop))
-	  ((null? h) (speech-exec-list lan (cdr t) (list)))
-	  ((speech-exec-hook (apply string-append h))
-	   (speech-exec-list lan t (list)))
-	  ((string->number key*)
-	   (speech-insert-number key*)
-	   (speech-exec-list lan t (list)))
-	  ((kbd-find-key-binding key)
-	   (with cmd (kbd-find-key-binding key)
-	     (when (pair? cmd) (set! cmd (car cmd)))
-	     (when (procedure? cmd)
-	       ;;(display* "  Execute " key*
-	       ;;          " -> " (procedure-source cmd) "\n")
-	       (cmd))
-	     (speech-exec-list lan t (list))))
-	  (else (speech-exec-list lan (cDr h) (cons (cAr h) t))))))
+          ((null? h) (speech-exec-list lan (cdr t) (list)))
+          ((speech-exec-hook (apply string-append h)) (speech-exec-list lan t (list)))
+          ((string->number key*)
+           (speech-insert-number key*)
+           (speech-exec-list lan t (list))
+          ) ;
+          ((kbd-find-key-binding key)
+           (with cmd
+             (kbd-find-key-binding key)
+             (when (pair? cmd)
+               (set! cmd (car cmd))
+             ) ;when
+             (when (procedure? cmd)
+               ;; (display* "  Execute " key*
+               ;;          " -> " (procedure-source cmd) "\n")
+               (cmd)
+             ) ;when
+             (speech-exec-list lan t (list))
+           ) ;with
+          ) ;
+          (else (speech-exec-list lan (cDr h) (cons (cAr h) t)))
+    ) ;cond
+  ) ;let*
+) ;define
 
 (tm-define (speech-exec s)
-  ;;(display* "Execute " (cork->utf8 s) "\n")
+  ;; (display* "Execute " (cork->utf8 s) "\n")
   (let* ((lan (speech-language))
          (mode (speech-current-mode))
          (r (speech-rewrite lan mode s))
-         (l (string-decompose r " ")))
-    ;;(display* "Rewritten " (cork->utf8 r) "\n")
-    (speech-exec-list lan l (list))))
+         (l (string-decompose r " "))
+        ) ;
+    ;; (display* "Rewritten " (cork->utf8 r) "\n")
+    (speech-exec-list lan l (list))
+  ) ;let*
+) ;tm-define
 
 (tm-define (speech-make S)
-  (with lan (get-preference "language")
+  (with lan
+    (get-preference "language")
     (when (!= lan "english")
-      (set! S (translate-from-to S lan "english"))))
-  (with s (string-replace (locase-all S) " " "-")
+      (set! S (translate-from-to S lan "english"))
+    ) ;when
+  ) ;with
+  (with s
+    (string-replace (locase-all S) " " "-")
     (and (style-has? s)
-         (>= (string-length s) 3)
-         (begin
-           (make (string->symbol s))
-           #t))))
+      (>= (string-length s) 3)
+      (begin
+        (make (string->symbol s))
+        #t
+      ) ;begin
+    ) ;and
+  ) ;with
+) ;tm-define
 
 (define (speech-command* key)
-  (and-with cmd (kbd-find-key-binding key)
-    (when (pair? cmd) (set! cmd (car cmd)))
+  (and-with cmd
+    (kbd-find-key-binding key)
+    (when (pair? cmd)
+      (set! cmd (car cmd))
+    ) ;when
     (cond ((procedure? cmd)
-           ;;(display* "  Command " key* " -> " (procedure-source cmd) "\n")
-           (cmd))
+           ;; (display* "  Command " key* " -> " (procedure-source cmd) "\n")
+           (cmd)
+          ) ;
           ((string? cmd)
-           ;;(display* "  Insert " cmd "\n")
-           (insert cmd)))
-    #t))
+           ;; (display* "  Insert " cmd "\n")
+           (insert cmd)
+          ) ;
+    ) ;cond
+    #t
+  ) ;and-with
+) ;define
 
 (tm-define (speech-command key)
   (let* ((lan (symbol->string (speech-language)))
-         (key* (string-append lan  ":" (locase-all key))))
-    (or (speech-command* key)
-        (speech-command* key*))))
+         (key* (string-append lan ":" (locase-all key)))
+        ) ;
+    (or (speech-command* key) (speech-command* key*))
+  ) ;let*
+) ;tm-define
 
 (tm-define (kbd-speech s)
-  ;;(display* "Speech " (cork->utf8 s) "\n")
+  ;; (display* "Speech " (cork->utf8 s) "\n")
   (cond ((speech-command s) (noop))
         ((speech-make s) (noop))
-        (else (kbd-insert s))))
+        (else (kbd-insert s))
+  ) ;cond
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Outer interface
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (speech-cleanup)
-  (noop))
+(tm-define (speech-cleanup) (noop))
 
-(tm-define (speech-pause)
-  (noop))
+(tm-define (speech-pause) (noop))
 
 (define last-speech-time #f)
 
 (tm-define (keyboard-speech l)
   (when (nnull? l)
-    (with t (texmacs-time)
+    (with t
+      (texmacs-time)
       (set! last-speech-time t)
       (speech-cleanup)
-      (for (s (cDr l))
-        (kbd-speech s)
-        (speech-pause))
+      (for (s (cDr l)) (kbd-speech s) (speech-pause))
       (kbd-speech (cAr l))
-      (exec-delayed-pause
-       (lambda ()
-         (with left (- 1000 (idle-time))
-           (or (!= last-speech-time t)
-               (if (> left 0) left
-                   (begin
-                     (set! last-speech-time #f)
-                     (speech-pause)
-                     #t)))))))))
+      (exec-delayed-pause (lambda ()
+                            (with left
+                              (- 1000 (idle-time))
+                              (or (!= last-speech-time t)
+                                (if (> left 0) left (begin (set! last-speech-time #f) (speech-pause) #t))
+                              ) ;or
+                            ) ;with
+                          ) ;lambda
+      ) ;exec-delayed-pause
+    ) ;with
+  ) ;when
+) ;tm-define

--- a/TeXmacs/progs/kernel/old-gui/old-gui-factory.scm
+++ b/TeXmacs/progs/kernel/old-gui/old-gui-factory.scm
@@ -12,250 +12,295 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel old-gui old-gui-factory)
-  (:use (kernel old-gui old-gui-widget)))
+  (:use (kernel old-gui old-gui-widget))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Building content
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (build-options-sub l)
-  (if (null? l) (cons '() '())
-      (with (options . args) (build-options-sub (cdr l))
-	(if (and (pair? (car l)) (keyword? (caar l)))
-	    (cons (cons (car l) options) args)
-	    (cons options (cons (car l) args))))))
+  (if (null? l)
+    (cons '() '())
+    (with (options . args)
+      (build-options-sub (cdr l))
+      (if (and (pair? (car l)) (keyword? (caar l)))
+        (cons (cons (car l) options) args)
+        (cons options (cons (car l) args))
+      ) ;if
+    ) ;with
+  ) ;if
+) ;define
 
-(tm-define (build-options l)
-  (build-options-sub (cdr l)))
+(tm-define (build-options l) (build-options-sub (cdr l)))
 
 (define (with-bindings l)
-  (if (null? l) l
-      (cons* (keyword->string (caar l)) (cadar l)
-	     (with-bindings (cdr l)))))
+  (if (null? l)
+    l
+    (cons* (keyword->string (caar l)) (cadar l) (with-bindings (cdr l)))
+  ) ;if
+) ;define
 
 (tm-define (build-with options builder)
-  (if (null? options) builder
-      (let* ((bindings (with-bindings options))
-	     (fun (lambda (x) `(with ,@bindings ,x))))
-	`(map ,fun ,builder))))
+  (if (null? options)
+    builder
+    (let* ((bindings (with-bindings options)) (fun (lambda (x) `(with ,@bindings
+                                                                  ,x))))
+      `(map ,fun ,builder)
+    ) ;let*
+  ) ;if
+) ;tm-define
 
 (tm-define (build-content w)
   (:synopsis "Generate a content builder from a scheme program @w")
   (cond ((list? w)
-	 (with (options . body) (build-options w)
-	   (with l (cons (car w) body)
-	     (build-with options `(list ,(build-content-list l))))))
-	((== w '---) `(list '(gui-hrule)))
-	((== w '===) `(list '(gui-medskip)))
-	((== w '>>>) `(list '(htab "1em")))
-	((symbol? w) `(list ',w))
-	(else `(list ,w))))
+         (with (options . body)
+           (build-options w)
+           (with l
+             (cons (car w) body)
+             (build-with options `(list ,(build-content-list l)))
+           ) ;with
+         ) ;with
+        ) ;
+        ((== w '---) '(list '(gui-hrule)))
+        ((== w '===) '(list '(gui-medskip)))
+        ((== w '>>>) '(list '(htab "1em")))
+        ((symbol? w) `(list (quote ,w)))
+        (else `(list ,w))
+  ) ;cond
+) ;tm-define
 
-(tm-define (build-content-list ws)
-  `(append ,@(map build-content ws)))
+(tm-define (build-content-list ws) `(append ,@(map build-content ws)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Declare new content builders
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define-macro (tm-build proto . body)
-  (let* ((fun (car proto))
-	 (args (cdr proto)))
+  (let* ((fun (car proto)) (args (cdr proto)))
     `(tm-define (build-content w)
-       (:require (tm-is? w ',fun))
-       (with ,(cons 'options args) (build-options w)
-	 (build-with options
-           (begin ,@body))))))
+       (,:require (tm-is? w (quote ,fun)))
+       (with ,(cons 'options args)
+         (build-options w)
+         (build-with options (begin ,@body))))
+  ) ;let*
+) ;tm-define-macro
 
 (tm-define-macro (tm-build-macro proto . body)
-  (let* ((fun (car proto))
-	 (args (cdr proto)))
+  (let* ((fun (car proto)) (args (cdr proto)))
     `(tm-define (build-content w)
-       (:require (tm-is? w ',fun))
-       (with ,(cons 'options args) (build-options w)
-	 (build-with options
-	   (build-content (begin ,@body)))))))
+       (,:require (tm-is? w (quote ,fun)))
+       (with ,(cons 'options args)
+         (build-options w)
+         (build-with options (build-content (begin ,@body)))))
+  ) ;let*
+) ;tm-define-macro
 
 (tm-define-macro (tm-build-widget proto . body)
-  (let* ((fun (car proto))
-	 (args (cdr proto)))
+  (let* ((fun (car proto)) (args (cdr proto)))
     `(tm-define (build-content w)
-       (:require (tm-is? w ',fun))
-       (with ,(cons 'options args) (build-options w)
-	 (build-with options
-	   (build-content-list ,(list 'quasiquote body)))))))
+       (,:require (tm-is? w (quote ,fun)))
+       (with ,(cons 'options args)
+         (build-options w)
+         (build-with options (build-content-list ,(list 'quasiquote body)))))
+  ) ;let*
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Fundamental constructs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-build (sequence . body)
-  (build-content-list body))
+(tm-build (sequence . body) (build-content-list body))
 
-(tm-build (let bindings . body)
-  `(let* ,bindings
-     ,(build-content-list body)))
+(tm-build (let bindings . body) `(let* ,bindings ,(build-content-list body)))
 
-(tm-build (quote x)
-  `(list ',x))
+(tm-build 'x `(list (quote ,x)))
 
 (tm-build (with . body)
   (let* ((bindings (with-bindings options))
-	 (fun (lambda (x) `(with ,@bindings ,x)))
-	 (builder (build-content-list body)))
-    `(map ,fun ,builder)))
+         (fun (lambda (x) `(with ,@bindings ,x)))
+         (builder (build-content-list body))
+        ) ;
+    `(map ,fun ,builder)
+  ) ;let*
+) ;tm-build
 
 (tm-define (concat l)
   (cond ((null? l) "")
-	((null? (cdr l)) (car l))
-	(else (cons 'concat l))))
+        ((null? (cdr l)) (car l))
+        (else (cons 'concat l))
+  ) ;cond
+) ;tm-define
 
-(tm-build (concat . body)
-  `(list (concat ,(build-content-list body))))
+(tm-build (concat . body) `(list (concat ,(build-content-list body))))
 
 (tm-define (document l)
   (cond ((null? l) "")
-	((null? (cdr l)) (car l))
-	(else (cons 'document l))))
+        ((null? (cdr l)) (car l))
+        (else (cons 'document l))
+  ) ;cond
+) ;tm-define
 
-(tm-build (document . body)
-  `(list (document ,(build-content-list body))))
+(tm-build (document . body) `(list (document ,(build-content-list body))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Fundamental interactive constructs for building widget
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-build (command . cmds)
-  `(list (widget-new-call-back (lambda () ,@cmds))))
+(tm-build (command . cmds) `(list (widget-new-call-back (lambda ,() ,@cmds))))
 
-(tm-build (instruct . cmds)
-  `(begin
-     ,@cmds
-     '()))
+(tm-build (instruct . cmds) `(begin ,@cmds '()))
 
 (tm-define (widget-entry name val type)
   (when (== val :auto)
     (set! val `(begin
-		 (assoc-set! form-type ,name ,type)
-		 (form-auto ,name ,type))))
+                 (assoc-set! form-type ,name ,type)
+                 (form-auto ,name ,type)))
+  ) ;when
   (when (== type "boolean")
-    (set! val `(if ,val "true" "false")))
-  val)
+    (set! val `(if ,val ,"true" ,"false"))
+  ) ;when
+  val
+) ;tm-define
 
-(tm-build (entry name val type)
-  `(list ,(widget-entry name val type)))
+(tm-build (entry name val type) `(list ,(widget-entry name val type)))
 
 (tm-build-macro (internal var val)
-  `(instruct (widget-internal-set! aux-handle ,var ,val)))
+  `(instruct (widget-internal-set! aux-handle ,var ,val))
+) ;tm-build-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Buttons, toggles, alternatives and input fields
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-build-macro (short-input name val)
-  `((quote short-input) ,name (entry ,name ,val "content")))
+  `((quote short-input) ,name (entry ,name ,val ,"content"))
+) ;tm-build-macro
 
 (tm-build-macro (input name val)
-  `((quote wide-input) ,name "0%" (entry ,name ,val "content")))
+  `((quote wide-input) ,name ,"0%" (entry ,name ,val ,"content"))
+) ;tm-build-macro
 
 (tm-build-macro (block-input name val)
-  `((quote block-input) ,name (entry ,name ,val "content")))
+  `((quote block-input) ,name (entry ,name ,val ,"content"))
+) ;tm-build-macro
 
 (tm-build-macro (canvas-input name y1 y2 val)
-  `((quote canvas-input) ,name ,y1 ,y2 "0%" "0%"
-    (entry ,name ,val "content")))
+  `((quote canvas-input)
+    ,name
+    ,y1
+    ,y2
+    ,"0%"
+    ,"0%"
+    (entry ,name ,val ,"content"))
+) ;tm-build-macro
 
 (tm-build-macro (hidden-input name val . body)
-  `((quote hidden-input) ,name (entry ,name ,val "string")
-    (document ,@body)))
+  `((quote hidden-input) ,name (entry ,name ,val ,"string") (document ,@body))
+) ;tm-build-macro
 
 (tm-build-macro (button body . cmds)
-  `((quote button) (concat ,body) (command ,@cmds)))
+  `((quote button) (concat ,body) (command ,@cmds))
+) ;tm-build-macro
 
 (tm-build-macro (toggle name val)
-  `((quote toggle-box) ,name (entry ,name ,val "boolean")))
+  `((quote toggle-box) ,name (entry ,name ,val ,"boolean"))
+) ;tm-build-macro
 
 (tm-build-macro (toggle-button name val . body)
-  `((quote toggle-button) ,name (entry ,name ,val "boolean")
-    (concat ,@body)))
+  `((quote toggle-button) ,name (entry ,name ,val ,"boolean") (concat ,@body))
+) ;tm-build-macro
 
-(tm-build-macro (radio name val)
-  `((quote radio-box) ,name ,val))
+(tm-build-macro (radio name val) `((quote radio-box) ,name ,val))
 
 (tm-build-macro (radio-button name val . body)
-  `((quote radio-button) ,name ,val
-    (concat ,@body)))
+  `((quote radio-button) ,name ,val (concat ,@body))
+) ;tm-build-macro
 
-(tm-build-macro (header-bar . body)
-  `((quote header-bar) (concat ,@body)))
+(tm-build-macro (header-bar . body) `((quote header-bar) (concat ,@body)))
 
 (tm-build-macro (pagelet name val . body)
-  `((quote pagelet) ,name ,val
-    (document ,@body)))
+  `((quote pagelet) ,name ,val (document ,@body))
+) ;tm-build-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tabular constructs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-build-macro (cell . body)
-  (cond ((== body '(>>>)) `(gui-tab))
-	(else `((quote cell) (concat ,@body)))))
+  (cond ((== body '(>>>)) '(gui-tab))
+        (else `((quote cell) (concat ,@body)))
+  ) ;cond
+) ;tm-build-macro
 
 (tm-build-macro (row . body)
   (let* ((make-cell (lambda (x) (if (func? x 'cell) x `(cell ,x))))
-	 (body* (map make-cell body)))
-    `((quote row) ,@body*)))
+         (body* (map make-cell body))
+        ) ;
+    `((quote row) ,@body*)
+  ) ;let*
+) ;tm-build-macro
 
 (tm-build-macro (table . body)
   (let* ((make-row (lambda (x) (if (func? x 'row) x `(row ,@x))))
-	 (body* (map make-row body)))
-    `((quote table) ,@body*)))
+         (body* (map make-row body))
+        ) ;
+    `((quote table) ,@body*)
+  ) ;let*
+) ;tm-build-macro
 
 (define (range-start x)
   (cond ((number? x) (number->string x))
-	((== x '*) "1")
-	((list-2? x) (number->string (car x)))
-	(else "1")))
+        ((== x '*) "1")
+        ((list-2? x) (number->string (car x)))
+        (else "1")
+  ) ;cond
+) ;define
 
 (define (range-end x)
   (cond ((number? x) (number->string x))
-	((== x '*) "-1")
-	((list-2? x) (number->string (car x)))
-	(else "-1")))
+        ((== x '*) "-1")
+        ((list-2? x) (number->string (car x)))
+        (else "-1")
+  ) ;cond
+) ;define
 
 (define (table-attribute x)
   (cond ((string-starts? (keyword->string (car x)) "table-")
-	 `(twith ,(keyword->string (car x)) ,(cadr x)))
-	((string-starts? (keyword->string (car x)) "cell-")
-	 `(cwith ,(range-start (cadr x)) ,(range-end (cadr x))
-		 ,(range-start (caddr x)) ,(range-end (caddr x))
-		 ,(keyword->string (car x)) ,(cadddr x)))
-	(else #f)))
+         `(twith ,(keyword->string (car x)) ,(cadr x))
+        ) ;
+        ((string-starts? (keyword->string (car x)) "cell-")
+         `(cwith ,(range-start (cadr x))
+            ,(range-end (cadr x))
+            ,(range-start (caddr x))
+            ,(range-end (caddr x))
+            ,(keyword->string (car x))
+            ,(cadddr x))
+        ) ;
+        (else #f)
+  ) ;cond
+) ;define
 
 (tm-define-macro (tm-build-table name rows)
-  `(with attrs (filter-map table-attribute options)
+  `(with attrs
+     (filter-map table-attribute options)
      (set! options (list-filter options (non table-attribute)))
-     (list '(quote ,name)
-	   (rcons (cons 'tformat attrs)
-		  (cons 'table ,rows)))))
+     (list (quote (quote ,name))
+       (rcons (cons 'tformat attrs) (cons 'table ,rows))))
+) ;tm-define-macro
 
-(tm-build-macro (dense-tile . rows)
-  (tm-build-table dense-tile rows))
+(tm-build-macro (dense-tile . rows) (tm-build-table dense-tile rows))
 
-(tm-build-macro (short-tile . rows)
-  (tm-build-table short-tile rows))
+(tm-build-macro (short-tile . rows) (tm-build-table short-tile rows))
 
 (tm-build-macro (association-tile . rows)
-  (tm-build-table association-tile rows))
+  (tm-build-table association-tile rows)
+) ;tm-build-macro
 
-(tm-build-macro (tile . rows)
-  (tm-build-table wide-tile rows))
+(tm-build-macro (tile . rows) (tm-build-table wide-tile rows))
 
-(tm-build-macro (dense-bar . cells)
-  (tm-build-table dense-tile (list cells)))
+(tm-build-macro (dense-bar . cells) (tm-build-table dense-tile (list cells)))
 
-(tm-build-macro (short-bar . cells)
-  (tm-build-table short-tile (list cells)))
+(tm-build-macro (short-bar . cells) (tm-build-table short-tile (list cells)))
 
-(tm-build-macro (bar . cells)
-  (tm-build-table wide-tile (list cells)))
+(tm-build-macro (bar . cells) (tm-build-table wide-tile (list cells)))

--- a/TeXmacs/progs/kernel/old-gui/old-gui-form.scm
+++ b/TeXmacs/progs/kernel/old-gui/old-gui-form.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel old-gui old-gui-form)
-  (:use (kernel old-gui old-gui-factory)))
+  (:use (kernel old-gui old-gui-factory))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Typed form entries
@@ -20,139 +21,165 @@
 
 (tm-define (default-value-of-type type)
   (cond ((in? type '("string" "password" "file")) "")
-	((== type "boolean") #f)
-	((== type "integer") 0)
-	((== type "floating") 0.0)
-	((== type "content") "")
-	((== type "tree") (tree ""))
-	(else "")))
+        ((== type "boolean") #f)
+        ((== type "integer") 0)
+        ((== type "floating") 0.0)
+        ((== type "content") "")
+        ((== type "tree") (tree ""))
+        (else "")
+  ) ;cond
+) ;tm-define
 
 (tm-define (form->type val type)
   (cond ((in? type '("string" "password" "file")) (tree->string val))
-	((== type "boolean") (== (tree->string val) "true"))
-	((== type "integer") (string->number (tree->string val)))
-	((== type "floating") (string->number (tree->string val)))
-	((== type "content") (tree->stree val))
-	((== type "tree") val)
-	(else val)))
+        ((== type "boolean") (== (tree->string val) "true"))
+        ((== type "integer") (string->number (tree->string val)))
+        ((== type "floating") (string->number (tree->string val)))
+        ((== type "content") (tree->stree val))
+        ((== type "tree") val)
+        (else val)
+  ) ;cond
+) ;tm-define
 
 (tm-define (type->form val type)
   (cond ((in? type '("string" "password" "file")) (string->tree val))
-	((== type "boolean") (string->tree (if val "true" "false")))
-	((== type "integer") (string->tree (number->string val)))
-	((== type "floating") (string->tree (number->string val)))
-	((== type "content") (stree->tree val))
-	((== type "tree") val)
-	((not (tree? val)) (tree ""))
-	(else val)))
+        ((== type "boolean") (string->tree (if val "true" "false")))
+        ((== type "integer") (string->tree (number->string val)))
+        ((== type "floating") (string->tree (number->string val)))
+        ((== type "content") (stree->tree val))
+        ((== type "tree") val)
+        ((not (tree? val)) (tree ""))
+        (else val)
+  ) ;cond
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Subroutines for remembering previous values of form fields
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (form-load name vars)
-  (learned-interactive name))
+(tm-define (form-load name vars) (learned-interactive name))
 
 (tm-define (form-save name vars vals)
-  (learn-interactive name (map cons vars vals)))
+  (learn-interactive name (map cons vars vals))
+) ;tm-define
 
 (tm-define (form-get-proposal var type nr memo suggest)
   (if (null? suggest) (set! nr (- nr 1)))
   (if (and (< nr 0) (> (- nr) (length memo))) (set! nr (- (length memo))))
-  (cond ((and (< nr 0) (assoc-ref (list-ref memo (- -1 nr)) var)) =>
-	 identity)
-	((with l (assoc-ref suggest var)
-	   (and l (>= nr 0) (< nr (length l)) (list-ref l nr))) =>
-	   (lambda (x) (tree->stree (type->form x type))))
-	(else (tree->stree (type->form (default-value-of-type type) type)))))
+  (cond ((and (< nr 0) (assoc-ref (list-ref memo (- -1 nr)) var)) => identity)
+        ((with l
+           (assoc-ref suggest var)
+           (and l (>= nr 0) (< nr (length l)) (list-ref l nr))
+         ) ;with
+         =>
+         (lambda (x) (tree->stree (type->form x type)))
+        ) ;
+        (else (tree->stree (type->form (default-value-of-type type) type)))
+  ) ;cond
+) ;tm-define
 
 (tm-define (form-fill-out var type nr memo suggest)
-  (with val (form-get-proposal var type nr memo suggest)
-    (widget-set! var val)))
+  (with val (form-get-proposal var type nr memo suggest) (widget-set! var val))
+) ;tm-define
 
 (tm-define (form-equalize positions)
   (when (nnull? positions)
-    (with pos (cdar positions)
-      (map (lambda (x) (cons (car x) pos)) positions))))
+    (with pos (cdar positions) (map (lambda (x) (cons (car x) pos)) positions))
+  ) ;when
+) ;tm-define
 
 (tm-define (form-increment positions plus start end)
-  (with inside (lambda (p) (min (max p start) end))
-    (map (lambda (x) (cons (car x) (inside (+ (cdr x) plus)))) positions)))
+  (with inside
+    (lambda (p) (min (max p start) end))
+    (map (lambda (x) (cons (car x) (inside (+ (cdr x) plus)))) positions)
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Forms
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-build (form proto . body)
-  (with (name . vars) proto
-    (with f (lambda (x) (if (string? x) (cons x #f) (cons (car x) (cadr x))))
-      (set! vars (map f vars)))
+  (with (name . vars)
+    proto
+    (with f
+      (lambda (x) (if (string? x) (cons x #f) (cons (car x) (cadr x))))
+      (set! vars (map f vars))
+    ) ;with
     `(let* ((form-name ,name)
-	    (form-vars (map car ',vars))
-	    (form-type ',vars)
-	    (form-types (map cdr form-type))
-	    (form-suggest '())
-	    (form-memo (form-load form-name form-vars))
-	    (form-position (map (cut cons <> 0) form-vars)))
-       (letrec ((form-auto
-		 (lambda (var type)
-		   (form-get-proposal var type 0 form-memo form-suggest)))
-		(form-field-values
-		 (lambda ()
-		   (map widget-ref form-vars)))
-		(form-return-values
-		 (lambda ()
-		   (map form->type (form-field-values) form-types)))
-		(form-ok?
-		 (lambda ()
-		   (== (form-field-values)
-		       (map type->form (form-return-values) form-types))))
-		(form-memorize
-		 (lambda ()
-		   (form-save form-name form-vars (form-field-values)))))
-	 ,(build-content-list body)))))
+            (form-vars (map car (quote ,vars)))
+            (form-type (quote ,vars))
+            (form-types (map cdr form-type))
+            (form-suggest '())
+            (form-memo (form-load form-name form-vars))
+            (form-position (map (cut cons <> 0) form-vars)))
+       (letrec ((form-auto (lambda (var type)
+                             (form-get-proposal var
+                               type
+                               0
+                               form-memo
+                               form-suggest)))
+                (form-field-values (lambda () (map widget-ref form-vars)))
+                (form-return-values (lambda ()
+                                      (map form->type
+                                        (form-field-values)
+                                        form-types)))
+                (form-ok? (lambda ()
+                            (== (form-field-values)
+                              (map type->form (form-return-values) form-types))))
+                (form-memorize (lambda ()
+                                 (form-save form-name
+                                   form-vars
+                                   (form-field-values)))))
+         ,(build-content-list body)))
+  ) ;with
+) ;tm-build
 
 (tm-build (suggestions var l)
-  `(begin
-     (set! form-suggest (assoc-set! form-suggest ,var ,l))
-     '()))
+  `(begin (set! form-suggest (assoc-set! form-suggest ,var ,l)) '())
+) ;tm-build
 
 (tm-build-macro (form-previous)
-  `(button "<less>"
-     ;;(:button-shape "circular")
-     ;;(:button-color "pastel blue")
+  '(button "<less>"
+     ;; (:button-shape "circular")
+     ;; (:button-color "pastel blue")
      (set! form-position (form-equalize form-position))
      (let* ((start (- (if (null? form-suggest) 1 0) (length form-memo)))
-	    (lengths (map length (map cdr form-suggest)))
-	    (end (if (null? lengths) 0 (max 0 (- (apply max lengths) 1)))))
+            (lengths (map length (map cdr form-suggest)))
+            (end (if (null? lengths) 0 (max 0 (- (apply max lengths) 1)))))
        (set! form-position (form-increment form-position -1 start end)))
      (for-each (cut form-fill-out <> <> <> form-memo form-suggest)
-	       form-vars (map cdr form-type) (map cdr form-position))))
+       form-vars
+       (map cdr form-type)
+       (map cdr form-position)))
+) ;tm-build-macro
 
 (tm-build-macro (form-next)
-  `(button "<gtr>"
-     ;;(:button-shape "circular")
-     ;;(:button-color "pastel blue")
+  '(button "<gtr>"
+     ;; (:button-shape "circular")
+     ;; (:button-color "pastel blue")
      (set! form-position (form-equalize form-position))
      (let* ((start (- (if (null? form-suggest) 1 0) (length form-memo)))
-	    (lengths (map length (map cdr form-suggest)))
-	    (end (if (null? lengths) 0 (max 0 (- (apply max lengths) 1)))))
+            (lengths (map length (map cdr form-suggest)))
+            (end (if (null? lengths) 0 (max 0 (- (apply max lengths) 1)))))
        (set! form-position (form-increment form-position 1 start end)))
      (for-each (cut form-fill-out <> <> <> form-memo form-suggest)
-	       form-vars (map cdr form-type) (map cdr form-position))))
+       form-vars
+       (map cdr form-type)
+       (map cdr form-position)))
+) ;tm-build-macro
 
-(tm-build-macro (form-cancel)
-  `(button "Cancel" (dismiss)))		 
+(tm-build-macro (form-cancel) '(button "Cancel" (dismiss)))
 
 (tm-build-macro (form-done body fun)
   `(button ,body
      (when (form-ok?)
-       (with args (form-return-values)
-	 (form-memorize)
-	 (dismiss)
-	 (delayed
-	   (:idle 1)
-	   (apply ,fun args))))))
+       (with args
+         (form-return-values)
+         (form-memorize)
+         (dismiss)
+         (delayed (:idle 1) (apply ,fun args)))))
+) ;tm-build-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Building forms for interactive functions
@@ -162,46 +189,58 @@
   (:argument num "content" "Numerator")
   (:argument den "content" "Denominator")
   (:proposals num '("1" "x" "a+b"))
-  (insert `(frac ,num ,den)))
+  (insert `(frac ,num ,den))
+) ;tm-define
 
 (define (interactive-vars args nr)
-  (if (null? args) '()
-      (cons (number->string nr)
-	    (interactive-vars (cdr args) (+ nr 1)))))
+  (if (null? args)
+    '()
+    (cons (number->string nr) (interactive-vars (cdr args) (+ nr 1)))
+  ) ;if
+) ;define
 
 (define (interactive-proposals var proposals)
-  (and (nnull? proposals)
-       `(suggestions ,var ',proposals)))
+  (and (nnull? proposals) `(suggestions ,var (quote ,proposals)))
+) ;define
 
 (define (interactive-field prompt var type)
-  `(,prompt (input ,var :auto)))
+  `(,prompt (input ,var ,:auto))
+) ;define
 
 (define (interactive-fields prompts vars types)
-  (with rows (map interactive-field prompts vars types)
-    `(association-tile ,@rows)))
+  (with rows
+    (map interactive-field prompts vars types)
+    `(association-tile ,@rows)
+  ) ;with
+) ;define
 
 (tm-define (interactive-form fun prompts vars types defaults)
   (:synopsis "Standard form for a simple function application")
-  (with name (or (procedure-string-name fun) "Enter function arguments")
+  (with name
+    (or (procedure-string-name fun) "Enter function arguments")
     `(form (,name ,@(map list vars types))
        ,@(list-filter (map interactive-proposals vars defaults) identity)
        ,(interactive-fields prompts vars types)
        ===
-       (bar
-	 (form-previous)
-	 (form-next)
-	 >>>
-	 (form-cancel)
-	 (form-done "Ok" ,fun)))))
+       (bar (form-previous)
+         (form-next)
+         >>>
+         (form-cancel)
+         (form-done ,"Ok" ,fun)))
+  ) ;with
+) ;tm-define
 
 (tm-define (interactive-popup fun . args)
   (lazy-define-force fun)
   (if (null? args) (set! args (compute-interactive-args fun)))
   (let* ((name (or (procedure-string-name fun) "Enter function arguments"))
-	 (fun-args (build-interactive-args fun args 0 #f))
-	 (prompts (map car fun-args))
-	 (vars (interactive-vars prompts 0))
-	 (types (map cadr fun-args))
-	 (defaults (map cddr fun-args))
-	 (widget (interactive-form fun prompts vars types defaults)))
-    (widget-popup name widget)))
+         (fun-args (build-interactive-args fun args 0 #f))
+         (prompts (map car fun-args))
+         (vars (interactive-vars prompts 0))
+         (types (map cadr fun-args))
+         (defaults (map cddr fun-args))
+         (widget (interactive-form fun prompts vars types defaults))
+        ) ;
+    (widget-popup name widget)
+  ) ;let*
+) ;tm-define

--- a/TeXmacs/progs/kernel/old-gui/old-gui-test.scm
+++ b/TeXmacs/progs/kernel/old-gui/old-gui-test.scm
@@ -15,14 +15,15 @@
 
 (tm-define (open-test-widget)
   ;; NOTE: close with Done in order to test other widgets
-  (widget-popup "Test" '(widget-4)))
+  (widget-popup "Test" '(widget-4))
+) ;tm-define
 
 (tm-build-widget (widget-1)
   "Hallo, hier komt een lange regel met tekst."
-  (concat "Links" >>> "Rechts"))
+  (concat "Links" >>> "Rechts")
+) ;tm-build-widget
 
-(tm-build-widget (widget-2)
-  (concat "a+" (frac "1" "2")))
+(tm-build-widget (widget-2) (concat "a+" (frac "1" "2")))
 
 (tm-build-widget (widget-3 given)
   (center (concat (strong "Different types of data") (vspace "0.5em")))
@@ -31,85 +32,94 @@
     (input "visible" "")
     ===
     (with (:button-shape "invisible")
-      (bar
-	(button "Parameter" (display* ,given "\n"))
-	(button "Hidden" (display* hidden "\n"))
-	(button "Internal" (display* (internal-ref "internal") "\n"))
-	(button "Visible" (display* (widget-ref "visible") "\n"))
-	>>>
-	(button "Done" (dismiss))))))
+      (bar (button "Parameter" (display* ,given "\n"))
+        (button "Hidden" (display* hidden "\n"))
+        (button "Internal" (display* (internal-ref "internal") "\n"))
+        (button "Visible" (display* (widget-ref "visible") "\n"))
+        >>>
+        (button "Done" (dismiss))
+      ) ;bar
+    ) ;with
+  ) ;let
+) ;tm-build-widget
 
 (tm-build-widget (widget-4)
-  (short-bar
-    (toggle "pressed?" #f)
+  (short-bar (toggle "pressed?" #f)
     (toggle (:box-shape "square") "second?" #f)
-    (toggle-button "third?" #f "Toggle"))
-  (hidden-input "color" "red"
-    (short-bar
-      "Green" (radio (:box-color "pastel green") "color" "green")
-      "Red" (radio (:box-color "pastel red") "color" "red")
-      "Blue" (radio (:box-color "pastel blue") "color" "blue")))
-  (short-bar
-    (button "Toggles"
-      (display* (widget-ref "pressed?") ", "
-		(widget-ref "second?") ", "
-		(widget-ref "third?") "\n"))
-    (button "Radio buttons"
-      (display* (widget-ref "color") "\n"))
-    (button "Done" (dismiss))))
+    (toggle-button "third?" #f "Toggle")
+  ) ;short-bar
+  (hidden-input "color"
+    "red"
+    (short-bar "Green"
+      (radio (:box-color "pastel green") "color" "green")
+      "Red"
+      (radio (:box-color "pastel red") "color" "red")
+      "Blue"
+      (radio (:box-color "pastel blue") "color" "blue")
+    ) ;short-bar
+  ) ;hidden-input
+  (short-bar (button "Toggles"
+               (display* (widget-ref "pressed?")
+                 ", "
+                 (widget-ref "second?")
+                 ", "
+                 (widget-ref "third?")
+                 "\n"
+               ) ;display*
+             ) ;button
+    (button "Radio buttons" (display* (widget-ref "color") "\n"))
+    (button "Done" (dismiss))
+  ) ;short-bar
+) ;tm-build-widget
 
 (tm-build-widget (widget-5)
-  (association-tile
-    (:font-shape "italic")
-    ("From:" (input "First" ""))
-    ("To:" (input "Second" "")))
+  (association-tile (:font-shape "italic")
+   ("From:" (input "First" ""))
+   ("To:" (input "Second" ""))
+  ) ;association-tile
   ===
-  (bar
-    (button "Copy" (widget-set! "Second" (widget-ref "First")))
+  (bar (button "Copy" (widget-set! "Second" (widget-ref "First")))
     (button "Clear" (widget-set! "Second" ""))
     >>>
-    (button "Done" (dismiss))))
+    (button "Done" (dismiss))
+  ) ;bar
+) ;tm-build-widget
 
 (tm-build-widget (widget-6)
   (let ((nr 0)
-	(busy #f)
-	(sync (lambda () (widget-set! "Output" (tree (number->string nr)))))
-	(inc (lambda () (set! nr (+ nr 1)) (sync))))
+        (busy #f)
+        (sync (lambda () (widget-set! "Output" (tree (number->string nr)))))
+        (inc (lambda () (set! nr (+ nr 1)) (sync)))
+       ) ;
     (input "Output" "0")
     ===
-    (bar
-      (button "Start"
-	(when (not busy)
-	  (set! busy #t)
-	  (widget-delayed
-	    (:while busy)
-	    (:every 1000)
-	    (inc))))
-      (button "End"
-	(set! busy #f))
-      (button "Reset"
-	(set! nr 0)
-	(sync))
-      (button "Increase"
-	(inc))
+    (bar (button "Start"
+           (when (not busy)
+             (set! busy #t)
+             (widget-delayed (:while busy) (:every 1000) (inc))
+           ) ;when
+         ) ;button
+      (button "End" (set! busy #f))
+      (button "Reset" (set! nr 0) (sync))
+      (button "Increase" (inc))
       >>>
-      (button "Done"
-	(dismiss)))))
+      (button "Done" (dismiss))
+    ) ;bar
+  ) ;let
+) ;tm-build-widget
 
 (tm-build-widget (widget-7)
-  (hidden-input "page" "1"
-    (header-bar
-      (radio-button "page" "1" "First")
+  (hidden-input "page"
+    "1"
+    (header-bar (radio-button "page" "1" "First")
       (radio-button "page" "2" "Second")
-      (radio-button "page" "3" "Third"))
-    (pagelet "page" "1"
-      "Hallo"
-      "Hop")
-    (pagelet "page" "2"
-      "Blah"
-      "Boem")
-    (pagelet "page" "3"
-      "Einde verhaal")))
+      (radio-button "page" "3" "Third")
+    ) ;header-bar
+    (pagelet "page" "1" "Hallo" "Hop")
+    (pagelet "page" "2" "Blah" "Boem")
+    (pagelet "page" "3" "Einde verhaal")
+  ) ;hidden-input
+) ;tm-build-widget
 
 (tm-build-widget (widget-8)
   "Input:"
@@ -118,94 +128,113 @@
   "Output:"
   (math (block-input "output" ""))
   ===
-  (bar
-    (button "Differentiate"
-      (widget->script "tmin" "input")
-      (script->widget "output" "diff(tmin,x)"))
+  (bar (button "Differentiate"
+         (widget->script "tmin" "input")
+         (script->widget "output" "diff(tmin,x)")
+       ) ;button
     (button "Integrate"
       (widget->script "tmin" "input")
-      (script->widget "output" "integrate(tmin,x)"))
+      (script->widget "output" "integrate(tmin,x)")
+    ) ;button
     (button "Taylor series"
       (widget->script "tmin" "input")
-      (script->widget "output" "taylor(tmin,x,0,25)"))
+      (script->widget "output" "taylor(tmin,x,0,25)")
+    ) ;button
     >>>
-    (button "Done" (dismiss))))
+    (button "Done" (dismiss))
+  ) ;bar
+) ;tm-build-widget
 
 (tm-build-widget (widget-9)
   (form ("test" "first" "second")
     (suggestions "first" '("hallo" "hop"))
-    (association-tile
-      ("First input:" (input "first" :auto))
-      ("Second input:" (input "second" :auto)))
+    (association-tile ("First input:" (input "first" :auto))
+     ("Second input:" (input "second" :auto))
+    ) ;association-tile
     ===
-    (bar
-      (form-previous)
+    (bar (form-previous)
       (form-next)
       >>>
       (form-cancel)
-      (form-done "Ok" (lambda (x y) (display* x ", " y "\n"))))))
+      (form-done "Ok" (lambda (x y) (display* x ", " y "\n")))
+    ) ;bar
+  ) ;form
+) ;tm-build-widget
 
 (tm-build-widget (widget-10)
   (canvas-input "canvas" "-6em" "6em" "")
   ===
-  (bar
-    (button "Display" (display* (widget-ref "canvas") "\n"))
+  (bar (button "Display" (display* (widget-ref "canvas") "\n"))
     >>>
-    (button "Done" (dismiss))))
+    (button "Done" (dismiss))
+  ) ;bar
+) ;tm-build-widget
 
 (tm-build-widget (print-widget)
-  (center
-    (short-tile
-      (:cell-halign * 1 "r")
-      (:cell-lsep * -1 "2em")
-      ("Printer:"
-       (short-input (:short-width "10em") "printer" "default")
-       (button (small "Configure")
-	  (:button-shape "invisible")
-	  (with name (tree->string (widget-ref "printer"))
-	    (widget-popup "Printer configuration"
-	      `(configure-printer-widget ,name)))))
-      ("Options:"
-       (short-input (:short-width "10em") "options" "default")
-       (button (small "Configure")
-	  (with type (tree->string (widget-ref "printer"))
-	    (widget-popup "Printer options configuration"
-	      `(configure-printer-options-widget ,type)))))))
+  (center (short-tile (:cell-halign * 1 "r")
+            (:cell-lsep * -1 "2em")
+            ("Printer:"
+              (short-input (:short-width "10em") "printer" "default")
+              (button (small "Configure")
+                (:button-shape "invisible")
+                (with name
+                  (tree->string (widget-ref "printer"))
+                  (widget-popup "Printer configuration" `(configure-printer-widget ,name))
+                ) ;with
+              ) ;button
+            ) ;
+            ("Options:"
+              (short-input (:short-width "10em") "options" "default")
+              (button (small "Configure")
+                (with type
+                  (tree->string (widget-ref "printer"))
+                  (widget-popup "Printer options configuration"
+                    `(configure-printer-options-widget ,type)
+                  ) ;widget-popup
+                ) ;with
+              ) ;button
+            ) ;
+          ) ;short-tile
+  ) ;center
   ---
-  (center
-    (short-tile
-      (:cell-halign * 1 "r")
-      ("Pages:" (concat (short-input (:short-width "2em") "first" "1") " -- "
-			(short-input (:short-width "2em") "last" "1")))
-      ("Copies:" (short-input (:short-width "2em") "number" "1"))))
+  (center (short-tile (:cell-halign * 1 "r")
+           ("Pages:"
+             (concat (short-input (:short-width "2em") "first" "1")
+               " -- "
+               (short-input (:short-width "2em") "last" "1")
+             ) ;concat
+           ) ;
+           ("Copies:" (short-input (:short-width "2em") "number" "1"))
+          ) ;short-tile
+  ) ;center
   ---
-  (bar
-    (button "Preview" (noop))
+  (bar (button "Preview" (noop))
     (button "Export" (noop))
     >>>
     (button "Cancel" (dismiss))
-    (button "Print" (noop))))
+    (button "Print" (noop))
+  ) ;bar
+) ;tm-build-widget
 
 (tm-build-widget (configure-printer-widget which)
   (let ((name ,which)
-	(cmd (if (== name "default") "lpr" (string-append "lpr -P" name))))
+        (cmd (if (== name "default") "lpr" (string-append "lpr -P" name)))
+       ) ;
     (form ("configure-printer" "name" "command" "paper" "dpi")
       (suggestions "name" (list name))
       (suggestions "command" (list cmd))
       (suggestions "paper" (list "a4"))
       (suggestions "dpi" (list "600"))
-      (association-tile
-	("Printer name:" (input "name" :auto))
-	("Printing command:" (input "command" :auto))
-	("Paper format:" (input "paper" :auto))
-	("Dots per inch:" (input "dpi" :auto)))
+      (association-tile ("Printer name:" (input "name" :auto))
+       ("Printing command:" (input "command" :auto))
+       ("Paper format:" (input "paper" :auto))
+       ("Dots per inch:" (input "dpi" :auto))
+      ) ;association-tile
       ===
-      (bar
-	(form-previous)
-	(form-next)
-	>>>
-	(form-cancel)
-	(form-done "Save" ignore)))))
+      (bar (form-previous) (form-next) >>> (form-cancel) (form-done "Save" ignore))
+    ) ;form
+  ) ;let
+) ;tm-build-widget
 
 (tm-build-widget (configure-printer-options-widget which)
   (let ((type ,which))
@@ -214,18 +243,16 @@
       (suggestions "parity" (list "all"))
       (suggestions "reduce" (list "1"))
       (suggestions "booklet" (list "false"))
-      (association-tile
-	("Printer options type:" (input "type" :auto))
-	("Filter pages:" (input "parity" :auto))
-	("Document pages per page:" (input "reduce" :auto))
-	("Reorder pages as booklet:" (toggle "booklet" :auto)))
+      (association-tile ("Printer options type:" (input "type" :auto))
+       ("Filter pages:" (input "parity" :auto))
+       ("Document pages per page:" (input "reduce" :auto))
+       ("Reorder pages as booklet:" (toggle "booklet" :auto))
+      ) ;association-tile
       ===
-      (bar
-	(form-previous)
-	(form-next)
-	>>>
-	(form-cancel)
-	(form-done "Save" ignore)))))
+      (bar (form-previous) (form-next) >>> (form-cancel) (form-done "Save" ignore))
+    ) ;form
+  ) ;let
+) ;tm-build-widget
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Regtest routines for old-gui widgets
@@ -233,53 +260,30 @@
 
 (define (regtest-old-gui-widgets)
   ;; Basic test to ensure old-gui module loads without errors
-  (regression-test-group
-   "old-gui" "widgets"
-   values values
-   (test "module loaded successfully" 
-     #t 
-     #t)
-   (test "tm-build-widget macro available" 
-     (defined? 'tm-build-widget) 
-     #t)
-   (test "widget-popup function available" 
-     (defined? 'widget-popup) 
-     #t)
-   (test "widget-ref function available" 
-     (defined? 'widget-ref) 
-     #t)
-   (test "widget-set! function available" 
-     (defined? 'widget-set!) 
-     #t)
-   (test "widget-delayed function available" 
-     (defined? 'widget-delayed) 
-     #t)
-   (test "widget->script function available" 
-     (defined? 'widget->script) 
-     #t)
-   (test "script->widget function available" 
-     (defined? 'script->widget) 
-     #t)
-   (test "display* function available" 
-     (defined? 'display*) 
-     #t)
-   (test "noop function available" 
-     (defined? 'noop) 
-     #t)
-   (test "tree->string function available" 
-     (defined? 'tree->string) 
-     #t)
-   (test "string-append function available" 
-     (defined? 'string-append) 
-     #t)
-   (test "list function available" 
-     (defined? 'list) 
-     #t)
-   (test "concat function available" 
-     (defined? 'concat) 
-     #t)))
+  (regression-test-group "old-gui"
+    "widgets"
+    values
+    values
+    (test "module loaded successfully" #t #t)
+    (test "tm-build-widget macro available" (defined? 'tm-build-widget) #t)
+    (test "widget-popup function available" (defined? 'widget-popup) #t)
+    (test "widget-ref function available" (defined? 'widget-ref) #t)
+    (test "widget-set! function available" (defined? 'widget-set!) #t)
+    (test "widget-delayed function available" (defined? 'widget-delayed) #t)
+    (test "widget->script function available" (defined? 'widget->script) #t)
+    (test "script->widget function available" (defined? 'script->widget) #t)
+    (test "display* function available" (defined? 'display*) #t)
+    (test "noop function available" (defined? 'noop) #t)
+    (test "tree->string function available" (defined? 'tree->string) #t)
+    (test "string-append function available" (defined? 'string-append) #t)
+    (test "list function available" (defined? 'list) #t)
+    (test "concat function available" (defined? 'concat) #t)
+  ) ;regression-test-group
+) ;define
 
 (tm-define (regtest-old-gui)
   (let ((n (regtest-old-gui-widgets)))
     (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-old-gui: ok\n")))
+    (display "Test suite of regtest-old-gui: ok\n")
+  ) ;let
+) ;tm-define

--- a/TeXmacs/progs/kernel/old-gui/old-gui-widget.scm
+++ b/TeXmacs/progs/kernel/old-gui/old-gui-widget.scm
@@ -18,24 +18,26 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define widget-call-back-nr 0)
+
 (define widget-call-back-table (make-ahash-table))
 
 (tm-define (widget-call-back handle)
   (:secure #t)
-  (and-with fun (ahash-ref widget-call-back-table handle)
-    (fun)))
+  (and-with fun (ahash-ref widget-call-back-table handle) (fun))
+) ;tm-define
 
 (tm-define (widget-new-call-back fun)
   (set! widget-call-back-nr (+ widget-call-back-nr 1))
   (ahash-set! widget-call-back-table widget-call-back-nr fun)
-  (string-append "(widget-call-back "
-		 (number->string widget-call-back-nr)
-		 ")"))
+  (string-append "(widget-call-back " (number->string widget-call-back-nr) ")")
+) ;tm-define
 
 (tm-define (widget-delete-call-backs start end)
   (when (< start end)
     (ahash-set! widget-call-back-table start #f)
-    (widget-delete-call-backs (+ start 1) end)))
+    (widget-delete-call-backs (+ start 1) end)
+  ) ;when
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Internal widget fields
@@ -44,30 +46,44 @@
 (define widget-internal-table (make-ahash-table))
 
 (tm-define (widget-internal-new handle)
-  (ahash-set! widget-internal-table handle (make-ahash-table)))
+  (ahash-set! widget-internal-table handle (make-ahash-table))
+) ;tm-define
 
 (tm-define (widget-internal-delete handle)
-  (ahash-remove! widget-internal-table handle))
+  (ahash-remove! widget-internal-table handle)
+) ;tm-define
 
 (tm-define (widget-internal-set! handle var val)
-  (and-with t (ahash-ref widget-internal-table handle)
-    (ahash-set! t var val)))
+  (and-with t (ahash-ref widget-internal-table handle) (ahash-set! t var val))
+) ;tm-define
 
 (tm-define (widget-internal-ref handle var)
-  (and-with t (ahash-ref widget-internal-table handle)
-    (ahash-ref t var)))
+  (and-with t (ahash-ref widget-internal-table handle) (ahash-ref t var))
+) ;tm-define
 
 (tm-define (internal-set! var val)
   (when (context-has? "widget-prefix")
-    (and-with handle* (get-env "widget-prefix")
-      (with handle (if (== handle* "") "" (string-drop-right handle* 1))
-	(widget-internal-set! handle var val)))))
+    (and-with handle*
+      (get-env "widget-prefix")
+      (with handle
+        (if (== handle* "") "" (string-drop-right handle* 1))
+        (widget-internal-set! handle var val)
+      ) ;with
+    ) ;and-with
+  ) ;when
+) ;tm-define
 
 (tm-define (internal-ref var)
   (when (context-has? "widget-prefix")
-    (and-with handle* (get-env "widget-prefix")
-      (with handle (if (== handle* "") "" (string-drop-right handle* 1))
-	(widget-internal-ref handle var)))))
+    (and-with handle*
+      (get-env "widget-prefix")
+      (with handle
+        (if (== handle* "") "" (string-drop-right handle* 1))
+        (widget-internal-ref handle var)
+      ) ;with
+    ) ;and-with
+  ) ;when
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The widget prefix and delayed evaluation
@@ -77,32 +93,31 @@
 
 (tm-define-macro (widget-with prefix . body)
   (:secure #t)
-  `(let ((new-prefix ,prefix)
-	 (old-prefix widget-prefix))
+  `(let ((new-prefix ,prefix) (old-prefix widget-prefix))
      (set! widget-prefix new-prefix)
-     (let ((result (begin ,@body)))
-       (set! widget-prefix old-prefix)
-       result)))
+     (let ((result (begin ,@body))) (set! widget-prefix old-prefix) result))
+) ;tm-define-macro
 
 (define (widget-get-prefix opt-prefix)
   (cond ((null? opt-prefix) widget-prefix)
-	((tree? (car opt-prefix)) (tree->string (car opt-prefix)))
-	(else (car opt-prefix))))
+        ((tree? (car opt-prefix)) (tree->string (car opt-prefix)))
+        (else (car opt-prefix))
+  ) ;cond
+) ;define
 
-(tm-define-macro (widget-delay . body)
-  (:secure #t)
-  `(delayed
-     (:idle 1)
-     ,@body))
+(tm-define-macro (widget-delay . body) (:secure #t) `(delayed (:idle 1) ,@body))
 
 (tm-define-macro (widget-delayed . body)
-  (with normal? (lambda (x) (or (npair? x) (not (keyword? (car x)))))
-    (receive (mods cmds) (list-break body normal?)
-      `(with widget-delayed-prefix widget-prefix
-	 (delayed
-	   ,@mods
-	   (widget-with widget-delayed-prefix
-	     ,@cmds))))))
+  (with normal?
+    (lambda (x) (or (npair? x) (not (keyword? (car x)))))
+    (receive (mods cmds)
+      (list-break body normal?)
+      `(with widget-delayed-prefix
+         widget-prefix
+         (delayed ,@mods (widget-with widget-delayed-prefix ,@cmds)))
+    ) ;receive
+  ) ;with
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Input and output
@@ -112,14 +127,20 @@
   (:secure #t)
   (if (tree? handle) (set! handle (tree->string handle)))
   (let* ((prefix (widget-get-prefix opt-prefix))
-	 (l (id->trees (string-append prefix handle))))
-    (and l (nnull? l) (car l))))
+         (l (id->trees (string-append prefix handle)))
+        ) ;
+    (and l (nnull? l) (car l))
+  ) ;let*
+) ;tm-define
 
 (tm-define (widget-set! handle new-tree . opt-prefix)
   (:secure #t)
   (if (tree? handle) (set! handle (tree->string handle)))
-  (and-with old-tree (apply widget-ref (cons handle opt-prefix))
-    (tree-set! old-tree (tree-copy (tm->tree new-tree)))))
+  (and-with old-tree
+    (apply widget-ref (cons handle opt-prefix))
+    (tree-set! old-tree (tree-copy (tm->tree new-tree)))
+  ) ;and-with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Armouring widgets
@@ -129,27 +150,27 @@
 
 (tm-define (widget-armour body)
   `(let* ((aux-handle widget-serial-number)
-	  (aux-num (number->string aux-handle))
-	  (aux-serial (string-append "widget-" aux-num))
-	  (aux-begin (+ widget-call-back-nr 1))
-	  (aux-end (+ widget-call-back-nr 1))
-	  (aux-result #f)
-	  (internal-ref
-	   (lambda (var)
-	     (widget-internal-ref aux-handle var)))
-	  (internal-set!
-	   (lambda (var val)
-	     (widget-internal-set! aux-handle var val)))
-	  (dismiss
-	   (lambda ()
-	     (widget-delete-call-backs aux-begin aux-end)
-	     (widget-internal-delete aux-handle)
-	     (kill-current-window-and-buffer))))
+          (aux-num (number->string aux-handle))
+          (aux-serial (string-append "widget-" aux-num))
+          (aux-begin (+ widget-call-back-nr 1))
+          (aux-end (+ widget-call-back-nr 1))
+          (aux-result #f)
+          (internal-ref (lambda (var) (widget-internal-ref aux-handle var)))
+          (internal-set! (lambda (var val)
+                           (widget-internal-set! aux-handle var val)))
+          (dismiss (lambda ()
+                     (widget-delete-call-backs aux-begin aux-end)
+                     (widget-internal-delete aux-handle)
+                     (kill-current-window-and-buffer))))
      (set! widget-serial-number (+ widget-serial-number 1))
      (widget-internal-new aux-handle)
      (set! aux-result ,body)
      (set! aux-end (+ widget-call-back-nr 1))
-     `(widget ,aux-serial (document ,@aux-result))))
+     (#_list-values
+      'widget
+      aux-serial
+      (#_list-values 'document (#_apply-values aux-result))))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Stand-alone widgets
@@ -157,20 +178,26 @@
 
 (define (stand-alone body)
   (let* ((style '(tuple "generic" "gui"))
-	 (init '(collection (associate "window-bars" "false")
-			    (associate "prog-scripts" "maxima"))))
-    `(document (style ,style) (body ,body) (initial ,init))))
+         (init '(collection (associate "window-bars" "false")
+                  (associate "prog-scripts" "maxima"))
+         ) ;init
+        ) ;
+    `(document (style ,style) (body ,body) (initial ,init))
+  ) ;let*
+) ;define
 
-(tm-define (widget-build w)
-  (tm->tree (eval (widget-armour (build-content w)))))
+(tm-define (widget-build w) (tm->tree (eval (widget-armour (build-content w)))))
 
 (tm-define (widget-popup aux w)
   (let* ((name (aux-name aux))
          (master (buffer-master))
          (body* (tm->tree (eval (widget-armour (build-content w)))))
-	 (body `(document (disable-writability ,body*)))
-	 (doc (stand-alone body))
-	 (geom (tree-extents doc)))
+         (body `(document (disable-writability ,body*)))
+         (doc (stand-alone body))
+         (geom (tree-extents doc))
+        ) ;
     (aux-set-document aux doc)
     (aux-set-master aux (buffer-master))
-    (open-buffer-in-window name doc geom)))
+    (open-buffer-in-window name doc geom)
+  ) ;let*
+) ;tm-define

--- a/TeXmacs/progs/kernel/regexp/regexp-match.scm
+++ b/TeXmacs/progs/kernel/regexp/regexp-match.scm
@@ -23,22 +23,25 @@
 
 (define-public (bindings-add bl var val)
   "Bind variable @var to @val in @bl if possible."
-  (cond ((assoc-ref bl var)
-	 (if (== (assoc-ref bl var) val) bl #f))
-	(else (cons (cons var val) bl))))
+  (cond ((assoc-ref bl var) (if (== (assoc-ref bl var) val) bl #f))
+        (else (cons (cons var val) bl))
+  ) ;cond
+) ;define-public
 
 (define (match-any l pat bls)
   "Matches for @l == @pat under any of the bindings in @bls."
-  (if (null? bls) '()
-      (append (match l pat (car bls))
-	      (match-any l pat (cdr bls)))))
+  (if (null? bls)
+    '()
+    (append (match l pat (car bls)) (match-any l pat (cdr bls)))
+  ) ;if
+) ;define
 
 (define-macro (match-cup expr1 expr2)
   `(let ((l1 ,expr1))
-     (if (== l1 '(())) '(())
-	 (let ((l2 ,expr2))
-	   (if (== l2 '(())) '(())
-	       (append l1 l2))))))
+     (if (== l1 '(()))
+       '(())
+       (let ((l2 ,expr2)) (if (== l2 '(())) '(()) (append l1 l2)))))
+) ;define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special patterns
@@ -46,46 +49,59 @@
 
 (define (match-or l args pat bl)
   "Matches for @l == @((:or . args) . pat) under bindings @bl."
-  (if (null? args) '()
-      (match-cup (match l (cons (car args) pat) bl)
-		 (match-or l (cdr args) pat bl))))
+  (if (null? args)
+    '()
+    (match-cup (match l (cons (car args) pat) bl) (match-or l (cdr args) pat bl))
+  ) ;if
+) ;define
 
 (define (match-and l args pat bl)
   "Matches for @l == @((:and . args) . pat) under bindings @bl."
-  (if (null? args) (list bl)
-      (match-any l (cons (car args) pat)
-		 (match-and l (cdr args) pat bl))))
+  (if (null? args)
+    (list bl)
+    (match-any l (cons (car args) pat) (match-and l (cdr args) pat bl))
+  ) ;if
+) ;define
 
 (define (match-not l args pat bl)
   "Matches for @l == @((:not . args) . pat) under bindings @bl."
   ;; WARNING: the behaviour of this routine w.r.t. bindings
   ;; has not been investigated in detail
-  (if (or (null? l) (!= (length args) 1)
-	  (nnull? (match l (append args pat) bl)))
-      '()
-      (match (cdr l) pat bl)))
+  (if (or (null? l) (!= (length args) 1) (nnull? (match l (append args pat) bl)))
+    '()
+    (match (cdr l) pat bl)
+  ) ;if
+) ;define
 
 (define (match-repeat l args pat bl)
   "Matches for @l == @((:repeat . args) . pat) under bindings @bl."
-  (if (null? args) '()
-      (match-cup (match l pat bl)
-		 (match l (append args (cons (cons :repeat args) pat)) bl))))
+  (if (null? args)
+    '()
+    (match-cup (match l pat bl)
+      (match l (append args (cons (cons :repeat args) pat)) bl)
+    ) ;match-cup
+  ) ;if
+) ;define
 
 (define (match-group l args pat bl)
   "Matches for @l == @((:group . args) . pat) under bindings @bl."
-  (match l (append args pat) bl))
+  (match l (append args pat) bl)
+) ;define
 
 (define (match-quote l args pat bl)
   "Matches for @l == @((:quote . args) . pat) under bindings @bl."
   (if (or (null? l) (!= (length args) 1) (!= (car l) (car args)))
-      '()
-      (match (cdr l) pat bl)))
+    '()
+    (match (cdr l) pat bl)
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Pattern matching
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public match-term (make-ahash-table))
+
 (define match-table (make-ahash-table))
 (ahash-set! match-table :or match-or)
 (ahash-set! match-table :and match-and)
@@ -96,45 +112,53 @@
 
 (define-public (match l pat bl)
   "Matches for @l == @pat under bindings @bl."
-  (if (null? pat) (if (== l '()) (list bl) '())
-      (let ((fpat (car pat)))
-	(cond ((keyword? fpat)
-	       (let* ((symb (keyword->symbol fpat))
-		      (n (string->number
-			  (string-tail
-			   (symbol->string symb) 1))))
-		 (cond ((== fpat :*) (list bl))
-		       (n (if (>= (length l) n)
-			      (match (list-tail l n) (cdr pat) bl)
-			      '()))
-		       ((null? l) '())
-		       ((ahash-ref match-term fpat)
-			(with upat (ahash-ref match-term fpat)
-			  (match l (append upat (cdr pat)) bl)))
-		       ((not (apply (eval symb) (list (car l)))) '())
-		       (else (match (cdr l) (cdr pat) bl)))))
-	      ((and (list? fpat) (nnull? fpat))
-	       (let ((ffpat (car fpat)))
-		 (cond ((and (keyword? ffpat) (ahash-ref match-table ffpat))
-			(apply (ahash-ref match-table ffpat)
-			       (list l (cdr fpat) (cdr pat) bl)))
-		       ((or (nlist? l) (null? l)) '())
-		       ((== ffpat 'quote)
-			(let ((new-bl (bindings-add bl (cadr fpat) (car l))))
-			  (if new-bl (match (cdr l) (cdr pat) new-bl) '())))
-		       ((list? (car l))
-			(match-any (cdr l) (cdr pat)
-				   (match (car l) fpat bl)))
-		       ((compound-tree? (car l))
-			(match-any (cdr l) (cdr pat)
-				   (match (tree->list (car l)) fpat bl)))
-		       ((string? (car l))
-			(match-any (cdr l) (cdr pat)
-				   (match (string->list (car l)) fpat bl)))
-		       (else '()))))
-	      ((null? l) '())
-	      ((not (tm-equal? (car l) fpat)) '())
-	      (else (match (cdr l) (cdr pat) bl))))))
+  (if (null? pat)
+    (if (== l '()) (list bl) '())
+    (let ((fpat (car pat)))
+      (cond ((keyword? fpat)
+             (let* ((symb (keyword->symbol fpat))
+                    (n (string->number (string-tail (symbol->string symb) 1)))
+                   ) ;
+               (cond ((== fpat :*) (list bl))
+                     (n (if (>= (length l) n) (match (list-tail l n) (cdr pat) bl) '()))
+                     ((null? l) '())
+                     ((ahash-ref match-term fpat)
+                      (with upat (ahash-ref match-term fpat) (match l (append upat (cdr pat)) bl))
+                     ) ;
+                     ((not (apply (eval symb) (list (car l)))) '())
+                     (else (match (cdr l) (cdr pat) bl))
+               ) ;cond
+             ) ;let*
+            ) ;
+            ((and (list? fpat) (nnull? fpat))
+             (let ((ffpat (car fpat)))
+               (cond ((and (keyword? ffpat) (ahash-ref match-table ffpat))
+                      (apply (ahash-ref match-table ffpat) (list l (cdr fpat) (cdr pat) bl))
+                     ) ;
+                     ((or (nlist? l) (null? l)) '())
+                     ((== ffpat 'quote)
+                      (let ((new-bl (bindings-add bl (cadr fpat) (car l))))
+                        (if new-bl (match (cdr l) (cdr pat) new-bl) '())
+                      ) ;let
+                     ) ;
+                     ((list? (car l)) (match-any (cdr l) (cdr pat) (match (car l) fpat bl)))
+                     ((compound-tree? (car l))
+                      (match-any (cdr l) (cdr pat) (match (tree->list (car l)) fpat bl))
+                     ) ;
+                     ((string? (car l))
+                      (match-any (cdr l) (cdr pat) (match (string->list (car l)) fpat bl))
+                     ) ;
+                     (else '())
+               ) ;cond
+             ) ;let
+            ) ;
+            ((null? l) '())
+            ((not (tm-equal? (car l) fpat)) '())
+            (else (match (cdr l) (cdr pat) bl))
+      ) ;cond
+    ) ;let
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; User interface
@@ -143,15 +167,20 @@
 (define-public (define-regexp-grammar-decls l)
   (define (insert rule)
     (if (== (length (cdr rule)) 1)
-        (ahash-set! match-term (car rule) (cdr rule))
-        (ahash-set! match-term (car rule) (list (cons :or (cdr rule))))))
-  (for-each insert l))
+      (ahash-set! match-term (car rule) (cdr rule))
+      (ahash-set! match-term (car rule) (list (cons :or (cdr rule))))
+    ) ;if
+  ) ;define
+  (for-each insert l)
+) ;define-public
 
 (define-public-macro (define-regexp-grammar . l)
-  `(begin
-     (define-regexp-grammar-decls ,(list 'quasiquote l))))
+  `(begin (define-regexp-grammar-decls ,(list 'quasiquote l)))
+) ;define-public-macro
 
 (define-public (match? x pattern)
   "Does @x match the pattern @pat?"
   (let ((sols (match (list x) (list pattern) '())))
-    (if (null? sols) #f sols)))
+    (if (null? sols) #f sols)
+  ) ;let
+) ;define-public

--- a/TeXmacs/progs/kernel/regexp/regexp-select.scm
+++ b/TeXmacs/progs/kernel/regexp/regexp-select.scm
@@ -23,22 +23,31 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (bindings-merge l1 l2)
-  (if (null? l2) l1
-      (with r1 (bindings-add l1 (caar l2) (cdar l2))
-	(if r1 (bindings-merge r1 (cdr l2)) #f))))
+  (if (null? l2)
+    l1
+    (with r1
+      (bindings-add l1 (caar l2) (cdar l2))
+      (if r1 (bindings-merge r1 (cdr l2)) #f)
+    ) ;with
+  ) ;if
+) ;define
 
 (define (bindings-subst x bl)
   (cond ((npair? x) x)
-	((func? x 'quote 1)
-	 (with val (assoc-ref bl (cadr x))
-	   (if val val x)))
-	(else (cons (bindings-subst (car x) bl)
-		    (bindings-subst (cdr x) bl)))))
+        ((func? x 'quote 1) (with val (assoc-ref bl (cadr x)) (if val val x)))
+        (else (cons (bindings-subst (car x) bl) (bindings-subst (cdr x) bl)))
+  ) ;cond
+) ;define
 
 (define (select-cap x1 x2)
-  (if (!= (car x1) (car x2)) '()
-      (with bl (bindings-merge (cddr x1) (cddr x2))
-	(if bl (list (cons* (car x1) (cadr x1) bl)) '()))))
+  (if (!= (car x1) (car x2))
+    '()
+    (with bl
+      (bindings-merge (cddr x1) (cddr x2))
+      (if bl (list (cons* (car x1) (cadr x1) bl)) '())
+    ) ;with
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special patterns
@@ -47,134 +56,166 @@
 (define (select-symbol l nr sym bl)
   "Select symbols"
   (cond ((null? l) l)
-	((and (tm-compound? (car l)) (== (tm-car (car l)) sym))
-	 (cons (cons* (list nr) (car l) bl)
-	       (select-symbol (cdr l) (+ nr 1) sym bl)))
-	(else (select-symbol (cdr l) (+ nr 1) sym bl))))
+        ((and (tm-compound? (car l)) (== (tm-car (car l)) sym))
+         (cons (cons* (list nr) (car l) bl) (select-symbol (cdr l) (+ nr 1) sym bl))
+        ) ;
+        (else (select-symbol (cdr l) (+ nr 1) sym bl))
+  ) ;cond
+) ;define
 
 (define (select-exclude-symbols l nr syms bl)
   "Select all except symbols in a given list"
   (cond ((null? l) l)
-	((and (tm-compound? (car l)) (nin? (tm-car (car l)) syms))
-	 (cons (cons* (list nr) (car l) bl)
-	       (select-exclude-symbols (cdr l) (+ nr 1) syms bl)))
-	(else (select-exclude-symbols (cdr l) (+ nr 1) syms bl))))
+        ((and (tm-compound? (car l)) (nin? (tm-car (car l)) syms))
+         (cons (cons* (list nr) (car l) bl)
+           (select-exclude-symbols (cdr l) (+ nr 1) syms bl)
+         ) ;cons
+        ) ;
+        (else (select-exclude-symbols (cdr l) (+ nr 1) syms bl))
+  ) ;cond
+) ;define
 
 (define (select-exclude x args bl)
   "Select :exclude patterns"
-  (select-exclude-symbols (cdr (tm->list x)) 0 args bl))
+  (select-exclude-symbols (cdr (tm->list x)) 0 args bl)
+) ;define
 
 (define (select-range l nr begin end bl)
   "Select ranges"
   (cond ((or (null? l) (>= nr end)) '())
-	((< nr begin) (select-range (cdr l) (+ nr 1) begin end bl))
-	(else (cons (cons* (list nr) (car l) bl)
-		    (select-range (cdr l) (+ nr 1) begin end bl)))))
+        ((< nr begin) (select-range (cdr l) (+ nr 1) begin end bl))
+        (else (cons (cons* (list nr) (car l) bl) (select-range (cdr l) (+ nr 1) begin end bl))
+        ) ;else
+  ) ;cond
+) ;define
 
 (define (select-range* x args bl)
   "Select :range patterns"
   (if (and (tm-compound? x) (= (length args) 2))
-      (select-range (cdr (tm->list x)) 0 (car args) (cadr args) bl)
-      '()))
+    (select-range (cdr (tm->list x)) 0 (car args) (cadr args) bl)
+    '()
+  ) ;if
+) ;define
 
 (define (select-or x args bl)
   "Select :or patterns"
-  (if (null? args) '()
-      (append (select-one x (car args) bl)
-	      (select-or x (cdr args) bl))))
+  (if (null? args)
+    '()
+    (append (select-one x (car args) bl) (select-or x (cdr args) bl))
+  ) ;if
+) ;define
 
 (define (select-and x args bl)
   "Select :and patterns"
   (cond ((null? (cdr args)) (select-one x (car args) bl))
-	(else
-	 (let* ((l1 (select-one x (car args) bl))
-		(l2 (select-and x (cdr args) bl))
-		(f1 (lambda (x1)
-		      (with f2 (lambda (x2) (select-cap x1 x2))
-			(append-map f2 l2)))))
-	   (append-map f1 l1)))))
+        (else (let* ((l1 (select-one x (car args) bl))
+                     (l2 (select-and x (cdr args) bl))
+                     (f1 (lambda (x1) (with f2 (lambda (x2) (select-cap x1 x2)) (append-map f2 l2))))
+                    ) ;
+                (append-map f1 l1)
+              ) ;let*
+        ) ;else
+  ) ;cond
+) ;define
 
 (define (select-and-not x args bl)
   "Select :and-not patterns"
   (let* ((l1 (select-one x (car args) bl))
-	 (l2 (select-or x (cdr args) bl))
-	 (f1 (lambda (x1)
-	       (let f2 ((l2 l2))
-		 (cond ((null? l2) (list x1))
-		       ((null? (select-cap x1 (car l2))) (f2 (cdr l2)))
-		       (else '()))))))
-    (append-map f1 l1)))
+         (l2 (select-or x (cdr args) bl))
+         (f1 (lambda (x1)
+               (let f2
+                 ((l2 l2))
+                 (cond ((null? l2) (list x1))
+                       ((null? (select-cap x1 (car l2))) (f2 (cdr l2)))
+                       (else '())
+                 ) ;cond
+               ) ;let
+             ) ;lambda
+         ) ;f1
+        ) ;
+    (append-map f1 l1)
+  ) ;let*
+) ;define
 
 (define (select-group x args bl)
   "Select :group patterns"
-  (select-list x args bl))
+  (select-list x args bl)
+) ;define
 
 (define (select-match x args bl)
   "Select :match patterns"
   (let* ((sols (match (list x) args '()))
-	 (fun (lambda (sol-bl) (cons* (list) x sol-bl))))
-    (map fun sols)))
+         (fun (lambda (sol-bl) (cons* (list) x sol-bl)))
+        ) ;
+    (map fun sols)
+  ) ;let*
+) ;define
 
 (define (select-replace x args bl)
   "Replace selected pattern"
-  (with r (bindings-subst (car args) bl)
-    (list (cons* (list (list ':replace r)) r bl))))
+  (with r
+    (bindings-subst (car args) bl)
+    (list (cons* (list (list ':replace r)) r bl))
+  ) ;with
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Navigation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (navigate-same p pat bl)
-  (if (and p (nnull? p))
-      (select-list (path->tree p) pat bl)
-      '()))
+  (if (and p (nnull? p)) (select-list (path->tree p) pat bl) '())
+) ;define
 
 (define (navigate-up p pat bl)
-  (if (and p (nnull? p))
-      (select-list (path->tree (cDr p)) pat bl)
-      '()))
+  (if (and p (nnull? p)) (select-list (path->tree (cDr p)) pat bl) '())
+) ;define
 
 (define (navigate-down p pat bl)
-  (with q (cDr (cursor-path))
+  (with q
+    (cDr (cursor-path))
     (if (and p (list-starts? (cDr q) p))
-	(select-list (path->tree (list-head q (1+ (length p)))) pat bl)
-	'())))
+      (select-list (path->tree (list-head q (1+ (length p)))) pat bl)
+      '()
+    ) ;if
+  ) ;with
+) ;define
 
 (define (navigate-first p pat bl)
   (if p
-      (let* ((t (path->tree p))
-	     (a (tree-arity t)))
-	(if (> a 0)
-	    (select-list (tree-ref t 0) pat bl)
-	    '()))
-      '()))
+    (let* ((t (path->tree p)) (a (tree-arity t)))
+      (if (> a 0) (select-list (tree-ref t 0) pat bl) '())
+    ) ;let*
+    '()
+  ) ;if
+) ;define
 
 (define (navigate-last p pat bl)
   (if p
-      (let* ((t (path->tree p))
-	     (a (tree-arity t)))
-	(if (> a 0)
-	    (select-list (tree-ref t (- a 1)) pat bl)
-	    '()))
-      '()))
+    (let* ((t (path->tree p)) (a (tree-arity t)))
+      (if (> a 0) (select-list (tree-ref t (- a 1)) pat bl) '())
+    ) ;let*
+    '()
+  ) ;if
+) ;define
 
 (define (navigate-next p pat bl)
   (if (and p (nnull? p))
-      (let* ((t (path->tree (cDr p)))
-	     (l (cAr p)))
-	(if (< l (- (tree-arity t) 1))
-	    (select-list (tree-ref t (+ l 1)) pat bl)
-	    '()))
-      '()))
+    (let* ((t (path->tree (cDr p))) (l (cAr p)))
+      (if (< l (- (tree-arity t) 1)) (select-list (tree-ref t (+ l 1)) pat bl) '())
+    ) ;let*
+    '()
+  ) ;if
+) ;define
 
 (define (navigate-previous p pat bl)
   (if (and p (nnull? p))
-      (let* ((t (path->tree (cDr p)))
-	     (l (cAr p)))
-	(if (> l 0)
-	    (select-list (tree-ref t (- l 1)) pat bl)
-	    '()))
-      '()))
+    (let* ((t (path->tree (cDr p))) (l (cAr p)))
+      (if (> l 0) (select-list (tree-ref t (- l 1)) pat bl) '())
+    ) ;let*
+    '()
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Pattern selecting
@@ -200,65 +241,89 @@
 (ahash-set! navigate-table :previous navigate-previous)
 
 (define (select-one x pat bl)
-  (cond  ((pair? pat)
-	  (with fpat (car pat)
-	   (cond ((and (keyword? fpat) (ahash-ref select-table fpat))
-		  (apply (ahash-ref select-table fpat)
-			 (list x (cdr pat) bl)))
-		 ((and (== fpat 'quote) (= (length pat) 2))
-		  (with new-bl (bindings-add bl (cadr pat) x)
-		    (if new-bl (list (cons* (list) x new-bl)) '())))
-		 (else '()))))
-	 ((and (keyword? pat) (!= pat :%1)) (select-list x (list pat) bl))
-	 ((not (tm-compound? x)) '())
-	 ((symbol? pat) (select-symbol (cdr (tm->list x)) 0 pat bl))
-	 ((integer? pat) (select-range (cdr (tm->list x)) 0 pat (+ pat 1) bl))
-	 ((== pat :%1) (select-range (cdr (tm->list x)) 0 0 (tm-arity x) bl))
-	 (else '())))
+  (cond ((pair? pat)
+         (with fpat
+           (car pat)
+           (cond ((and (keyword? fpat) (ahash-ref select-table fpat))
+                  (apply (ahash-ref select-table fpat) (list x (cdr pat) bl))
+                 ) ;
+                 ((and (== fpat 'quote) (= (length pat) 2))
+                  (with new-bl
+                    (bindings-add bl (cadr pat) x)
+                    (if new-bl (list (cons* (list) x new-bl)) '())
+                  ) ;with
+                 ) ;
+                 (else '())
+           ) ;cond
+         ) ;with
+        ) ;
+        ((and (keyword? pat) (!= pat :%1)) (select-list x (list pat) bl))
+        ((not (tm-compound? x)) '())
+        ((symbol? pat) (select-symbol (cdr (tm->list x)) 0 pat bl))
+        ((integer? pat) (select-range (cdr (tm->list x)) 0 pat (+ pat 1) bl))
+        ((== pat :%1) (select-range (cdr (tm->list x)) 0 0 (tm-arity x) bl))
+        (else '())
+  ) ;cond
+) ;define
 
 (define (select-continue-sub x pat)
   (let* ((l (select-list (cadr x) pat (cddr x)))
-	 (fun (lambda (r) (cons (append (car x) (car r)) (cdr r)))))
-    (map fun l)))
+         (fun (lambda (r) (cons (append (car x) (car r)) (cdr r))))
+        ) ;
+    (map fun l)
+  ) ;let*
+) ;define
 
 (define (select-continue l pat)
-  (with fun (lambda (r) (select-continue-sub r pat))
-    (append-map fun l)))
+  (with fun (lambda (r) (select-continue-sub r pat)) (append-map fun l))
+) ;define
 
 (define (select-list x pat bl)
   ;; (display* "select list " x ", " pat ", " bl "\n")
   "Selects subexpressions of @l using the pattern @pat and under bindings @bl."
   (cond ((null? pat) (list (cons* (list) x bl)))
-	((npair? pat) '())
-	((keyword? (car pat))
-	 (with fpat (car pat)
-	   (cond ((== fpat :%0)
-		  (select-list x (cdr pat) bl))
-		 ((== fpat :*)
-		  (let* ((r (select-list x (cdr pat) bl))
-			 (l (select-one x :%1 bl)))
-		    (append r (select-continue l pat))))
-		 ((keyword->number fpat)
-		  (let* ((h (number->keyword (- (keyword->number fpat) 1)))
-			 (l (select-one x :%1 bl)))
-		    (select-continue l (cons h (cdr pat)))))
-		 ((ahash-ref navigate-table fpat)
-                  (with p (and (tree? x) (tree-get-path x))
+        ((npair? pat) '())
+        ((keyword? (car pat))
+         (with fpat
+           (car pat)
+           (cond ((== fpat :%0) (select-list x (cdr pat) bl))
+                 ((== fpat :*)
+                  (let* ((r (select-list x (cdr pat) bl)) (l (select-one x :%1 bl)))
+                    (append r (select-continue l pat))
+                  ) ;let*
+                 ) ;
+                 ((keyword->number fpat)
+                  (let* ((h (number->keyword (- (keyword->number fpat) 1))) (l (select-one x :%1 bl)))
+                    (select-continue l (cons h (cdr pat)))
+                  ) ;let*
+                 ) ;
+                 ((ahash-ref navigate-table fpat)
+                  (with p
+                    (and (tree? x) (tree-get-path x))
                     (cond (p ((ahash-ref navigate-table fpat) p (cdr pat) bl))
-                          ((and (in? fpat (list :first :last))
-                                (tm-compound? x) (>= (tm-arity x) 1))
-                           (with c (if (== fpat :first)
-                                       (tm-ref x 0)
-                                       (tm-ref x (- (tm-arity x) 1)))
-                             (select-list c (cdr pat) bl)))
-                          (else (list)))))
-		 ((ahash-ref match-term fpat)
-		  (with upat (ahash-ref match-term fpat)
-		    (select-list x (append upat (cdr pat)) bl)))
-		 (else (with l (select-one x (car pat) bl)
-			 (select-continue l (cdr pat)))))))
-	(else (with l (select-one x (car pat) bl)
-		(select-continue l (cdr pat))))))
+                          ((and (in? fpat (list :first :last)) (tm-compound? x) (>= (tm-arity x) 1))
+                           (with c
+                             (if (== fpat :first) (tm-ref x 0) (tm-ref x (- (tm-arity x) 1)))
+                             (select-list c (cdr pat) bl)
+                           ) ;with
+                          ) ;
+                          (else (list))
+                    ) ;cond
+                  ) ;with
+                 ) ;
+                 ((ahash-ref match-term fpat)
+                  (with upat
+                    (ahash-ref match-term fpat)
+                    (select-list x (append upat (cdr pat)) bl)
+                  ) ;with
+                 ) ;
+                 (else (with l (select-one x (car pat) bl) (select-continue l (cdr pat))))
+           ) ;cond
+         ) ;with
+        ) ;
+        (else (with l (select-one x (car pat) bl) (select-continue l (cdr pat))))
+  ) ;cond
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; User interface
@@ -266,13 +331,15 @@
 
 (define-public (tm-select x pattern)
   "Select all subtrees of @x which match a given path pattern @pattern"
-  (with sols (select-list x pattern '())
+  (with sols
+    (select-list x pattern '())
     ;; (display* "sols= " sols "\n")
-    (map cadr sols)))
+    (map cadr sols)
+  ) ;with
+) ;define-public
 
 (varlet *texmacs-module* 'select tm-select)
 
 (define-public (tm-ref t . l)
-  (and (tm? t)
-       (with r (select t l)
-	 (and (nnull? r) (car r)))))
+  (and (tm? t) (with r (select t l) (and (nnull? r) (car r))))
+) ;define-public

--- a/TeXmacs/progs/kernel/regexp/regexp-test.scm
+++ b/TeXmacs/progs/kernel/regexp/regexp-test.scm
@@ -13,16 +13,13 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel regexp regexp-test)
-  (:use (kernel regexp regexp-match)))
+(texmacs-module (kernel regexp regexp-test) (:use (kernel regexp regexp-match)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Example of a grammar for regular expressions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-regexp-grammar
-  (:a a b c)
-  (:b (:repeat :a)))
+(define-regexp-grammar (:a a b c) (:b (:repeat :a)))
 
 ;; (match? '(a b c a b c x) '(:b x))
 
@@ -32,56 +29,37 @@
 
 (define (regtest-regexp-match)
   ;; Basic test to ensure regexp module loads without errors
-  (regression-test-group
-   "regexp" "match"
-   values values
-   (test "module loaded successfully" 
-     #t 
-     #t)
-   (test "match? function available" 
-     (defined? 'match?) 
-     #t)
-   (test "define-regexp-grammar macro available" 
-     (defined? 'define-regexp-grammar) 
-     #t)
-   (test "match function available" 
-     (defined? 'match) 
-     #t)
-   (test "match-term table available" 
-     (defined? 'match-term) 
-     #t)
-   (test "bindings-add function available" 
-     (defined? 'bindings-add) 
-     #t)
-   (test "define-regexp-grammar-decls function available" 
-     (defined? 'define-regexp-grammar-decls) 
-     #t)
-   (test "display* function available" 
-     (defined? 'display*) 
-     #t)
-   (test "cons function available" 
-     (defined? 'cons) 
-     #t)
-   (test "list function available" 
-     (defined? 'list) 
-     #t)
-   (test "append function available" 
-     (defined? 'append) 
-     #t)
-   (test "for-each function available" 
-     (defined? 'for-each) 
-     #t)
-   (test "ahash-set! function available" 
-     (defined? 'ahash-set!) 
-     #t)
-   (test "ahash-ref function available" 
-     (defined? 'ahash-ref) 
-     #t)
-   (test "make-ahash-table function available" 
-     (defined? 'make-ahash-table) 
-     #t)))
+  (regression-test-group "regexp"
+    "match"
+    values
+    values
+    (test "module loaded successfully" #t #t)
+    (test "match? function available" (defined? 'match?) #t)
+    (test "define-regexp-grammar macro available"
+      (defined? 'define-regexp-grammar)
+      #t
+    ) ;test
+    (test "match function available" (defined? 'match) #t)
+    (test "match-term table available" (defined? 'match-term) #t)
+    (test "bindings-add function available" (defined? 'bindings-add) #t)
+    (test "define-regexp-grammar-decls function available"
+      (defined? 'define-regexp-grammar-decls)
+      #t
+    ) ;test
+    (test "display* function available" (defined? 'display*) #t)
+    (test "cons function available" (defined? 'cons) #t)
+    (test "list function available" (defined? 'list) #t)
+    (test "append function available" (defined? 'append) #t)
+    (test "for-each function available" (defined? 'for-each) #t)
+    (test "ahash-set! function available" (defined? 'ahash-set!) #t)
+    (test "ahash-ref function available" (defined? 'ahash-ref) #t)
+    (test "make-ahash-table function available" (defined? 'make-ahash-table) #t)
+  ) ;regression-test-group
+) ;define
 
 (tm-define (regtest-regexp)
   (let ((n (regtest-regexp-match)))
     (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-regexp: ok\n")))
+    (display "Test suite of regtest-regexp: ok\n")
+  ) ;let
+) ;tm-define

--- a/TeXmacs/progs/kernel/texmacs/tm-convert.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-convert.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel texmacs tm-convert)
-  (:use (kernel texmacs tm-define) (kernel texmacs tm-modes)))
+  (:use (kernel texmacs tm-define) (kernel texmacs tm-modes))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy formats
@@ -22,148 +23,215 @@
 
 (define-public-macro (lazy-format module . ignored)
   (set! lazy-format-todo (cons module lazy-format-todo))
-  `(delayed (:idle 2000) (import-from ,module)))
+  `(delayed (:idle 2000) (import-from ,module))
+) ;define-public-macro
 
 (define (lazy-format-force)
-  (if (nnull? lazy-format-todo)
-      (eval (cons 'import-from lazy-format-todo)))
-  (set! lazy-format-todo '()))
+  (if (nnull? lazy-format-todo) (eval (cons 'import-from lazy-format-todo)))
+  (set! lazy-format-todo '())
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Adding new converters
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define converter-forward (make-ahash-table))
+
 (define converter-backward (make-ahash-table))
+
 (define converter-function (make-ahash-table))
+
 (define converter-options (make-ahash-table))
+
 (define converter-option-for (make-ahash-table))
+
 (define converter-distance (make-ahash-table))
+
 (define converter-path (make-ahash-table))
 
 (define (converter-set-penalty from to penalty)
   (if (not (ahash-ref converter-forward from))
-      (ahash-set! converter-forward from (make-ahash-table)))
+    (ahash-set! converter-forward from (make-ahash-table))
+  ) ;if
   (ahash-set! (ahash-ref converter-forward from) to penalty)
   (if (not (ahash-ref converter-backward to))
-      (ahash-set! converter-backward to (make-ahash-table)))
-  (ahash-set! (ahash-ref converter-backward to) from penalty))
+    (ahash-set! converter-backward to (make-ahash-table))
+  ) ;if
+  (ahash-set! (ahash-ref converter-backward to) from penalty)
+) ;define
 
 (define (converter-remove from to)
   (converter-set-penalty from to #f)
   (ahash-remove! (ahash-ref converter-forward from) to)
-  (ahash-remove! (ahash-ref converter-backward to) from))
+  (ahash-remove! (ahash-ref converter-backward to) from)
+) ;define
 
 (define (converter-change-option from to option val)
-  (with key (list from to)
+  (with key
+    (list from to)
     (if (not (ahash-ref converter-options key))
-        (ahash-set! converter-options key '()))
-    (ahash-set! converter-options key
-                (assoc-set! (ahash-ref converter-options key) option val))))
+      (ahash-set! converter-options key '())
+    ) ;if
+    (ahash-set! converter-options
+      key
+      (assoc-set! (ahash-ref converter-options key) option val)
+    ) ;ahash-set!
+  ) ;with
+) ;define
 
 (define (converter-set-option option val)
-  (with key (ahash-ref converter-option-for option)
-    (if key (converter-change-option (car key) (cadr key) option val))))
+  (with key
+    (ahash-ref converter-option-for option)
+    (if key (converter-change-option (car key) (cadr key) option val))
+  ) ;with
+) ;define
 
 (define (converter-define-option from to option val)
-  (with key (list from to)
+  (with key
+    (list from to)
     (ahash-set! converter-option-for option key)
     (converter-change-option from to option key)
-    (define-preferences
-      (option val converter-set-option))))
+    (define-preferences (option val converter-set-option))
+  ) ;with
+) ;define
 
 (define-public (converter-cmd from to cmd)
   "Helper routine for converter macro"
-  (cond ((func? cmd :penalty 1)
-         (converter-set-penalty from to (second cmd)))
-;;        ((func? cmd :require 1) ;; already handled earlier now 
-;;       (if (not ((second cmd))) (converter-remove from to)))
+  (cond ((func? cmd :penalty 1) (converter-set-penalty from to (second cmd)))
+        ;;        ((func? cmd :require 1) ;; already handled earlier now
+        ;;       (if (not ((second cmd))) (converter-remove from to)))
         ((func? cmd :option 2)
-         (converter-define-option from to (second cmd) (third cmd)))
+         (converter-define-option from to (second cmd) (third cmd))
+        ) ;
         ((func? cmd :function 1)
-         (ahash-set! converter-function (list from to)
-                     (lambda (x opts) ((second cmd) x))))
+         (ahash-set! converter-function
+           (list from to)
+           (lambda (x opts) ((second cmd) x))
+         ) ;ahash-set!
+        ) ;
         ((func? cmd :function-with-options 1)
-         (ahash-set! converter-function (list from to) (second cmd)))
+         (ahash-set! converter-function (list from to) (second cmd))
+        ) ;
         ((func? cmd :shell)
-         (if (not (url-exists-in-path? (second cmd)))
-             (converter-remove from to))
-         (ahash-set! converter-function (list from to)
-                     (lambda (what opts)
-                       (converter-shell (cdr cmd) what to opts))))))
+         (if (not (url-exists-in-path? (second cmd))) (converter-remove from to))
+         (ahash-set! converter-function
+           (list from to)
+           (lambda (what opts) (converter-shell (cdr cmd) what to opts))
+         ) ;ahash-set!
+        ) ;
+  ) ;cond
+) ;define-public
 
 (define-public (converter-sub cmd)
   "Helper routine for converter macro"
-  (cond ((and (list? cmd) (= (length cmd) 2)
-              (in? (car cmd) '(:function :function-with-options)))
-         (list (car cmd) (list 'unquote (cadr cmd))))
-        ((and (list? cmd) (= (length cmd) 2)
-              (in? (car cmd) '(:require)))
-         (list (car cmd) (list 'unquote `(lambda () ,(cadr cmd)))))
-        (else cmd)))
+  (cond ((and (list? cmd)
+           (= (length cmd) 2)
+           (in? (car cmd) '(:function :function-with-options))
+         ) ;and
+         (list (car cmd) (list 'unquote (cadr cmd)))
+        ) ;
+        ((and (list? cmd) (= (length cmd) 2) (in? (car cmd) '(:require)))
+         (list (car cmd) (list 'unquote `(lambda ,() ,(cadr cmd))))
+        ) ;
+        (else cmd)
+  ) ;cond
+) ;define-public
 
 (define-public-macro (converter from* to* . options)
   "Declare a converter between @from@ and @to* according to @options"
   (let* ((from (if (string? from*) from* (symbol->string from*)))
-         (to (if (string? to*) to* (symbol->string to*))))
+         (to (if (string? to*) to* (symbol->string to*)))
+        ) ;
     (set! converter-distance (make-ahash-table))
     (set! converter-path (make-ahash-table))
-;; NEW if (:required) clause present but not fulfilled do nothing
-;; this enables to define several possible implementations of a given converter
-;; not presuming on the availability of external tools : the last valid one is retained
-;; (previously the last defined -even if unavailable- erased whatever was already defined)
-    (cond ((and (in? (car (first options)) '(:penalty)) 
-            (in? (car (second options)) '(:require)) 
-            (not (eval (second (second options))))) (noop))
-          ((and (in? (car (first options)) '(:require)) 
-            (not (eval (second (first options))))) (noop))
-          (else (converter-set-penalty from to 1.0) 
-             `(for-each (lambda (x) (converter-cmd ,from ,to x))
-                 ,(list 'quasiquote (map converter-sub options)))))))
+    ;; NEW if (:required) clause present but not fulfilled do nothing
+    ;; this enables to define several possible implementations of a given converter
+    ;; not presuming on the availability of external tools : the last valid one is retained
+    ;; (previously the last defined -even if unavailable- erased whatever was already defined)
+    (cond ((and (in? (car (first options)) '(:penalty))
+             (in? (car (second options)) '(:require))
+             (not (eval (second (second options))))
+           ) ;and
+           (noop)
+          ) ;
+          ((and (in? (car (first options)) '(:require))
+             (not (eval (second (first options))))
+           ) ;and
+           (noop)
+          ) ;
+          (else (converter-set-penalty from to 1.0)
+            `(for-each (lambda (x) (converter-cmd ,from ,to x))
+               ,(list 'quasiquote (map converter-sub options)))
+          ) ;else
+    ) ;cond
+  ) ;let*
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special converters
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (converter-shell-cmd l from to)
-  (with x (car l)
-    (string-append (if (or (os-win32?) (os-mingw?)) 
-                     (escape-shell (url-concretize (url-resolve-in-path x))) x) " "
-      (converter-shell-cmd-args (cdr l) from to))))
+  (with x
+    (car l)
+    (string-append (if (or (os-win32?) (os-mingw?))
+                     (escape-shell (url-concretize (url-resolve-in-path x)))
+                     x
+                   ) ;if
+      " "
+      (converter-shell-cmd-args (cdr l) from to)
+    ) ;string-append
+  ) ;with
+) ;define
 
 (define (converter-shell-cmd-args l from to)
-  (if (null? l) ""
-      (with x (car l)
-        (string-append (cond ((== x 'from) (escape-shell (url-concretize from)))
-                             ((== x 'to) (escape-shell (url-concretize to)))
-                             (else x))
-                       (cond ((and (string? x) (string-ends? x "=")) "")
-                             (else " "))
-                       (converter-shell-cmd-args (cdr l) from to)))))
+  (if (null? l)
+    ""
+    (with x
+      (car l)
+      (string-append (cond ((== x 'from) (escape-shell (url-concretize from)))
+                           ((== x 'to) (escape-shell (url-concretize to)))
+                           (else x)
+                     ) ;cond
+        (cond ((and (string? x) (string-ends? x "=")) "")
+              (else " ")
+        ) ;cond
+        (converter-shell-cmd-args (cdr l) from to)
+      ) ;string-append
+    ) ;with
+  ) ;if
+) ;define
 
 (define (converter-shell l from to-format opts)
-  ;;(display* "converter-shell " l ", " from ", " to-format ", " opts "\n")
+  ;; (display* "converter-shell " l ", " from ", " to-format ", " opts "\n")
   (let* ((last? (assoc-ref opts 'last?))
          (dest (assoc-ref opts 'dest))
          (dsuf (format-default-suffix to-format))
          (suf (if (and dsuf (!= dsuf "")) (string-append "." dsuf) ""))
          (to (if (and last? dest) dest (url-glue (url-temp) suf)))
-         (cmd (converter-shell-cmd l from to)))
+         (cmd (converter-shell-cmd l from to))
+        ) ;
     (debug-message "io" (string-append "shell: " cmd "\n"))
     (system cmd)
-    (if (url-exists? to) to #f)))
+    (if (url-exists? to) to #f)
+  ) ;let*
+) ;define
 
 (define-public (converter-save s opts)
   "Helper routine for define-format macro"
   (let* ((last? (assoc-ref opts 'last?))
          (dest (assoc-ref opts 'dest))
-         (to (if (and last? dest) dest (url-temp))))
+         (to (if (and last? dest) dest (url-temp)))
+        ) ;
     (string-save s to)
-    (if (url-exists? to) to #f)))
+    (if (url-exists? to) to #f)
+  ) ;let*
+) ;define-public
 
 (define-public (converter-load u opts)
   "Helper routine for define-format macro"
-  (string-load u))
+  (string-load u)
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Finding converters from and to a format
@@ -172,256 +240,344 @@
 (define (converters-sub l h p)
   (cond ((null? l) (map car (ahash-table->list h)))
         ((ahash-ref h (car l)) (converters-sub (cdr l) h p))
-        (else (let* ((hn (ahash-ref p (car l)))
-                     (next (if hn (map car (ahash-table->list hn)) '())))
+        (else (let* ((hn (ahash-ref p (car l))) (next (if hn (map car (ahash-table->list hn)) '())))
                 (ahash-set! h (car l) #t)
-                (converters-sub (append next (cdr l)) h p)))))
+                (converters-sub (append next (cdr l)) h p)
+              ) ;let*
+        ) ;else
+  ) ;cond
+) ;define
 
 (define-public (converters-from . from)
   (lazy-format-force)
-  (converters-sub from (make-ahash-table) converter-forward))
+  (converters-sub from (make-ahash-table) converter-forward)
+) ;define-public
 
 (define-public (converters-to . to)
   (lazy-format-force)
-  (converters-sub to (make-ahash-table) converter-backward))
+  (converters-sub to (make-ahash-table) converter-backward)
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Finding the shortest path
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (converter-insert from to penalty path)
-  (if (ahash-ref converter-distance (list from to)) #f
-      (begin
-        (ahash-set! converter-distance (list from to) penalty)
-        (ahash-set! converter-path (list from to) path)
-        #t)))
+  (if (ahash-ref converter-distance (list from to))
+    #f
+    (begin
+      (ahash-set! converter-distance (list from to) penalty)
+      (ahash-set! converter-path (list from to) path)
+      #t
+    ) ;begin
+  ) ;if
+) ;define
 
 (define (converter-walk from l*)
-  ;;(display* "convert-walk " from ", " l* "\n")
+  ;; (display* "convert-walk " from ", " l* "\n")
   (if (nnull? l*)
-      (let* ((l (list-sort l* (lambda (x y) (< (cadr x) (cadr y)))))
-             (aux (caar l))
-             (d (cadar l))
-             (path (caddar l)))
-        (if (converter-insert from aux d (reverse path))
-            (let* ((hn (ahash-ref converter-forward aux))
-                   (next (if hn (ahash-table->list hn) '()))
-                   (r (map (lambda (x) (list (car x)
-                                             (+ d (cdr x))
-                                             (cons (car x) path)))
-                           next)))
-              (converter-walk from (append (cdr l) r)))
-            (converter-walk from (cdr l))))))
+    (let* ((l (list-sort l* (lambda (x y) (< (cadr x) (cadr y)))))
+           (aux (caar l))
+           (d (cadar l))
+           (path (caddar l))
+          ) ;
+      (if (converter-insert from aux d (reverse path))
+        (let* ((hn (ahash-ref converter-forward aux))
+               (next (if hn (ahash-table->list hn) '()))
+               (r (map (lambda (x) (list (car x) (+ d (cdr x)) (cons (car x) path))) next))
+              ) ;
+          (converter-walk from (append (cdr l) r))
+        ) ;let*
+        (converter-walk from (cdr l))
+      ) ;if
+    ) ;let*
+  ) ;if
+) ;define
 
 (define-public (converter-search from to)
   (lazy-format-force)
   (converter-walk from (list (list from 0.0 (list from))))
-  (ahash-ref converter-path (list from to)))
+  (ahash-ref converter-path (list from to))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Actual conversion
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (std-converter-options from to)
-  (or (ahash-ref converter-options (list from to)) '()))
+  (or (ahash-ref converter-options (list from to)) '())
+) ;define-public
 
 (define (convert-via what from path options)
-  ;;(display* "convert-via " what ", " from ", " path ", " options "\n")
+  ;; (display* "convert-via " what ", " from ", " path ", " options "\n")
   (if (null? path)
-      (with dest (assoc-ref options 'dest)
-        (when (and dest (url? what) (url? dest) (!= dest what))
-          (system-copy what dest))
-        what)
-      (with fun (ahash-ref converter-function (list from (car path)))
-        (if fun
-            (let* ((last? (null? (cdr path)))
-                   (opts1 (acons 'last? last? options))
-                   (opts2 (std-converter-options from (car path)))
-                   (what* (fun what (append opts1 opts2)))
-                   (result (convert-via what* (car path) (cdr path) options)))
-              (if (and (not last?) (string-ends? (car path) "-file"))
-                  (system-remove what*))
-              result)
-            #f))))
+    (with dest
+      (assoc-ref options 'dest)
+      (when (and dest (url? what) (url? dest) (!= dest what))
+        (system-copy what dest)
+      ) ;when
+      what
+    ) ;with
+    (with fun
+      (ahash-ref converter-function (list from (car path)))
+      (if fun
+        (let* ((last? (null? (cdr path)))
+               (opts1 (acons 'last? last? options))
+               (opts2 (std-converter-options from (car path)))
+               (what* (fun what (append opts1 opts2)))
+               (result (convert-via what* (car path) (cdr path) options))
+              ) ;
+          (if (and (not last?) (string-ends? (car path) "-file")) (system-remove what*))
+          result
+        ) ;let*
+        #f
+      ) ;if
+    ) ;with
+  ) ;if
+) ;define
 
 (define-public (convert what from to . options)
-  ;;(display* "convert " what ", " from ", " to ", " options "\n")
+  ;; (display* "convert " what ", " from ", " to ", " options "\n")
   (lazy-format-force)
-  (with path (converter-search from to)
-    (if path
-        (convert-via what from (cdr path) options)
-        #f)))
+  (with path
+    (converter-search from to)
+    (if path (convert-via what from (cdr path) options) #f)
+  ) ;with
+) ;define-public
 
 (define-public (convert-to-file what from to dest . options)
-  (apply convert (cons* what from to (acons 'dest dest options))))
+  (apply convert (cons* what from to (acons 'dest dest options)))
+) ;define-public
 
 (define-public (image->postscript name)
   (let* ((suffix (locase-all (url-suffix name)))
          (fm (string-append (format-from-suffix suffix) "-file"))
-         (s (convert name fm "postscript-document")))
-    (if (string? s) s "")))
+         (s (convert name fm "postscript-document"))
+        ) ;
+    (if (string? s) s "")
+  ) ;let*
+) ;define-public
 
 (define-public (texmacs->generic doc fm)
-  (with r (convert doc "texmacs-tree" fm)
-    (if r r "Error: bad format or data")))
+  (with r (convert doc "texmacs-tree" fm) (if r r "Error: bad format or data"))
+) ;define-public
 
 (define-public (generic->texmacs s fm)
-  (with r (convert s fm "texmacs-tree")
-    (if r r (stree->tree '(error "bad format or data")))))
+  (with r
+    (convert s fm "texmacs-tree")
+    (if r r (stree->tree '(error "bad format or data")))
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setting up conversion menus
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (format<=? fm1 fm2)
-  (string<=? (ahash-ref format-name fm1) (ahash-ref format-name fm2)))
+  (string<=? (ahash-ref format-name fm1) (ahash-ref format-name fm2))
+) ;define
 
 (define-public (converters-from-special* fm suf tm?)
   (let* ((l1 (converters-from fm))
          (l2 (list-filter l1 (lambda (s) (string-ends? s suf))))
          (l3 (map (lambda (s) (string-drop-right s (string-length suf))) l2))
          (l3 (list-filter l3 (lambda (s) (not (ahash-ref format-hidden s)))))
-         (l4 (if tm? l3 (list-filter l3 (lambda (s) (!= s "texmacs"))))))
-    (list-sort l4 format<=?)))
+         (l4 (if tm? l3 (list-filter l3 (lambda (s) (!= s "texmacs")))))
+        ) ;
+    (list-sort l4 format<=?)
+  ) ;let*
+) ;define-public
 
 (define-public (converters-to-special* fm suf tm?)
   (let* ((l1 (converters-to fm))
          (l2 (list-filter l1 (lambda (s) (string-ends? s suf))))
          (l3 (map (lambda (s) (string-drop-right s (string-length suf))) l2))
          (l3 (list-filter l3 (lambda (s) (not (ahash-ref format-hidden s)))))
-         (l4 (if tm? l3 (list-filter l3 (lambda (s) (!= s "texmacs"))))))
-    (list-sort l4 format<=?)))
+         (l4 (if tm? l3 (list-filter l3 (lambda (s) (!= s "texmacs")))))
+        ) ;
+    (list-sort l4 format<=?)
+  ) ;let*
+) ;define-public
 
 (define (source-code? s)
-  (with name (locase-all (format-get-name s))
-    (or (string-ends? name " source code")
-        (in? name (list "csv" "json")))))
+  (with name
+    (locase-all (format-get-name s))
+    (or (string-ends? name " source code") (in? name (list "csv" "json")))
+  ) ;with
+) ;define
 
 (define-public (converters-from-special fm suf tm?)
-  (list-filter (converters-from-special* fm suf tm?) (non source-code?)))
+  (list-filter (converters-from-special* fm suf tm?) (non source-code?))
+) ;define-public
 
 (define-public (converters-to-special fm suf tm?)
-  (list-filter (converters-to-special* fm suf tm?) (non source-code?)))
+  (list-filter (converters-to-special* fm suf tm?) (non source-code?))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Other useful subroutines
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (tmfile-pair? t)
-  (and (tm-compound? t)
-       (nnull? (tm-children t))))
+  (and (tm-compound? t) (nnull? (tm-children t)))
+) ;define
 
 (define-public (tmfile-get doc what)
   (and (tm-func? doc 'document)
-       (list-and (map tmfile-pair? (tm-children doc)))
-       (with val (assoc-ref (map tm->list (tm-children doc)) what)
-         (if (pair? val) (set! val (car val)))
-         val)))
+    (list-and (map tmfile-pair? (tm-children doc)))
+    (with val
+      (assoc-ref (map tm->list (tm-children doc)) what)
+      (if (pair? val) (set! val (car val)))
+      val
+    ) ;with
+  ) ;and
+) ;define-public
 
 (define-public (tmfile-set doc what val)
   (and (tm-func? doc 'document)
-       (list-and (map tmfile-pair? (tm-children doc)))
-       (with l (reverse (map tm->list (tm-children doc)))
-         (set! l (assoc-set! l what (list val)))
-         (cons 'document (reverse l)))))
+    (list-and (map tmfile-pair? (tm-children doc)))
+    (with l
+      (reverse (map tm->list (tm-children doc)))
+      (set! l (assoc-set! l what (list val)))
+      (cons 'document (reverse l))
+    ) ;with
+  ) ;and
+) ;define-public
 
 (define-public (tmfile? doc)
-  (and (tmfile-get doc 'TeXmacs) (tmfile-get doc 'body)))
+  (and (tmfile-get doc 'TeXmacs) (tmfile-get doc 'body))
+) ;define-public
 
 (define-public (tmfile-extract doc what)
   ;; FIXME: use tmfile-get instead whenever possible
   (if (tree? doc) (set! doc (tree->stree doc)))
   (and (func? doc 'document)
-       (list-and (map tmfile-pair? (tm-children doc)))
-       (with val (assoc-ref (cdr doc) what)
-         (if (pair? val) (set! val (car val)))
-         (if (tree? val) (set! val (tree->stree val)))
-         val)))
+    (list-and (map tmfile-pair? (tm-children doc)))
+    (with val
+      (assoc-ref (cdr doc) what)
+      (if (pair? val) (set! val (car val)))
+      (if (tree? val) (set! val (tree->stree val)))
+      val
+    ) ;with
+  ) ;and
+) ;define-public
 
 (define-public (tmfile-assign doc what val)
   ;; FIXME: use tmfile-set instead whenever possible
   (if (tree? doc) (set! doc (tree->stree doc)))
   (and (func? doc 'document)
-       (list-and (map tmfile-pair? (tm-children doc)))
-       (with l (reverse (cdr doc))
-         (set! l (assoc-set! l what (list (tm->tree val))))
-         (cons 'document (reverse l)))))
+    (list-and (map tmfile-pair? (tm-children doc)))
+    (with l
+      (reverse (cdr doc))
+      (set! l (assoc-set! l what (list (tm->tree val))))
+      (cons 'document (reverse l))
+    ) ;with
+  ) ;and
+) ;define-public
 
 (define (default-init var)
   ;; FIXME: should use C++ code
   (cond ((== var "mode") "text")
         ((== var "language") "english")
-        (else "")))
+        (else "")
+  ) ;cond
+) ;define
 
 (tm-define (tmfile-init doc var . explicit?)
-  (with init (tmfile-extract doc 'initial)
+  (with init
+    (tmfile-extract doc 'initial)
     (if (not init)
-        (and (null? explicit?)
-             (default-init var))
-        (with item (list-find (cdr init) (lambda (x) (== (cadr x) var)))
-          (if item (caddr item)
-              (and (null? explicit?)
-                   (default-init var)))))))
+      (and (null? explicit?) (default-init var))
+      (with item
+        (list-find (cdr init) (lambda (x) (== (cadr x) var)))
+        (if item (caddr item) (and (null? explicit?) (default-init var)))
+      ) ;with
+    ) ;if
+  ) ;with
+) ;tm-define
 
 (tm-define (tmfile-style-list doc)
-  (with style (tmfile-extract doc 'style)
+  (with style
+    (tmfile-extract doc 'style)
     (cond ((tm-func? style 'tuple) (cdr style))
           ((string? style) (list style))
-          (else (list)))))
+          (else (list))
+    ) ;cond
+  ) ;with
+) ;tm-define
 
 (tm-define (tmfile-language doc)
   (let* ((style (tmfile-style-list doc))
          (lans (list-intersection style supported-languages))
-         (lan (tmfile-init doc "language" #t)))
+         (lan (tmfile-init doc "language" #t))
+        ) ;
     (cond (lan lan)
           ((nnull? lans) (car lans))
-          (else "english"))))
+          (else "english")
+    ) ;cond
+  ) ;let*
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Adding new formats
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define format-name (make-ahash-table))
+
 (define format-suffixes (make-ahash-table))
+
 (define format-hidden (make-ahash-table))
+
 (define format-mime (make-ahash-table))
+
 (define format-recognize (make-ahash-table))
+
 (define format-must-recognize (make-ahash-table))
 
 (define-public (format-cmd name cmd)
   "Helper routine for define-format"
-  (cond ((func? cmd :name 1)
-         (ahash-set! format-name name (second cmd)))
+  (cond ((func? cmd :name 1) (ahash-set! format-name name (second cmd)))
         ((func? cmd :suffix)
          (ahash-set! format-suffixes name (cdr cmd))
-         (for-each (lambda (s) (ahash-set! format-mime s name)) (cdr cmd)))
-        ((func? cmd :hidden)
-         (ahash-set! format-hidden name #t))
-        ((func? cmd :recognize 1)
-         (ahash-set! format-recognize name (second cmd)))
+         (for-each (lambda (s) (ahash-set! format-mime s name)) (cdr cmd))
+        ) ;
+        ((func? cmd :hidden) (ahash-set! format-hidden name #t))
+        ((func? cmd :recognize 1) (ahash-set! format-recognize name (second cmd)))
         ((func? cmd :must-recognize 1)
          (ahash-set! format-recognize name (second cmd))
-         (ahash-set! format-must-recognize name #t))))
+         (ahash-set! format-must-recognize name #t)
+        ) ;
+  ) ;cond
+) ;define-public
 
 (define-public (format-sub cmd)
   "Helper routine for define-format"
-  (if (and (list? cmd) (= (length cmd) 2)
-           (in? (car cmd) '(:recognize :must-recognize)))
-      (list (car cmd) (list 'unquote (cadr cmd)))
-      cmd))
+  (if (and (list? cmd)
+        (= (length cmd) 2)
+        (in? (car cmd) '(:recognize :must-recognize))
+      ) ;and
+    (list (car cmd) (list 'unquote (cadr cmd)))
+    cmd
+  ) ;if
+) ;define-public
 
 (define-public-macro (define-format name* . options)
   "Declare data format @name* according to @options"
   (let* ((name (if (string? name*) name* (symbol->string name*)))
          (name-document (string-append name "-document"))
-         (name-file (string-append name "-file")))
+         (name-file (string-append name "-file"))
+        ) ;
     `(begin
-       (converter ,name-document ,name-file
+       (converter ,name-document
+         ,name-file
          (:function-with-options converter-save))
-       (converter ,name-file ,name-document
+       (converter ,name-file
+         ,name-document
          (:function-with-options converter-load))
        (for-each (lambda (x) (format-cmd ,name x))
-                 ,(list 'quasiquote (map format-sub options))))))
+         ,(list 'quasiquote (map format-sub options))))
+  ) ;let*
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Useful routines for format recognition
@@ -429,62 +585,121 @@
 
 (define-public (format-skip-spaces s pos)
   (cond ((>= pos (string-length s)) pos)
-        ((tm-char-whitespace? (string-ref s pos))
-         (format-skip-spaces s (+ pos 1)))
-        (else pos)))
+        ((tm-char-whitespace? (string-ref s pos)) (format-skip-spaces s (+ pos 1)))
+        (else pos)
+  ) ;cond
+) ;define-public
 
 (define-public (format-skip-line s pos)
   (cond ((>= pos (string-length s)) pos)
         ((in? (string-ref s pos) '(#\newline #\cr)) (+ pos 1))
-        (else (format-skip-line s (+ pos 1)))))
+        (else (format-skip-line s (+ pos 1)))
+  ) ;cond
+) ;define-public
 
 (define-public (format-test? s pos what)
-  (with end (+ pos (string-length what))
+  (with end
+    (+ pos (string-length what))
     (and (>= (string-length s) end)
-         (== (string-downcase (substring s pos end)) what))))
+      (== (string-downcase (substring s pos end)) what)
+    ) ;and
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Getting suffix information
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (format-get-suffixes-sub fm)
-  (with l (ahash-ref format-suffixes fm)
-    (if l l '())))
+  (with l (ahash-ref format-suffixes fm) (if l l '()))
+) ;define
 
 (define (format-image-suffixes)
-  (with l (converters-to-special "postscript-file" "-file" #f)
-    (apply append (map format-get-suffixes-sub l))))
+  (with l
+    (converters-to-special "postscript-file" "-file" #f)
+    (apply append (map format-get-suffixes-sub l))
+  ) ;with
+) ;define
 
 (define (format-get-suffixes fm)
   (cond ((and (== fm "image") (os-win32?))
-         '("ps" "eps" "bmp" "gif" "ico" "tga" "pcx" "wbmp" "wmf" "jpg"
-           "jpeg" "png" "tif" "jbig" "ras" "pnm" "jp2" "jpc" "pgx"
-           "cut" "iff" "lbm" "jng" "koa" "mng" "pbm" "pcd" "pcx"
-           "pgm" "ppm" "psd" "tga" "tiff" "xbm" "xpm"))
-        ((== fm "image") '("png""gif" "jpg" "jpeg" "ps" "eps" "svg" "tif" "tiff"))
-        ((== fm "sound")
-         '("au" "cdr" "cvs" "dat" "gsm" "ogg" "snd" "voc" "wav"))
+         '("ps"
+           "eps"
+           "bmp"
+           "gif"
+           "ico"
+           "tga"
+           "pcx"
+           "wbmp"
+           "wmf"
+           "jpg"
+           "jpeg"
+           "png"
+           "tif"
+           "jbig"
+           "ras"
+           "pnm"
+           "jp2"
+           "jpc"
+           "pgx"
+           "cut"
+           "iff"
+           "lbm"
+           "jng"
+           "koa"
+           "mng"
+           "pbm"
+           "pcd"
+           "pcx"
+           "pgm"
+           "ppm"
+           "psd"
+           "tga"
+           "tiff"
+           "xbm"
+           "xpm")
+        ) ;
+        ((== fm "image") '("png"
+                           "gif"
+                           "jpg"
+                           "jpeg"
+                           "ps"
+                           "eps"
+                           "svg"
+                           "tif"
+                           "tiff"))
+        ((== fm "sound") '("au" "cdr" "cvs" "dat" "gsm" "ogg" "snd" "voc" "wav"))
         ((== fm "animation") '("gif"))
-        (else (format-get-suffixes-sub fm))))
+        (else (format-get-suffixes-sub fm))
+  ) ;cond
+) ;define
 
 (define-public (format-get-suffixes* fm)
   (lazy-format-force)
-  (cons 'tuple (format-get-suffixes fm)))
+  (cons 'tuple (format-get-suffixes fm))
+) ;define-public
 
 (define-public (format-default-suffix fm)
   (lazy-format-force)
-  (with l (ahash-ref format-suffixes fm)
+  (with l
+    (ahash-ref format-suffixes fm)
     (cond ((== fm "image") "png")
           ((or (not l) (null? l))
            (if (string-ends? fm "-file")
-               (format-default-suffix (string-drop-right fm 5))
-               ""))
-          (else (car l)))))
+             (format-default-suffix (string-drop-right fm 5))
+             ""
+           ) ;if
+          ) ;
+          (else (car l))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (image-formats)
-  (let* ((suffixes (format-image-suffixes))
-         (formats (map format-from-suffix suffixes)))
-    (sort (list-remove-duplicates formats) string<=?)))
+  (let* ((suffixes (format-image-suffixes)) (formats (map format-from-suffix suffixes)))
+    (sort (list-remove-duplicates formats) string<=?)
+  ) ;let*
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Automatic determination of the format
@@ -492,49 +707,62 @@
 
 (define-public (format? fm)
   (lazy-format-force)
-  (not (not (ahash-ref format-name fm))))
+  (not (not (ahash-ref format-name fm)))
+) ;define-public
 
 (define-public (format-get-name fm)
   (lazy-format-force)
-  (ahash-ref format-name fm))
+  (ahash-ref format-name fm)
+) ;define-public
 
 (define-public (format-recognizes? doc fm)
   (lazy-format-force)
-  (with pred? (ahash-ref format-recognize fm)
-    (and pred? (pred? doc))))
+  (with pred? (ahash-ref format-recognize fm) (and pred? (pred? doc)))
+) ;define-public
 
 (define-public (format-from-suffix suffix)
   (lazy-format-force)
-  (with fm (ahash-ref format-mime (locase-all suffix))
-    (if fm fm "generic")))
+  (with fm (ahash-ref format-mime (locase-all suffix)) (if fm fm "generic"))
+) ;define-public
 
 (define-public (format-determine body suffix)
   (lazy-format-force)
-  (with p (list-find (ahash-table->list format-recognize)
-                     (lambda (p) ((cdr p) body)))
-    (if p (car p)
-        (with fm (ahash-ref format-mime (locase-all suffix))
-          (cond ((not fm) "verbatim")
-                ((ahash-ref format-must-recognize fm) "verbatim")
-                (else fm))))))
+  (with p
+    (list-find (ahash-table->list format-recognize) (lambda (p) ((cdr p) body)))
+    (if p
+      (car p)
+      (with fm
+        (ahash-ref format-mime (locase-all suffix))
+        (cond ((not fm) "verbatim")
+              ((ahash-ref format-must-recognize fm) "verbatim")
+              (else fm)
+        ) ;cond
+      ) ;with
+    ) ;if
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utilities for file conversions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (file-of-format? u fm)
-  (in? (url-suffix u) (format-get-suffixes fm)))
+  (in? (url-suffix u) (format-get-suffixes fm))
+) ;define-public
 
 (define-public (file-format u)
-  (string-append (format-from-suffix (url-suffix u)) "-file"))
+  (string-append (format-from-suffix (url-suffix u)) "-file")
+) ;define-public
 
 (define-public (file-converter-exists? what dest)
-  (nnot (converter-search (file-format what) (file-format dest))))
+  (nnot (converter-search (file-format what) (file-format dest)))
+) ;define-public
 
 (define-public (file-convert what dest . options)
-  (let* ((from (file-format what))
-         (to   (file-format dest)))
-    (apply convert (cons* what from to (acons 'dest dest options)))))
+  (let* ((from (file-format what)) (to (file-format dest)))
+    (apply convert (cons* what from to (acons 'dest dest options)))
+  ) ;let*
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Viewers

--- a/TeXmacs/progs/kernel/texmacs/tm-define-test.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-define-test.scm
@@ -11,19 +11,21 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (prog prog-format-test)
-  (:use (kernel texmacs tm-define)))
+(texmacs-module (prog prog-format-test) (:use (kernel texmacs tm-define)))
 
 (import (liii check))
 
 (check-set-mode! 'report-failed)
 
 (define (test-define-procedure)
-  (display "This is a test procedure defined with define\n"))
+  (display "This is a test procedure defined with define\n")
+) ;define
 
 (tm-define (test-tm-define-procedure)
-  #:synopsis "Test procedure defined via tm-define"
-  (display "This is a test procedure defined with tm-define\n"))
+  :synopsis
+  "Test procedure defined via tm-define"
+  (display "This is a test procedure defined with tm-define\n")
+) ;tm-define
 
 (tm-define alias-car car)
 
@@ -38,13 +40,13 @@
   (check (procedure-name 1) => #f)
   ;; Test lambda serialization - anonymous lambdas should return #f
   (let ((lambda-func (lambda (x) (+ x 1))))
-    (check (procedure-name lambda-func) => #f))
+    (check (procedure-name lambda-func) => #f)
+  ) ;let
   ;; Test that different anonymous lambdas all return #f
-  (let ((lambda1 (lambda () 1))
-        (lambda2 (lambda () 2)))
+  (let ((lambda1 (lambda () 1)) (lambda2 (lambda () 2)))
     (check (procedure-name lambda1) => #f)
-    (check (procedure-name lambda2) => #f)))
+    (check (procedure-name lambda2) => #f)
+  ) ;let
+) ;define
 
-(tm-define (regtest-tm-define)
-  (test-procedure-name)
-  (check-report))
+(tm-define (regtest-tm-define) (test-procedure-name) (check-report))

--- a/TeXmacs/progs/kernel/texmacs/tm-define.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-define.scm
@@ -18,35 +18,42 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (ctx-add-condition l kind opt)
-  ;;(display* "add condition " l ", " opt "\n")
-  (append l (list opt)))
+  ;; (display* "add condition " l ", " opt "\n")
+  (append l (list opt))
+) ;define-public
 
 (define-public (ctx-insert ctx data conds)
-  ;;(display* "insert " ctx ", " data ", " conds "\n")
-  (cons (cons conds data) (or ctx '())))
+  ;; (display* "insert " ctx ", " data ", " conds "\n")
+  (cons (cons conds data) (or ctx '()))
+) ;define-public
 
 (define-public (ctx-find ctx conds)
-  ;;(display* "find " ctx ", " conds "\n")
+  ;; (display* "find " ctx ", " conds "\n")
   (cond ((or (not ctx) (null? ctx)) #f)
         ((== (caar ctx) conds) (cdar ctx))
-        (else (ctx-find (cdr ctx) conds))))
+        (else (ctx-find (cdr ctx) conds))
+  ) ;cond
+) ;define-public
 
 (define-public (ctx-remove ctx conds)
-  ;;(display* "remove " ctx ", " conds "\n")
+  ;; (display* "remove " ctx ", " conds "\n")
   (cond ((or (not ctx) (null? ctx)) '())
         ((== (caar ctx) conds) (ctx-remove (cdr ctx) conds))
-        (else (cons (car ctx) (ctx-remove (cdr ctx) conds)))))
+        (else (cons (car ctx) (ctx-remove (cdr ctx) conds)))
+  ) ;cond
+) ;define-public
 
 (define (and-apply l args)
-  (or (null? l)
-      (and (apply (car l) (or args '()))
-           (and-apply (cdr l) args))))
+  (or (null? l) (and (apply (car l) (or args '())) (and-apply (cdr l) args)))
+) ;define
 
 (define-public (ctx-resolve ctx args)
-  ;;(display* "resolve " ctx ", " args "\n")
+  ;; (display* "resolve " ctx ", " args "\n")
   (cond ((or (not ctx) (null? ctx)) #f)
         ((and-apply (caar ctx) args) (cdar ctx))
-        (else (ctx-resolve (cdr ctx) args))))
+        (else (ctx-resolve (cdr ctx) args))
+  ) ;cond
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Global variables and subroutines
@@ -60,77 +67,98 @@
 (define-public cur-conds '())
 
 (define cur-props-table (make-ahash-table))
+
 (define cur-props '())
 
-(define (ca*r x) (if (pair? x) (ca*r (car x)) x))
-(define (ca*adr x) (ca*r (cadr x)))
+(define (ca*r x)
+  (if (pair? x) (ca*r (car x)) x)
+) ;define
+
+(define (ca*adr x)
+  (ca*r (cadr x))
+) ;define
 
 (define (lambda* head body)
-  (if (pair? head)
-      (lambda* (car head) `((lambda ,(cdr head) ,@body)))
-      (car body)))
+  (if (pair? head) (lambda* (car head) `((lambda ,(cdr head) ,@body))) (car body))
+) ;define
 
 (define (listify args)
-  (if (pair? args)
-      (cons (car args) (listify (cdr args)))
-      (list args)))
+  (if (pair? args) (cons (car args) (listify (cdr args))) (list args))
+) ;define
 
 (define (apply* fun head)
-  (cond ((list? head)
-         `(,(apply* fun (car head)) ,@(cdr head)))
-        ((pair? head)
-         `(apply ,(apply* fun (car head)) (cons* ,@(listify (cdr head)))))
-        (else fun)))
+  (cond ((list? head) `(,(apply* fun (car head)) ,@(cdr head)))
+        ((pair? head) `(apply ,(apply* fun (car head))
+                         (cons* ,@(listify (cdr head)))))
+        (else fun)
+  ) ;cond
+) ;define
 
 (define (and* conds)
-  (if (list-1? conds) (car conds) `(and ,@conds)))
+  (if (list-1? conds) (car conds) `(and ,@conds))
+) ;define
 
 (define (begin* conds)
-  (if (list-1? conds) (car conds) `(begin ,@conds)))
+  (if (list-1? conds) (car conds) `(begin ,@conds))
+) ;define
 
 (define-public (procedure-name fun)
   (if (procedure? fun)
     (or (ahash-ref tm-defined-name fun)
-        (let ((str (format #f "~A" fun)))
-          (if (string-starts? str "#<lambda")
-              #f ; lambda 无法可靠序列化，返回#f
-              (string->symbol str))))
-    #f))
+      (let ((str (format #f "~A" fun)))
+        (if (string-starts? str "#<lambda") #f (string->symbol str))
+      ) ;let
+    ) ;or
+    #f
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Overloading
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (ctx-add-condition! kind opt)
-  (set! cur-conds (ctx-add-condition cur-conds kind opt)))
+  (set! cur-conds (ctx-add-condition cur-conds kind opt))
+) ;define
 
 (define (define-option-mode opt decl)
   (ctx-add-condition! 0 (car opt))
-  decl)
+  decl
+) ;define
 
 (define-public (predicate-option? x)
   (or (and (symbol? x) (string-ends? (symbol->string x) "?"))
-      (and (pair? x) (== (car x) 'lambda))))
+    (and (pair? x) (== (car x) 'lambda))
+  ) ;or
+) ;define-public
 
 (define (define-option-match opt decl)
   (cond ((predicate-option? opt) (ctx-add-condition! 3 opt))
-        ((and (pair? opt) (null? (cdr opt))
-              (predicate-option? (car opt))
-              (list? (cadr decl)) (= (length (cadr decl)) 3))
-         (ctx-add-condition! 3 (car opt)))
-        (else (ctx-add-condition! 3 `(lambda args (match? args ',opt)))))
-  decl)
+        ((and (pair? opt)
+           (null? (cdr opt))
+           (predicate-option? (car opt))
+           (list? (cadr decl))
+           (= (length (cadr decl)) 3)
+         ) ;and
+         (ctx-add-condition! 3 (car opt))
+        ) ;
+        (else (ctx-add-condition! 3 `(lambda args (match? args (quote ,opt)))))
+  ) ;cond
+  decl
+) ;define
 
 (define (define-option-require opt decl)
-  (define-option-match
-    `(lambda ,(cdadr decl) ,(car opt))
-    decl))
+  (define-option-match `(lambda ,(cdadr decl) ,(car opt)) decl)
+) ;define
 
 (define (define-option-applicable opt decl)
-  (with prop `(',(ca*adr decl) :applicable (list (lambda args ,@opt)))
+  (with prop
+    `((quote ,(ca*adr decl)) ,:applicable (list (lambda args ,@opt)))
     (set! cur-props (cons prop cur-props))
-    ;;(define-option-require opt decl)
-    decl))
+    ;; (define-option-require opt decl)
+    decl
+  ) ;with
+) ;define
 
 (ahash-set! define-option-table :mode define-option-mode)
 (ahash-set! define-option-table :require define-option-require)
@@ -144,67 +172,99 @@
   "Remove conditions which depend on arguments from list"
   (cond ((null? l) l)
         ((>= (car l) 2) (filter-conds (cddr l)))
-        (else (cons (car l) (cons (cadr l) (filter-conds (cddr l)))))))
+        (else (cons (car l) (cons (cadr l) (filter-conds (cddr l)))))
+  ) ;cond
+) ;define
 
 (define-public (property-set! var prop what conds*)
   "Associate a property to a function symbol under conditions"
-  (let* ((key (cons var prop))
-         (conds (filter-conds conds*)))
-    (ahash-set! cur-props-table key
-                (ctx-insert (ahash-ref cur-props-table key) what conds))))
+  (let* ((key (cons var prop)) (conds (filter-conds conds*)))
+    (ahash-set! cur-props-table
+      key
+      (ctx-insert (ahash-ref cur-props-table key) what conds)
+    ) ;ahash-set!
+  ) ;let*
+) ;define-public
 
 (define-public (property var prop)
   "Retrieve a property of a function symbol"
   (if (procedure? var) (set! var (procedure-name var)))
   (let* ((key (cons var prop)))
-    (ctx-resolve (ahash-ref cur-props-table key) #f)))
+    (ctx-resolve (ahash-ref cur-props-table key) #f)
+  ) ;let*
+) ;define-public
 
 (define (property-rewrite l)
-  `(property-set! ,@l (list ,@cur-conds)))
+  `(property-set! ,@l (list ,@cur-conds))
+) ;define
 
-(define (define-property which) (lambda (opt decl)
-  (set! cur-props (cons `(',(ca*adr decl) ,which ',opt) cur-props))
-  decl))
+(define (define-property which)
+  (lambda (opt decl)
+    (set! cur-props (cons `((quote ,(ca*adr decl)) ,which (quote ,opt)) cur-props))
+    decl
+  ) ;lambda
+) ;define
 
-(define (define-property . l) (lambda (opt decl)
-  (for (which l)
-    (set! cur-props (cons `(',(ca*adr decl) ,which ',opt) cur-props)))
-   decl))
+(define (define-property . l)
+  (lambda (opt decl)
+    (for (which l)
+      (set! cur-props (cons `((quote ,(ca*adr decl)) ,which (quote ,opt)) cur-props))
+    ) ;for
+    decl
+  ) ;lambda
+) ;define
 
-(define (define-property* which) (lambda (opt decl)
-  (set! cur-props (cons `(',(ca*adr decl) ,which (list ,@opt)) cur-props))
-  decl))
+(define (define-property* which)
+  (lambda (opt decl)
+    (set! cur-props (cons `((quote ,(ca*adr decl)) ,which (list ,@opt)) cur-props))
+    decl
+  ) ;lambda
+) ;define
 
 (define (compute-arguments decl)
   (cond ((pair? (cadr decl)) (cdadr decl))
-        ((and (pair? (caddr decl)) (== (caaddr decl) 'lambda))
-         (cadr (caddr decl)))
-        (else
-         (texmacs-error "compute-arguments" "Bad argument documentation"))))
+        ((and (pair? (caddr decl)) (== (caaddr decl) 'lambda)) (cadr (caddr decl)))
+        (else (texmacs-error "compute-arguments" "Bad argument documentation"))
+  ) ;cond
+) ;define
 
 (define (define-option-argument opt decl)
   (let* ((var (ca*adr decl))
          (args (compute-arguments decl))
-         (arg (list :argument (car opt))))
-    (set! cur-props (cons `(',var :arguments ',args) cur-props))
-    (set! cur-props (cons `(',var ',arg ',(cdr opt)) cur-props))
-    decl))
+         (arg (list :argument (car opt)))
+        ) ;
+    (set! cur-props (cons `((quote ,var) ,:arguments (quote ,args)) cur-props))
+    (set! cur-props
+      (cons `((quote ,var) (quote ,arg) (quote ,(cdr opt))) cur-props)
+    ) ;set!
+    decl
+  ) ;let*
+) ;define
 
 (define (define-option-default opt decl)
-  (let* ((var (ca*adr decl))
-         (arg (list :default (car opt))))
-    (set! cur-props (cons `(',var ',arg (lambda () ,@(cdr opt))) cur-props))
-    decl))
+  (let* ((var (ca*adr decl)) (arg (list :default (car opt))))
+    (set! cur-props
+      (cons `((quote ,var) (quote ,arg) (lambda ,() ,@(cdr opt))) cur-props)
+    ) ;set!
+    decl
+  ) ;let*
+) ;define
 
 (define (define-option-proposals opt decl)
-  (let* ((var (ca*adr decl))
-         (arg (list :proposals (car opt))))
-    (set! cur-props (cons `(',var ',arg (lambda () ,@(cdr opt))) cur-props))
-    decl))
+  (let* ((var (ca*adr decl)) (arg (list :proposals (car opt))))
+    (set! cur-props
+      (cons `((quote ,var) (quote ,arg) (lambda ,() ,@(cdr opt))) cur-props)
+    ) ;set!
+    decl
+  ) ;let*
+) ;define
 
 (ahash-set! define-option-table :type (define-property :type))
 (ahash-set! define-option-table :synopsis (define-property :synopsis))
-(ahash-set! define-option-table :synopsis* (define-property :synopsis :synopsis*))
+(ahash-set! define-option-table
+  :synopsis*
+  (define-property :synopsis :synopsis*)
+) ;ahash-set!
 (ahash-set! define-option-table :returns (define-property :returns))
 (ahash-set! define-option-table :note (define-property :note))
 (ahash-set! define-option-table :argument define-option-argument)
@@ -216,79 +276,92 @@
 (ahash-set! define-option-table :balloon (define-property* :balloon))
 
 (define-public (procedure-sources about)
-  (or (and (procedure? about)
-           (ahash-ref tm-defined-table (procedure-name about)))
-      (and (procedure-source about)
-           (list (procedure-source about)))))
+  (or (and (procedure? about) (ahash-ref tm-defined-table (procedure-name about)))
+    (and (procedure-source about) (list (procedure-source about)))
+  ) ;or
+) ;define-public
 
 (define-public (help about)
   ;; very provisional
-  (cond ((property about :synopsis)
-         (property about :synopsis))
-        ((procedure-documentation about)
-         (procedure-documentation about))
-        (else #f)))
+  (cond ((property about :synopsis) (property about :synopsis))
+        ((procedure-documentation about) (procedure-documentation about))
+        (else #f)
+  ) ;cond
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Overloaded functions with properties
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (unlambda pred?)
-  (if (func? pred? 'lambda)
-      (caddr pred?)
-      (list pred?)))
+  (if (func? pred? 'lambda) (caddr pred?) (list pred?))
+) ;define
 
 (define-public (tm-add-condition var head body)
-  (if (null? cur-conds) body
-      `((if ,(and* (map unlambda cur-conds))
-            ,(begin* body)
-            ,(apply* 'former head)))))
+  (if (null? cur-conds)
+    body
+    `((if ,(and* (map unlambda cur-conds))
+        ,(begin* body)
+        ,(apply* 'former head)))
+  ) ;if
+) ;define-public
 
 (define-public-macro (tm-define-overloaded head . body)
   (let* ((var (ca*r head))
          (nbody (tm-add-condition var head body))
-         (nval (lambda* head nbody)))
+         (nval (lambda* head nbody))
+        ) ;
     (if (ahash-ref tm-defined-table var)
-        `(let ((former ,var))
-           ;;(if (== (length (ahash-ref tm-defined-table ',var)) 1)
-           ;;    (display* "Overloaded " ',var "\n"))
-           ;;(display* "Overloaded " ',var "\n")
-           ;;(display* "   " ',nval "\n")
-           (set! ,var ,nval)
-           (ahash-set! tm-defined-table ',var
-                       (cons ',nval (ahash-ref tm-defined-table ',var)))
-           (ahash-set! tm-defined-name ,var ',var)
-          (ahash-set! tm-defined-module ',var
-             (cons *module-name*
-              (ahash-ref tm-defined-module ',var)))
-          ,@(map property-rewrite cur-props))
-        `(begin
-           (when (nnull? cur-conds)
-             (display* "warning: conditional master routine " ',var "\n")
-             (display* "   " ',nval "\n"))
-           ;;(display* "Defined " ',var "\n")
-           ;;(if (nnull? cur-conds) (display* "   " ',nval "\n"))
-           (varlet (rootlet) ',var
-                 (if (null? cur-conds) ,nval
-                     ,(list 'let '((former (lambda args (noop)))) nval)))
-           (ahash-set! tm-defined-table ',var (list ',nval))
-           (ahash-set! tm-defined-name ,var ',var)
-          (ahash-set! tm-defined-module ',var
-                         (list *module-name*))
-          ,@(map property-rewrite cur-props)))))
+      `(let ((former ,var))
+         ;; (if (== (length (ahash-ref tm-defined-table ',var)) 1)
+         ;;    (display* "Overloaded " ',var "\n"))
+         ;; (display* "Overloaded " ',var "\n")
+         ;; (display* "   " ',nval "\n")
+         (set! ,var ,nval)
+         (ahash-set! tm-defined-table
+           (quote ,var)
+           (cons (quote ,nval) (ahash-ref tm-defined-table (quote ,var))))
+         (ahash-set! tm-defined-name ,var (quote ,var))
+         (ahash-set! tm-defined-module
+           (quote ,var)
+           (cons *module-name* (ahash-ref tm-defined-module (quote ,var))))
+         ,@(map property-rewrite cur-props))
+      `(begin
+         (when (nnull? cur-conds)
+           (display* ,"warning: conditional master routine " (quote ,var) ,"\n")
+           (display* ,"   " (quote ,nval) ,"\n"))
+         ;; (display* "Defined " ',var "\n")
+         ;; (if (nnull? cur-conds) (display* "   " ',nval "\n"))
+         (varlet (rootlet)
+           (quote ,var)
+           (if (null? cur-conds)
+             ,nval
+             ,(list 'let '((former (lambda args (noop)))) nval)))
+         (ahash-set! tm-defined-table (quote ,var) (list (quote ,nval)))
+         (ahash-set! tm-defined-name ,var (quote ,var))
+         (ahash-set! tm-defined-module (quote ,var) (list *module-name*))
+         ,@(map property-rewrite cur-props))
+    ) ;if
+  ) ;let*
+) ;define-public-macro
 
 (define-public (tm-define-sub head body)
   (if (and (pair? (car body)) (keyword? (caar body)))
-      (let ((decl (tm-define-sub head (cdr body))))
-        (if (not (ahash-ref define-option-table (caar body)))
-            (texmacs-error "tm-define-sub" "unknown option ~S" (caar body)))
-        ((ahash-ref define-option-table (caar body)) (cdar body) decl))
-      (cons 'tm-define-overloaded (cons head body))))
+    (let ((decl (tm-define-sub head (cdr body))))
+      (if (not (ahash-ref define-option-table (caar body)))
+        (texmacs-error "tm-define-sub" "unknown option ~S" (caar body))
+      ) ;if
+      ((ahash-ref define-option-table (caar body)) (cdar body) decl)
+    ) ;let
+    (cons 'tm-define-overloaded (cons head body))
+  ) ;if
+) ;define-public
 
 (define-public-macro (tm-define head . body)
   (set! cur-conds '())
   (set! cur-props '())
-  (tm-define-sub head body))
+  (tm-define-sub head body)
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Overloaded macros with properties
@@ -296,20 +369,24 @@
 
 (define-public (tm-macroify head)
   (if (pair? head)
-      (cons (tm-macroify (car head)) (cdr head))
-      (string->symbol (string-append (symbol->string head) "$impl"))))
+    (cons (tm-macroify (car head)) (cdr head))
+    (string->symbol (string-append (symbol->string head) "$impl"))
+  ) ;if
+) ;define-public
 
 (define-public-macro (tm-define-macro head . body)
-  (with macro-head (tm-macroify head)
-    ;;(display* (ca*r head) "\n")
-    ;;(display* "   " `(tm-define ,macro-head ,@body) "\n")
-    ;;(display* "   " `(define-public-macro ,head
+  (with macro-head
+    (tm-macroify head)
+    ;; (display* (ca*r head) "\n")
+    ;; (display* "   " `(tm-define ,macro-head ,@body) "\n")
+    ;; (display* "   " `(define-public-macro ,head
     ;;                   ,(apply* (ca*r macro-head) head)) "\n")
     `(begin
        (tm-define ,macro-head ,@body)
        (with-module *texmacs-user-module*
-         (define-public-macro ,head
-           ,(apply* (ca*r macro-head) head))))))
+         (define-public-macro ,head ,(apply* (ca*r macro-head) head))))
+  ) ;with
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Associating extra properties to existing function symbols
@@ -317,18 +394,22 @@
 
 (define-public (tm-property-sub head body)
   (if (null? body)
-      (cons 'tm-property-overloaded (cons head body))
-      (let ((decl (tm-property-sub head (cdr body))))
-        ((ahash-ref define-option-table (caar body)) (cdar body) decl))))
+    (cons 'tm-property-overloaded (cons head body))
+    (let ((decl (tm-property-sub head (cdr body))))
+      ((ahash-ref define-option-table (caar body)) (cdar body) decl)
+    ) ;let
+  ) ;if
+) ;define-public
 
 (define-public-macro (tm-property head . body)
   (set! cur-conds '())
   (set! cur-props '())
-  (tm-property-sub head body))
+  (tm-property-sub head body)
+) ;define-public-macro
 
 (define-public-macro (tm-property-overloaded head . body)
-  `(begin
-     ,@(map property-rewrite cur-props)))
+  `(begin ,@(map property-rewrite cur-props))
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy function declations
@@ -337,32 +418,39 @@
 (define lazy-define-table (make-ahash-table))
 
 (define-public (not-define-option? item)
-  (not (and (pair? item) (keyword? (car item)))))
+  (not (and (pair? item) (keyword? (car item))))
+) ;define-public
 
 (define-public (lazy-define-one module opts name)
   (let* ((old (ahash-ref lazy-define-table name))
-         (new (if old (cons module old) (list module))))
-    (ahash-set! lazy-define-table name new))
-  (with name-star (string->symbol (string-append (symbol->string name) "*"))
-    `(when (not (defined? ',name))
+         (new (if old (cons module old) (list module)))
+        ) ;
+    (ahash-set! lazy-define-table name new)
+  ) ;let*
+  (with name-star
+    (string->symbol (string-append (symbol->string name) "*"))
+    `(when (not (defined? (quote ,name)))
        (tm-define (,name . args)
          ,@opts
-         (let* ((m (resolve-module ',module))
-                (r (m ',name)))
+         (let* ((m (resolve-module (quote ,module))) (r (m (quote ,name))))
            (if (not r)
-               (texmacs-error "lazy-define"
-                              ,(string-append "Could not retrieve "
-                                              (symbol->string name))))
-           (apply r args))))))
+             (texmacs-error ,"lazy-define"
+               ,(string-append "Could not retrieve " (symbol->string name))))
+           (apply r args))))
+  ) ;with
+) ;define-public
 
 (define-public-macro (lazy-define module . names)
-  (receive (opts real-names) (list-break names not-define-option?)
-    `(begin
-       ,@(map (lambda (name) (lazy-define-one module opts name)) names))))
+  (receive (opts real-names)
+    (list-break names not-define-option?)
+    `(begin ,@(map (lambda (name) (lazy-define-one module opts name)) names))
+  ) ;receive
+) ;define-public-macro
 
 (define-public (lazy-define-force name)
   (if (procedure? name) (set! name (procedure-name name)))
-  (let* ((im (ahash-ref lazy-define-table name))
-         (modules (if im im '())))
+  (let* ((im (ahash-ref lazy-define-table name)) (modules (if im im '())))
     (ahash-remove! lazy-define-table name)
-    (for-each module-provide modules)))
+    (for-each module-provide modules)
+  ) ;let*
+) ;define-public

--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
@@ -11,38 +11,45 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel texmacs tm-dialogue)
-  (:use (kernel texmacs tm-define)))
-(import (liii njson)
-        (liii time)
-        (liii list))
+(texmacs-module (kernel texmacs tm-dialogue) (:use (kernel texmacs tm-define)))
+(import (liii njson) (liii time) (liii list))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Questions with user interaction
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (user-ask prompt cont)
   (tm-interactive cont
-    (if (string? prompt)
-        (list (build-interactive-arg prompt))
-        (list prompt))))
+    (if (string? prompt) (list (build-interactive-arg prompt)) (list prompt))
+  ) ;tm-interactive
+) ;define-public
 
 (define-public (user-confirm prompt default cont)
   (let ((k (lambda (answ) (cont (yes? answ)))))
     (if default
-        (user-ask (list prompt "question" (translate "yes") (translate "no")) k)
-        (user-ask (list prompt "question" (translate "no") (translate "yes")) k))))
+      (user-ask (list prompt "question" (translate "yes") (translate "no")) k)
+      (user-ask (list prompt "question" (translate "no") (translate "yes")) k)
+    ) ;if
+  ) ;let
+) ;define-public
 
 (define-public (user-simple-confirm prompt default cont)
-    (let ((k (lambda (answ) (cont (yes? answ)))))
-      (if default
-          (user-ask (list prompt "question-no-cancel" (translate "yes") (translate "no")) k)
-          (user-ask (list prompt "question-no-cancel" (translate "no") (translate "yes")) k))))
+  (let ((k (lambda (answ) (cont (yes? answ)))))
+    (if default
+      (user-ask (list prompt "question-no-cancel" (translate "yes") (translate "no"))
+        k
+      ) ;user-ask
+      (user-ask (list prompt "question-no-cancel" (translate "no") (translate "yes"))
+        k
+      ) ;user-ask
+    ) ;if
+  ) ;let
+) ;define-public
 
 (define-public (user-url prompt type cont)
-  (user-delayed (lambda () (choose-file cont prompt type))))
+  (user-delayed (lambda () (choose-file cont prompt type)))
+) ;define-public
 
-(define-public (user-delayed cont)
-  (exec-delayed cont))
+(define-public (user-delayed cont) (exec-delayed cont))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Delayed execution of commands
@@ -50,76 +57,88 @@
 
 (define-public (delayed-sub body)
   (cond ((or (npair? body) (nlist? (car body)) (not (keyword? (caar body))))
-         `(lambda () ,@body #t))
+         `(lambda ,() ,@body ,#t)
+        ) ;
         ((== (caar body) :pause)
-         `(let* ((start (texmacs-time))
-                 (proc ,(delayed-sub (cdr body))))
-            (lambda ()
-              (with left (- (+ start ,(cadar body)) (texmacs-time))
-                (if (> left 0) left
-                    (begin
-                      (set! start (texmacs-time))
-                      (proc)))))))
+         `(let* ((start (texmacs-time)) (proc ,(delayed-sub (cdr body))))
+            (lambda ,()
+              (with left
+                (- (+ start ,(cadar body)) (texmacs-time))
+                (if (> left 0) left (begin (set! start (texmacs-time)) (proc))))))
+        ) ;
         ((== (caar body) :every)
          `(let* ((time (+ (texmacs-time) ,(cadar body)))
                  (proc ,(delayed-sub (cdr body))))
-            (lambda ()
-              (with left (- time (texmacs-time))
-                (if (> left 0) left
-                    (begin
-                      (set! time (+ (texmacs-time) ,(cadar body)))
-                      (proc)))))))
+            (lambda ,()
+              (with left
+                (- time (texmacs-time))
+                (if (> left 0)
+                  left
+                  (begin (set! time (+ (texmacs-time) ,(cadar body))) (proc))))))
+        ) ;
         ((== (caar body) :idle)
-         `(with proc ,(delayed-sub (cdr body))
-            (lambda ()
-              (with left (- ,(cadar body) (idle-time))
-                (if (> left 0) left
-                    (proc))))))
+         `(with proc
+            ,(delayed-sub (cdr body))
+            (lambda ,()
+              (with left
+                (- ,(cadar body) (idle-time))
+                (if (> left 0) left (proc)))))
+        ) ;
         ((== (caar body) :refresh)
-         (with sym (gensym)
-           `(let* ((,sym #f)
-                   (proc ,(delayed-sub (cdr body))))
-              (lambda ()
-                (if (!= ,sym (change-time)) 0
-                    (with left (- ,(cadar body) (idle-time))
-                      (if (> left 0) left
-                          (begin
-                            (set! ,sym (change-time))
-                            (proc)))))))))
+         (with sym
+           (gensym)
+           `(let* ((,sym ,#f) (proc ,(delayed-sub (cdr body))))
+              (lambda ,()
+                (if (!= ,sym (change-time))
+                  ,0
+                  (with left
+                    (- ,(cadar body) (idle-time))
+                    (if (> left 0)
+                      left
+                      (begin (set! ,sym (change-time)) (proc)))))))
+         ) ;with
+        ) ;
         ((== (caar body) :require)
-         `(with proc ,(delayed-sub (cdr body))
-            (lambda ()
-              (if (not ,(cadar body)) 0
-                  (proc)))))
+         `(with proc
+            ,(delayed-sub (cdr body))
+            (lambda ,() (if (not ,(cadar body)) ,0 (proc))))
+        ) ;
         ((== (caar body) :while)
-         `(with proc ,(delayed-sub (cdr body))
-            (lambda ()
-              (if (not ,(cadar body)) #t
-                  (with left (proc)
-                    (if (== left #t) 0 left))))))
+         `(with proc
+            ,(delayed-sub (cdr body))
+            (lambda ,()
+              (if (not ,(cadar body))
+                ,#t
+                (with left (proc) (if (== left #t) 0 left)))))
+        ) ;
         ((== (caar body) :clean)
-         `(with proc ,(delayed-sub (cdr body))
-            (lambda ()
-              (with left (proc)
-                (if (!= left #t) left
-                    (begin ,(cadar body) #t))))))
+         `(with proc
+            ,(delayed-sub (cdr body))
+            (lambda ,()
+              (with left
+                (proc)
+                (if (!= left #t) left (begin ,(cadar body) ,#t)))))
+        ) ;
         ((== (caar body) :permanent)
-         `(with proc ,(delayed-sub (cdr body))
-            (lambda ()
-              (with left (proc)
-                (if (!= left #t) left
-                    (with next ,(cadar body)
-                      (if (!= next #t) #t
-                          0)))))))
+         `(with proc
+            ,(delayed-sub (cdr body))
+            (lambda ,()
+              (with left
+                (proc)
+                (if (!= left #t)
+                  left
+                  (with next ,(cadar body) (if (!= next #t) #t 0))))))
+        ) ;
         ((== (caar body) :do)
-         `(with proc ,(delayed-sub (cdr body))
-            (lambda ()
-              ,(cadar body)
-              (proc))))
-        (else (delayed-sub (cdr body)))))
+         `(with proc
+            ,(delayed-sub (cdr body))
+            (lambda ,() ,(cadar body) (proc)))
+        ) ;
+        (else (delayed-sub (cdr body)))
+  ) ;cond
+) ;define-public
 
-(define-public-macro (delayed . body)
-  `(exec-delayed-pause ,(delayed-sub body)))
+(define-public-macro (delayed . body) `(exec-delayed-pause ,(delayed-sub body)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Messages and feedback on the status bar
@@ -127,261 +146,346 @@
 
 (define-public message-serial 0)
 
-(define-public (set-message-notify)
-  (set! message-serial (+ message-serial 1)))
+(define-public (set-message-notify) (set! message-serial (+ message-serial 1)))
 
 (define-public (recall-message-after len)
-  (with current message-serial
-    (delayed
-      (:idle len)
-      (when (== message-serial current)
-        (recall-message)))))
+  (with current
+    message-serial
+    (delayed (:idle len) (when (== message-serial current) (recall-message)))
+  ) ;with
+) ;define-public
 
 (define-public (set-temporary-message left right len)
   (set-message-temp left right #t)
-  (recall-message-after len))
+  (recall-message-after len)
+) ;define-public
 
 (define-public (texmacs-banner)
-  (with tmv (string-append "GNU TeXmacs " (texmacs-version))
-    (delayed
-     (set-message "Welcome to GNU TeXmacs" tmv)
-     (delayed
-     (:pause 5000)
-     (set-message "GNU TeXmacs falls under the GNU general public license" tmv)
-     (delayed
-     (:pause 2500)
-     (set-message "GNU TeXmacs comes without any form of legal warranty" tmv)
-     (delayed
-     (:pause 2500)
-     (set-message
-      "More information about GNU TeXmacs can be found in the Help->About menu"
-      tmv)
-     (delayed
-     (:pause 2500)
-     (set-message "" ""))))))))
+  (with tmv
+    (string-append "GNU TeXmacs " (texmacs-version))
+    (delayed (set-message "Welcome to GNU TeXmacs" tmv)
+      (delayed (:pause 5000)
+        (set-message "GNU TeXmacs falls under the GNU general public license" tmv)
+        (delayed (:pause 2500)
+          (set-message "GNU TeXmacs comes without any form of legal warranty" tmv)
+          (delayed (:pause 2500)
+            (set-message "More information about GNU TeXmacs can be found in the Help->About menu"
+              tmv
+            ) ;set-message
+            (delayed (:pause 2500) (set-message "" ""))
+          ) ;delayed
+        ) ;delayed
+      ) ;delayed
+    ) ;delayed
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interactive commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define interactive-arg-version 1)
+
 (define interactive-arg-file "$TEXMACS_HOME_PATH/system/interactive.json")
-(define interactive-arg-recent-file-path "$TEXMACS_HOME_PATH/system/recent-files.json")
+
+(define interactive-arg-recent-file-path
+  "$TEXMACS_HOME_PATH/system/recent-files.json"
+) ;define
+
 (define legacy-interactive-arg-file "$TEXMACS_HOME_PATH/system/interactive.scm")
+
 (define interactive-arg-migration-marker-v1
-  "$TEXMACS_HOME_PATH/system/interactive.scm->v1")
+  "$TEXMACS_HOME_PATH/system/interactive.scm->v1"
+) ;define
+
 (define recent-files-migration-marker-v1
-  "$TEXMACS_HOME_PATH/system/recent-files.scm->v1")
+  "$TEXMACS_HOME_PATH/system/recent-files.scm->v1"
+) ;define
+
 (define interactive-arg-file-system
-  (url->system (string->url interactive-arg-file)))
+  (url->system (string->url interactive-arg-file))
+) ;define
+
 (define interactive-arg-recent-file-system
-  (url->system (string->url interactive-arg-recent-file-path)))
+  (url->system (string->url interactive-arg-recent-file-path))
+) ;define
 
 (define (make-empty-state kind)
   (case kind
-    ((interactive-arg)
-     (let ((root (string->njson "{\"meta\":{},\"commands\":{}}")))
-       (njson-set! root "meta" "version" interactive-arg-version)
-       root))
-    ((recent-file)
-     (string->njson "{\"meta\":{\"version\":1,\"total\":0},\"files\":[]}"))
-    (else
-     (string->njson "{}"))))
+   ((interactive-arg)
+    (let ((root (string->njson "{\"meta\":{},\"commands\":{}}")))
+      (njson-set! root "meta" "version" interactive-arg-version)
+      root
+    ) ;let
+   ) ;
+   ((recent-file)
+    (string->njson "{\"meta\":{\"version\":1,\"total\":0},\"files\":[]}")
+   ) ;
+   (else (string->njson "{}"))
+  ) ;case
+) ;define
 
-(define interactive-arg-json
-  (make-empty-state 'interactive-arg))
+(define interactive-arg-json (make-empty-state 'interactive-arg))
 
 
-(define interactive-arg-recent-file-json
-  (make-empty-state 'recent-file))
+(define interactive-arg-recent-file-json (make-empty-state 'recent-file))
 
 (define interactive-args-schema-v1
-  (string->njson
-   "{\"type\":\"object\",\"required\":[\"meta\",\"commands\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\"],\"properties\":{\"version\":{\"type\":\"integer\",\"minimum\":1}}},\"commands\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}}}}}}"))
+  (string->njson "{\"type\":\"object\",\"required\":[\"meta\",\"commands\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\"],\"properties\":{\"version\":{\"type\":\"integer\",\"minimum\":1}}},\"commands\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}}}}}}"
+  ) ;string->njson
+) ;define
 
 (define recent-files-schema-v1
-  (string->njson
-   "{\"type\":\"object\",\"required\":[\"meta\",\"files\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\",\"total\"],\"properties\":{\"version\":{\"type\":\"number\"},\"total\":{\"type\":\"integer\",\"minimum\":0}}},\"files\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"required\":[\"path\",\"name\",\"last_open\",\"open_count\",\"show\"],\"properties\":{\"path\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"last_open\":{\"type\":\"number\"},\"open_count\":{\"type\":\"number\"},\"show\":{\"type\":\"boolean\"}}}}}}"))
+  (string->njson "{\"type\":\"object\",\"required\":[\"meta\",\"files\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\",\"total\"],\"properties\":{\"version\":{\"type\":\"number\"},\"total\":{\"type\":\"integer\",\"minimum\":0}}},\"files\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"required\":[\"path\",\"name\",\"last_open\",\"open_count\",\"show\"],\"properties\":{\"path\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"last_open\":{\"type\":\"number\"},\"open_count\":{\"type\":\"number\"},\"show\":{\"type\":\"boolean\"}}}}}}"
+  ) ;string->njson
+) ;define
 
 (define (njson-schema-valid? schema instance)
   (catch #t
     (lambda ()
       (let ((report (njson-schema-report schema instance)))
-        (hash-table-ref report 'valid?)))
-    (lambda args #f)))
+        (hash-table-ref report 'valid?)
+      ) ;let
+    ) ;lambda
+    (lambda args #f)
+  ) ;catch
+) ;define
 
 (define (interactive-args-json-valid? interactive-args)
-  (njson-schema-valid? interactive-args-schema-v1 interactive-args))
+  (njson-schema-valid? interactive-args-schema-v1 interactive-args)
+) ;define
 
 (define (interactive-command-learned command-name)
   (let-njson ((commands (njson-ref interactive-arg-json "commands")))
     (if (njson-contains-key? commands command-name)
-        (let-njson ((items (njson-ref commands command-name)))
-          (if (njson-array? items)
-              (vector->list (njson->json items))
-              '()))
-        '())))
+      (let-njson ((items (njson-ref commands command-name)))
+        (if (njson-array? items) (vector->list (njson->json items)) '())
+      ) ;let-njson
+      '()
+    ) ;if
+  ) ;let-njson
+) ;define
 
 (define (set-interactive-command-learned command-name items)
   (let-njson ((payload (json->njson (list->vector items))))
-    (njson-set! interactive-arg-json "commands" command-name payload)))
+    (njson-set! interactive-arg-json "commands" command-name payload)
+  ) ;let-njson
+) ;define
 
 (define (remove-interactive-command-learned command-name)
   (let-njson ((commands (njson-ref interactive-arg-json "commands")))
     (when (njson-contains-key? commands command-name)
-      (njson-drop! interactive-arg-json "commands" command-name))))
+      (njson-drop! interactive-arg-json "commands" command-name)
+    ) ;when
+  ) ;let-njson
+) ;define
 
 (define (recent-files-json-valid? recent-files)
-  (njson-schema-valid? recent-files-schema-v1 recent-files))
+  (njson-schema-valid? recent-files-schema-v1 recent-files)
+) ;define
 
-;;recent-files-remove-by-path
-;;按路径从最近文件缓存中删除对应条目。
+;; recent-files-remove-by-path
+;; 按路径从最近文件缓存中删除对应条目。
 ;;
-;;语法
-;;----
-;;(recent-files-remove-by-path path)
+;; 语法
+;; ----
+;; (recent-files-remove-by-path path)
 ;;
-;;参数
-;;----
-;;path : string
+;; 参数
+;; ----
+;; path : string
 ;;    目标文件路径。用于在 `interactive-arg-recent-file-json` 的 `files`
 ;;    列表中定位要移除的记录。
 ;;
-;;返回值
-;;----
-;;unspecified
-;;- 函数通过副作用更新全局变量 `interactive-arg-recent-file-json`。
-;;- 若路径不存在，则不做任何修改。
+;; 返回值
+;; ----
+;; unspecified
+;; - 函数通过副作用更新全局变量 `interactive-arg-recent-file-json`。
+;; - 若路径不存在，则不做任何修改。
 ;;
-;;逻辑
-;;----
-;;1. 调用 `recent-files-index-by-path` 查找 `path` 在 `files` 中的索引。
-;;2. 若找到索引，调用 `njson-drop!` 删除该项。
-;;3. 将 `meta.total` 减一（不低于 0）。
-;;4. 将更新后的 JSON 结构回写到 `interactive-arg-recent-file-json`。
+;; 逻辑
+;; ----
+;; 1. 调用 `recent-files-index-by-path` 查找 `path` 在 `files` 中的索引。
+;; 2. 若找到索引，调用 `njson-drop!` 删除该项。
+;; 3. 将 `meta.total` 减一（不低于 0）。
+;; 4. 将更新后的 JSON 结构回写到 `interactive-arg-recent-file-json`。
 (define-public (recent-files-remove-by-path path)
   (let ((idx (recent-files-index-by-path interactive-arg-recent-file-json path)))
     (when idx
       (let* ((total (njson-ref interactive-arg-recent-file-json "meta" "total"))
              (total (if (number? total) total 0))
-             (new-total (if (<= total 0) 0 (- total 1))))
+             (new-total (if (<= total 0) 0 (- total 1)))
+            ) ;
         (njson-drop! interactive-arg-recent-file-json "files" idx)
-        (njson-set! interactive-arg-recent-file-json "meta" "total" new-total)))))
+        (njson-set! interactive-arg-recent-file-json "meta" "total" new-total)
+      ) ;let*
+    ) ;when
+  ) ;let
+) ;define-public
 
 
 
 (define (recent-files-apply-lru recent-files limit)
   (let-njson ((files (njson-ref recent-files "files")))
     (let* ((n (njson-size files))
-           (indexed
-            (let loop ((i 0) (acc '()))
-              (if (>= i n) acc
-                  (let* ((t (njson-ref files i "last_open"))
-                         (t (if (number? t) t 0)))
-                    (loop (+ i 1) (cons (cons i t) acc))))))
-           (sorted (sort indexed (lambda (a b) (> (cdr a) (cdr b))))))
+           (indexed (let loop
+                      ((i 0) (acc '()))
+                      (if (>= i n)
+                        acc
+                        (let* ((t (njson-ref files i "last_open")) (t (if (number? t) t 0)))
+                          (loop (+ i 1) (cons (cons i t) acc))
+                        ) ;let*
+                      ) ;if
+                    ) ;let
+           ) ;indexed
+           (sorted (sort indexed (lambda (a b) (> (cdr a) (cdr b)))))
+          ) ;
       (let-njson ((new-files (string->njson "[]")))
-        (let loop ((rank 0) (rest sorted))
+        (let loop
+          ((rank 0) (rest sorted))
           (when (pair? rest)
-            (let* ((p (car rest))
-                   (idx (car p))
-                   (show? (< rank limit)))
+            (let* ((p (car rest)) (idx (car p)) (show? (< rank limit)))
               (let-njson ((item (njson-ref files idx)))
                 (njson-set! item "show" show?)
-                (njson-append! new-files item))
-              (loop (+ rank 1) (cdr rest)))))
-        (njson-set! recent-files "files" new-files)))
-    recent-files))
+                (njson-append! new-files item)
+              ) ;let-njson
+              (loop (+ rank 1) (cdr rest))
+            ) ;let*
+          ) ;when
+        ) ;let
+        (njson-set! recent-files "files" new-files)
+      ) ;let-njson
+    ) ;let*
+    recent-files
+  ) ;let-njson
+) ;define
 
 (define (recent-files-add recent-files path name)
-  (let-njson ((item (json->njson
-                      `(("path" . ,path)
-                        ("name" . ,name)
-                        ("last_open" . ,(current-second))
-                        ("open_count" . 1)
-                        ("show" . #t)))))
-    (njson-append! recent-files "files" item))
+  (let-njson ((item (json->njson `((,"path" unquote path)
+                                   (,"name" unquote name)
+                                   (,"last_open" unquote (current-second))
+                                   (,"open_count" unquote 1)
+                                   (,"show" unquote #t))
+                    ) ;json->njson
+              ) ;item
+             ) ;
+    (njson-append! recent-files "files" item)
+  ) ;let-njson
   (let* ((total (njson-ref recent-files "meta" "total"))
-         (total (if (number? total) total 0)))
-    (njson-set! recent-files "meta" "total" (+ total 1)))
-  (recent-files-apply-lru recent-files 25))
+         (total (if (number? total) total 0))
+        ) ;
+    (njson-set! recent-files "meta" "total" (+ total 1))
+  ) ;let*
+  (recent-files-apply-lru recent-files 25)
+) ;define
 
 (define (recent-files-set recent-files idx)
   (let* ((count* (njson-ref recent-files "files" idx "open_count"))
-         (count* (if (number? count*) count* 0)))
+         (count* (if (number? count*) count* 0))
+        ) ;
     (njson-set! recent-files "files" idx "last_open" (current-second))
     (njson-set! recent-files "files" idx "open_count" (+ count* 1))
     (njson-set! recent-files "files" idx "show" #t)
-    (recent-files-apply-lru recent-files 25)))
+    (recent-files-apply-lru recent-files 25)
+  ) ;let*
+) ;define
 
 
 
 (define (recent-files-index-by-path recent-files path)
   (let-njson ((files (njson-ref recent-files "files")))
-    (let loop ((i 0))
+    (let loop
+      ((i 0))
       (if (>= i (njson-size files))
-          #f
-          (if (equal? (njson-ref files i "path") path)
-              i
-              (loop (+ i 1)))))))
+        #f
+        (if (equal? (njson-ref files i "path") path) i (loop (+ i 1)))
+      ) ;if
+    ) ;let
+  ) ;let-njson
+) ;define
 
 (define (recent-files-paths recent-files)
   (let-njson ((files (njson-ref recent-files "files")))
-    (let loop ((i 0) (n (njson-size files)) (acc '()))
-      (if (>= i n) (reverse acc)
-          (loop (+ i 1) n
-                (cons (list (cons "0" (njson-ref files i "path"))) acc))))))
+    (let loop
+      ((i 0) (n (njson-size files)) (acc '()))
+      (if (>= i n)
+        (reverse acc)
+        (loop (+ i 1) n (cons (list (cons "0" (njson-ref files i "path"))) acc))
+      ) ;if
+    ) ;let
+  ) ;let-njson
+) ;define
 
 
 (define (list-but l1 l2)
   (cond ((null? l1) l1)
         ((in? (car l1) l2) (list-but (cdr l1) l2))
-        (else (cons (car l1) (list-but (cdr l1) l2)))))
+        (else (cons (car l1) (list-but (cdr l1) l2)))
+  ) ;cond
+) ;define
 
 (define (as-stree x)
   (cond ((tree? x) (tree->stree x))
         ((== x #f) "false")
         ((== x #t) "true")
-        (else x)))
+        (else x)
+  ) ;cond
+) ;define
 
 (define (interactive-key->string x)
   (cond ((string? x) x)
         ((symbol? x) (symbol->string x))
         ((number? x) (number->string x))
-        (else (object->string x))))
+        (else (object->string x))
+  ) ;cond
+) ;define
 
 (define (interactive-value->string x)
-  (with y (as-stree x)
+  (with y
+    (as-stree x)
     (cond ((string? y) y)
           ((symbol? y) (symbol->string y))
           ((number? y) (number->string y))
           ((boolean? y) (if y "true" "false"))
-          (else (object->string y)))))
+          (else (object->string y))
+    ) ;cond
+  ) ;with
+) ;define
 
 (define (normalize-interactive-assoc assoc-t)
   (map (lambda (x)
-         (cons (interactive-key->string (car x))
-               (interactive-value->string (cdr x))))
-       assoc-t))
+         (cons (interactive-key->string (car x)) (interactive-value->string (cdr x)))
+       ) ;lambda
+    assoc-t
+  ) ;map
+) ;define
 
 (define-public (procedure-symbol-name fun)
   (cond ((symbol? fun) fun)
         ((string? fun) (string->symbol fun))
         ((and (procedure? fun) (procedure-name fun)) => identity)
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define-public
 
 (define-public (procedure-string-name fun)
-  (and-with name (procedure-symbol-name fun)
-    (symbol->string name)))
+  (and-with name (procedure-symbol-name fun) (symbol->string name))
+) ;define-public
 
 (define (recent-buffer-json file-path)
   (let* ((name (url->system (url-tail (system->url file-path))))
-         (idx (recent-files-index-by-path interactive-arg-recent-file-json file-path)))
+         (idx (recent-files-index-by-path interactive-arg-recent-file-json file-path))
+        ) ;
     (if idx
-        (set! interactive-arg-recent-file-json
-              (recent-files-set interactive-arg-recent-file-json idx))
-        (set! interactive-arg-recent-file-json
-              (recent-files-add interactive-arg-recent-file-json file-path name)))))
+      (set! interactive-arg-recent-file-json
+        (recent-files-set interactive-arg-recent-file-json idx)
+      ) ;set!
+      (set! interactive-arg-recent-file-json
+        (recent-files-add interactive-arg-recent-file-json file-path name)
+      ) ;set!
+    ) ;if
+  ) ;let*
+) ;define
 
 
 (define-public (learn-interactive fun assoc-t)
@@ -391,77 +495,81 @@
   (when (symbol? fun)
     (let* ((name (symbol->string fun))
            (l1 (interactive-command-learned name))
-           (l2 (cons assoc-t (list-but l1 (list assoc-t)))))
+           (l2 (cons assoc-t (list-but l1 (list assoc-t))))
+          ) ;
       (case fun
-        ((recent-buffer)
-          (recent-buffer-json (cdr (car (car l2)))))
-        (else (set-interactive-command-learned name l2)))
-      )))
+       ((recent-buffer) (recent-buffer-json (cdr (car (car l2)))))
+       (else (set-interactive-command-learned name l2))
+      ) ;case
+    ) ;let*
+  ) ;when
+) ;define-public
 
 
-;;learned-interactive
-;;读取交互命令已学习的参数候选值。
+;; learned-interactive
+;; 读取交互命令已学习的参数候选值。
 ;;
-;;语法
-;;----
-;;(learned-interactive fun)
+;; 语法
+;; ----
+;; (learned-interactive fun)
 ;;
-;;参数
-;;----
-;;fun : procedure | symbol | string
+;; 参数
+;; ----
+;; fun : procedure | symbol | string
 ;;    目标命令。函数内部会先调用 `procedure-symbol-name` 归一化为符号。
 ;;
-;;返回值
-;;----
-;;list
-;;- 当命令是 `recent-buffer` 时：返回最近文件路径列表，元素形如
+;; 返回值
+;; ----
+;; list
+;; - 当命令是 `recent-buffer` 时：返回最近文件路径列表，元素形如
 ;;  `(("0" . 文件路径))`。
-;;- 其他命令：返回 `interactive-arg-json` 中为该命令记录的历史参数列表。
-;;- 若无记录，返回空列表 `()`。
+;; - 其他命令：返回 `interactive-arg-json` 中为该命令记录的历史参数列表。
+;; - 若无记录，返回空列表 `()`。
 ;;
-;;逻辑
-;;----
-;;1. 归一化：将 `fun` 转为符号名。
-;;2. 分支：`recent-buffer` 走最近文件 JSON 缓存分支。
-;;3. 默认：从 `interactive-arg-json` 读取命令历史，缺省为 `()`。
+;; 逻辑
+;; ----
+;; 1. 归一化：将 `fun` 转为符号名。
+;; 2. 分支：`recent-buffer` 走最近文件 JSON 缓存分支。
+;; 3. 默认：从 `interactive-arg-json` 读取命令历史，缺省为 `()`。
 (define-public (learned-interactive fun)
   "Return learned list of interactive values for @fun"
   (set! fun (procedure-symbol-name fun))
   (case fun
-    ((recent-buffer)
-     (recent-files-paths interactive-arg-recent-file-json))
-    (else
-     (with name (procedure-string-name fun)
-       (if (string? name)
-           (interactive-command-learned name)
-           '())))))
+   ((recent-buffer) (recent-files-paths interactive-arg-recent-file-json))
+   (else (with name
+           (procedure-string-name fun)
+           (if (string? name) (interactive-command-learned name) '())
+         ) ;with
+   ) ;else
+  ) ;case
+) ;define-public
 
 
 
 
-;;forget-interactive
-;;清除指定交互命令的已学习参数。
+;; forget-interactive
+;; 清除指定交互命令的已学习参数。
 ;;
-;;语法
-;;----
-;;(forget-interactive fun)
+;; 语法
+;; ----
+;; (forget-interactive fun)
 ;;
-;;参数
-;;----
-;;fun : procedure | symbol | string
+;; 参数
+;; ----
+;; fun : procedure | symbol | string
 ;;    目标命令。函数内部会先调用 `procedure-symbol-name` 归一化为符号。
 ;;
-;;返回值
-;;----
-;;unspecified
-;;- 通过副作用修改全局状态。
-;;- 若 `fun` 不能归一化为符号，则不执行清除操作。
+;; 返回值
+;; ----
+;; unspecified
+;; - 通过副作用修改全局状态。
+;; - 若 `fun` 不能归一化为符号，则不执行清除操作。
 ;;
-;;逻辑
-;;----
-;;1. 归一化：将 `fun` 转为符号名。
-;;2. 校验：仅当 `fun` 是符号时继续。
-;;3. 分支清理：
+;; 逻辑
+;; ----
+;; 1. 归一化：将 `fun` 转为符号名。
+;; 2. 校验：仅当 `fun` 是符号时继续。
+;; 3. 分支清理：
 ;;   - `recent-buffer`：将最近文件列表重置为空向量 `#()`，并把计数清零。
 ;;   - 其他命令：从 `interactive-arg-json` 中删除对应键。
 (define-public (forget-interactive fun)
@@ -469,120 +577,170 @@
   (set! fun (procedure-symbol-name fun))
   (when (symbol? fun)
     (case fun
-      ((recent-buffer)
-       (njson-free interactive-arg-recent-file-json)
-       (set! interactive-arg-recent-file-json
-             (make-empty-state 'recent-file)))
-      (else
-       (with name (procedure-string-name fun)
-         (when (string? name)
-           (remove-interactive-command-learned name)))))))
+     ((recent-buffer)
+      (njson-free interactive-arg-recent-file-json)
+      (set! interactive-arg-recent-file-json (make-empty-state 'recent-file))
+     ) ;
+     (else (with name
+             (procedure-string-name fun)
+             (when (string? name)
+               (remove-interactive-command-learned name)
+             ) ;when
+           ) ;with
+     ) ;else
+    ) ;case
+  ) ;when
+) ;define-public
 
 
 (define (learned-interactive-arg fun nr)
   (let* ((l (learned-interactive fun))
          (arg (number->string nr))
-         (extract (lambda (assoc-l) (assoc-ref assoc-l arg))))
-    (map extract l)))
+         (extract (lambda (assoc-l) (assoc-ref assoc-l arg)))
+        ) ;
+    (map extract l)
+  ) ;let*
+) ;define
 
 (define (compute-interactive-arg-text fun which)
-  (with arg (property fun (list :argument which))
+  (with arg
+    (property fun (list :argument which))
     (cond ((npair? arg) (upcase-first (symbol->string which)))
           ((and (string? (car arg)) (null? (cdr arg))) (car arg))
           ((string? (cadr arg)) (cadr arg))
-          (else (upcase-first (symbol->string which))))))
+          (else (upcase-first (symbol->string which)))
+    ) ;cond
+  ) ;with
+) ;define
 
 (define (compute-interactive-arg-type fun which)
-  (with arg (property fun (list :argument which))
+  (with arg
+    (property fun (list :argument which))
     (cond ((or (npair? arg) (npair? (cdr arg))) "string")
           ((string? (car arg)) (car arg))
           ((symbol? (car arg)) (symbol->string (car arg)))
-          (else "string"))))
+          (else "string")
+    ) ;cond
+  ) ;with
+) ;define
 
 (define (compute-interactive-arg-proposals fun which)
   (let* ((default (property fun (list :default which)))
          (proposals (property fun (list :proposals which)))
-         (learned '()))
+         (learned '())
+        ) ;
     (cond ((procedure? default) (list (default)))
           ((procedure? proposals) (proposals))
-          (else '()))))
+          (else '())
+    ) ;cond
+  ) ;let*
+) ;define
 
 (define (compute-interactive-arg fun which)
   (cons (compute-interactive-arg-text fun which)
-        (cons (compute-interactive-arg-type fun which)
-              (compute-interactive-arg-proposals fun which))))
+    (cons (compute-interactive-arg-type fun which)
+      (compute-interactive-arg-proposals fun which)
+    ) ;cons
+  ) ;cons
+) ;define
 
 (define (compute-interactive-args-try-hard fun)
-  (with src (procedure-source fun)
-    (if (and (pair? src) (== (car src) 'lambda)
-             (pair? (cdr src)) (list? (cadr src)))
-        (map upcase-first (map symbol->string (cadr src)))
-        '())))
+  (with src
+    (procedure-source fun)
+    (if (and (pair? src) (== (car src) 'lambda) (pair? (cdr src)) (list? (cadr src)))
+      (map upcase-first (map symbol->string (cadr src)))
+      '()
+    ) ;if
+  ) ;with
+) ;define
 
 (define (compute-interactive-arg-list fun l)
-  (if (npair? l) (list)
-      (cons (compute-interactive-arg fun (car l))
-            (compute-interactive-arg-list fun (cdr l)))))
+  (if (npair? l)
+    (list)
+    (cons (compute-interactive-arg fun (car l))
+      (compute-interactive-arg-list fun (cdr l))
+    ) ;cons
+  ) ;if
+) ;define
 
 (tm-define (compute-interactive-args fun)
-  (let* ((args (property fun :arguments))
-         (syn* (property fun :synopsis*)))
-    (cond ((not args)
-           (compute-interactive-args-try-hard fun))
+  (let* ((args (property fun :arguments)) (syn* (property fun :synopsis*)))
+    (cond ((not args) (compute-interactive-args-try-hard fun))
           ((and (not (side-tools?)) (list-1? syn*) (string? (car syn*)))
            (let* ((type (compute-interactive-arg-type fun (car args)))
                   (prop (compute-interactive-arg-proposals fun (car args)))
-                  (tail (compute-interactive-arg-list fun (cdr args))))
-             (cons (cons (car syn*) (cons type prop)) tail)))
-          (else (compute-interactive-arg-list fun args)))))
+                  (tail (compute-interactive-arg-list fun (cdr args)))
+                 ) ;
+             (cons (cons (car syn*) (cons type prop)) tail)
+           ) ;let*
+          ) ;
+          (else (compute-interactive-arg-list fun args))
+    ) ;cond
+  ) ;let*
+) ;tm-define
 
 (define (build-interactive-arg s)
   (cond ((string-ends? s ":") s)
         ((string-ends? s "?") s)
-        (else (string-append s ":"))))
+        (else (string-append s ":"))
+  ) ;cond
+) ;define
 
 (tm-define (build-interactive-args fun l nr learned?)
   (cond ((null? l) l)
         ((string? (car l))
-         (build-interactive-args
-          fun (cons (list (car l) "string") (cdr l)) nr learned?))
-        (else
-         (let* ((name (build-interactive-arg (caar l)))
-                (type (cadar l))
-                (pl (cddar l))
-                (ql pl)
-                ;;(ql (if (null? pl) '("") pl))
-                (ll (if learned? (learned-interactive-arg fun nr) '()))
-                (rl (append ql (list-but ll ql)))
-                (props (if (<= (length ql) 1) rl ql)))
-           (cons (cons name (cons type props))
-                 (build-interactive-args fun (cdr l) (+ nr 1) learned?))))))
+         (build-interactive-args fun (cons (list (car l) "string") (cdr l)) nr learned?)
+        ) ;
+        (else (let* ((name (build-interactive-arg (caar l)))
+                     (type (cadar l))
+                     (pl (cddar l))
+                     (ql pl)
+                     ;; (ql (if (null? pl) '("") pl))
+                     (ll (if learned? (learned-interactive-arg fun nr) '()))
+                     (rl (append ql (list-but ll ql)))
+                     (props (if (<= (length ql) 1) rl ql))
+                    ) ;
+                (cons (cons name (cons type props))
+                  (build-interactive-args fun (cdr l) (+ nr 1) learned?)
+                ) ;cons
+              ) ;let*
+        ) ;else
+  ) ;cond
+) ;tm-define
 
 (tm-define (tm-interactive-new fun args)
-  ;;(display* "interactive " fun ", " args "\n")
+  ;; (display* "interactive " fun ", " args "\n")
   (if (side-tools?)
-      (begin
-        (tool-select :transient-bottom (list 'interactive-tool fun args))
-        (delayed
-          (:pause 500)
-          (keyboard-focus-on "interactive-0")))
-      (tm-interactive fun args)))
+    (begin
+      (tool-select :transient-bottom (list 'interactive-tool fun args))
+      (delayed (:pause 500) (keyboard-focus-on "interactive-0"))
+    ) ;begin
+    (tm-interactive fun args)
+  ) ;if
+) ;tm-define
 
 (tm-define (interactive fun . args)
   (:synopsis "Call @fun with interactively specified arguments @args")
   (:interactive #t)
   (lazy-define-force fun)
   (if (null? args) (set! args (compute-interactive-args fun)))
-  (with fun-args (build-interactive-args fun args 0 #t)
-    (tm-interactive-new fun fun-args)))
+  (with fun-args
+    (build-interactive-args fun args 0 #t)
+    (tm-interactive-new fun fun-args)
+  ) ;with
+) ;tm-define
 
 (tm-define (interactive-title fun)
   (let* ((val (property fun :synopsis))
          (name (procedure-name fun))
-         (name* (and name (symbol->string name))))
+         (name* (and name (symbol->string name)))
+        ) ;
     (or (and (list-1? val) (string? (car val)) (car val))
-        (and name (string-append "Interactive command '" name* "'"))
-        "Interactive command")))
+      (and name (string-append "Interactive command '" name* "'"))
+      "Interactive command"
+    ) ;or
+  ) ;let*
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Store learned arguments from one session to another
@@ -590,199 +748,282 @@
 
 (define (save-learned)
   (njson->file interactive-arg-file-system interactive-arg-json)
-  (njson->file interactive-arg-recent-file-system interactive-arg-recent-file-json))
+  (njson->file interactive-arg-recent-file-system
+    interactive-arg-recent-file-json
+  ) ;njson->file
+) ;define
 
 (define (load-njson-with-fallback file valid? fallback-maker)
   (catch #t
     (lambda ()
       (let ((parsed (file->njson file)))
-        (if (valid? parsed)
-            parsed
-            (begin
-              (njson-free parsed)
-              (fallback-maker)))))
-    (lambda args
-      (fallback-maker))))
+        (if (valid? parsed) parsed (begin (njson-free parsed) (fallback-maker)))
+      ) ;let
+    ) ;lambda
+    (lambda args (fallback-maker))
+  ) ;catch
+) ;define
 
 (define (reload-state current-state file valid? fallback-maker)
   (njson-free current-state)
-  (load-njson-with-fallback file valid? fallback-maker))
+  (load-njson-with-fallback file valid? fallback-maker)
+) ;define
 
 (define (write-migration-marker marker-file)
-  (string-save
-   "migrated\n"
-   (string->url marker-file)))
+  (string-save "migrated\n" (string->url marker-file))
+) ;define
 
 (define (legacy-scm-interactive-assoc-valid? assoc-t)
-  (and (list? assoc-t)
-       (list-and (map pair? assoc-t))))
+  (and (list? assoc-t) (list-and (map pair? assoc-t)))
+) ;define
 
 (define (normalize-legacy-scm-interactive-items items)
-  (list-filter
-   (map (lambda (assoc-t)
-          (and (legacy-scm-interactive-assoc-valid? assoc-t)
-               (normalize-interactive-assoc assoc-t)))
-        items)
-   (lambda (x) x)))
+  (list-filter (map (lambda (assoc-t)
+                      (and (legacy-scm-interactive-assoc-valid? assoc-t)
+                        (normalize-interactive-assoc assoc-t)
+                      ) ;and
+                    ) ;lambda
+                 items
+               ) ;map
+    (lambda (x) x)
+  ) ;list-filter
+) ;define
 
 (define (interactive-item-exists? item items)
-  (list-and
-   (map (lambda (existing) (not (equal? existing item))) items)))
+  (list-and (map (lambda (existing) (not (equal? existing item))) items))
+) ;define
 
 (define (merge-legacy-scm-interactive-items existing-items legacy-items)
-  (let loop ((legacy legacy-items) (merged existing-items))
+  (let loop
+    ((legacy legacy-items) (merged existing-items))
     (if (null? legacy)
-        merged
-        (with item (car legacy)
-          (if (interactive-item-exists? item merged)
-              (loop (cdr legacy) (append merged (list item)))
-              (loop (cdr legacy) merged))))))
+      merged
+      (with item
+        (car legacy)
+        (if (interactive-item-exists? item merged)
+          (loop (cdr legacy) (append merged (list item)))
+          (loop (cdr legacy) merged)
+        ) ;if
+      ) ;with
+    ) ;if
+  ) ;let
+) ;define
 
 (define (legacy-scm-interactive-command-name key)
-  (and-with sym (procedure-symbol-name key)
-    (symbol->string sym)))
+  (and-with sym (procedure-symbol-name key) (symbol->string sym))
+) ;define
 
 (define (legacy-scm-recent-buffer-key? key)
-  (== (procedure-symbol-name key) 'recent-buffer))
+  (== (procedure-symbol-name key) 'recent-buffer)
+) ;define
 
 (define (legacy-scm-ahash-set-2! t x)
-  (with (key . l) x
-    (with (form arg) key
-      (with a (or (ahash-ref t form) '())
+  (with (key . l)
+    x
+    (with (form arg)
+      key
+      (with a
+        (or (ahash-ref t form) '())
         (set! a (assoc-set! a arg l))
-        (ahash-set! t form a)))))
+        (ahash-set! t form a)
+      ) ;with
+    ) ;with
+  ) ;with
+) ;define
 
 (define (legacy-scm-rearrange-old-interactive x)
-  (with (form . l) x
+  (with (form . l)
+    x
     (let ((lengths (map length l)))
       (if (or (null? lengths) (<= (apply min lengths) 0))
-          (cons form '())
-          (let* ((len (apply min lengths))
-                 (truncl (map (cut sublist <> 0 len) l))
-                 (sl (sort truncl (lambda (l1 l2) (< (car l1) (car l2)))))
-                 (nl (map (lambda (y) (cons (number->string (car y)) (cdr y))) sl))
-                 (build (lambda args (map cons (map car nl) args)))
-                 (r (apply map (cons build (map cdr nl)))))
-            (cons form r))))))
+        (cons form '())
+        (let* ((len (apply min lengths))
+               (truncl (map (cut sublist <> 0 len) l))
+               (sl (sort truncl (lambda (l1 l2) (< (car l1) (car l2)))))
+               (nl (map (lambda (y) (cons (number->string (car y)) (cdr y))) sl))
+               (build (lambda args (map cons (map car nl) args)))
+               (r (apply map (cons build (map cdr nl))))
+              ) ;
+          (cons form r)
+        ) ;let*
+      ) ;if
+    ) ;let
+  ) ;with
+) ;define
 
 (define (decode-legacy-scm-interactive-old l)
-  (let* ((t (make-ahash-table))
-         (setter (cut legacy-scm-ahash-set-2! t <>)))
+  (let* ((t (make-ahash-table)) (setter (cut legacy-scm-ahash-set-2! t <>)))
     (for-each setter l)
-    (let* ((r (ahash-table->list t))
-           (m (map legacy-scm-rearrange-old-interactive r)))
-      (list->ahash-table m))))
+    (let* ((r (ahash-table->list t)) (m (map legacy-scm-rearrange-old-interactive r)))
+      (list->ahash-table m)
+    ) ;let*
+  ) ;let*
+) ;define
 
 (define (load-legacy-scm-interactive-table)
   (and (url-exists? legacy-interactive-arg-file)
-       (catch #t
-         (lambda ()
-           (let* ((loaded (load-object legacy-interactive-arg-file))
-                  (old? (and (pair? loaded) (pair? (car loaded))
-                             (list-2? (caar loaded))))
-                  (decode (if old?
-                              decode-legacy-scm-interactive-old
-                              list->ahash-table)))
-             (and (list? loaded)
-                  (decode loaded))))
-         (lambda args #f))))
+    (catch #t
+      (lambda ()
+        (let* ((loaded (load-object legacy-interactive-arg-file))
+               (old? (and (pair? loaded) (pair? (car loaded)) (list-2? (caar loaded))))
+               (decode (if old? decode-legacy-scm-interactive-old list->ahash-table))
+              ) ;
+          (and (list? loaded) (decode loaded))
+        ) ;let*
+      ) ;lambda
+      (lambda args #f)
+    ) ;catch
+  ) ;and
+) ;define
 
 (define (import-legacy-scm-interactive-commands! legacy-table)
-  (for-each
-   (lambda (entry)
-     (with (key . items) entry
-       (when (and (not (legacy-scm-recent-buffer-key? key))
-                  (list? items))
-         (and-with name (legacy-scm-interactive-command-name key)
-           (let* ((existing (interactive-command-learned name))
-                  (normalized (normalize-legacy-scm-interactive-items items))
-                  (merged (merge-legacy-scm-interactive-items existing normalized)))
-             (when (not (equal? merged existing))
-               (set-interactive-command-learned name merged)))))))
-   (ahash-table->list legacy-table)))
+  (for-each (lambda (entry)
+              (with (key . items)
+                entry
+                (when (and (not (legacy-scm-recent-buffer-key? key)) (list? items))
+                  (and-with name
+                    (legacy-scm-interactive-command-name key)
+                    (let* ((existing (interactive-command-learned name))
+                           (normalized (normalize-legacy-scm-interactive-items items))
+                           (merged (merge-legacy-scm-interactive-items existing normalized))
+                          ) ;
+                      (when (not (equal? merged existing))
+                        (set-interactive-command-learned name merged)
+                      ) ;when
+                    ) ;let*
+                  ) ;and-with
+                ) ;when
+              ) ;with
+            ) ;lambda
+    (ahash-table->list legacy-table)
+  ) ;for-each
+) ;define
 
 (define (legacy-scm-recent-path assoc-t)
-  (or (assoc-ref assoc-t "0")
-      (assoc-ref assoc-t 0)))
+  (or (assoc-ref assoc-t "0") (assoc-ref assoc-t 0))
+) ;define
 
 (define (recent-files-min-last-open recent-files)
   (let-njson ((files (njson-ref recent-files "files")))
     (if (<= (njson-size files) 0)
-        #f
-        (let loop ((i 1)
-                   (min-t (let ((t (njson-ref files 0 "last_open")))
-                            (if (number? t) t 0))))
-          (if (>= i (njson-size files))
-              min-t
-              (let* ((t (njson-ref files i "last_open"))
-                     (t (if (number? t) t 0)))
-                (loop (+ i 1) (min min-t t))))))))
+      #f
+      (let loop
+        ((i 1) (min-t (let ((t (njson-ref files 0 "last_open"))) (if (number? t) t 0))))
+        (if (>= i (njson-size files))
+          min-t
+          (let* ((t (njson-ref files i "last_open")) (t (if (number? t) t 0)))
+            (loop (+ i 1) (min min-t t))
+          ) ;let*
+        ) ;if
+      ) ;let
+    ) ;if
+  ) ;let-njson
+) ;define
 
 (define (append-recent-file-entry! recent-files path last-open)
   (let* ((name (url->system (url-tail (system->url path))))
-         (item (json->njson
-                `(("path" . ,path)
-                  ("name" . ,name)
-                  ("last_open" . ,last-open)
-                  ("open_count" . 1)
-                  ("show" . #t)))))
-    (njson-append! recent-files "files" item))
+         (item (json->njson `((,"path" unquote path)
+                              (,"name" unquote name)
+                              (,"last_open" unquote last-open)
+                              (,"open_count" unquote 1)
+                              (,"show" unquote #t))
+               ) ;json->njson
+         ) ;item
+        ) ;
+    (njson-append! recent-files "files" item)
+  ) ;let*
   (let* ((total (njson-ref recent-files "meta" "total"))
-         (total (if (number? total) total 0)))
-    (njson-set! recent-files "meta" "total" (+ total 1))))
+         (total (if (number? total) total 0))
+        ) ;
+    (njson-set! recent-files "meta" "total" (+ total 1))
+  ) ;let*
+) ;define
 
 (define (import-legacy-scm-recent-files! legacy-items)
   (let* ((min-open (recent-files-min-last-open interactive-arg-recent-file-json))
-         (base (if (number? min-open) (- min-open 1) (current-second))))
-    (let loop ((items legacy-items) (rank 0) (seen '()))
+         (base (if (number? min-open) (- min-open 1) (current-second)))
+        ) ;
+    (let loop
+      ((items legacy-items) (rank 0) (seen '()))
       (if (null? items)
-          (set! interactive-arg-recent-file-json
-                (recent-files-apply-lru interactive-arg-recent-file-json 25))
-          (let* ((assoc-t (car items))
-                 (path (and (legacy-scm-interactive-assoc-valid? assoc-t)
-                            (legacy-scm-recent-path assoc-t))))
-            (if (or (not (string? path))
-                    (== path "")
-                    (in? path seen)
-                    (recent-files-index-by-path interactive-arg-recent-file-json path))
-                (loop (cdr items) (+ rank 1) seen)
-                (begin
-                  (append-recent-file-entry!
-                   interactive-arg-recent-file-json path (- base rank))
-                  (loop (cdr items) (+ rank 1) (cons path seen)))))))))
+        (set! interactive-arg-recent-file-json
+          (recent-files-apply-lru interactive-arg-recent-file-json 25)
+        ) ;set!
+        (let* ((assoc-t (car items))
+               (path (and (legacy-scm-interactive-assoc-valid? assoc-t)
+                       (legacy-scm-recent-path assoc-t)
+                     ) ;and
+               ) ;path
+              ) ;
+          (if (or (not (string? path))
+                (== path "")
+                (in? path seen)
+                (recent-files-index-by-path interactive-arg-recent-file-json path)
+              ) ;or
+            (loop (cdr items) (+ rank 1) seen)
+            (begin
+              (append-recent-file-entry! interactive-arg-recent-file-json path (- base rank))
+              (loop (cdr items) (+ rank 1) (cons path seen))
+            ) ;begin
+          ) ;if
+        ) ;let*
+      ) ;if
+    ) ;let
+  ) ;let*
+) ;define
 
 (define (maybe-import-legacy-scm-interactive-state)
   (let ((need-interactive? (not (url-exists? interactive-arg-migration-marker-v1)))
-        (need-recent? (not (url-exists? recent-files-migration-marker-v1))))
+        (need-recent? (not (url-exists? recent-files-migration-marker-v1)))
+       ) ;
     (when (and (or need-interactive? need-recent?)
-               (url-exists? legacy-interactive-arg-file))
-      (and-with legacy-table (load-legacy-scm-interactive-table)
+            (url-exists? legacy-interactive-arg-file)
+          ) ;and
+      (and-with legacy-table
+        (load-legacy-scm-interactive-table)
         (when need-interactive?
-          (import-legacy-scm-interactive-commands! legacy-table))
+          (import-legacy-scm-interactive-commands! legacy-table)
+        ) ;when
         (when need-recent?
-          (with recent-items (or (ahash-ref legacy-table 'recent-buffer)
-                                 (ahash-ref legacy-table "recent-buffer")
-                                 '())
+          (with recent-items
+            (or (ahash-ref legacy-table 'recent-buffer)
+              (ahash-ref legacy-table "recent-buffer")
+              '()
+            ) ;or
             (when (list? recent-items)
-              (import-legacy-scm-recent-files! recent-items))))
+              (import-legacy-scm-recent-files! recent-items)
+            ) ;when
+          ) ;with
+        ) ;when
         (save-learned)
         (when need-interactive?
-          (write-migration-marker interactive-arg-migration-marker-v1))
+          (write-migration-marker interactive-arg-migration-marker-v1)
+        ) ;when
         (when need-recent?
-          (write-migration-marker recent-files-migration-marker-v1))))))
+          (write-migration-marker recent-files-migration-marker-v1)
+        ) ;when
+      ) ;and-with
+    ) ;when
+  ) ;let
+) ;define
 
 (define (retrieve-learned)
   (set! interactive-arg-json
-        (reload-state interactive-arg-json
-                      interactive-arg-file-system
-                      interactive-args-json-valid?
-                      (lambda () (make-empty-state 'interactive-arg))))
+    (reload-state interactive-arg-json
+      interactive-arg-file-system
+      interactive-args-json-valid?
+      (lambda () (make-empty-state 'interactive-arg))
+    ) ;reload-state
+  ) ;set!
   (set! interactive-arg-recent-file-json
-        (reload-state interactive-arg-recent-file-json
-                      interactive-arg-recent-file-system
-                      recent-files-json-valid?
-                      (lambda () (make-empty-state 'recent-file))))
-  (maybe-import-legacy-scm-interactive-state))
+    (reload-state interactive-arg-recent-file-json
+      interactive-arg-recent-file-system
+      recent-files-json-valid?
+      (lambda () (make-empty-state 'recent-file))
+    ) ;reload-state
+  ) ;set!
+  (maybe-import-legacy-scm-interactive-state)
+) ;define
 
 
 (on-entry (retrieve-learned))

--- a/TeXmacs/progs/kernel/texmacs/tm-file-system.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-file-system.scm
@@ -20,14 +20,18 @@
 (define-public lazy-tmfs-table (make-ahash-table))
 
 (define-public-macro (lazy-tmfs-handler module . classes)
-  `(for-each (lambda (class) (ahash-set! lazy-tmfs-table class ',module))
-             ',classes))
+  `(for-each (lambda (class) (ahash-set! lazy-tmfs-table class (quote ,module)))
+     (quote ,classes))
+) ;define-public-macro
 
 (define-public (lazy-tmfs-force class)
   (if (string? class) (set! class (string->symbol class)))
-  (and-with module (ahash-ref lazy-tmfs-table class)
+  (and-with module
+    (ahash-ref lazy-tmfs-table class)
     (ahash-remove! lazy-tmfs-table class)
-    (eval `(use-modules ,module))))
+    (eval `(use-modules ,module))
+  ) ;and-with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Handler system
@@ -36,334 +40,458 @@
 (define-public tmfs-handler-table (make-ahash-table))
 
 (define-public (object->tmstring s)
- ;; S7 impose an upper bound on the lenght of sequences to be printed
- ;; we override it...
- ;; FIXME: do we have a more elegant way to do it??
- (let-temporarily (((*s7* 'print-length) 9223372036854775807)) (unescape-guile (object->string s))))
- 
-(define (tmstring->object s) (string->object s))
+  ;; S7 impose an upper bound on the lenght of sequences to be printed
+  ;; we override it...
+  ;; FIXME: do we have a more elegant way to do it??
+  (let-temporarily (((*s7* 'print-length) 9223372036854775807))
+    (unescape-guile (object->string s))
+  ) ;let-temporarily
+) ;define-public
+
+(define (tmstring->object s)
+  (string->object s)
+) ;define
 
 (define-public (tmfs-handler class action handle)
-  ;;(display* "Define " class " :: " action "\n")
-  (ahash-set! tmfs-handler-table (cons class action) handle))
+  ;; (display* "Define " class " :: " action "\n")
+  (ahash-set! tmfs-handler-table (cons class action) handle)
+) ;define-public
 
 (define-public (tmfs-decompose-name name)
   (if (not (string? name)) (set! name (url->string name)))
   (if (string-starts? name "tmfs://") (set! name (string-drop name 7)))
-  (with i (string-index name #\/)
+  (with i
+    (string-index name #\/)
     (list (if i (substring name 0 i) "file")
-          (if i (substring name (+ i 1) (string-length name)) name))))
+      (if i (substring name (+ i 1) (string-length name)) name)
+    ) ;list
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-load u)
   "Load url @u on TeXmacs file system."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'load)) =>
+    (cond ((ahash-ref tmfs-handler-table (cons class 'load))
+           =>
            (lambda (handler)
-             (with r (handler name)
-               (if (string? r) r (object->tmstring r)))))
-          ((ahash-ref tmfs-handler-table (cons #t 'load)) =>
+             (with r (handler name) (if (string? r) r (object->tmstring r)))
+           ) ;lambda
+          ) ;
+          ((ahash-ref tmfs-handler-table (cons #t 'load))
+           =>
            (lambda (handler)
-             (with r (handler name)
-               (if (string? r) r (object->tmstring r)))))
-          (else ""))))
+             (with r (handler name) (if (string? r) r (object->tmstring r)))
+           ) ;lambda
+          ) ;
+          (else "")
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-save u what)
   "Save string @what to url @u on TeXmacs file system."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'save)) =>
-           (lambda (handler) (handler name (tmstring->object what))))
-          (else ((ahash-ref tmfs-handler-table (cons #t 'save)) u what)))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'save))
+           =>
+           (lambda (handler) (handler name (tmstring->object what)))
+          ) ;
+          (else ((ahash-ref tmfs-handler-table (cons #t 'save)) u what))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-autosave u suf)
   "Autosave name for url @u with suffix @suf on TeXmacs file system, or @#f."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'autosave)) =>
-           (lambda (handler) (handler name suf)))
-          (else ((ahash-ref tmfs-handler-table (cons #t 'autosave)) u suf)))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'autosave))
+           =>
+           (lambda (handler) (handler name suf))
+          ) ;
+          (else ((ahash-ref tmfs-handler-table (cons #t 'autosave)) u suf))
+    ) ;cond
+  ) ;with
+) ;define-public
 
-(define-public (tmfs-can-autosave? u)
-  (not (not (tmfs-autosave u "~"))))
+(define-public (tmfs-can-autosave? u) (not (not (tmfs-autosave u "~"))))
 
 (define-public (tmfs-remove u)
   "Remove url @u from TeXmacs file system and return @#t on success."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'remove)) =>
-           (lambda (handler) (handler name)))
-          (else ((ahash-ref tmfs-handler-table (cons #t 'remove)) u)))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'remove))
+           =>
+           (lambda (handler) (handler name))
+          ) ;
+          (else ((ahash-ref tmfs-handler-table (cons #t 'remove)) u))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-wrap u)
   "Underlying wrapped url for url @u on TeXmacs file system, or @#f."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'wrap)) =>
-           (lambda (handler) (handler name)))
-          (else ((ahash-ref tmfs-handler-table (cons #t 'wrap)) u)))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'wrap))
+           =>
+           (lambda (handler) (handler name))
+          ) ;
+          (else ((ahash-ref tmfs-handler-table (cons #t 'wrap)) u))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-date u)
   "Get last modification date for url @u on TeXmacs file system, or @#f."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'date)) =>
-           (lambda (handler) (handler name)))
-          (else ((ahash-ref tmfs-handler-table (cons #t 'date)) u)))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'date))
+           =>
+           (lambda (handler) (handler name))
+          ) ;
+          (else ((ahash-ref tmfs-handler-table (cons #t 'date)) u))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-title u doc)
   "Get a nice title for url @u on TeXmacs file system."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'title)) =>
-           (lambda (handler) (handler name doc)))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'title))
+           =>
+           (lambda (handler) (handler name doc))
+          ) ;
           ((ahash-ref tmfs-handler-table (cons class 'load))
-           (if (url? u) (url->system u) u))
-          (else ((ahash-ref tmfs-handler-table (cons #t 'title)) u doc)))))
+           (if (url? u) (url->system u) u)
+          ) ;
+          (else ((ahash-ref tmfs-handler-table (cons #t 'title)) u doc))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-permission? u type)
   "Check whether we have the permission of a given @type for the url @u."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
     (cond ((and (string-ends? (url->unix u) "~")
-                (not (tmfs-autosave (url-unglue u 1) "~"))) #f)
+             (not (tmfs-autosave (url-unglue u 1) "~"))
+           ) ;and
+           #f
+          ) ;
           ((and (string-ends? (url->unix u) "#")
-                (not (tmfs-autosave (url-unglue u 1) "#"))) #f)
-          ((ahash-ref tmfs-handler-table (cons class 'permission?)) =>
-           (lambda (handler) (handler name type)))
-          ((tmfs-wrap u)
-           ((ahash-ref tmfs-handler-table (cons #t 'permission?)) u type))
-          ((ahash-ref tmfs-handler-table (cons class 'load))
-           (== type "read"))
-          (else
-            ((ahash-ref tmfs-handler-table (cons #t 'permission?)) u type)))))
+             (not (tmfs-autosave (url-unglue u 1) "#"))
+           ) ;and
+           #f
+          ) ;
+          ((ahash-ref tmfs-handler-table (cons class 'permission?))
+           =>
+           (lambda (handler) (handler name type))
+          ) ;
+          ((tmfs-wrap u) ((ahash-ref tmfs-handler-table (cons #t 'permission?)) u type))
+          ((ahash-ref tmfs-handler-table (cons class 'load)) (== type "read"))
+          (else ((ahash-ref tmfs-handler-table (cons #t 'permission?)) u type))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-master u)
   "Get a master url @u for linking and navigation."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'master)) =>
-           (lambda (handler) (handler name)))
-          (else u))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'master))
+           =>
+           (lambda (handler) (handler name))
+          ) ;
+          (else u)
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-format u)
   "Get file format for url @u."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (cond ((ahash-ref tmfs-handler-table (cons class 'format)) =>
-           (lambda (handler) (handler name)))
-          (else "stm"))))
+    (cond ((ahash-ref tmfs-handler-table (cons class 'format))
+           =>
+           (lambda (handler) (handler name))
+          ) ;
+          (else "stm")
+    ) ;cond
+  ) ;with
+) ;define-public
 
 (define-public (tmfs-remote? u)
   "Check whether the url @u is handled remotedly."
-  (with (class name) (tmfs-decompose-name u)
+  (with (class name)
+    (tmfs-decompose-name u)
     (lazy-tmfs-force class)
-    (not (ahash-ref tmfs-handler-table (cons class 'load)))))
+    (not (ahash-ref tmfs-handler-table (cons class 'load)))
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for making and decomposing queries
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; FIXME: these two procedures should be more general and in the glue
 (define (escape-entry s)
-  (if (string? s) (string-replace s ":" "%3A") ""))
+  (if (string? s) (string-replace s ":" "%3A") "")
+) ;define
 
 (define (unescape-entry s)
-  (if (string? s) (string-replace s "%3A" ":") ""))
+  (if (string? s) (string-replace s "%3A" ":") "")
+) ;define
 
 (define (pair->entry p)
-  (string-append (escape-entry (car p)) "=" (escape-entry (cdr p))))
+  (string-append (escape-entry (car p)) "=" (escape-entry (cdr p)))
+) ;define
 
 (define-public (list->query l)
-  (with r (map pair->entry l)
-    (string-recompose r "&")))
+  (with r (map pair->entry l) (string-recompose r "&"))
+) ;define-public
 
 (define (entry->pair e)
-  (with l (string-tokenize-by-char-n e #\= 1)
+  (with l
+    (string-tokenize-by-char-n e #\= 1)
     (cond ((== (length l) 0) (cons "" ""))
           ((== (length l) 1) (cons (unescape-entry (car l)) ""))
-          (else (cons (unescape-entry (car l)) (unescape-entry (cadr l)))))))
+          (else (cons (unescape-entry (car l)) (unescape-entry (cadr l))))
+    ) ;cond
+  ) ;with
+) ;define
 
 (define-public (query->list q)
-  (with l (string-tokenize-by-char q #\&)
-    (map entry->pair l)))
+  (with l (string-tokenize-by-char q #\&) (map entry->pair l))
+) ;define-public
 
 (define-public (query-ref q var)
-  (tmstring->string (or (assoc-ref (query->list q) var) "")))
+  (tmstring->string (or (assoc-ref (query->list q) var) ""))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Subroutines for building and analyzing TMFS URLs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (tmfs-pair? s)
-  (string-index s #\/))
+(define-public (tmfs-pair? s) (string-index s #\/))
 
 (define-public (tmfs-car s)
-  (with i (string-index s #\/)
-    (and i (substring s 0 i))))
+  (with i (string-index s #\/) (and i (substring s 0 i)))
+) ;define-public
 
 (define-public (tmfs-cdr s)
-  (with i (string-index s #\/)
-    (and i (substring s (+ i 1) (string-length s)))))
+  (with i (string-index s #\/) (and i (substring s (+ i 1) (string-length s))))
+) ;define-public
 
 (define-public (tmfs->list s)
-  (if (not (tmfs-pair? s)) (list s)
-      (cons (tmfs-car s) (tmfs->list (tmfs-cdr s)))))
+  (if (not (tmfs-pair? s)) (list s) (cons (tmfs-car s) (tmfs->list (tmfs-cdr s))))
+) ;define-public
 
-(define-public (list->tmfs l)
-  (apply string-append (list-intersperse l "/")))
+(define-public (list->tmfs l) (apply string-append (list-intersperse l "/")))
 
 (define-public (strip-colon s)
   (if (and (>= (string-length s) 3)
-           (string-alpha? (substring s 0 1))
-           (== (substring s 1 3) ":/"))
-      (string-append (substring s 0 1)
-                     (substring s 2 (string-length s)))
-      s))
+        (string-alpha? (substring s 0 1))
+        (== (substring s 1 3) ":/")
+      ) ;and
+    (string-append (substring s 0 1) (substring s 2 (string-length s)))
+    s
+  ) ;if
+) ;define-public
 
 (define-public (url->tmfs-string u)
-  (if (and (url-descends? u (get-texmacs-path))
-           (!= (url->url u) (get-texmacs-path)))
-      (with base (url-append (get-texmacs-path) "x")
-        (string-append "tm/" (url->unix (url-delta base u))))
-      (let* ((protocol (url-root u))
-             (file (url->unix (url-unroot u))))
-        (cond ((== protocol "")
-               (string-append "here/" file))
-              ((== protocol "default")
-               (if (os-mingw?)
-                   (string-append "file/" (strip-colon file))
-                   (string-append "file/" file)))
-              (else (string-append protocol "/" file))))))
+  (if (and (url-descends? u (get-texmacs-path)) (!= (url->url u) (get-texmacs-path)))
+    (with base
+      (url-append (get-texmacs-path) "x")
+      (string-append "tm/" (url->unix (url-delta base u)))
+    ) ;with
+    (let* ((protocol (url-root u)) (file (url->unix (url-unroot u))))
+      (cond ((== protocol "") (string-append "here/" file))
+            ((== protocol "default")
+             (if (os-mingw?)
+               (string-append "file/" (strip-colon file))
+               (string-append "file/" file)
+             ) ;if
+            ) ;
+            (else (string-append protocol "/" file))
+      ) ;cond
+    ) ;let*
+  ) ;if
+) ;define-public
 
 (define-public (tmfs-string->url s)
   (if (not (tmfs-pair? s))
-      (unix->url s)
-      (let* ((protocol (tmfs-car s))
-             (file (unix->url (tmfs-cdr s))))
-        (cond ((== protocol "tm") (url-append (get-texmacs-path) file))
-              ((== protocol "here") file)
-              ((== protocol "file")
-               (if (os-mingw?)
-                   (string->url (string-append "/" (tmfs-cdr s)))
-                   (url-append (root->url "default") file)))
-              ((in? protocol '("http" "https" "ftp" "tmfs"))
-               (url-append (root->url protocol) file))
-              (else (url-append (root->url "default") s))))))
+    (unix->url s)
+    (let* ((protocol (tmfs-car s)) (file (unix->url (tmfs-cdr s))))
+      (cond ((== protocol "tm") (url-append (get-texmacs-path) file))
+            ((== protocol "here") file)
+            ((== protocol "file")
+             (if (os-mingw?)
+               (string->url (string-append "/" (tmfs-cdr s)))
+               (url-append (root->url "default") file)
+             ) ;if
+            ) ;
+            ((in? protocol '("http" "https" "ftp" "tmfs"))
+             (url-append (root->url protocol) file)
+            ) ;
+            (else (url-append (root->url "default") s))
+      ) ;cond
+    ) ;let*
+  ) ;if
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Macros for defining handlers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public-macro (tmfs-load-handler head . body)
-  (with (type what) head
-    `(tmfs-handler ,(symbol->string type) 'load
-                   (lambda (,what) ,@body))))
+  (with (type what)
+    head
+    `(tmfs-handler ,(symbol->string type) 'load (lambda (,what) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-save-handler head . body)
-  (with (type what doc) head
-    `(tmfs-handler ,(symbol->string type) 'save
-                   (lambda (,what ,doc) ,@body))))
+  (with (type what doc)
+    head
+    `(tmfs-handler ,(symbol->string type) 'save (lambda (,what ,doc) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-autosave-handler head . body)
-  (with (type what suf) head
-    `(tmfs-handler ,(symbol->string type) 'autosave
-                   (lambda (,what ,suf) ,@body))))
+  (with (type what suf)
+    head
+    `(tmfs-handler ,(symbol->string type)
+       'autosave
+       (lambda (,what ,suf) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-remove-handler head . body)
-  (with (type what) head
-    `(tmfs-handler ,(symbol->string type) 'remove
-                   (lambda (,what) ,@body))))
+  (with (type what)
+    head
+    `(tmfs-handler ,(symbol->string type) 'remove (lambda (,what) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-wrap-handler head . body)
-  (with (type what) head
-    `(tmfs-handler ,(symbol->string type) 'wrap
-                   (lambda (,what) ,@body))))
+  (with (type what)
+    head
+    `(tmfs-handler ,(symbol->string type) 'wrap (lambda (,what) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-date-handler head . body)
-  (with (type what) head
-    `(tmfs-handler ,(symbol->string type) 'date
-                   (lambda (,what) ,@body))))
+  (with (type what)
+    head
+    `(tmfs-handler ,(symbol->string type) 'date (lambda (,what) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-title-handler head . body)
-  (with (type what doc) head
-    `(tmfs-handler ,(symbol->string type) 'title
-                   (lambda (,what ,doc) ,@body))))
+  (with (type what doc)
+    head
+    `(tmfs-handler ,(symbol->string type) 'title (lambda (,what ,doc) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-permission-handler head . body)
-  (with (type what kind) head
-    `(tmfs-handler ,(symbol->string type) 'permission?
-                   (lambda (,what ,kind) ,@body))))
+  (with (type what kind)
+    head
+    `(tmfs-handler ,(symbol->string type)
+       'permission?
+       (lambda (,what ,kind) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-master-handler head . body)
-  (with (type what) head
-    `(tmfs-handler ,(symbol->string type) 'master
-                   (lambda (,what) ,@body))))
+  (with (type what)
+    head
+    `(tmfs-handler ,(symbol->string type) 'master (lambda (,what) ,@body))
+  ) ;with
+) ;define-public-macro
 
 (define-public-macro (tmfs-format-handler head . body)
-  (with (type what) head
-    `(tmfs-handler ,(symbol->string type) 'format
-                   (lambda (,what) ,@body))))
+  (with (type what)
+    head
+    `(tmfs-handler ,(symbol->string type) 'format (lambda (,what) ,@body))
+  ) ;with
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Simple example
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tmfs-load-handler (id what)
-  `(document
-     (TeXmacs ,(texmacs-version))
+  `(document (TeXmacs ,(texmacs-version))
      (style (tuple "generic"))
-     (body (document ,what))))
+     (body (document ,what)))
+) ;tmfs-load-handler
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Default handlers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tmfs-handler #t 'load
+(tmfs-handler #t
+  'load
   (lambda (name)
-    `(document
-       (TeXmacs ,(texmacs-version))
+    `(document (TeXmacs ,(texmacs-version))
        (style (tuple "generic"))
-       (body (document "Invalid tmfs document.")))))
+       (body (document "Invalid tmfs document.")))
+  ) ;lambda
+) ;tmfs-handler
 
-(tmfs-handler #t 'save
-  (lambda (name doc) (noop)))
+(tmfs-handler #t 'save (lambda (name doc) (noop)))
 
-(tmfs-handler #t 'autosave
+(tmfs-handler #t
+  'autosave
   (lambda (name suf)
-    (and-with u (tmfs-wrap name)
-      (and (url-autosave u suf)
-           (url-glue name suf)))))
+    (and-with u (tmfs-wrap name) (and (url-autosave u suf) (url-glue name suf)))
+  ) ;lambda
+) ;tmfs-handler
 
-(tmfs-handler #t 'remove
-  (lambda (name)
-    (and-with u (tmfs-wrap name)
-      (url-remove u))))
+(tmfs-handler #t
+  'remove
+  (lambda (name) (and-with u (tmfs-wrap name) (url-remove u)))
+) ;tmfs-handler
 
-(tmfs-handler #t 'wrap
-  (lambda (name) #f))
+(tmfs-handler #t 'wrap (lambda (name) #f))
 
-(tmfs-handler #t 'date
-  (lambda (name)
-    (and-with u (tmfs-wrap name)
-      (url-last-modified u))))
+(tmfs-handler #t
+  'date
+  (lambda (name) (and-with u (tmfs-wrap name) (url-last-modified u)))
+) ;tmfs-handler
 
-(tmfs-handler #t 'title
-  (lambda (name doc) name))
+(tmfs-handler #t 'title (lambda (name doc) name))
 
-(tmfs-handler #t 'permission?
+(tmfs-handler #t
+  'permission?
   (lambda (name kind)
-    (with u (tmfs-wrap name)
+    (with u
+      (tmfs-wrap name)
       (cond ((not u) (== kind "read"))
             ((== kind "read") (url-test? u "r"))
             ((== kind "write") (url-test? u "w"))
-            (else #f)))))
+            (else #f)
+      ) ;cond
+    ) ;with
+  ) ;lambda
+) ;tmfs-handler
 
-(tmfs-handler #t 'master
-  (lambda (name) name))
+(tmfs-handler #t 'master (lambda (name) name))
 
-(tmfs-handler #t 'format
-  (lambda (name) "stm"))
+(tmfs-handler #t 'format (lambda (name) "stm"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Auxiliary buffers
@@ -374,56 +502,69 @@
 
 (tmfs-load-handler (aux name)
   (or (ahash-ref aux-buffers name)
-      `(document
-         (TeXmacs ,(texmacs-version))
-         (style (tuple "generic"))
-         (body (document "")))))
+    `(document (TeXmacs ,(texmacs-version))
+       (style (tuple "generic"))
+       (body (document "")))
+  ) ;or
+) ;tmfs-load-handler
 
-(tmfs-title-handler (aux name doc)
-  name)
+(tmfs-title-handler (aux name doc) name)
 
 (tmfs-master-handler (aux name)
-  (or (ahash-ref aux-masters name)
-      (unix->url (string-append "tmfs://aux/" name))))
+  (or (ahash-ref aux-masters name) (unix->url (string-append "tmfs://aux/" name)))
+) ;tmfs-master-handler
 
-(define-public (aux-name aux)
-  (unix->url (string-append "tmfs://aux/" aux)))
+(define-public (aux-name aux) (unix->url (string-append "tmfs://aux/" aux)))
 
 (define-public (aux-set-document aux doc)
-  (with name (aux-name aux)
+  (with name
+    (aux-name aux)
     (buffer-set name doc)
-    (ahash-set! aux-buffers aux (buffer-get name))))
+    (ahash-set! aux-buffers aux (buffer-get name))
+  ) ;with
+) ;define-public
 
 (define-public (aux-set-master aux master)
-  (with name (aux-name aux)
-    (buffer-set-master name master)    
-    (ahash-set! aux-masters aux (buffer-get-master name))))
+  (with name
+    (aux-name aux)
+    (buffer-set-master name master)
+    (ahash-set! aux-masters aux (buffer-get-master name))
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Importation of files using a different format
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (tmfs-document t)
-  (with doc (tm->stree t)
-    (if (and (tm-func? doc 'document)
-             (not (tm-func? (tm-ref doc 0) 'TeXmacs)))
-        `(document (TeXmacs ,(texmacs-version)) ,@(cdr doc))
-        doc)))
+  (with doc
+    (tm->stree t)
+    (if (and (tm-func? doc 'document) (not (tm-func? (tm-ref doc 0) 'TeXmacs)))
+      `(document (TeXmacs ,(texmacs-version)) ,@(cdr doc))
+      doc
+    ) ;if
+  ) ;with
+) ;define-public
 
 (tmfs-load-handler (import name)
   (if (and (tmfs-pair? name) (tmfs-pair? (tmfs-cdr name)))
-      (let* ((fm (tmfs-car name))
-             (u (tmfs-string->url (tmfs-cdr name))))
-        (tmfs-document (tree-import u fm)))
-      `(document
-         (TeXmacs ,(texmacs-version))
-         (style (tuple "generic"))
-         (body (document "")))))
+    (let* ((fm (tmfs-car name)) (u (tmfs-string->url (tmfs-cdr name))))
+      (tmfs-document (tree-import u fm))
+    ) ;let*
+    `(document (TeXmacs ,(texmacs-version))
+       (style (tuple "generic"))
+       (body (document "")))
+  ) ;if
+) ;tmfs-load-handler
 
 (tmfs-title-handler (import name doc)
   (if (and (tmfs-pair? name) (tmfs-pair? (tmfs-cdr name)))
-      (let* ((fm (tmfs-car name))
-             (u (tmfs-string->url (tmfs-cdr name)))
-             (last (url->system (url-tail u))))
-        (string-append last " - " (upcase-first fm)))
-      (url-tail name)))
+    (let* ((fm (tmfs-car name))
+           (u (tmfs-string->url (tmfs-cdr name)))
+           (last (url->system (url-tail u)))
+          ) ;
+      (string-append last " - " (upcase-first fm))
+    ) ;let*
+    (url-tail name)
+  ) ;if
+) ;tmfs-title-handler

--- a/TeXmacs/progs/kernel/texmacs/tm-language.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-language.scm
@@ -9,8 +9,7 @@
 ;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (kernel texmacs tm-language)
-  (:use (kernel texmacs tm-define)))
+(texmacs-module (kernel texmacs tm-language) (:use (kernel texmacs tm-define)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Language definition
@@ -30,119 +29,138 @@
         ((== x :char) (tm->tree '(tm-char)))
         ((== x :cursor) (tm->tree '(tm-cursor)))
         ((and (keyword? x) (string-starts? (keyword->string x) "<"))
-         (with s (string-drop (keyword->string x) 1)
-           (string->tree (string-append "<\\" s ">"))))
+         (with s
+           (string-drop (keyword->string x) 1)
+           (string->tree (string-append "<\\" s ">"))
+         ) ;with
+        ) ;
         ((func? x 'or) (tm->tree `(or ,@(map scheme->packrat (cdr x)))))
         ((func? x '* 1) (tm->tree `(while ,@(map scheme->packrat (cdr x)))))
         ((func? x '+ 1) (tm->tree `(repeat ,@(map scheme->packrat (cdr x)))))
         ((func? x '- 2) (tm->tree `(range ,@(map scheme->packrat (cdr x)))))
         ((func? x 'not 1) (tm->tree `(not ,@(map scheme->packrat (cdr x)))))
-        ((func? x 'except 2)
-         (tm->tree `(except ,@(map scheme->packrat (cdr x)))))
+        ((func? x 'except 2) (tm->tree `(except ,@(map scheme->packrat (cdr x)))))
         ((list? x) (tm->tree `(concat ,@(map scheme->packrat x))))
-        (else (texmacs-error "scheme->packrat"
-                             "~S is not a packrat grammar" x))))
+        (else (texmacs-error "scheme->packrat" "~S is not a packrat grammar" x))
+  ) ;cond
+) ;define
 
 (define (penalty? x)
-  (or (symbol? x) (number? x)))
+  (or (symbol? x) (number? x))
+) ;define
 
 (define (penalty->string x)
-  (if (symbol? x)
-      (symbol->string x)
-      (number->string x)))
+  (if (symbol? x) (symbol->string x) (number->string x))
+) ;define
 
 (define (define-rule-one lan sym l)
-  (cond ((null? l)
-         (packrat-define lan sym '(or)))
+  (cond ((null? l) (packrat-define lan sym '(or)))
         ((and (func? (car l) :type 1) (symbol? (cadar l)))
          (packrat-property lan sym "type" (symbol->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :penalty 1) (penalty? (cadar l)))
          (packrat-property lan sym "right-penalty" (penalty->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
-        ((and (func? (car l) :penalty 2)
-              (penalty? (cadar l)) (penalty? (caddar l)))
-         (packrat-property lan sym "left-penalty"
-                           (penalty->string (cadar l)))
-         (packrat-property lan sym "right-penalty"
-                           (penalty->string (caddar l)))
-         (define-rule-one lan sym (cdr l)))
-        ((and (func? (car l) :spacing 2)
-              (symbol? (cadar l)) (symbol? (caddar l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
+        ((and (func? (car l) :penalty 2) (penalty? (cadar l)) (penalty? (caddar l)))
+         (packrat-property lan sym "left-penalty" (penalty->string (cadar l)))
+         (packrat-property lan sym "right-penalty" (penalty->string (caddar l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
+        ((and (func? (car l) :spacing 2) (symbol? (cadar l)) (symbol? (caddar l)))
          (packrat-property lan sym "left-spacing" (symbol->string (cadar l)))
          (packrat-property lan sym "right-spacing" (symbol->string (caddar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :limits 1) (symbol? (cadar l)))
          (packrat-property lan sym "limits" (symbol->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :highlight 1) (symbol? (cadar l)))
          (packrat-property lan sym "highlight" (symbol->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :transparent 1) (symbol? (cadar l)))
          (packrat-property lan sym "highlight" (symbol->string (cadar l)))
          (packrat-property lan sym "transparent" "true")
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((func? (car l) :atomic 0)
          (packrat-property lan sym "atomic" "true")
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :focus 1) (symbol? (cadar l)))
          (packrat-property lan sym "focus" (symbol->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :selectable 1) (symbol? (cadar l)))
          (packrat-property lan sym "selectable" (symbol->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((and (func? (car l) :operator 1) (symbol? (cadar l)))
          (packrat-property lan sym "operator" "true")
          (packrat-property lan sym "associativity" (symbol->string (cadar l)))
-         (define-rule-one lan sym (cdr l)))
+         (define-rule-one lan sym (cdr l))
+        ) ;
         ((func? (car l) :operator 0)
          (packrat-property lan sym "operator" "true")
-         (define-rule-one lan sym (cdr l)))
-        (else
-          (ahash-set! packrat-definition-table (list lan sym) l)
-          ;;(display* "Define " lan "::" sym " := " l "\n")
-          ;;(display* "Packrat= " (scheme->packrat `(or ,@l)) "\n")
-          (packrat-define lan sym (scheme->packrat `(or ,@l))))))
+         (define-rule-one lan sym (cdr l))
+        ) ;
+        (else (ahash-set! packrat-definition-table (list lan sym) l)
+          ;; (display* "Define " lan "::" sym " := " l "\n")
+          ;; (display* "Packrat= " (scheme->packrat `(or ,@l)) "\n")
+          (packrat-define lan sym (scheme->packrat `(or ,@l)))
+        ) ;else
+  ) ;cond
+) ;define
 
 (define (attach-macros lan l)
   (for (x l)
     (when (and (list-2? x) (string? (car x)) (symbol? (cadr x)))
-      (packrat-property lan (car x) "macro" (symbol->string (cadr x))))))
+      (packrat-property lan (car x) "macro" (symbol->string (cadr x)))
+    ) ;when
+  ) ;for
+) ;define
 
 (define (define-rule-impl lan x)
-  (cond ((func? x :synopsis)
-         (noop))
-        ((func? x 'define)
-         (define-rule-one lan (symbol->string (cadr x)) (cddr x)))
-        ((func? x 'inherit 1)
-         (packrat-inherit lan (symbol->string (cadr x))))
-        ((func? x 'attach-macro)
-         (attach-macros lan (cdr x)))
-        (else (error "invalid packrat rule"))))
+  (cond ((func? x :synopsis) (noop))
+        ((func? x 'define) (define-rule-one lan (symbol->string (cadr x)) (cddr x)))
+        ((func? x 'inherit 1) (packrat-inherit lan (symbol->string (cadr x))))
+        ((func? x 'attach-macro) (attach-macros lan (cdr x)))
+        (else (error "invalid packrat rule"))
+  ) ;cond
+) ;define
 
 (tm-define (define-language-impl lan gr)
-  (for-each (lambda (x) (define-rule-impl lan x)) gr))
+  (for-each (lambda (x) (define-rule-impl lan x)) gr)
+) ;tm-define
 
 (tm-define (get-packrat-definition lan sym)
-  (ahash-ref packrat-definition-table (list lan sym)))
+  (ahash-ref packrat-definition-table (list lan sym))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy language definition
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define lazy-language-waiting (make-ahash-table))
+
 (define lazy-language-done (make-ahash-table))
 
-(tm-define (lazy-language-impl lan m)
-  (ahash-set! lazy-language-waiting lan m))
+(tm-define (lazy-language-impl lan m) (ahash-set! lazy-language-waiting lan m))
 
 (tm-define (lazy-language-force-impl lan)
   (when (not (ahash-ref lazy-language-done lan))
-    (and-with m (ahash-ref lazy-language-waiting lan)
-      ;;(display* "Lazy definition of " lan " in " m "\n")
+    (and-with m
+      (ahash-ref lazy-language-waiting lan)
+      ;; (display* "Lazy definition of " lan " in " m "\n")
       (ahash-remove! lazy-language-waiting lan)
       (ahash-set! lazy-language-done lan #t)
-      (module-load m))))
+      (module-load m)
+    ) ;and-with
+  ) ;when
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; User interface for language definition
@@ -150,15 +168,18 @@
 
 (tm-define-macro (define-language lan . gr)
   (:synopsis "Define the formal language @lan")
-  `(define-language-impl (symbol->string ',lan) ',gr))
+  `(define-language-impl (symbol->string (quote ,lan)) (quote ,gr))
+) ;tm-define-macro
 
 (tm-define-macro (lazy-language m . lans)
   (:synopsis "Promise that the languages @lans are defined in the module @m")
-  `(for-each (lambda (lan) (lazy-language-impl lan ',m)) ',lans))
+  `(for-each (lambda (lan) (lazy-language-impl lan (quote ,m))) (quote ,lans))
+) ;tm-define-macro
 
 (tm-define-macro (lazy-language-force lan)
   (:synopsis "Execute promise to define the language @lan")
-  `(lazy-language-force-impl ',lan))
+  `(lazy-language-force-impl (quote ,lan))
+) ;tm-define-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Semantic routines based on current language
@@ -166,16 +187,18 @@
 
 (tm-define-macro (semantic-end lan gr in)
   (:synopsis "Get rightmost path until where @x can be parsed in @lan")
-  `(let* ((lan2 (symbol->string ',lan))
-          (gr2 (symbol->string ',gr))
+  `(let* ((lan2 (symbol->string (quote ,lan)))
+          (gr2 (symbol->string (quote ,gr)))
           (in2 ,in))
-     (packrat-parse lan2 gr2 in2)))
+     (packrat-parse lan2 gr2 in2))
+) ;tm-define-macro
 
 (tm-define-macro (semantic-context lan gr in pos)
   (:synopsis "Get semantic selections englobing @in at @pos")
-  `(let* ((lan2 (symbol->string ',lan))
-          (gr2 (symbol->string ',gr))
+  `(let* ((lan2 (symbol->string (quote ,lan)))
+          (gr2 (symbol->string (quote ,gr)))
           (in2 ,in)
           (pos1 ,pos)
           (pos2 (if (number? pos1) (list pos1) pos1)))
-     (packrat-context lan2 gr2 in2 pos2)))
+     (packrat-context lan2 gr2 in2 pos2))
+) ;tm-define-macro

--- a/TeXmacs/progs/kernel/texmacs/tm-modes.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-modes.scm
@@ -12,9 +12,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel texmacs tm-modes)
-  (:use
-    (kernel logic logic-rules) (kernel logic logic-query) (kernel logic logic-data)
-    (kernel texmacs tm-plugins) (kernel texmacs tm-preferences)))
+  (:use (kernel logic logic-rules)
+    (kernel logic logic-query)
+    (kernel logic logic-data)
+    (kernel texmacs tm-plugins)
+    (kernel texmacs tm-preferences)
+  ) ;:use
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining new modes
@@ -23,107 +27,121 @@
 (define (texmacs-mode-pred mode)
   (let* ((mode-str (symbol->string mode))
          (mode-root (substring mode-str 0 (- (string-length mode-str) 1)))
-         (pred-str (string-append mode-root "?")))
-    (string->symbol pred-str)))
+         (pred-str (string-append mode-root "?"))
+        ) ;
+    (string->symbol pred-str)
+  ) ;let*
+) ;define
 
 (define-public (texmacs-mode item)
-  (with (mode action . deps) item
+  (with (mode action . deps)
+    item
     (let* ((pred (texmacs-mode-pred mode))
            (deps* (map list (map texmacs-mode-pred deps)))
            (l (if (== action #t) deps* (cons action deps*)))
            (test (if (null? l) #t (if (null? (cdr l)) (car l) (cons 'and l))))
-           (defn `(varlet *texmacs-module* ',pred (lambda () ,test)))
+           (defn `(varlet *texmacs-module* (quote ,pred) (lambda ,() ,test)))
            (rules (map (lambda (dep) (list dep mode)) deps))
            (logic-cmd `(logic-rules ,@rules))
-           (arch1 `(set-symbol-procedure! ',mode ,pred))
-           (arch2 `(set-symbol-procedure! ',pred ,pred)))
+           (arch1 `(set-symbol-procedure! (quote ,mode) ,pred))
+           (arch2 `(set-symbol-procedure! (quote ,pred) ,pred))
+          ) ;
       (if (== mode 'always%) (set! defn '(noop)))
       (if (null? deps)
-          (list 'begin defn arch1 arch2)
-          (list 'begin defn arch1 arch2 logic-cmd)))))
+        (list 'begin defn arch1 arch2)
+        (list 'begin defn arch1 arch2 logic-cmd)
+      ) ;if
+    ) ;let*
+  ) ;with
+) ;define-public
 
-(define-public-macro (texmacs-modes . l)
-  `(begin
-     ,@(map texmacs-mode l)))
+(define-public-macro (texmacs-modes . l) `(begin ,@(map texmacs-mode l)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Checking modes
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;FIXME: in-active-graphics% and developer-mode%
-; seems to be the only two modes which do not have the associated procedure
-; is the code below meaningful? why we need to do the eval?
-; I want maybe to have the catch inside the eval
 
 (define-public (texmacs-in-mode? mode)
-  (with proc (symbol-procedure mode)
-    (if proc (proc)
-        (catch #t (lambda () (eval (list mode))) (lambda err #f)))))
+  (with proc
+    (symbol-procedure mode)
+    (if proc (proc) (catch #t (lambda () (eval (list mode))) (lambda err #f)))
+  ) ;with
+) ;define-public
 
 (define-public (texmacs-mode-mode pred)
   "Get drd predicate name associated to scheme predicate or symbol"
   (if (procedure? pred)
-      (with name (procedure-name pred)
-        (if name (texmacs-mode-mode name) 'unknown%))
-      (let* ((pred-str (symbol->string pred))
-             (pred-root (substring pred-str 0 (- (string-length pred-str) 1)))
-             (mode-str (string-append pred-root "%")))
-        (string->symbol mode-str))))
+    (with name (procedure-name pred) (if name (texmacs-mode-mode name) 'unknown%))
+    (let* ((pred-str (symbol->string pred))
+           (pred-root (substring pred-str 0 (- (string-length pred-str) 1)))
+           (mode-str (string-append pred-root "%"))
+          ) ;
+      (string->symbol mode-str)
+    ) ;let*
+  ) ;if
+) ;define-public
 
 (define texmacs-submode-table (make-ahash-table))
 
 (define-public (texmacs-submode? what* of*)
   "Test whether @what* is a sub-mode of @of*"
-  (let* ((key (cons what* of*))
-         (handle (ahash-get-handle texmacs-submode-table key)))
-    (if handle (cdr handle)
-        (let* ((what (texmacs-mode-mode what*))
-               (of (texmacs-mode-mode of*))
-               (result (or (== of 'always%)
-                           (== what 'prevail%)
-                           (nnull? (query of what)))))
-          (ahash-set! texmacs-submode-table key result)
-          result))))
+  (let* ((key (cons what* of*)) (handle (ahash-get-handle texmacs-submode-table key)))
+    (if handle
+      (cdr handle)
+      (let* ((what (texmacs-mode-mode what*))
+             (of (texmacs-mode-mode of*))
+             (result (or (== of 'always%) (== what 'prevail%) (nnull? (query of what))))
+            ) ;
+        (ahash-set! texmacs-submode-table key result)
+        result
+      ) ;let*
+    ) ;if
+  ) ;let*
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Checking whether certain features are supported
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (supports-chinese?)
-  (!= (default-chinese-font) "roman"))
+(define-public (supports-chinese?) (!= (default-chinese-font) "roman"))
 
-(define-public (supports-japanese?)
-  (!= (default-japanese-font) "roman"))
+(define-public (supports-japanese?) (!= (default-japanese-font) "roman"))
 
-(define-public (supports-korean?)
-  (!= (default-korean-font) "roman"))
+(define-public (supports-korean?) (!= (default-korean-font) "roman"))
 
-(define-public (supports-db?)
-  (== (get-preference "database tool") "on"))
+(define-public (supports-db?) (== (get-preference "database tool") "on"))
 
 (define-public (side-tools?)
   (and (== (get-preference "side tools") "on")
-       (== (get-preference "developer tool") "on")))
+    (== (get-preference "developer tool") "on")
+  ) ;and
+) ;define-public
 
 (define-public (left-tools?)
   (and (== (get-preference "left tools") "on")
-       (== (get-preference "developer tool") "on")))
+    (== (get-preference "developer tool") "on")
+  ) ;and
+) ;define-public
 
 (define-public (has-side-tools? n)
   (cond ((== n 0) (side-tools?))
         ((== n 1) (left-tools?))
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define-public
 
 (define-public (has-markup-gui?)
   (and (== (get-preference "markup gui") "on")
-       (== (get-preference "developer tool") "on")))
+    (== (get-preference "developer tool") "on")
+  ) ;and
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Mode related
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-modes
-  (always% #t)
+(texmacs-modes (always% #t)
   (prevail% #t)
   (in-source% (== (get-env "mode") "src"))
   (in-text% (and (== (get-env "mode") "text") (not (in-graphics?))))
@@ -135,8 +153,8 @@
   (in-math-or-hybrid% (or (in-math?) (inside? 'hybrid)))
   (in-sem-math% (== (get-preference "semantic correctness") "on") in-math%)
   (in-table% (and (inside? 'table) (not (in-graphics?))))
-  (in-session% (and (or (inside? 'session) (inside? 'program))
-                    (not (in-graphics?))))
+  (in-session% (and (or (inside? 'session) (inside? 'program)) (not (in-graphics?)))
+  ) ;in-session%
   (not-in-session% (not (inside? 'session)))
   (in-math-in-session% #t in-math% in-session%)
   (in-math-not-in-session% #t in-math% not-in-session%)
@@ -151,8 +169,8 @@
   (in-bib% (style-has? "database-bib-style") in-database%)
   (in-preview-ref% (style-has? "preview-ref-package"))
   (in-smart-ref% (style-has? "smart-ref-package"))
-  (in-plugin-with-converters%
-   (plugin-supports-math-input-ref (get-env "prog-language")))
+  (in-plugin-with-converters% (plugin-supports-math-input-ref (get-env "prog-language"))
+  ) ;in-plugin-with-converters%
   (in-screens% (inside? 'screens))
   (in-article% (style-has? "header-article-package"))
   (in-book% (style-has? "header-book-package"))
@@ -170,37 +188,72 @@
   (in-comment% (style-has? "comment-dtd"))
   (with-any-selection% (selection-active-any?))
   (with-active-selection% (selection-active-normal?))
-  (in-verbatim% (or (inside? 'verbatim) (inside? 'verbatim-code) 
-                    (inside? 'code)) in-text%)
-  (in-variants-disabled% 
-   (tree-in? (tree-up (cursor-tree)) '(hlink reference pageref label))))
+  (in-verbatim% (or (inside? 'verbatim) (inside? 'verbatim-code) (inside? 'code))
+    in-text%
+  ) ;in-verbatim%
+  (in-variants-disabled% (tree-in? (tree-up (cursor-tree)) '(hlink reference
+                                                              pageref
+                                                              label))
+  ) ;in-variants-disabled%
+) ;texmacs-modes
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Language related
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public supported-languages
-  '("british" "bulgarian" "chinese" "croatian" "czech"
-    "danish" "dutch" "english" "esperanto" "finnish" "french" "german" "greek"
-    "hungarian" "italian" "japanese" "korean" "polish"
-    "portuguese" "romanian" "russian" "slovak" "slovene" "spanish"
-    "swedish" "taiwanese" "ukrainian"))
+  '("british"
+    "bulgarian"
+    "chinese"
+    "croatian"
+    "czech"
+    "danish"
+    "dutch"
+    "english"
+    "esperanto"
+    "finnish"
+    "french"
+    "german"
+    "greek"
+    "hungarian"
+    "italian"
+    "japanese"
+    "korean"
+    "polish"
+    "portuguese"
+    "romanian"
+    "russian"
+    "slovak"
+    "slovene"
+    "spanish"
+    "swedish"
+    "taiwanese"
+    "ukrainian")
+) ;define-public
 
 (define-public (supported-language? lan)
   (and (in? lan supported-languages)
-       (cond ((== lan "chinese") (supports-chinese?))
-             ((== lan "japanese") (supports-japanese?))
-             ((== lan "korean") (supports-korean?))
-             ((== lan "taiwanese") (supports-chinese?))
-             (else #t))))
+    (cond ((== lan "chinese") (supports-chinese?))
+          ((== lan "japanese") (supports-japanese?))
+          ((== lan "korean") (supports-korean?))
+          ((== lan "taiwanese") (supports-chinese?))
+          (else #t)
+    ) ;cond
+  ) ;and
+) ;define-public
 
-(texmacs-modes
-  (in-cyrillic% (in? (get-env "language")
-                     '("bulgarian" "russian" "ukrainian")) in-text%)
-  (in-oriental% (in? (get-env "language")
-                     '("chinese" "japanese" "korean" "taiwanese")) in-text%)
-  (in-english% (in? (get-env "language")
-                    '("british" "english")) in-text%)
+(texmacs-modes (in-cyrillic% (in? (get-env "language") '("bulgarian"
+                                                         "russian"
+                                                         "ukrainian"))
+                 in-text%
+               ) ;in-cyrillic%
+  (in-oriental% (in? (get-env "language") '("chinese"
+                                            "japanese"
+                                            "korean"
+                                            "taiwanese"))
+    in-text%
+  ) ;in-oriental%
+  (in-english% (in? (get-env "language") '("british" "english")) in-text%)
   (in-american% (== (get-env "language") "english") in-text%)
   (in-british% (== (get-env "language") "british") in-text%)
   (in-bulgarian% (== (get-env "language") "bulgarian") in-cyrillic%)
@@ -229,8 +282,7 @@
   (in-taiwanese% (== (get-env "language") "taiwanese") in-oriental%)
   (in-ukrainian% (== (get-env "language") "ukrainian") in-cyrillic%)
 
-  (in-math-english% (in? (get-env "language")
-                         '("british" "english")) in-math%)
+  (in-math-english% (in? (get-env "language") '("british" "english")) in-math%)
   (in-math-american% (== (get-env "language") "english") in-math%)
   (in-math-british% (== (get-env "language") "british") in-math%)
   (in-math-dutch% (== (get-env "language") "dutch") in-math%)
@@ -238,7 +290,8 @@
   (in-math-german% (== (get-env "language") "german") in-math%)
   (in-math-italian% (== (get-env "language") "italian") in-math%)
   (in-math-portuguese% (== (get-env "language") "portuguese") in-math%)
-  (in-math-spanish% (== (get-env "language") "spanish") in-math%))
+  (in-math-spanish% (== (get-env "language") "spanish") in-math%)
+) ;texmacs-modes
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Keyboard related
@@ -248,10 +301,10 @@
 (define-public remote-control-remap (make-ahash-table))
 
 (define-public (cyrillic-input-method? what)
-  (== (get-preference "cyrillic input method") what))
+  (== (get-preference "cyrillic input method") what)
+) ;define-public
 
-(texmacs-modes
-  (like-emacs% (has-look-and-feel? "emacs"))
+(texmacs-modes (like-emacs% (has-look-and-feel? "emacs"))
   (like-gnome% (has-look-and-feel? "gnome"))
   (like-kde% (has-look-and-feel? "kde"))
   (like-macos% (has-look-and-feel? "macos"))
@@ -271,8 +324,11 @@
   (with-versioning-tool% (== (get-preference "versioning tool") "on"))
   (with-keyboard-tool% (== (get-preference "keyboard tool") "on"))
   (in-presentation% (or (style-has? "beamer-style")
-                        (== (get-preference "presentation tool") "on")
-                        (inside? 'screens)) in-beamer%)
+                      (== (get-preference "presentation tool") "on")
+                      (inside? 'screens)
+                    ) ;or
+    in-beamer%
+  ) ;in-presentation%
   (search-mode% (== (get-input-mode) 1))
   (replace-mode% (== (get-input-mode) 2))
   (spell-mode% (== (get-input-mode) 3))
@@ -283,7 +339,8 @@
   (in-cyrillic-jcuken% (cyrillic-input-method? "jcuken") in-cyrillic%)
   (in-cyrillic-translit% (cyrillic-input-method? "translit") in-cyrillic%)
   (in-cyrillic-yawerty% (cyrillic-input-method? "yawerty") in-cyrillic%)
-  (in-math-like-macos% #t in-math% like-macos%))
+  (in-math-like-macos% #t in-math% like-macos%)
+) ;texmacs-modes
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy initializations
@@ -294,29 +351,33 @@
 
 (define-public (lazy-initialize-impl id pred? module)
   (set! lazy-initialize-pending
-        (cons (list id pred? module) lazy-initialize-pending)))
+    (cons (list id pred? module) lazy-initialize-pending)
+  ) ;set!
+) ;define-public
 
 (define-public (lazy-initialize-do l id)
   (cond ((null? l) l)
         ((or (== (caar l) id) (and (== id #t) ((cadar l))))
          ((caddar l))
-         (lazy-initialize-do (cdr l) id))
-        (else (cons (car l) (lazy-initialize-do (cdr l) id)))))
+         (lazy-initialize-do (cdr l) id)
+        ) ;
+        (else (cons (car l) (lazy-initialize-do (cdr l) id)))
+  ) ;cond
+) ;define-public
 
 (define-public-macro (lazy-initialize module pred?)
-  `(with id lazy-initialize-id
+  `(with id
+     lazy-initialize-id
      (set! lazy-initialize-id (+ id 1))
      (lazy-initialize-impl id
-       (lambda ()
-         ,pred?)
-       (lambda ()
-         (import-from ,module)))
-     (delayed
-       (:idle 5000)
+       (lambda ,() ,pred?)
+       (lambda ,() (import-from ,module)))
+     (delayed (:idle 5000)
        (set! lazy-initialize-pending
-             (lazy-initialize-do lazy-initialize-pending id))
-       (import-from ,module))))
+         (lazy-initialize-do lazy-initialize-pending id))
+       (import-from ,module)))
+) ;define-public-macro
 
 (define-public (lazy-initialize-force)
-  (set! lazy-initialize-pending
-        (lazy-initialize-do lazy-initialize-pending #t)))
+  (set! lazy-initialize-pending (lazy-initialize-do lazy-initialize-pending #t))
+) ;define-public

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel texmacs tm-plugins)
-  (:use (kernel texmacs tm-define) (kernel texmacs tm-modes)))
+  (:use (kernel texmacs tm-define) (kernel texmacs tm-modes))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy exports from other modules
@@ -46,54 +47,70 @@
 (define (connection-setup name val . opt)
   (ahash-set! connection-defined name #t)
   (if (null? opt) (set! opt (list "default")))
-  (with l (or (ahash-ref connection-varlist name) (list))
+  (with l
+    (or (ahash-ref connection-varlist name) (list))
     (ahash-set! connection-variant (list name (car opt)) val)
-    (if (nin? (car opt) l)
-      (ahash-set! connection-varlist name (rcons l (car opt))))))
+    (if (nin? (car opt) l) (ahash-set! connection-varlist name (rcons l (car opt))))
+  ) ;with
+) ;define
 
 (define-public (connection-list)
   (list-sort (list-union (map car (ahash-table->list connection-defined))
-                         (remote-connection-list))
-             string<=?))
+               (remote-connection-list)
+             ) ;list-union
+    string<=?
+  ) ;list-sort
+) ;define-public
 
 (define-public (local-connection-variants name)
   (lazy-plugin-force)
-  (or (ahash-ref connection-varlist name) (list)))
+  (or (ahash-ref connection-varlist name) (list))
+) ;define-public
 
 (define-public (connection-variants name)
-  (append (local-connection-variants name)
-          (remote-connection-variants name)))
+  (append (local-connection-variants name) (remote-connection-variants name))
+) ;define-public
 
 (define-public (connection-defined? name)
   (lazy-plugin-force)
-  (or (ahash-ref connection-defined name)
-      (remote-connection-defined? name)))
+  (or (ahash-ref connection-defined name) (remote-connection-defined? name))
+) ;define-public
 
 (define-public (connection-info-sub name session)
   (or (remote-connection-info name session)
-      (ahash-ref connection-variant (list name session))
-      (with l (connection-variants name)
-        (and (nnull? l)
-             (!= session (car l))
-             (connection-info-sub name (car l))))))
+    (ahash-ref connection-variant (list name session))
+    (with l
+      (connection-variants name)
+      (and (nnull? l) (!= session (car l)) (connection-info-sub name (car l)))
+    ) ;with
+  ) ;or
+) ;define-public
 
 (define-public (connection-info name session)
   (lazy-plugin-force)
-  (with pos (string-index session #\:)
-    (if pos (connection-info name (substring session 0 pos))
-        (connection-info-sub name session))))
+  (with pos
+    (string-index session #\:)
+    (if pos
+      (connection-info name (substring session 0 pos))
+      (connection-info-sub name session)
+    ) ;if
+  ) ;with
+) ;define-public
 
 (define (connection-insert-handler name channel routine)
   (if (not (ahash-ref connection-handler name))
-      (ahash-set! connection-handler name '()))
-  (ahash-set! connection-handler name
-              (cons (list 'tuple channel routine)
-                    (ahash-ref connection-handler name))))
+    (ahash-set! connection-handler name '())
+  ) ;if
+  (ahash-set! connection-handler
+    name
+    (cons (list 'tuple channel routine) (ahash-ref connection-handler name))
+  ) ;ahash-set!
+) ;define
 
 (define-public (connection-get-handlers name)
   (lazy-plugin-force)
-  (with r (ahash-ref connection-handler name)
-    (if r (cons 'tuple r) '(tuple))))
+  (with r (ahash-ref connection-handler name) (if r (cons 'tuple r) '(tuple)))
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Plug-ins for console sessions and scripting languages
@@ -101,114 +118,136 @@
 
 (define (session-setup name menu-name)
   (if (symbol? name) (set! name (symbol->string name)))
-  (ahash-set! connection-session name menu-name))
+  (ahash-set! connection-session name menu-name)
+) ;define
 
 (define-public (session-list)
   (lazy-plugin-force)
-  (with l (map car (ahash-table->list connection-session))
-    (list-sort (list-union l (remote-session-list)) string<=?)))
+  (with l
+    (map car (ahash-table->list connection-session))
+    (list-sort (list-union l (remote-session-list)) string<=?)
+  ) ;with
+) ;define-public
 
 (define (session-ref name)
-  (or (ahash-ref connection-session name)
-      (remote-session-ref name)))
+  (or (ahash-ref connection-session name) (remote-session-ref name))
+) ;define
 
-(define-public (session-defined? name)
-  (session-ref name))
+(define-public (session-defined? name) (session-ref name))
 
-(define-public (session-name name)
-  (or (session-ref name) (upcase-first name)))
+(define-public (session-name name) (or (session-ref name) (upcase-first name)))
 
 (define (scripts-setup name menu-name)
   (if (symbol? name) (set! name (symbol->string name)))
-  (ahash-set! connection-scripts name menu-name))
+  (ahash-set! connection-scripts name menu-name)
+) ;define
 
 (define-public (scripts-list)
   (lazy-plugin-force)
-  (with l (map car (ahash-table->list connection-scripts))
-    (list-sort (list-union l (remote-scripts-list)) string<=?)))
+  (with l
+    (map car (ahash-table->list connection-scripts))
+    (list-sort (list-union l (remote-scripts-list)) string<=?)
+  ) ;with
+) ;define-public
 
 (define (scripts-ref name)
-  (or (ahash-ref connection-scripts name)
-      (remote-scripts-ref name)))
+  (or (ahash-ref connection-scripts name) (remote-scripts-ref name))
+) ;define
 
-(define-public (scripts-defined? name)
-  (scripts-ref name))
+(define-public (scripts-defined? name) (scripts-ref name))
 
-(define-public (scripts-name name)
-  (or (scripts-ref name) (upcase-first name)))
+(define-public (scripts-name name) (or (scripts-ref name) (upcase-first name)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Remote plugins
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (launcher? x)
-  (and (func? (cdr x) 'tuple 2)
-       (== (caddr x) "pipe")))
+  (and (func? (cdr x) 'tuple 2) (== (caddr x) "pipe"))
+) ;define
 
 (define (launcher-entry x)
-  (rcons (car x) (cadddr x)))
+  (rcons (car x) (cadddr x))
+) ;define
 
 (define (launcher<=? l1 l2)
   (or (string<=? (car l1) (car l2))
-      (and (== (car l1) (car l2))
-           (string<=? (cadr l1) (cadr l2)))))
+    (and (== (car l1) (car l2)) (string<=? (cadr l1) (cadr l2)))
+  ) ;or
+) ;define
 
 (define (launcher-list)
   (lazy-plugin-force)
   (let* ((l1 (ahash-table->list connection-variant))
          (l2 (list-filter l1 launcher?))
          (l3 (map launcher-entry l2))
-         (l4 (list-sort l3 launcher<=?)))
-    l4))
+         (l4 (list-sort l3 launcher<=?))
+        ) ;
+    l4
+  ) ;let*
+) ;define
 
 (define-public (write-local-plugin-info)
   (lazy-plugin-force)
   (write (list (url->system (string->url "$PATH"))
-               (launcher-list)
-               (ahash-table->list connection-session)
-               (ahash-table->list connection-scripts)
-               (url->system (string->url "$TEXMACS_PATH"))
-               (url->system (string->url "$TEXMACS_HOME_PATH"))))
-  (display "\n"))
+           (launcher-list)
+           (ahash-table->list connection-session)
+           (ahash-table->list connection-scripts)
+           (url->system (string->url "$TEXMACS_PATH"))
+           (url->system (string->url "$TEXMACS_HOME_PATH"))
+         ) ;list
+  ) ;write
+  (display "\n")
+) ;define-public
 
 (define-public (get-remote-plugin-info where)
   ;; NOTE: prepare environment in ~/.bashrc
   (let* ((tmp "$TEXMACS_HOME_PATH/system/remote-plugin-info")
          (rcmd "texmacs -s -x \"(write-local-plugin-info)\" -q")
          (qcmd (string-quote rcmd))
-         (lcmd (string-append "ssh " where " " qcmd " > " tmp)))
+         (lcmd (string-append "ssh " where " " qcmd " > " tmp))
+        ) ;
     (system lcmd)
-    (with res (string-load tmp)
-      (system-remove tmp)
-      (string->object res))))
+    (with res (string-load tmp) (system-remove tmp) (string->object res))
+  ) ;let*
+) ;define-public
 
 (define remote-plugins "$TEXMACS_HOME_PATH/system/remote-plugins.scm")
+
 (define remote-plugins-initialized? #f)
+
 (define remote-plugins-table (make-ahash-table))
 
 (define-public (load-remote-plugins)
   (when (not remote-plugins-initialized?)
     (set! remote-plugins-initialized? #t)
     (when (url-exists? remote-plugins)
-      (with l (load-object remote-plugins)
+      (with l
+        (load-object remote-plugins)
         (set! remote-plugins-table (list->ahash-table l))
-        (update-remote-tables)))))
+        (update-remote-tables)
+      ) ;with
+    ) ;when
+  ) ;when
+) ;define-public
 
 (define-public (save-remote-plugins)
-  (with l (ahash-table->list remote-plugins-table)
-    (save-object remote-plugins l)))
+  (with l (ahash-table->list remote-plugins-table) (save-object remote-plugins l))
+) ;define-public
 
 (tm-define (detect-remote-plugins where)
   (:argument where "Remote server")
   (load-remote-plugins)
   (ahash-set! remote-plugins-table where (get-remote-plugin-info where))
   (update-remote-tables)
-  (save-remote-plugins))
+  (save-remote-plugins)
+) ;tm-define
 
 (tm-define (update-remote-plugins where)
   (:argument where "Remote server")
   (:proposals where (remote-connection-servers))
-  (detect-remote-plugins where))
+  (detect-remote-plugins where)
+) ;tm-define
 
 (tm-define (remove-remote-plugins where)
   (:argument where "Remote server")
@@ -216,28 +255,41 @@
   (load-remote-plugins)
   (ahash-remove! remote-plugins-table where)
   (update-remote-tables)
-  (save-remote-plugins))
+  (save-remote-plugins)
+) ;tm-define
 
 (define-public (list-remote-plugins where)
   (load-remote-plugins)
-  (ahash-ref remote-plugins-table where))
+  (ahash-ref remote-plugins-table where)
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Retrieve data about remote plug-ins
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define remote-servers-table (make-ahash-table))
+
 (define remote-supported-table (make-ahash-table))
+
 (define remote-variant-table (make-ahash-table))
+
 (define remote-launch-table (make-ahash-table))
+
 (define remote-session-table (make-ahash-table))
+
 (define remote-scripts-table (make-ahash-table))
 
 (define (opt-export env opts)
-  (if (null? opts) env
-      (string-append env
-                     "; export TEXMACS_PATH=" (car opts)
-                     "; export TEXMACS_HOME_PATH=" (cadr opts))))
+  (if (null? opts)
+    env
+    (string-append env
+      "; export TEXMACS_PATH="
+      (car opts)
+      "; export TEXMACS_HOME_PATH="
+      (cadr opts)
+    ) ;string-append
+  ) ;if
+) ;define
 
 (define-public (update-remote-tables)
   (set! remote-servers-table (make-ahash-table))
@@ -247,65 +299,88 @@
   (set! remote-session-table (make-ahash-table))
   (set! remote-scripts-table (make-ahash-table))
   (for (entry (ahash-table->list remote-plugins-table))
-    (with (where path launch session scripts . opts) entry
+    (with (where path launch session scripts . opts)
+      entry
       (ahash-set! remote-servers-table where #t)
       (for (x launch)
-        (with (p v c) x
+        (with (p v c)
+          x
           (ahash-set! remote-supported-table p #t)
-          (with variant (string-append where "/" v)
-            (with l (or (ahash-ref remote-variant-table p) (list))
-              (ahash-set! remote-variant-table p (rcons l variant)))
+          (with variant
+            (string-append where "/" v)
+            (with l
+              (or (ahash-ref remote-variant-table p) (list))
+              (ahash-set! remote-variant-table p (rcons l variant))
+            ) ;with
             (let* ((env (opt-export (string-append "export PATH=" path) opts))
                    (rem (string-quote (string-append env "; " c)))
                    (cmd (string-append "ssh " where " " rem))
-                   (val `(tuple "pipe" ,cmd)))
-              (ahash-set! remote-launch-table (cons p variant) val)))))
-      (for (x session)
-        (ahash-set! remote-session-table (car x) (cdr x)))
-      (for (x scripts)
-        (ahash-set! remote-scripts-table (car x) (cdr x))))))
+                   (val `(tuple ,"pipe" ,cmd))
+                  ) ;
+              (ahash-set! remote-launch-table (cons p variant) val)
+            ) ;let*
+          ) ;with
+        ) ;with
+      ) ;for
+      (for (x session) (ahash-set! remote-session-table (car x) (cdr x)))
+      (for (x scripts) (ahash-set! remote-scripts-table (car x) (cdr x)))
+    ) ;with
+  ) ;for
+) ;define-public
 
 (define remote-initialized-data? #f)
+
 (define (remote-initialize-data)
   (when (not remote-initialized-data?)
     (load-remote-plugins)
-    (set! remote-initialized-data? #t)))
+    (set! remote-initialized-data? #t)
+  ) ;when
+) ;define
 
 (define-public (remote-connection-servers)
   (remote-initialize-data)
-  (sort (map car (ahash-table->list remote-servers-table)) string<=?))
+  (sort (map car (ahash-table->list remote-servers-table)) string<=?)
+) ;define-public
 
 (define (remote-connection-list)
   (remote-initialize-data)
-  (sort (map car (ahash-table->list remote-supported-table)) string<=?))
+  (sort (map car (ahash-table->list remote-supported-table)) string<=?)
+) ;define
 
 (define (remote-connection-variants name)
   (remote-initialize-data)
-  (or (ahash-ref remote-variant-table name) (list)))
+  (or (ahash-ref remote-variant-table name) (list))
+) ;define
 
 (define-public (remote-connection-defined? name)
   (remote-initialize-data)
-  (nnot (ahash-ref remote-variant-table name)))
+  (nnot (ahash-ref remote-variant-table name))
+) ;define-public
 
 (define (remote-connection-info name session)
   (remote-initialize-data)
-  (ahash-ref remote-launch-table (cons name session)))
+  (ahash-ref remote-launch-table (cons name session))
+) ;define
 
 (define (remote-session-list)
   (remote-initialize-data)
-  (map car (ahash-table->list remote-session-table)))
+  (map car (ahash-table->list remote-session-table))
+) ;define
 
 (define (remote-session-ref name)
   (remote-initialize-data)
-  (ahash-ref remote-session-table name))
+  (ahash-ref remote-session-table name)
+) ;define
 
 (define (remote-scripts-list)
   (remote-initialize-data)
-  (map car (ahash-table->list remote-scripts-table)))
+  (map car (ahash-table->list remote-scripts-table))
+) ;define
 
 (define (remote-scripts-ref name)
   (remote-initialize-data)
-  (ahash-ref remote-scripts-table name))
+  (ahash-ref remote-scripts-table name)
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Cache plugin reinit
@@ -318,24 +393,33 @@
   (set! connection-varlist (make-ahash-table))
   (set! connection-handler (make-ahash-table))
   (set! connection-session (make-ahash-table))
-  (set! connection-scripts (make-ahash-table)))
+  (set! connection-scripts (make-ahash-table))
+) ;define
 
 (define-public (reinit-plugin-cache)
   (reinit-connection)
   (set! reconfigure-flag? #t)
-  (with plugins (plugin-list)
+  (with plugins
+    (plugin-list)
     (for-each (cut ahash-set! plugin-initialize-todo <> #t) plugins)
-    (for-each (cut plugin-initialize <>) plugins)))
+    (for-each (cut plugin-initialize <>) plugins)
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Cache plugin settings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public reconfigure-flag? #t)
+
 (define plugin-loaded-setup? #f)
-(define plugin-cache (url->string (url-append (get-tm-cache-path) "plugin_cache.scm")))
+
+(define plugin-cache
+  (url->string (url-append (get-tm-cache-path) "plugin_cache.scm"))
+) ;define
 
 (define plugin-check-path "")
+
 (define check-dir-table (make-ahash-table))
 (define-public plugin-data-table (make-ahash-table))
 
@@ -343,94 +427,137 @@
   (when (not plugin-loaded-setup?)
     (set! plugin-loaded-setup? #t)
     (when (url-exists? plugin-cache)
-      (with cached (load-object plugin-cache)
+      (with cached
+        (load-object plugin-cache)
         (if (== (length cached) 2) (set! cached (cons "" cached)))
-        (with (p t1 t2) cached
+        (with (p t1 t2)
+          cached
           (set! plugin-check-path p)
           (set! plugin-data-table (list->ahash-table t1))
           (set! check-dir-table (list->ahash-table t2))
           (when (path-up-to-date?)
-            (set! reconfigure-flag? #f)))))
-    ;;(display* "Reconfigure " reconfigure-flag? "\n")
+            (set! reconfigure-flag? #f)
+          ) ;when
+        ) ;with
+      ) ;with
+    ) ;when
+    ;; (display* "Reconfigure " reconfigure-flag? "\n")
     (when reconfigure-flag?
       (set! check-dir-table (make-ahash-table))
       (set! plugin-data-table (make-ahash-table))
-      (init-check-dir-table))))
+      (init-check-dir-table)
+    ) ;when
+  ) ;when
+) ;define
 
 (define (plugin-save-setup)
   (when reconfigure-flag?
     (save-object plugin-cache
-                 (list (get-original-path)
-                       (ahash-table->list plugin-data-table)
-                       (ahash-table->list check-dir-table)))))
+      (list (get-original-path)
+        (ahash-table->list plugin-data-table)
+        (ahash-table->list check-dir-table)
+      ) ;list
+    ) ;save-object
+  ) ;when
+) ;define
 
 (define-public (plugin-versions name)
-  (with versions (ahash-ref plugin-data-table name)
+  (with versions
+    (ahash-ref plugin-data-table name)
     (cond ((not versions) (list))
           ((list? versions) versions)
           ((string? versions) (list versions))
-          (else (list "default")))))
+          (else (list "default"))
+    ) ;cond
+  ) ;with
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Manage directories where to search for plugins
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define home-dir (string->url "~"))
+
 (define texmacs-dir (string->url "$TEXMACS_PATH"))
 
 (define (init-check-dir-table)
   (set! check-dir-table (make-ahash-table))
-  (add-to-check-dir-table "$PATH"))
+  (add-to-check-dir-table "$PATH")
+) ;define
 
 (define (add-to-check-dir-table u)
-  (cond ((in? u (list (url-head u) home-dir texmacs-dir))
-         (noop))
+  (cond ((in? u (list (url-head u) home-dir texmacs-dir)) (noop))
         ((url-or? u)
          (add-to-check-dir-table (url-ref u 1))
-         (add-to-check-dir-table (url-ref u 2)))
+         (add-to-check-dir-table (url-ref u 2))
+        ) ;
         ((url-concat? u)
          (add-to-check-dir-table (url-head u))
          (for (v (url->list (url-expand (url-complete u "dr"))))
-           (with s (url->system v)
+           (with s
+             (url->system v)
              (when (not (ahash-ref check-dir-table s))
-               (ahash-set! check-dir-table s (url-last-modified v))))))))
+               (ahash-set! check-dir-table s (url-last-modified v))
+             ) ;when
+           ) ;with
+         ) ;for
+        ) ;
+  ) ;cond
+) ;define
 
 (define (add-to-path u after?)
   (add-to-check-dir-table u)
   (let* ((u1 (url-complete u "dr"))
          (u2 "$PATH")
          (u3 (if after? (url-or u2 u1) (url-or u1 u2)))
-         (p  (url-expand u3)))
+         (p (url-expand u3))
+        ) ;
     (when (not (url-none? u1))
-      (system-setenv "PATH" (url->system p)))))
+      (system-setenv "PATH" (url->system p))
+    ) ;when
+  ) ;let*
+) ;define
 
 (define (add-to-path* prefix u after?)
-  (add-to-path (url-append (system->url prefix) u) after?))
+  (add-to-path (url-append (system->url prefix) u) after?)
+) ;define
 
 (define (add-windows-program-path u after?)
   (add-to-path* "C:\\." u after?)
   (add-to-path* "C:\\Program File*" u after?)
   (add-to-path* "$HOME\\AppData\\Local" u after?)
-  (add-to-path* "$HOME\\AppData\\Local\\Programs" u after?))
+  (add-to-path* "$HOME\\AppData\\Local\\Programs" u after?)
+) ;define
 
 (define (add-macos-program-path u after?)
   (add-to-path* "/Applications" u after?)
-  (add-to-path* "$HOME/Applications" u after?))
+  (add-to-path* "$HOME/Applications" u after?)
+) ;define
 
 (define-public (plugin-add-windows-path rad rel after?)
   (when (or (os-win32?) (os-mingw?))
-    (add-windows-program-path (url-append rad rel) after?)))
+    (add-windows-program-path (url-append rad rel) after?)
+  ) ;when
+) ;define-public
 
 (define-public (plugin-add-macos-path rad rel after?)
   (when (os-macos?)
-    (add-macos-program-path (url-append rad rel) after?)))
+    (add-macos-program-path (url-append rad rel) after?)
+  ) ;when
+) ;define-public
 
 (define (path-up-to-date?)
-  (with ok? (== plugin-check-path (get-original-path))
+  (with ok?
+    (== plugin-check-path (get-original-path))
     (for (p (ahash-table->list check-dir-table))
-      (with modified? (!= (url-last-modified (system->url (car p))) (cdr p))
-        (if modified? (set! ok? #f))))
-    ok?))
+      (with modified?
+        (!= (url-last-modified (system->url (car p))) (cdr p))
+        (if modified? (set! ok? #f))
+      ) ;with
+    ) ;for
+    ok?
+  ) ;with
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Configuration of plugins
@@ -439,130 +566,162 @@
 (define (plugin-configure-cmd name cmd)
   (cond ((func? cmd :require 1)
          (when reconfigure-flag?
-           (ahash-set! plugin-data-table name ((second cmd)))))
+           (ahash-set! plugin-data-table name ((second cmd)))
+         ) ;when
+        ) ;
         ((func? cmd :versions 1)
          (when reconfigure-flag?
-           (ahash-set! plugin-data-table name ((second cmd)))))
-        ((func? cmd :setup 1)
-         (if reconfigure-flag? ((second cmd))))
+           (ahash-set! plugin-data-table name ((second cmd)))
+         ) ;when
+        ) ;
+        ((func? cmd :setup 1) (if reconfigure-flag? ((second cmd))))
         ((func? cmd :prioritary 1)
-         (ahash-set! plugin-data-table (list name :prioritary) (cadr cmd)))
-        ((func? cmd :initialize 1)
-         ((second cmd)))
-        ((func? cmd :launch 1)
-         (connection-setup name `(tuple "pipe" ,(second cmd))))
+         (ahash-set! plugin-data-table (list name :prioritary) (cadr cmd))
+        ) ;
+        ((func? cmd :initialize 1) ((second cmd)))
+        ((func? cmd :launch 1) (connection-setup name `(tuple ,"pipe"
+                                                         ,(second cmd))))
         ((func? cmd :launch 2)
-         (connection-setup name `(tuple "pipe" ,(third cmd)) (cadr cmd)))
+         (connection-setup name `(tuple ,"pipe" ,(third cmd)) (cadr cmd))
+        ) ;
         ((func? cmd :socket 2)
-         (connection-setup name `(tuple "socket" ,(second cmd) ,(third cmd))))
+         (connection-setup name `(tuple ,"socket" ,(second cmd) ,(third cmd)))
+        ) ;
         ((func? cmd :socket 3)
-         (connection-setup
-          name `(tuple "socket" ,(third cmd) ,(fourth cmd)) (cadr cmd)))
+         (connection-setup name `(tuple ,"socket" ,(third cmd) ,(fourth cmd)) (cadr cmd))
+        ) ;
         ((func? cmd :link 3)
-         (connection-setup
-          name `(tuple "dynlink" ,(second cmd) ,(third cmd) ,(fourth cmd))))
+         (connection-setup name
+           `(tuple ,"dynlink" ,(second cmd) ,(third cmd) ,(fourth cmd))
+         ) ;connection-setup
+        ) ;
         ((func? cmd :link 4)
-         (connection-setup
-          name `(tuple "dynlink" ,(third cmd) ,(fourth cmd) ,(fifth cmd))
-          (cadr cmd)))
+         (connection-setup name
+           `(tuple ,"dynlink" ,(third cmd) ,(fourth cmd) ,(fifth cmd))
+           (cadr cmd)
+         ) ;connection-setup
+        ) ;
         ((func? cmd :handler 2)
-         (connection-insert-handler
-          name (second cmd) (symbol->string (third cmd))))
+         (connection-insert-handler name (second cmd) (symbol->string (third cmd)))
+        ) ;
         ((func? cmd :winpath 2)
          (when (os-mingw?)
-           (add-windows-program-path (url-append (second cmd) (third cmd)) #t)))
+           (add-windows-program-path (url-append (second cmd) (third cmd)) #t)
+         ) ;when
+        ) ;
         ((func? cmd :macpath 2)
          (when (os-macos?)
-           (add-macos-program-path (url-append (second cmd) (third cmd)) #t)))
-        ((func? cmd :session 1)
-         (session-setup name (second cmd)))
-        ((func? cmd :scripts 1)
-         (scripts-setup name (second cmd)))
-        ((func? cmd :filter-in 1)
-         (noop))
-        ((func? cmd :serializer 1)
-         (plugin-serializer-set! name (second cmd)))
-        ((func? cmd :commander 1)
-         (plugin-commander-set! name (second cmd)))
+           (add-macos-program-path (url-append (second cmd) (third cmd)) #t)
+         ) ;when
+        ) ;
+        ((func? cmd :session 1) (session-setup name (second cmd)))
+        ((func? cmd :scripts 1) (scripts-setup name (second cmd)))
+        ((func? cmd :filter-in 1) (noop))
+        ((func? cmd :serializer 1) (plugin-serializer-set! name (second cmd)))
+        ((func? cmd :commander 1) (plugin-commander-set! name (second cmd)))
         ((func? cmd :tab-completion 1)
-         (if (second cmd) (plugin-supports-completions-set! name)))
+         (if (second cmd) (plugin-supports-completions-set! name))
+        ) ;
         ((func? cmd :test-input-done 1)
-         (if (second cmd) (plugin-supports-input-done-set! name))))
+         (if (second cmd) (plugin-supports-input-done-set! name))
+        ) ;
+  ) ;cond
 
-  (or (in? (car cmd) '(:macpath :winpath))
-      (ahash-ref plugin-data-table name)))
+  (or (in? (car cmd) '(:macpath :winpath)) (ahash-ref plugin-data-table name))
+) ;define
 
 (define-public (plugin-configure-cmds name cmds)
   "Helper function for plugin-configure"
   (when (and (nnull? cmds) (plugin-configure-cmd name (car cmds)))
-    (plugin-configure-cmds name (cdr cmds))))
+    (plugin-configure-cmds name (cdr cmds))
+  ) ;when
+) ;define-public
 
 (define-public (plugin-configure-sub cmd)
   "Helper function for plugin-configure"
-  (if (and (list? cmd) (= (length cmd) 2)
-           (in? (car cmd) '(:require :versions :setup :initialize)))
-      (list (car cmd) (list 'unquote `(lambda () ,(cadr cmd))))
-      cmd))
+  (if (and (list? cmd)
+        (= (length cmd) 2)
+        (in? (car cmd) '(:require :versions :setup :initialize))
+      ) ;and
+    (list (car cmd) (list 'unquote `(lambda ,() ,(cadr cmd))))
+    cmd
+  ) ;if
+) ;define-public
 
 (define-public-macro (plugin-configure name2 . options)
   "Declare and configure plug-in with name @name2 according to @options"
   (let* ((name (if (string? name2) name2 (symbol->string name2)))
          (supports-name? (string->symbol (string-append "supports-" name "?")))
          (in-name (string->symbol (string-append "in-" name "%")))
-         (name-scripts (string->symbol (string-append name "-scripts%"))))
+         (name-scripts (string->symbol (string-append name "-scripts%")))
+        ) ;
     `(begin
        (texmacs-modes (,in-name (== (get-env "prog-language") ,name)))
        (texmacs-modes (,name-scripts (== (get-env "prog-scripts") ,name)))
        (define (,supports-name?)
          (or (ahash-ref plugin-data-table ,name)
-             (remote-connection-defined? ,name)))
-       (if reconfigure-flag? (ahash-set! plugin-data-table ,name #t))
+           (remote-connection-defined? ,name)))
+       (if reconfigure-flag? (ahash-set! plugin-data-table ,name ,#t))
        (plugin-configure-cmds ,name
-         ,(list 'quasiquote (map plugin-configure-sub options))))))
+         ,(list 'quasiquote (map plugin-configure-sub options))))
+  ) ;let*
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Initialization of plugins
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define plugin-initialize-todo (make-ahash-table))
+
 (define plugin-initialize-done? #f)
 
 (define (plugin-all-initialized?)
-  (with l (ahash-table->list plugin-initialize-todo)
-    (not (list-or (map cdr l)))))
+  (with l (ahash-table->list plugin-initialize-todo) (not (list-or (map cdr l))))
+) ;define
 
 (define-public (plugin-initialize name*)
   "Initialize plugin with name @name*"
   (plugin-load-setup)
   (if (ahash-ref plugin-initialize-todo name*)
-      (let* ((name (symbol->string name*))
-             (file (string-append "plugins/" name "/progs/init-" name ".scm"))
-             (u (url-unix "$TEXMACS_HOME_PATH:$TEXMACS_PATH" file)))
-        (ahash-set! plugin-initialize-todo name* #f)
-        (if (url-exists? u)
-            (with fname (url-materialize u "r")
-              ;;(display* "loading plugin " name* "\n")
-              ;;(display* "loading plugin " fname "\n")
-              ;;(with start (texmacs-time)
-              ;;  (load fname)
-              ;;  (display* name " -> " (- (texmacs-time) start) " ms\n"))
-              (load fname)
-              ))
-        (if (plugin-all-initialized?) (plugin-save-setup)))))
+    (let* ((name (symbol->string name*))
+           (file (string-append "plugins/" name "/progs/init-" name ".scm"))
+           (u (url-unix "$TEXMACS_HOME_PATH:$TEXMACS_PATH" file))
+          ) ;
+      (ahash-set! plugin-initialize-todo name* #f)
+      (if (url-exists? u)
+        (with fname
+          (url-materialize u "r")
+          ;; (display* "loading plugin " name* "\n")
+          ;; (display* "loading plugin " fname "\n")
+          ;; (with start (texmacs-time)
+          ;;  (load fname)
+          ;;  (display* name " -> " (- (texmacs-time) start) " ms\n"))
+          (load fname)
+        ) ;with
+      ) ;if
+      (if (plugin-all-initialized?) (plugin-save-setup))
+    ) ;let*
+  ) ;if
+) ;define-public
 
 (define-public (lazy-plugin-initialize name)
   "Initialize the plug-in @name in a lazy way"
   (ahash-set! plugin-initialize-todo name #t)
   (if (eval (ahash-ref plugin-data-table (list name :prioritary)))
-      (plugin-initialize name)
-      (delayed
-        (:idle 1000)
-        (plugin-initialize name))))
+    (plugin-initialize name)
+    (delayed (:idle 1000) (plugin-initialize name))
+  ) ;if
+) ;define-public
 
 (define-public (lazy-plugin-force)
   "Force all lazy plugin initializations to take place"
-  (if plugin-initialize-done? #f
-      (with l (ahash-table->list plugin-initialize-todo)
-        (for-each plugin-initialize (map car l))
-        (set! plugin-initialize-done? #t)
-        #t)))
+  (if plugin-initialize-done?
+    #f
+    (with l
+      (ahash-table->list plugin-initialize-todo)
+      (for-each plugin-initialize (map car l))
+      (set! plugin-initialize-done? #t)
+      #t
+    ) ;with
+  ) ;if
+) ;define-public

--- a/TeXmacs/progs/kernel/texmacs/tm-preferences.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-preferences.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel texmacs tm-preferences)
-  (:use (kernel texmacs tm-define)))
+  (:use (kernel texmacs tm-define))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining preference call back routines
@@ -22,20 +23,28 @@
 (define-public preferences-call-back (make-ahash-table))
 
 (define (define-preference x)
-  (with (which value call-back) x
+  (with (which value call-back)
+    x
     `(if (not (ahash-ref preferences-default ,which))
-         (ahash-set! preferences-default ,which ,value))))
+       (ahash-set! preferences-default ,which ,value))
+  ) ;with
+) ;define
 
 (define (define-preference-call-back x)
-  (with (which value call-back) x
+  (with (which value call-back)
+    x
     `(begin
        (ahash-set! preferences-call-back ,which ,call-back)
-       (notify-preference ,which))))
+       (notify-preference ,which))
+  ) ;with
+) ;define
 
 (define-public-macro (define-preferences . l)
   (append '(begin)
-          (map-in-order define-preference l)
-          (map-in-order define-preference-call-back l)))
+    (map-in-order define-preference l)
+    (map-in-order define-preference-call-back l)
+  ) ;append
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setting and getting preferences
@@ -43,59 +52,80 @@
 
 (define (test-preference? which what)
   (== (get-preference which)
-      (if (!= what "default") what
-          (ahash-ref preferences-default which))))
+    (if (!= what "default") what (ahash-ref preferences-default which))
+  ) ;==
+) ;define
 
 (tm-define (set-preference which what)
   (:synopsis "Set preference @which to @what")
   (:check-mark "*" test-preference?)
-  ;;(display* "set-preference " which " := " what "\n")
-  (with val (if (string? what) what (object->string what))
+  ;; (display* "set-preference " which " := " what "\n")
+  (with val
+    (if (string? what) what (object->string what))
     (when (!= (get-preference which) val)
       (cpp-set-preference which val)
       (notify-preference which)
-      (save-preferences))))
+      (save-preferences)
+    ) ;when
+  ) ;with
+) ;tm-define
 
 (tm-define (reset-preference which)
   (:synopsis "Revert preference @which to default setting")
-  ;;(display* "reset-preference " which "\n")
+  ;; (display* "reset-preference " which "\n")
   (when (cpp-has-preference? which)
     (cpp-reset-preference which)
     (notify-preference which)
-    (save-preferences)))
+    (save-preferences)
+  ) ;when
+) ;tm-define
 
 (define (get-call-back what)
   (let ((r (ahash-ref preferences-call-back what)))
-    (if r r (lambda args (noop)))))
+    (if r r (lambda args (noop)))
+  ) ;let
+) ;define
 
 (tm-define (notify-preference which)
   (:synopsis "Notify that the preference @which was changed")
-  ;;(display* "notify-preference " which ", " (get-preference which) "\n")
-  ((get-call-back which) which (get-preference which)))
+  ;; (display* "notify-preference " which ", " (get-preference which) "\n")
+  ((get-call-back which) which (get-preference which))
+) ;tm-define
 
 (tm-define (get-preference which)
   (:synopsis "Get preference @which")
   (let* ((def (or (ahash-ref preferences-default which) "default"))
          (s? (string? def))
-         (r (cpp-get-preference which (if s? def (object->string def)))))
-    (if s? r (string->object r))))
+         (r (cpp-get-preference which (if s? def (object->string def))))
+        ) ;
+    (if s? r (string->object r))
+  ) ;let*
+) ;tm-define
 
-(tm-define (preference-on? which)
-  (test-preference? which "on"))
+(tm-define (preference-on? which) (test-preference? which "on"))
 
 (tm-define (toggle-preference which)
   (:synopsis "Toggle the preference @which")
   (:check-mark "v" preference-on?)
-  (with what (get-preference which)
-    (set-preference which (cond ((== what "on") "off")
-                                ((== what "off") "on")
-                                (else what)))))
+  (with what
+    (get-preference which)
+    (set-preference which
+      (cond ((== what "on") "off")
+            ((== what "off") "on")
+            (else what)
+      ) ;cond
+    ) ;set-preference
+  ) ;with
+) ;tm-define
 
 (tm-define (append-preference which val)
   (:synopsis "Appends @val to the list of values of preference @which")
-  (with cur (get-preference which)
+  (with cur
+    (get-preference which)
     (if (== cur "default") (set! cur '()))
-    (set-preference which (rcons cur val))))
+    (set-preference which (rcons cur val))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Nicer names for preference values
@@ -105,77 +135,92 @@
 (define-public preference-encode-table (make-ahash-table))
 
 (tm-define (set-pretty-preference which pretty-val)
-  (with val (ahash-ref preference-decode-table (cons which pretty-val))
-    (set-preference which (or val pretty-val))))
+  (with val
+    (ahash-ref preference-decode-table (cons which pretty-val))
+    (set-preference which (or val pretty-val))
+  ) ;with
+) ;tm-define
 
 (tm-define (get-pretty-preference which)
-  (with val (get-preference which)
-    (with pretty-val (ahash-ref preference-encode-table (cons which val))
-      ;;(display* "Get: " which ", " val " -> " pretty-val "\n")
-      (or pretty-val val "Default"))))
+  (with val
+    (get-preference which)
+    (with pretty-val
+      (ahash-ref preference-encode-table (cons which val))
+      ;; (display* "Get: " which ", " val " -> " pretty-val "\n")
+      (or pretty-val val "Default")
+    ) ;with
+  ) ;with
+) ;tm-define
 
 (tm-define (set-boolean-preference which val)
-  (set-preference which (if val "on" "off")))
+  (set-preference which (if val "on" "off"))
+) ;tm-define
 
-(tm-define (get-boolean-preference which)
-  (== (get-preference which) "on"))
+(tm-define (get-boolean-preference which) (== (get-preference which) "on"))
 
 (define-public (set-preference-name which var val)
   (ahash-set! preference-encode-table (cons which var) val)
-  (ahash-set! preference-decode-table (cons which val) var))
+  (ahash-set! preference-decode-table (cons which val) var)
+) ;define-public
 
 (define-public (set-preference-encode which x)
-   `(ahash-set! preference-encode-table
-                (cons ,which ,(car x)) ,(cadr x)))
+  `(ahash-set! preference-encode-table (cons ,which ,(car x)) ,(cadr x))
+) ;define-public
 
 (define-public (set-preference-decode which x)
-   `(ahash-set! preference-decode-table
-                (cons ,which ,(cadr x)) ,(car x)))
+  `(ahash-set! preference-decode-table (cons ,which ,(cadr x)) ,(car x))
+) ;define-public
 
 (define-public-macro (define-preference-names which . l)
   `(begin
      ,@(map (lambda (x) (set-preference-encode which x)) l)
-     ,@(map (lambda (x) (set-preference-decode which x)) l)))
+     ,@(map (lambda (x) (set-preference-decode which x)) l))
+) ;define-public-macro
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Look and feel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (xdg-dekstop-session)
-  (locase-all (system-getenv "XDG_SESSION_DESKTOP")))
+  (locase-all (system-getenv "XDG_SESSION_DESKTOP"))
+) ;define
 
 (define (default-look-and-feel)
-  (cond
-   ((os-macos?) "macos")
-   ((or (os-win32?) (os-mingw?)) "windows")
-   ((== (xdg-dekstop-session) "kde") "kde")
-   ((== (xdg-dekstop-session) "deepin") "kde")
-   ((== (xdg-dekstop-session) "gnome") "gnome")
-   ((== (xdg-dekstop-session) "ubuntu") "gnome")
-   (else "emacs")))
+  (cond ((os-macos?) "macos")
+        ((or (os-win32?) (os-mingw?)) "windows")
+        ((== (xdg-dekstop-session) "kde") "kde")
+        ((== (xdg-dekstop-session) "deepin") "kde")
+        ((== (xdg-dekstop-session) "gnome") "gnome")
+        ((== (xdg-dekstop-session) "ubuntu") "gnome")
+        (else "emacs")
+  ) ;cond
+) ;define
 
 (define-public (look-and-feel)
-  (with s (get-preference "look and feel")
-    (if (== s "default") (default-look-and-feel) s)))
+  (with s
+    (get-preference "look and feel")
+    (if (== s "default") (default-look-and-feel) s)
+  ) ;with
+) ;define-public
 
 (define (test-look-and-feel t)
-  ;;(display* "Check look and feel " t "\n")
+  ;; (display* "Check look and feel " t "\n")
   (cond ((list? t) (list-or (map test-look-and-feel t)))
         ((symbol? t) (test-look-and-feel (symbol->string t)))
         ((and (string? t) (string-starts? t "no-"))
-         (not (test-look-and-feel (substring t 3 (string-length t)))))
-        (else
-          (with s (look-and-feel)
-            (or (== t s) (and (== t "std") (!= s "emacs")))))))
+         (not (test-look-and-feel (substring t 3 (string-length t))))
+        ) ;
+        (else (with s (look-and-feel) (or (== t s) (and (== t "std") (!= s "emacs")))))
+  ) ;cond
+) ;define
 
-(define-public (use-popups?)
-  (== (get-preference "complex actions") "popups"))
+(define-public (use-popups?) (== (get-preference "complex actions") "popups"))
 
-(define-public (use-menus?)
-  (== (get-preference "complex actions") "menus"))
+(define-public (use-menus?) (== (get-preference "complex actions") "menus"))
 
 (define-public (use-print-dialog?)
-  (and (qt-gui?) (== (get-preference "gui:print dialogue") "on")))
+  (and (qt-gui?) (== (get-preference "gui:print dialogue") "on"))
+) ;define-public
 
 (set! has-look-and-feel? test-look-and-feel)
 

--- a/TeXmacs/progs/kernel/texmacs/tm-secure.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-secure.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel texmacs tm-secure)
-  (:use (kernel texmacs tm-define) (kernel texmacs tm-plugins)))
+  (:use (kernel texmacs tm-define) (kernel texmacs tm-plugins))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Primitive secure functions
@@ -20,88 +21,165 @@
 
 (define-public-macro (define-secure-symbols . l)
   (for-each (lambda (x) (property-set! x :secure #t '())) l)
-  '(noop))
+  '(noop)
+) ;define-public-macro
 
-(define-secure-symbols
-  boolean? null? symbol? string? pair? list?
-  equal? == not
-  string-length substring string-append
-  string->list list->string string-ref string-set!
-  + - * / gcd lcm quotient remainder modulo abs log exp sqrt
-  car cdr caar cadr cdar cddr
-  caaar caadr cadar caddr cdaar cdadr cddar cdddr
-  caaaar caaadr caadar caaddr cadaar cadadr caddar cadddr
-  cdaaar cdaadr cdadar cdaddr cddaar cddadr cdddar cddddr
-  cons list append length reverse
-  texmacs-version texmacs-version-release* xmacs-version
-  display display*
-  refresh-now)
+(define-secure-symbols boolean?
+  null?
+  symbol?
+  string?
+  pair?
+  list?
+  equal?
+  ==
+  not
+  string-length
+  substring
+  string-append
+  string->list
+  list->string
+  string-ref
+  string-set!
+  +
+  -
+  *
+  /
+  gcd
+  lcm
+  quotient
+  remainder
+  modulo
+  abs
+  log
+  exp
+  sqrt
+  car
+  cdr
+  caar
+  cadr
+  cdar
+  cddr
+  caaar
+  caadr
+  cadar
+  caddr
+  cdaar
+  cdadr
+  cddar
+  cdddr
+  caaaar
+  caaadr
+  caadar
+  caaddr
+  cadaar
+  cadadr
+  caddar
+  cadddr
+  cdaaar
+  cdaadr
+  cdadar
+  cdaddr
+  cddaar
+  cddadr
+  cdddar
+  cddddr
+  cons
+  list
+  append
+  length
+  reverse
+  texmacs-version
+  texmacs-version-release*
+  xmacs-version
+  display
+  display*
+  refresh-now
+) ;define-secure-symbols
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Secure evaluation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (secure-args? args env)
-  (if (null? args) #t
-      (and (secure-expr? (car args) env)
-           (secure-args? (cdr args) env))))
+  (if (null? args)
+    #t
+    (and (secure-expr? (car args) env) (secure-args? (cdr args) env))
+  ) ;if
+) ;define
 
 (define (secure-cond? args env)
-  (if (null? args) #t
-      (and (or (== (caar args) 'else) (secure-expr? (caar args) env))
-           (secure-expr? (cadar args) env)
-           (secure-cond? (cdr args) env))))
+  (if (null? args)
+    #t
+    (and (or (== (caar args) 'else) (secure-expr? (caar args) env))
+      (secure-expr? (cadar args) env)
+      (secure-cond? (cdr args) env)
+    ) ;and
+  ) ;if
+) ;define
 
 (define (local-env env l)
   (cond ((null? l) env)
         ((pair? l) (local-env (assoc-set! env (car l) #t) (cdr l)))
-        (else (assoc-set! env l #t))))
+        (else (assoc-set! env l #t))
+  ) ;cond
+) ;define
 
 (define (secure-lambda? args env)
-  (secure-args? (cdr args) (local-env env (car args))))
+  (secure-args? (cdr args) (local-env env (car args)))
+) ;define
 
 (define (secure-with args env)
   (and (>= (length args) 3)
-       (symbol? (car args))
-       (secure-expr? (cadr args) env)
-       (secure-args? (cddr args) (local-env env (list (car args))))))
+    (symbol? (car args))
+    (secure-expr? (cadr args) env)
+    (secure-args? (cddr args) (local-env env (list (car args))))
+  ) ;and
+) ;define
 
 (define (secure-quasiquote? args env)
   (cond ((npair? args) #t)
         ((func? args 'unquote 1) (secure-expr? (cadr args) env))
         ((func? args 'unquote-splicing 1) (secure-expr? (cadr args) env))
-        (else (and (secure-quasiquote? (car args) env)
-                   (secure-quasiquote? (cdr args) env)))))
+        (else (and (secure-quasiquote? (car args) env) (secure-quasiquote? (cdr args) env))
+        ) ;else
+  ) ;cond
+) ;define
 
 (define (secure-expr? expr env)
   (cond ((pair? expr)
-         (let* ((f (car expr))
-                (m (logic-ref secure-macros% f)))
+         (let* ((f (car expr)) (m (logic-ref secure-macros% f)))
            (cond (m (m (cdr expr) env))
                  ((assoc-ref env f) (secure-args? (cdr expr) env))
                  ((== f 'quote) #t)
                  ((== f 'quasiquote) (secure-quasiquote? (cdr expr) env))
-                 ((symbol? f)
-                  (and (property f :secure)
-                       (secure-args? (cdr expr) env)))
-                 (else (secure-args? expr env)))))
+                 ((symbol? f) (and (property f :secure) (secure-args? (cdr expr) env)))
+                 (else (secure-args? expr env))
+           ) ;cond
+         ) ;let*
+        ) ;
         ((symbol? expr) #t)
         ((number? expr) #t)
         ((string? expr) #t)
         ((tree? expr) #t)
         ((null? expr) #t)
         ((boolean? expr) #t)
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define
 
 (logic-table secure-macros%
   (and ,secure-args?)
-  (begin ,secure-args?)
-  (cond ,secure-cond?)
+  (begin
+    ,secure-args?
+  ) ;begin
+  (cond ,secure-cond?
+  ) ;cond
   (if ,secure-args?)
   (lambda ,secure-lambda?)
   (or ,secure-args?)
   (set! ,secure-args?)
-  (with ,secure-with))
+  (with ,secure-with)
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
@@ -109,9 +187,10 @@
 
 (define-public (secure? expr)
   "Test whether it is secure to evaluate the expression @expr"
-  (or (secure-expr? expr '())
-      (and (lazy-plugin-force) (secure-expr? expr '()))))
+  (or (secure-expr? expr '()) (and (lazy-plugin-force) (secure-expr? expr '())))
+) ;define-public
 
 (define-public (secure-eval expr)
   "Evaluate @expr only when it is secure to do so"
-  (and (secure? expr) (eval expr)))
+  (and (secure? expr) (eval expr))
+) ;define-public

--- a/TeXmacs/progs/kernel/texmacs/tm-states.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-states.scm
@@ -15,149 +15,159 @@
 
 ;; Low-level API
 (define-public (state-create slotlist)
-;; slotlist === ((<SLOT-DESCR>*) (<PROP-DESCR>*) (<COMPILED-PROP>*))
-  slotlist)
+  ;; slotlist === ((<SLOT-DESCR>*) (<PROP-DESCR>*) (<COMPILED-PROP>*))
+  slotlist
+) ;define-public
 
 (define (state-slots sr)
-  (car sr))
+  (car sr)
+) ;define
 
 (define (state-props sr)
-  (cadr sr))
+  (cadr sr)
+) ;define
 
 (define (state-cprops sr)
-  (caddr sr))
+  (caddr sr)
+) ;define
 
 (define (slotlist-load l)
- ;(display* "load=" l "\n")
   (for (e l)
-     (eval
-        `(begin
-           (if (not (defined? ',(car e)))
-               (define-public ,(car e) #f))
-           (set! ,(car e)
-                 ,(with val (cadr e)
-                     (if (and (pair? val) (eq? (car val) 'quote))
-                         val
-                        `(quote ,(eval val)))))))))
+    (eval `(begin
+             (if (not (defined? (quote ,(car e)))) (define-public ,(car e) ,#f))
+             (set! ,(car e)
+               ,(with val
+                  (cadr e)
+                  (if (and (pair? val) (eq? (car val) 'quote))
+                    val
+                    `(quote ,(eval val))))))
+    ) ;eval
+  ) ;for
+) ;define
 
 (define (proplist-load l funcs b)
- ;(display* "load[props]=" l "\n")
-  (for (e l)
-     (if (not (defined? `,(car e)))
-         (eval `(define-public ,(car e) #f))))
-  (if b
-      (for (f funcs)
-         (f))))
+  (for (e l) (if (not (defined? (car e))) (eval `(define-public ,(car e) ,#f))))
+  (if b (for (f funcs) (f)))
+) ;define
 
 (define (slotlist-save l)
-  (for (e l)
-     (set-car! (cdr e) `(quote ,(eval (car e)))))
- ;(display* "save=" l "\n")
- ;(for (e l)
- ;   (eval `(undefine ,(car e))))
-)
+  (for (e l) (set-car! (cdr e) `(quote ,(eval (car e)))))
+) ;define
 
 ;; User-level API
+
 (define current-state #f)
 
 (define-public (state-synchronize)
-  (with old-current current-state
+  (with old-current
+    current-state
     (set! current-state #f)
-    (state-save old-current)))
-  
+    (state-save old-current)
+  ) ;with
+) ;define-public
+
 (define-public (state-load sr . opt)
- ;(display* "sl=" sr "\n")
   (if sr
-      (begin
-        (if (not (eq? sr current-state))
-            (begin
-              (state-synchronize)
-              (slotlist-load (state-slots sr))))
-        (proplist-load (state-props sr) (state-cprops sr) (null? opt))
-        (set! current-state sr))))
+    (begin
+      (if (not (eq? sr current-state))
+        (begin
+          (state-synchronize)
+          (slotlist-load (state-slots sr))
+        ) ;begin
+      ) ;if
+      (proplist-load (state-props sr) (state-cprops sr) (null? opt))
+      (set! current-state sr)
+    ) ;begin
+  ) ;if
+) ;define-public
 
 (define-public (state-save sr)
-  (if (and sr (not (eq? sr current-state)))
-      (slotlist-save (state-slots sr)))
- ;(display* "ss=" sr "\n")
-  )
+  (if (and sr (not (eq? sr current-state))) (slotlist-save (state-slots sr)))
+) ;define-public
 
 (define (state-slotnames sr)
-  (map car (state-slots sr)))
+  (map car (state-slots sr))
+) ;define
 
 (define (state-propnames sr)
-  (map car (state-props sr)))
+  (map car (state-props sr))
+) ;define
 
 (define-public (state-names sr)
-  (append (state-slotnames sr) (state-propnames sr)))
+  (append (state-slotnames sr) (state-propnames sr))
+) ;define-public
 
 (define-public (state-type sr name)
-  (cond ((in? name (state-slotnames sr))
-         'slot)
-        ((in? name (state-propnames sr))
-         'prop)
-        (else #f)))
+  (cond ((in? name (state-slotnames sr)) 'slot)
+        ((in? name (state-propnames sr)) 'prop)
+        (else #f)
+  ) ;cond
+) ;define-public
 
 (define (seek-pred? pred? l)
   (define res #f)
-  (for (e l)
-     (if (pred? (car e))
-         (set! res e)))
-  res)
+  (for (e l) (if (pred? (car e)) (set! res e)))
+  res
+) ;define
 
 (define (state-entry sr name)
   (define ref #f)
   (set! ref (seek-pred? (lambda (x) (eq? x name)) (state-slots sr)))
   (if (not ref)
-      (set! ref (seek-pred? (lambda (x) (eq? x name)) (state-props sr))))
-  ref)
+    (set! ref (seek-pred? (lambda (x) (eq? x name)) (state-props sr)))
+  ) ;if
+  ref
+) ;define
 
 (define-public (state-read sr name)
   (define ref #f)
   (set! ref (state-entry sr name))
-  (if ref
-      (cadr ref)))
+  (if ref (cadr ref))
+) ;define-public
 
 (define-public (state-write sr name val)
   (define ref #f)
   (set! ref (state-entry sr name))
-  (if ref
-      (set-car! (cdr ref) val)))
+  (if ref (set-car! (cdr ref) val))
+) ;define-public
 
 (define-public-macro (define-state name . slotlists)
-;; slotlists === ((slots ((<NAME-SLOT1> <INIT1>) ... (<NAME-SLOTN> <INITN>)))
-;;                (props ((<NAME-PROP1> <PROP1>) ... (<NAME-PROPN> <PROPN>))))
+  ;; slotlists === ((slots ((<NAME-SLOT1> <INIT1>) ... (<NAME-SLOTN> <INITN>)))
+  ;;                (props ((<NAME-PROP1> <PROP1>) ... (<NAME-PROPN> <PROPN>))))
   (let* ((theslots (copy-tree slotlists))
          (slots (cadr (car theslots)))
-         (props (cadr (cadr theslots))))
+         (props (cadr (cadr theslots)))
+        ) ;
     `(begin
-        (if (not (defined? ',name))
-            (define-public ,name #f))
-        (with cprops #f
-          (set! cprops (map (lambda (x)
-                               (eval
-                                  `(lambda () (set! ,(car x) ,(cadr x)))))
-                           ',props))
-          (set! ,name (state-create (append '(,slots ,props) `(,cprops))))))))
+       (if (not (defined? (quote ,name))) (define-public ,name ,#f))
+       (with cprops
+         ,#f
+         (set! cprops
+           (map (lambda (x)
+                  (eval (#_list-values
+                         'lambda
+                         ()
+                         (#_list-values 'set! (car x) (cadr x)))))
+             (quote ,props)))
+         (set! ,name
+           (state-create (append (quote (,slots ,props)) (#_list-values cprops))))))
+  ) ;let*
+) ;define-public-macro
 
 (define-public-macro (with-state sr . body)
- `(begin
-     (state-load ,sr)
-     (with res (begin . ,body)
-       (state-save ,sr)
-       res)))
+  `(begin (state-load ,sr) (with res (begin unquote body) (state-save ,sr) res))
+) ;define-public-macro
 
 (define-public-macro (with-state-by-name name . body)
- `(with sr ,name
-     (with-state sr . ,body)))
+  `(with sr ,name (with-state sr unquote body))
+) ;define-public-macro
 
 (define-public-macro (with-state-slots sr . body)
- `(begin
-     (state-load ,sr #f)
-     (with res (begin . ,body)
-       (state-save ,sr)
-       res)))
+  `(begin
+     (state-load ,sr ,#f)
+     (with res (begin unquote body) (state-save ,sr) res))
+) ;define-public-macro
 
 (define-public-macro (with-state-slots-by-name name . body)
- `(with sr ,name
-     (with-state-slots sr . ,body)))
+  `(with sr ,name (with-state-slots sr unquote body))
+) ;define-public-macro

--- a/bin/format
+++ b/bin/format
@@ -32,6 +32,4 @@ clang-format -i moebius/**/*.hpp
 clang-format -i 3rdparty/lolly/**/*.cpp
 clang-format -i 3rdparty/lolly/**/*.hpp
 
-gf fix TeXmacs/progs/kernel/boot
-gf fix TeXmacs/progs/kernel/library
-gf fix TeXmacs/progs/kernel/logic
+gf fix TeXmacs/progs/kernel

--- a/devel/0102.md
+++ b/devel/0102.md
@@ -1,13 +1,11 @@
-# [0102] 将 gf fix TeXmacs/progs/kernel/boot 加入 bin/format
+# [0102] 将 gf fix TeXmacs/progs/kernel 加入 bin/format
 
 ## 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
 
 ## 任务相关的代码文件
 - `bin/format`
-- `TeXmacs/progs/kernel/boot/*.scm`
-- `TeXmacs/progs/kernel/library/*.scm`
-- `TeXmacs/progs/kernel/logic/*.scm`
+- `TeXmacs/progs/kernel/**/*.scm`
 
 ## 如何测试
 
@@ -18,9 +16,7 @@
 
 ### 非确定性测试（文档验证）
 ```bash
-gf fix TeXmacs/progs/kernel/boot
-gf fix TeXmacs/progs/kernel/library
-gf fix TeXmacs/progs/kernel/logic
+gf fix TeXmacs/progs/kernel
 ```
 
 ## 如何提交
@@ -33,27 +29,25 @@ git diff
 ```
 
 ## 工具版本
-- `gf` (Goldfish Scheme) 18.11.5
+- `gf` (Goldfish Scheme) 18.11.6
 
 ## What
 
-将 `TeXmacs/progs/kernel/boot` 目录下的 Scheme 启动文件纳入 `bin/format` 自动格式化流程。
+将 `TeXmacs/progs/kernel` 目录下的所有 Scheme 文件纳入 `bin/format` 自动格式化流程。
 
-1. 在 `bin/format` 中新增 `gf fix TeXmacs/progs/kernel/boot`
+1. 在 `bin/format` 中新增 `gf fix TeXmacs/progs/kernel`
 2. 运行 `./bin/format` 执行格式化
 
 ## Why
 
-`bin/format` 原本仅使用 `clang-format` 处理 C++ 源文件（`.cpp`、`.hpp`）。`TeXmacs/progs/kernel/boot` 目录下存放的是 Scheme（`.scm`）启动文件，需要用 `gf fix` 进行格式化，以保持代码风格一致。
+`bin/format` 原本仅使用 `clang-format` 处理 C++ 源文件（`.cpp`、`.hpp`）。`TeXmacs/progs/kernel` 目录下存放的是 Scheme 启动文件、基础库、逻辑查询、GUI 定义等，需要用 `gf fix` 进行格式化，以保持代码风格一致。
 
 ## How
 
-在 `bin/format` 脚本末尾、所有 `clang-format` 调用之后，追加以下三行：
+在 `bin/format` 脚本末尾、所有 `clang-format` 调用之后，追加以下一行：
 
 ```
-gf fix TeXmacs/progs/kernel/boot
-gf fix TeXmacs/progs/kernel/library
-gf fix TeXmacs/progs/kernel/logic
+gf fix TeXmacs/progs/kernel
 ```
 
 `gf`（Goldfish Scheme）的 `fix` 子命令会递归修正指定目录下所有 `.scm` 文件的括号格式。
@@ -61,3 +55,7 @@ gf fix TeXmacs/progs/kernel/logic
 1. `TeXmacs/progs/kernel/boot` — 启动文件
 2. `TeXmacs/progs/kernel/library` — 基础库文件
 3. `TeXmacs/progs/kernel/logic` — 逻辑查询文件
+4. `TeXmacs/progs/kernel/regexp` — 正则表达式文件
+5. `TeXmacs/progs/kernel/gui` — GUI 定义文件
+6. `TeXmacs/progs/kernel/old-gui` — 旧版 GUI 文件
+7. `TeXmacs/progs/kernel/texmacs` — TeXmacs 核心定义文件


### PR DESCRIPTION
## 变更内容

1. 将 `bin/format` 中的三行 `gf fix` 合并为一行 `gf fix TeXmacs/progs/kernel`，覆盖 kernel 下所有子目录
2. 使用 Goldfish Scheme 18.11.6 的 `gf fix` 递归格式化 `TeXmacs/progs/kernel` 下全部 `.scm` 文件（boot、library、logic、regexp、gui、old-gui、texmacs）
3. 更新 `devel/0102.md` 任务文档，记录版本升级和范围扩展

## 测试

- `./bin/format` 可正常执行
- `gf fix TeXmacs/progs/kernel` 无文件变更（已格式化完毕）

🤖 Generated with [Claude Code](https://claude.com/claude-code)