### PR TITLE
[0133] AI Tab 相关函数文档补充及代码改进

### DIFF
--- a/TeXmacs/progs/dynamic/chat-adapter.scm
+++ b/TeXmacs/progs/dynamic/chat-adapter.scm
@@ -19,6 +19,39 @@
 
 (define chat-tab-url (string->url "tmfs://chat-tab"))
 
+;; open-llm-chat-tab
+;; 打开或切换到 LLM 聊天标签页。
+;;
+;; 语法
+;; ----
+;; (open-llm-chat-tab . model-opt)
+;;
+;; 参数
+;; ----
+;; model-opt : list
+;; 可选参数列表。若提供，第一个元素为要选择的模型名称。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 检查是否提供了 model-opt
+;;    - 若提供，调用 chat-tab-session-select-model 设置模型
+;; 2. 检查聊天标签页缓冲区是否已存在
+;;    - 若存在，直接切换到该缓冲区
+;;    - 若不存在，创建新缓冲区并初始化：
+;;      a. 设置缓冲区内容为空文档
+;;      b. 设置缓冲区标题为 "Chat"
+;;      c. 切换到该缓冲区
+;;      d. 标记缓冲区为已保存状态
+;;
+;; 注意
+;; ----
+;; 此函数是 LLM 聊天功能的入口，负责聊天标签页的创建和切换。
+;; 聊天标签页使用固定的 tmfs://chat-tab URL。
 (tm-define (open-llm-chat-tab . model-opt)
   (:synopsis "Open or switch to the LLM Chat tab")
   (when (nnull? model-opt)
@@ -35,6 +68,39 @@
   ) ;if
 ) ;tm-define
 
+;; chat-tab-send
+;; 聊天标签的适配器发送入口。
+;;
+;; 语法
+;; ----
+;; (chat-tab-send message-buffer input-buffer body)
+;;
+;; 参数
+;; ----
+;; message-buffer : url
+;; 消息缓冲区名称（URL），用于存储对话历史。
+;;
+;; input-buffer : url
+;; 输入缓冲区名称（URL），用户在此输入消息。
+;;
+;; body : tree
+;; 输入消息树，即用户要发送的内容。
+;;
+;; 返回值
+;; ----
+;; boolean
+;; 委托 chat-tab-session-send 的返回值：
+;; - #t : 消息发送成功
+;; - #f : 消息为空，未发送
+;;
+;; 逻辑
+;; ----
+;; 1. 直接调用 chat-tab-session-send，将参数原样传递
+;;
+;; 注意
+;; ----
+;; 此函数是 chat-tab-session.scm 的薄包装层，用于解耦适配层与会话引擎。
+;; 所有实际发送逻辑由 chat-tab-session-send 处理。
 (tm-define (chat-tab-send message-buffer input-buffer body)
   (:synopsis "Adapter send entry for a chat tab")
   (:argument message-buffer "Message buffer name")

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -201,6 +201,42 @@
   ) ;let
 ) ;define
 
+;; chat-tab-session-encode
+;; 将聊天标签会话的上下文编码为一个列表，用于传递给 plugin-feed。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-encode input message-buffer input-buffer out opts)
+;;
+;; 参数
+;; ----
+;; input : tree
+;; 规范化后的输入消息树。
+;;
+;; message-buffer : url
+;; 消息缓冲区名称。
+;;
+;; input-buffer : url
+;; 输入缓冲区名称。
+;;
+;; out : tree
+;; 输出节点树。
+;;
+;; opts : list
+;; 附加选项列表。
+;;
+;; 返回值
+;; ----
+;; list
+;; 编码后的列表，结构为：
+;;   ((do notify next cancel) input message-buffer input-buffer tree-pointer opts)
+;; 其中第一个元素是四个回调函数的列表，out 被转换为 tree-pointer 以避免
+;; 在异步执行期间被垃圾回收。
+;;
+;; 注意
+;; ----
+;; 此函数与 chat-tab-session-decode 成对使用，负责在任务进入 pending
+;; 队列前将上下文打包。
 (define (chat-tab-session-encode input message-buffer input-buffer out opts)
   (list (list chat-tab-session-do
           chat-tab-session-notify
@@ -215,6 +251,29 @@
   ) ;list
 ) ;define
 
+;; chat-tab-session-decode
+;; 将 chat-tab-session-encode 编码的列表解码回会话上下文。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-decode l)
+;;
+;; 参数
+;; ----
+;; l : list
+;; 由 chat-tab-session-encode 编码的列表。
+;;
+;; 返回值
+;; ----
+;; list
+;; 解码后的上下文列表：
+;;   (input message-buffer input-buffer out opts)
+;; 其中 out 由 tree-pointer 还原为 tree。
+;;
+;; 注意
+;; ----
+;; 返回值通常通过 with 绑定解构为多个变量使用。
+;; 此函数与 chat-tab-session-encode 成对使用。
 (define (chat-tab-session-decode l)
   (list (second l) (third l) (fourth l) (tree-pointer->tree (fifth l)) (sixth l))
 ) ;define
@@ -223,6 +282,39 @@
   (tree-pointer-detach (fifth l))
 ) ;define
 
+;; chat-tab-session-do
+;; 聊天标签会话的任务开始回调。
+;; 解码 pending 队列首元素，并将输入消息写入插件会话。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-do lan ses)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 获取当前 (lan ses) 的待处理队列 l。
+;; 2. 若队列非空：
+;;    a. 解码首元素，获取 input、message-buffer 等上下文。
+;;    b. 若 input 为空树，调用 plugin-next 跳过当前任务。
+;;    c. 否则，调用 plugin-write 将 input 以 :session 模式写入插件。
+;;
+;; 注意
+;; ----
+;; 此函数作为 do 回调传递给 plugin-feed，由 plugin-do 在任务开始执行时调用。
+;; 当输入为空时直接跳过，避免向插件发送无意义请求。
 (define (chat-tab-session-do lan ses)
   (with l
     (pending-ref lan ses)
@@ -238,6 +330,41 @@
   ) ;with
 ) ;define
 
+;; chat-tab-session-next
+;; 聊天标签会话的任务完成回调。
+;; 清理输出区域的 script-busy 标记，并分离当前任务的 tree-pointer。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-next lan ses)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 获取当前 (lan ses) 的待处理队列 l。
+;; 2. 若队列非空：
+;;    a. 解码首元素，获取 message-buffer、out 等上下文。
+;;    b. 在 message-buffer 中检查 out 的最后一个节点是否为 script-busy，
+;;       若是则移除该节点。
+;;    c. 标记 message-buffer 为已保存。
+;;    d. 分离当前任务的 tree-pointer。
+;;
+;; 注意
+;; ----
+;; 此函数作为 next 回调传递给 plugin-feed，由 plugin-next 在任务完成后调用。
+;; 主要职责是结束输出区域的忙等状态并释放 tree-pointer 资源。
 (define (chat-tab-session-next lan ses)
   (with l
     (pending-ref lan ses)
@@ -259,6 +386,52 @@
   ) ;with
 ) ;define
 
+;; chat-tab-session-notify
+;; 聊天标签会话的插件通知回调。
+;; 根据通道类型处理插件返回的输出、错误、提示或输入数据。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-notify lan ses ch t)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; ch : string
+;; 通知通道名称：
+;; - "output" : 正常输出数据
+;; - "error"  : 错误输出数据
+;; - "prompt" : 提示信息
+;; - "input"  : 输入数据
+;;
+;; t : tree
+;; 通知携带的数据树。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 获取当前 (lan ses) 的待处理队列 l。
+;; 2. 若队列非空，解码首元素获取上下文。
+;; 3. 根据通道 ch 分派处理：
+;;    - "output" : 调用 chat-tab-output 将 t 追加到输出区域。
+;;    - "error"  : 调用 chat-tab-errput 将 t 追加到错误输出区域。
+;;    - "prompt" : 无操作。
+;;    - "input"  : 若队列中仅剩当前任务，将 t 设置到输入缓冲区。
+;; 4. 每次写入后标记 message-buffer 为已保存。
+;;
+;; 注意
+;; ----
+;; 此函数作为 notify 回调传递给 plugin-feed，由插件连接层异步调用。
+;; "input" 通道仅在队列为单任务时更新输入缓冲区，避免多任务竞争。
 (define (chat-tab-session-notify lan ses ch t)
   (with l
     (pending-ref lan ses)
@@ -287,6 +460,47 @@
   ) ;with
 ) ;define
 
+;; chat-tab-session-cancel
+;; 聊天标签会话的任务取消回调。
+;; 将输出区域的 script-busy 标记替换为 script-dead 或 script-interrupted，
+;; 并分离当前任务的 tree-pointer。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-cancel lan ses dead?)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; dead? : boolean
+;; 取消原因标志：
+;; - #t : 插件进程已死亡，替换为 script-dead。
+;; - #f : 任务被用户中断，替换为 script-interrupted。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 获取当前 (lan ses) 的待处理队列 l。
+;; 2. 若队列非空：
+;;    a. 解码首元素，获取 message-buffer、out 等上下文。
+;;    b. 在 message-buffer 中检查 out 的最后一个节点是否为 script-busy，
+;;       若是则根据 dead? 替换为 script-dead 或 script-interrupted。
+;;    c. 标记 message-buffer 为已保存。
+;;    d. 分离当前任务的 tree-pointer。
+;;
+;; 注意
+;; ----
+;; 此函数作为 cancel 回调传递给 plugin-feed，由 plugin-cancel 在任务被取消
+;; 或插件进程异常终止时调用。
 (define (chat-tab-session-cancel lan ses dead?)
   (with l
     (pending-ref lan ses)
@@ -310,6 +524,55 @@
   ) ;with
 ) ;define
 
+;; chat-tab-session-feed
+;; 将用户输入投递到插件会话的待处理队列，并标记输出区域为忙等状态。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-feed lan ses input message-buffer input-buffer out opts)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; input : tree
+;; 规范化后的输入消息树。
+;;
+;; message-buffer : url
+;; 消息缓冲区名称。
+;;
+;; input-buffer : url
+;; 输入缓冲区名称。
+;;
+;; out : tree
+;; 输出节点树，将被重置为 (document (script-busy))。
+;;
+;; opts : list
+;; 附加选项列表。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 调用 plugin-preprocess 对 input 进行预处理。
+;; 2. 在 message-buffer 中将 out 重置为 (document (script-busy))，表示开始忙等。
+;; 3. 调用 chat-tab-session-encode 编码上下文为 x。
+;;    - (car x) 为回调列表 (do notify next cancel)。
+;;    - (cdr x) 为附加参数列表 (input message-buffer input-buffer tree-pointer opts)。
+;; 4. 通过 apply 调用 plugin-feed，将任务加入 pending 队列。
+;;    若队列为空则立即开始执行。
+;;
+;; 注意
+;; ----
+;; 此函数是聊天标签会话向底层插件引擎提交任务的唯一入口。
+;; out 被重置为 script-busy 后，用户界面会显示忙等指示，直到任务完成。
 (define (chat-tab-session-feed lan ses input message-buffer input-buffer out opts)
   (set! input (plugin-preprocess lan ses input opts))
   (with-buffer message-buffer (tree-assign! out '(document (script-busy))))

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -317,6 +317,32 @@
   ) ;with
 ) ;define
 
+;; chat-tab-session-select-model
+;; 选择用于新聊天标签会话的模型。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-select-model model)
+;;
+;; 参数
+;; ----
+;; model : string
+;; 模型名称字符串。非空时更新当前模型；为空时仅返回当前模型。
+;;
+;; 返回值
+;; ----
+;; string
+;; 当前选中的模型名称（全局变量 chat-tab-current-model）。
+;;
+;; 逻辑
+;; ----
+;; 1. 检查 model 非空
+;;    - 若非空，将 chat-tab-current-model 设置为该模型
+;; 2. 返回 chat-tab-current-model
+;;
+;; 注意
+;; ----
+;; 此函数仅影响后续新建的会话，不会更改已有会话的模型。
 (tm-define (chat-tab-session-select-model model)
   (:synopsis "Select the model used for new chat tab sessions")
   (:argument model "Model")
@@ -326,6 +352,47 @@
   chat-tab-current-model
 ) ;tm-define
 
+;; chat-tab-session-send
+;; 通过聊天标签会话发送用户消息。
+;;
+;; 语法
+;; ----
+;; (chat-tab-session-send message-buffer input-buffer body)
+;;
+;; 参数
+;; ----
+;; message-buffer : url
+;; 消息缓冲区名称（URL），用于存储对话历史。
+;;
+;; input-buffer : url
+;; 输入缓冲区名称（URL），用户在此输入消息。
+;;
+;; body : tree
+;; 输入消息树，即用户要发送的内容。
+;;
+;; 返回值
+;; ----
+;; boolean
+;; - #t : 消息发送成功
+;; - #f : 消息为空，未发送
+;;
+;; 逻辑
+;; ----
+;; 1. 检查 body 是否为空
+;;    - 若为空，返回 #f
+;; 2. 规范化输入文档
+;; 3. 确保会话存在（chat-tab-ensure-session!）
+;; 4. 在消息缓冲区追加一轮对话（chat-tab-append-round!）
+;;    - 若追加失败，返回 #f
+;; 5. 清空输入缓冲区
+;; 6. 检查是否已定义 "llm" 连接
+;;    - 若未定义，直接将输入回显到输出区域
+;;    - 若已定义，通过 plugin 机制发送消息（chat-tab-session-feed）
+;; 7. 返回 #t
+;;
+;; 注意
+;; ----
+;; 此函数是聊天标签会话的核心发送入口，负责消息格式化、会话管理和插件交互。
 (tm-define (chat-tab-session-send message-buffer input-buffer body)
   (:synopsis "Send user message through chat tab session")
   (:argument message-buffer "Message buffer name")

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -237,6 +237,7 @@
 ;; ----
 ;; 此函数与 chat-tab-session-decode 成对使用，负责在任务进入 pending
 ;; 队列前将上下文打包。
+
 (define (chat-tab-session-encode input message-buffer input-buffer out opts)
   (list (list chat-tab-session-do
           chat-tab-session-notify
@@ -274,6 +275,7 @@
 ;; ----
 ;; 返回值通常通过 with 绑定解构为多个变量使用。
 ;; 此函数与 chat-tab-session-encode 成对使用。
+
 (define (chat-tab-session-decode l)
   (list (second l) (third l) (fourth l) (tree-pointer->tree (fifth l)) (sixth l))
 ) ;define
@@ -315,6 +317,7 @@
 ;; ----
 ;; 此函数作为 do 回调传递给 plugin-feed，由 plugin-do 在任务开始执行时调用。
 ;; 当输入为空时直接跳过，避免向插件发送无意义请求。
+
 (define (chat-tab-session-do lan ses)
   (with l
     (pending-ref lan ses)
@@ -365,6 +368,7 @@
 ;; ----
 ;; 此函数作为 next 回调传递给 plugin-feed，由 plugin-next 在任务完成后调用。
 ;; 主要职责是结束输出区域的忙等状态并释放 tree-pointer 资源。
+
 (define (chat-tab-session-next lan ses)
   (with l
     (pending-ref lan ses)
@@ -432,6 +436,7 @@
 ;; ----
 ;; 此函数作为 notify 回调传递给 plugin-feed，由插件连接层异步调用。
 ;; "input" 通道仅在队列为单任务时更新输入缓冲区，避免多任务竞争。
+
 (define (chat-tab-session-notify lan ses ch t)
   (with l
     (pending-ref lan ses)
@@ -501,6 +506,7 @@
 ;; ----
 ;; 此函数作为 cancel 回调传递给 plugin-feed，由 plugin-cancel 在任务被取消
 ;; 或插件进程异常终止时调用。
+
 (define (chat-tab-session-cancel lan ses dead?)
   (with l
     (pending-ref lan ses)
@@ -573,6 +579,7 @@
 ;; ----
 ;; 此函数是聊天标签会话向底层插件引擎提交任务的唯一入口。
 ;; out 被重置为 script-busy 后，用户界面会显示忙等指示，直到任务完成。
+
 (define (chat-tab-session-feed lan ses input message-buffer input-buffer out opts)
   (set! input (plugin-preprocess lan ses input opts))
   (with-buffer message-buffer (tree-assign! out '(document (script-busy))))
@@ -683,7 +690,14 @@
               #t
             ) ;begin
             (begin
-              (chat-tab-session-feed chat-tab-session-name ses input message-buffer input-buffer out '())
+              (chat-tab-session-feed chat-tab-session-name
+                ses
+                input
+                message-buffer
+                input-buffer
+                out
+                '()
+              ) ;chat-tab-session-feed
               #t
             ) ;begin
           ) ;if

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -20,6 +20,8 @@
   ) ;:use
 ) ;texmacs-module
 
+(define chat-tab-session-name "llm")
+
 (define chat-tab-current-model "default")
 
 (define chat-tab-session-serial 0)
@@ -191,7 +193,7 @@
              (ses (chat-tab-next-session-id model))
              (new (chat-tab-state input-buffer model ses))
             ) ;
-        (session-enable-text-input "llm" ses)
+        (session-enable-text-input chat-tab-session-name ses)
         (chat-tab-set-state! message-buffer new)
         new
       ) ;let*
@@ -385,7 +387,7 @@
 ;; 4. 在消息缓冲区追加一轮对话（chat-tab-append-round!）
 ;;    - 若追加失败，返回 #f
 ;; 5. 清空输入缓冲区
-;; 6. 检查是否已定义 "llm" 连接
+;; 6. 检查是否已定义 chat-tab-session-name 连接
 ;;    - 若未定义，直接将输入回显到输出区域
 ;;    - 若已定义，通过 plugin 机制发送消息（chat-tab-session-feed）
 ;; 7. 返回 #t
@@ -409,7 +411,7 @@
         #f
         (begin
           (chat-tab-clear-input! input-buffer)
-          (if (not (connection-defined? "llm"))
+          (if (not (connection-defined? chat-tab-session-name))
             (begin
               (with-buffer message-buffer
                 (chat-tab-output out input)
@@ -418,7 +420,7 @@
               #t
             ) ;begin
             (begin
-              (chat-tab-session-feed "llm" ses input message-buffer input-buffer out '())
+              (chat-tab-session-feed chat-tab-session-name ses input message-buffer input-buffer out '())
               #t
             ) ;begin
           ) ;if

--- a/TeXmacs/progs/utils/plugins/plugin-cmd.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-cmd.scm
@@ -11,8 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (utils plugins plugin-cmd)
-  (:use (utils plugins plugin-eval)))
+(texmacs-module (utils plugins plugin-cmd) (:use (utils plugins plugin-eval)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; serialization
@@ -23,31 +22,44 @@
 (tm-define (pre-serialize lan t)
   (cond ((func? t 'document 1) (pre-serialize lan (cadr t)))
         ((func? t 'math 1)
-         (pre-serialize lan (plugin-math-input (list 'tuple lan (cadr t)))))
-        (else t)))
+         (pre-serialize lan (plugin-math-input (list 'tuple lan (cadr t))))
+        ) ;
+        (else t)
+  ) ;cond
+) ;tm-define
 
 (define (hacked-texmacs->code x)
-  (with r (texmacs->code x)
-    (string-replace r "`" "`")))
+  (with r (texmacs->code x) (string-replace r "`" "`"))
+) ;define
 
 (tm-define (verbatim-serialize lan t)
-  (with u (pre-serialize lan t)
-    (string-append (escape-verbatim (hacked-texmacs->code u)) "\n")))
+  (with u
+    (pre-serialize lan t)
+    (string-append (escape-verbatim (hacked-texmacs->code u)) "\n")
+  ) ;with
+) ;tm-define
 
 (tm-define (generic-serialize lan t)
-  (with u (pre-serialize lan t)
-    (string-append (char->string #\x02) "verbatim:"
-                   (escape-generic (texmacs->code u))
-                   (char->string #\x05))))
+  (with u
+    (pre-serialize lan t)
+    (string-append (char->string #\x02)
+      "verbatim:"
+      (escape-generic (texmacs->code u))
+      (char->string #\x05)
+    ) ;string-append
+  ) ;with
+) ;tm-define
 
 (tm-define (plugin-serialize lan t)
-  (with fun (ahash-ref plugin-serializer lan)
-    (if fun
-        (fun lan t)
-        (verbatim-serialize lan t))))
+  (with fun
+    (ahash-ref plugin-serializer lan)
+    (if fun (fun lan t) (verbatim-serialize lan t))
+  ) ;with
+) ;tm-define
 
 (tm-define (plugin-serializer-set! lan val)
-  (ahash-set! plugin-serializer lan val))
+  (ahash-set! plugin-serializer lan val)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; commands
@@ -56,16 +68,19 @@
 (define plugin-commander (make-ahash-table))
 
 (define (default-format-command s)
-  (string-append (char->string #\x10) s "\n"))
+  (string-append (char->string #\x10) s "\n")
+) ;define
 
 (tm-define (format-command lan s)
-  (with fun (ahash-ref plugin-commander lan)
-    (if fun
-        (fun s)
-        (default-format-command s))))
+  (with fun
+    (ahash-ref plugin-commander lan)
+    (if fun (fun s) (default-format-command s))
+  ) ;with
+) ;tm-define
 
 (tm-define (plugin-commander-set! lan val)
-  (ahash-set! plugin-commander lan val))
+  (ahash-set! plugin-commander lan val)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Some subroutines for mathematical content
@@ -74,25 +89,37 @@
 
 (define (cell-context-inside-sub? t which)
   (or (and (list? which) (tree-in? t which))
-      (and (nlist? which) (tree-is? t which))
-      (and (tree-in? t '(table tformat document))
-           (cell-context-inside-sub? (tree-up t) which))))
+    (and (nlist? which) (tree-is? t which))
+    (and (tree-in? t '(table tformat document))
+      (cell-context-inside-sub? (tree-up t) which)
+    ) ;and
+  ) ;or
+) ;define
 
 (define (cell-context-inside? t which)
   (and (tree-is? t 'cell)
-       (tree-is? t :up 'row)
-       (cell-context-inside-sub? (tree-ref t :up :up)  which)))
+    (tree-is? t :up 'row)
+    (cell-context-inside-sub? (tree-ref t :up :up) which)
+  ) ;and
+) ;define
 
 (tm-define (formula-context? t)
-  (with u (tree-up t)
-    (and u (or (tree-in? u '(math equation equation*))
-               (match? u '(with "mode" "math" :%1))
-               (cell-context-inside? u '(eqnarray eqnarray*))))))
+  (with u
+    (tree-up t)
+    (and u
+      (or (tree-in? u '(math equation equation*))
+        (match? u '(with "mode" "math" :%1))
+        (cell-context-inside? u '(eqnarray eqnarray*))
+      ) ;or
+    ) ;and
+  ) ;with
+) ;tm-define
 
 (tm-define (in-var-math?)
-  (let* ((t1 (tree-innermost formula-context? #t))
-         (t2 (tree-innermost 'text)))
-    (and (nnot t1) (or (not t2) (tree-inside? t1 t2)))))
+  (let* ((t1 (tree-innermost formula-context? #t)) (t2 (tree-innermost 'text)))
+    (and (nnot t1) (or (not t2) (tree-inside? t1 t2)))
+  ) ;let*
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; tab completion
@@ -101,10 +128,12 @@
 (define plugin-supports-completions (make-ahash-table))
 
 (tm-define (plugin-supports-completions-set! key)
-  (ahash-set! plugin-supports-completions key #t))
+  (ahash-set! plugin-supports-completions key #t)
+) ;tm-define
 
 (tm-define (plugin-supports-completions? key)
-  (ahash-ref plugin-supports-completions key))
+  (ahash-ref plugin-supports-completions key)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; testing whether more input is needed
@@ -113,10 +142,12 @@
 (define plugin-supports-input-done (make-ahash-table))
 
 (tm-define (plugin-supports-input-done-set! key)
-  (ahash-set! plugin-supports-input-done key #t))
+  (ahash-set! plugin-supports-input-done key #t)
+) ;tm-define
 
 (tm-define (plugin-supports-input-done? key)
-  (ahash-ref plugin-supports-input-done key))
+  (ahash-ref plugin-supports-input-done key)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Command for numeric evaluation
@@ -125,7 +156,9 @@
 (define plugin-approx-command (make-ahash-table))
 
 (tm-define (plugin-approx-command-set! key val)
-  (ahash-set! plugin-approx-command key val))
+  (ahash-set! plugin-approx-command key val)
+) ;tm-define
 
 (tm-define (plugin-approx-command-ref key)
-  (ahash-ref plugin-approx-command key))
+  (ahash-ref plugin-approx-command key)
+) ;tm-define

--- a/TeXmacs/progs/utils/plugins/plugin-convert.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-convert.scm
@@ -12,7 +12,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (utils plugins plugin-convert)
-  (:use (convert rewrite tmtm-brackets)))
+  (:use (convert rewrite tmtm-brackets))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main conversion routines
@@ -23,36 +24,43 @@
 (define (convert-test)
   (set! current-plugin-input-stree (tree->stree (selection-tree)))
   (write (tm-with-output-to-string plugin-input-caller))
-  (display "\n"))
+  (display "\n")
+) ;define
 
 (tm-define (plugin-math-input l)
   (:synopsis "Convert mathematical input to a string")
   (:argument l "A list of the form @(tuple plugin expr)")
   (set! current-plugin-input-stree (caddr l))
   (set! plugin-input-current-plugin (cadr l))
-  (tm-with-output-to-string plugin-input-caller))
+  (tm-with-output-to-string plugin-input-caller)
+) ;tm-define
 
 (define (plugin-input-caller)
-  (plugin-input (tree-upgrade-big current-plugin-input-stree)))
+  (plugin-input (tree-upgrade-big current-plugin-input-stree))
+) ;define
 
 (tm-define (plugin-input t)
-  (cond ((string? t)
-         (plugin-input-tmtokens (string->tmtokens t 0 (string-length t))))
-        ((tree? t)
-         (plugin-input (tree->stree t)))
-        (else
-          (let* ((f (car t)) (args (cdr t)) (im (plugin-input-ref f)))
-            (cond ((!= im #f) (im args))
-                  (else (noop)))))))
+  (cond ((string? t) (plugin-input-tmtokens (string->tmtokens t 0 (string-length t))))
+        ((tree? t) (plugin-input (tree->stree t)))
+        (else (let* ((f (car t)) (args (cdr t)) (im (plugin-input-ref f)))
+                (cond ((!= im #f) (im args))
+                      (else (noop))
+                ) ;cond
+              ) ;let*
+        ) ;else
+  ) ;cond
+) ;tm-define
 
 (tm-define (plugin-input-arg t)
-  (if (and (string? t)
-           (= (length (string->tmtokens t 0 (string-length t))) 1))
+  (if (and (string? t) (= (length (string->tmtokens t 0 (string-length t))) 1))
+    (plugin-input t)
+    (begin
+      (display "(")
       (plugin-input t)
-      (begin
-        (display "(")
-        (plugin-input t)
-        (display ")"))))
+      (display ")")
+    ) ;begin
+  ) ;if
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; conversion of strings
@@ -61,126 +69,162 @@
 (define (string-find-char s i n c)
   (cond ((>= i n) n)
         ((== (string-ref s i) c) i)
-        (else (string-find-char s (+ i 1) n c))))
+        (else (string-find-char s (+ i 1) n c))
+  ) ;cond
+) ;define
 
 (define (string-find-end s i n pred)
   (cond ((>= i n) n)
         ((not (pred (string-ref s i))) i)
-        (else (string-find-end s (+ i 1) n pred))))
+        (else (string-find-end s (+ i 1) n pred))
+  ) ;cond
+) ;define
 
 (define (string->tmtokens s i n)
   (cond ((>= i n) '())
         ((== (string-ref s i) #\<)
          (let ((j (min n (+ (string-find-char s i n #\>) 1))))
-           (cons (substring s i j) (string->tmtokens s j n))))
+           (cons (substring s i j) (string->tmtokens s j n))
+         ) ;let
+        ) ;
         ((char-alphabetic? (string-ref s i))
          (let ((j (string-find-end s i n char-alphabetic?)))
-           (cons (substring s i j) (string->tmtokens s j n))))
+           (cons (substring s i j) (string->tmtokens s j n))
+         ) ;let
+        ) ;
         ((char-numeric? (string-ref s i))
          (let ((j (string-find-end s i n char-numeric?)))
-           (cons (substring s i j) (string->tmtokens s j n))))
-        (else (cons (substring s i (+ 1 i))
-                    (string->tmtokens s (+ 1 i) n)))))
+           (cons (substring s i j) (string->tmtokens s j n))
+         ) ;let
+        ) ;
+        (else (cons (substring s i (+ 1 i)) (string->tmtokens s (+ 1 i) n)))
+  ) ;cond
+) ;define
 
 (define (plugin-input-tmtoken s)
   (let ((im (plugin-input-ref s)))
     (if (== im #f)
-        (if (and (!= s "") (== (string-ref s 0) #\<))
-            (display (substring s 1 (- (string-length s) 1)))
-            (display s))
-        (if (procedure? im)
-            (im s)
-            (display im)))))
+      (if (and (!= s "") (== (string-ref s 0) #\<))
+        (display (substring s 1 (- (string-length s) 1)))
+        (display s)
+      ) ;if
+      (if (procedure? im) (im s) (display im))
+    ) ;if
+  ) ;let
+) ;define
 
 (define (plugin-input-tmtokens l)
   (if (nnull? l)
-      (begin
-        (plugin-input-tmtoken (car l))
-        (plugin-input-tmtokens (cdr l)))))
+    (begin
+      (plugin-input-tmtoken (car l))
+      (plugin-input-tmtokens (cdr l))
+    ) ;begin
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; conversion of other nodes
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (plugin-input-with args)
-  (if (null? (cdr args))
-      (plugin-input (car args))
-      (plugin-input-with (cdr args))))
+  (if (null? (cdr args)) (plugin-input (car args)) (plugin-input-with (cdr args)))
+) ;define
 
 (define (plugin-input-concat-big op args)
   (let* ((i (list-find-index args (lambda (x) (== x '(big ".")))))
          (head (if i (sublist args 0 i) args))
          (tail (if i (sublist args (+ i 1) (length args)) '()))
-         (bigop `(big-around ,(small-bracket op) (concat ,@head))))
-    (plugin-input `(concat ,bigop ,@tail))))
+         (bigop `(big-around ,(small-bracket op) (concat ,@head)))
+        ) ;
+    (plugin-input `(concat ,bigop ,@tail))
+  ) ;let*
+) ;define
 
 (define (plugin-input-concat args)
   (cond ((null? args) (noop))
         ((and (func? (car args) 'big) (nnull? (cdr args)))
-         (plugin-input-concat-big (car args) (cdr args)))
-        (else
-         (plugin-input (car args))
-         (plugin-input-concat (cdr args)))))
+         (plugin-input-concat-big (car args) (cdr args))
+        ) ;
+        (else (plugin-input (car args)) (plugin-input-concat (cdr args)))
+  ) ;cond
+) ;define
 
 (define (plugin-input-math args)
-  (plugin-input (car args)))
+  (plugin-input (car args))
+) ;define
 
 (define (plugin-input-frac args)
   (display "(")
   (plugin-input-arg (car args))
   (display "/")
   (plugin-input-arg (cadr args))
-  (display ")"))
+  (display ")")
+) ;define
 
 (define (plugin-input-sqrt args)
   (if (= (length args) 1)
-      (begin
-        (display "sqrt(")
-        (plugin-input (car args))
-        (display ")"))
-      (begin
-        (plugin-input-arg (car args))
-        (display "^(1/")
-        (plugin-input-arg (cadr args))
-        (display ")"))))
+    (begin
+      (display "sqrt(")
+      (plugin-input (car args))
+      (display ")")
+    ) ;begin
+    (begin
+      (plugin-input-arg (car args))
+      (display "^(1/")
+      (plugin-input-arg (cadr args))
+      (display ")")
+    ) ;begin
+  ) ;if
+) ;define
 
 (define (plugin-input-rsub args)
   (display "[")
   (plugin-input (car args))
-  (display "]"))
+  (display "]")
+) ;define
 
 (define (plugin-input-rsup args)
   (display "^")
-  (plugin-input-arg (car args)))
+  (plugin-input-arg (car args))
+) ;define
 
 (define (plugin-input-around args)
-  (plugin-input (tree-downgrade-brackets (cons 'around args) #f #t)))
+  (plugin-input (tree-downgrade-brackets (cons 'around args) #f #t))
+) ;define
 
 (define (plugin-input-around* args)
-  (plugin-input (tree-downgrade-brackets (cons 'around* args) #f #t)))
+  (plugin-input (tree-downgrade-brackets (cons 'around* args) #f #t))
+) ;define
 
 (define (plugin-input-big-around args)
   (let* ((b `(big-around ,@args))
          (name (big-name b))
          (sub (big-subscript b))
          (sup (big-supscript b))
-         (body (big-body b)))
+         (body (big-body b))
+        ) ;
     (display name)
     (display "(")
     (when sub
       (plugin-input sub)
-      (display ","))
+      (display ",")
+    ) ;when
     (when (and sub sup)
       (plugin-input sup)
-      (display ","))
+      (display ",")
+    ) ;when
     (plugin-input body)
-    (display ")")))
+    (display ")")
+  ) ;let*
+) ;define
 
 (define (plugin-input-large args)
-  (display (car args)))
+  (display (car args))
+) ;define
 
 (define (plugin-input-script-assign args)
-  (display ":="))
+  (display ":=")
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Conversion of matrices
@@ -188,47 +232,62 @@
 
 (define (plugin-input-descend-last args)
   (if (null? (cdr args))
-      (plugin-input (car args))
-      (plugin-input-descend-last (cdr args))))
+    (plugin-input (car args))
+    (plugin-input-descend-last (cdr args))
+  ) ;if
+) ;define
 
 (define (plugin-input-det args)
   (display "matdet(")
   (plugin-input-descend-last args)
-  (display ")"))
+  (display ")")
+) ;define
 
 (define (rewrite-cell c)
-  (if (and (list? c) (== (car c) 'cell)) (cadr c) c))
+  (if (and (list? c) (== (car c) 'cell)) (cadr c) c)
+) ;define
 
 (define (rewrite-row r)
-  (if (null? r) r (cons (rewrite-cell (car r)) (rewrite-row (cdr r)))))
+  (if (null? r) r (cons (rewrite-cell (car r)) (rewrite-row (cdr r))))
+) ;define
 
 (define (rewrite-table t)
-  (if (null? t) t (cons (rewrite-row (cdar t)) (rewrite-table (cdr t)))))
+  (if (null? t) t (cons (rewrite-row (cdar t)) (rewrite-table (cdr t))))
+) ;define
 
 (define (plugin-input-row r)
   (if (null? (cdr r))
+    (plugin-input (car r))
+    (begin
       (plugin-input (car r))
-      (begin
-        (plugin-input (car r))
-        (display ", ")
-        (plugin-input-row (cdr r)))))
+      (display ", ")
+      (plugin-input-row (cdr r))
+    ) ;begin
+  ) ;if
+) ;define
 
 (define (plugin-input-var-rows t)
   (if (nnull? t)
-      (begin
-        (display "; ")
-        (plugin-input-row (car t))
-        (plugin-input-var-rows (cdr t)))))
+    (begin
+      (display "; ")
+      (plugin-input-row (car t))
+      (plugin-input-var-rows (cdr t))
+    ) ;begin
+  ) ;if
+) ;define
 
 (define (plugin-input-rows t)
   (display "[")
   (plugin-input-row (car t))
   (plugin-input-var-rows (cdr t))
-  (display "]"))
+  (display "]")
+) ;define
 
 (define (plugin-input-table args)
   (let ((t (rewrite-table args)))
-    (plugin-input (cons 'rows t))))
+    (plugin-input (cons 'rows t))
+  ) ;let
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy input converters
@@ -239,15 +298,23 @@
 (tm-define-macro (lazy-input-converter module plugin)
   (lazy-input-converter-force plugin)
   (ahash-set! lazy-input-converter-table plugin module)
-  '(noop))
+  '(noop)
+) ;tm-define-macro
 
 (define (lazy-input-converter-force plugin2)
-  (with plugin (if (string? plugin2) (string->symbol plugin2) plugin2)
-    (with module (ahash-ref lazy-input-converter-table plugin)
+  (with plugin
+    (if (string? plugin2) (string->symbol plugin2) plugin2)
+    (with module
+      (ahash-ref lazy-input-converter-table plugin)
       (if module
-          (begin
-            (ahash-remove! lazy-input-converter-table plugin)
-            (module-load module))))))
+        (begin
+          (ahash-remove! lazy-input-converter-table plugin)
+          (module-load module)
+        ) ;begin
+      ) ;if
+    ) ;with
+  ) ;with
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Initialization subroutines
@@ -256,28 +323,36 @@
 (define plugin-input-current-plugin "generic")
 
 (define (plugin-input-converters-rules name l)
-  (if (null? l) '()
-      (cons (let* ((rule (car l))
-                   (key (car rule))
-                   (im (list 'unquote (cadr rule))))
-              (list (list 'plugin-input-converter% (list name key) im)))
-            (plugin-input-converters-rules name (cdr l)))))
+  (if (null? l)
+    '()
+    (cons (let* ((rule (car l)) (key (car rule)) (im (list 'unquote (cadr rule))))
+            (list (list 'plugin-input-converter% (list name key) im))
+          ) ;let*
+      (plugin-input-converters-rules name (cdr l))
+    ) ;cons
+  ) ;if
+) ;define
 
 (tm-define-macro (plugin-input-converters name2 . l)
   (let ((name (if (string? name2) name2 (symbol->string name2))))
     (lazy-input-converter-force name)
     (logic-group plugin-input-converters% ,name)
-    `(logic-rules ,@(plugin-input-converters-rules name l))))
+    `(logic-rules ,@(plugin-input-converters-rules name l))
+  ) ;let
+) ;tm-define-macro
 
 (define (plugin-input-ref key)
   (lazy-input-converter-force plugin-input-current-plugin)
-  (let ((im (logic-ref plugin-input-converter%
-                     (list plugin-input-current-plugin key))))
-    (if im im (logic-ref plugin-input-converter% (list "generic" key)))))
+  (let ((im (logic-ref plugin-input-converter% (list plugin-input-current-plugin key)))
+       ) ;
+    (if im im (logic-ref plugin-input-converter% (list "generic" key)))
+  ) ;let
+) ;define
 
 (tm-define (plugin-supports-math-input-ref key)
   (lazy-input-converter-force key)
-  (logic-in? key plugin-input-converters%))
+  (logic-in? key plugin-input-converters%)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Initialization
@@ -361,58 +436,59 @@
   ("<mathpi>" "(4*atan(1))")
   ("<mathi>" "(sqrt(-1))")
 
-  ("<alpha>"      "alpha")
-  ("<beta>"       "beta")
-  ("<gamma>"      "gamma")
-  ("<delta>"      "delta")
-  ("<epsilon>"    "epsilon")
+  ("<alpha>" "alpha")
+  ("<beta>" "beta")
+  ("<gamma>" "gamma")
+  ("<delta>" "delta")
+  ("<epsilon>" "epsilon")
   ("<varepsilon>" "epsilon")
-  ("<zeta>"       "zeta")
-  ("<eta>"        "eta")
-  ("<theta>"      "theta")
-  ("<vartheta>"   "theta")
-  ("<iota>"       "iota")
-  ("<kappa>"      "kappa")
-  ("<lambda>"     "lambda")
-  ("<mu>"         "mu")
-  ("<nu>"         "nu")
-  ("<xi>"         "xi")
-  ("<omicron>"    "omicron")
-  ("<pi>"         "pi")
-  ("<varpi>"         "pi")
-  ("<rho>"        "rho")
-  ("<varrho>"     "varrho")
-  ("<sigma>"      "sigma")
-  ("<varsigma>"   "sigma")
-  ("<tau>"        "tau")
-  ("<upsilon>"    "upsilon")
-  ("<phi>"        "phi")
-  ("<varphi>"     "phi")
-  ("<chi>"        "chi")
-  ("<psi>"        "psi")
-  ("<omega>"      "omega")
+  ("<zeta>" "zeta")
+  ("<eta>" "eta")
+  ("<theta>" "theta")
+  ("<vartheta>" "theta")
+  ("<iota>" "iota")
+  ("<kappa>" "kappa")
+  ("<lambda>" "lambda")
+  ("<mu>" "mu")
+  ("<nu>" "nu")
+  ("<xi>" "xi")
+  ("<omicron>" "omicron")
+  ("<pi>" "pi")
+  ("<varpi>" "pi")
+  ("<rho>" "rho")
+  ("<varrho>" "varrho")
+  ("<sigma>" "sigma")
+  ("<varsigma>" "sigma")
+  ("<tau>" "tau")
+  ("<upsilon>" "upsilon")
+  ("<phi>" "phi")
+  ("<varphi>" "phi")
+  ("<chi>" "chi")
+  ("<psi>" "psi")
+  ("<omega>" "omega")
 
-  ("<Alpha>"      "Alpha")
-  ("<Beta>"       "Beta")
-  ("<Gamma>"      "Gamma")
-  ("<Delta>"      "Delta")
-  ("<Epsilon>"    "Epsilon")
-  ("<Zeta>"       "Zeta")
-  ("<Eta>"        "Eta")
-  ("<Theta>"      "Theta")
-  ("<Iota>"       "Iota")
-  ("<Kappa>"      "Kappa")
-  ("<Lambda>"     "Lambda")
-  ("<Mu>"         "Mu")
-  ("<Nu>"         "Nu")
-  ("<Xi>"         "Xi")
-  ("<Omicron>"    "Omicron")
-  ("<Pi>"         "Pi")
-  ("<Rho>"        "Rho")
-  ("<Sigma>"      "Sigma")
-  ("<Tau>"        "Tau")
-  ("<Upsilon>"    "Upsilon")
-  ("<Phi>"        "Phi")
-  ("<Chi>"        "Chi")
-  ("<Psi>"        "Psi")
-  ("<Omega>"      "Omega"))
+  ("<Alpha>" "Alpha")
+  ("<Beta>" "Beta")
+  ("<Gamma>" "Gamma")
+  ("<Delta>" "Delta")
+  ("<Epsilon>" "Epsilon")
+  ("<Zeta>" "Zeta")
+  ("<Eta>" "Eta")
+  ("<Theta>" "Theta")
+  ("<Iota>" "Iota")
+  ("<Kappa>" "Kappa")
+  ("<Lambda>" "Lambda")
+  ("<Mu>" "Mu")
+  ("<Nu>" "Nu")
+  ("<Xi>" "Xi")
+  ("<Omicron>" "Omicron")
+  ("<Pi>" "Pi")
+  ("<Rho>" "Rho")
+  ("<Sigma>" "Sigma")
+  ("<Tau>" "Tau")
+  ("<Upsilon>" "Upsilon")
+  ("<Phi>" "Phi")
+  ("<Chi>" "Chi")
+  ("<Psi>" "Psi")
+  ("<Omega>" "Omega")
+) ;plugin-input-converters

--- a/TeXmacs/progs/utils/plugins/plugin-eval.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-eval.scm
@@ -73,9 +73,60 @@
 (define plugin-prompts (make-ahash-table))
 (define plugin-author  (make-ahash-table))
 
+;; pending-set
+;; 设置指定插件会话的待处理任务队列。
+;;
+;; 语法
+;; ----
+;; (pending-set lan ses l)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; l : list
+;; 新的待处理任务列表。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 注意
+;; ----
+;; 此函数直接操作内部 plugin-pending 哈希表，覆盖指定会话的原有队列。
+;; 通常由 plugin-feed、plugin-next、plugin-cancel 等函数调用。
 (define (pending-set lan ses l)
   (ahash-set! plugin-pending (list lan ses) l))
 
+;; pending-ref
+;; 获取指定插件会话的待处理任务队列。
+;;
+;; 语法
+;; ----
+;; (pending-ref lan ses)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; 返回值
+;; ----
+;; list
+;; 当前会话的待处理任务列表；若该会话无待处理任务，返回空列表 '()。
+;;
+;; 注意
+;; ----
+;; 此函数不会修改内部状态，返回的列表是 plugin-pending 哈希表中
+;; 对应键的值，或通过 or 表达式回退的空列表。
 (tm-define (pending-ref lan ses)
   (or (ahash-ref plugin-pending (list lan ses)) '()))
 
@@ -130,6 +181,39 @@
               (#t
                ((first (caar l)) lan ses)))))))
 
+;; plugin-next
+;; 当前任务完成时调用其 next 回调，并从待处理队列中移除该任务，
+;; 然后继续执行队列中的下一个任务。
+;;
+;; 语法
+;; ----
+;; (plugin-next lan ses)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 获取当前 (lan ses) 的待处理队列 l。
+;; 2. 若队列非空：
+;;    a. 调用当前任务回调列表中的 next 回调（第三个元素）。
+;;    b. 将队列首元素移除。
+;;    c. 调用 plugin-do 继续处理下一个任务。
+;;
+;; 注意
+;; ----
+;; 此函数通常在插件连接层报告任务完成时被调用，用于推进 pending 队列。
+;; 若队列为空，则不做任何操作。
 (tm-define (plugin-next lan ses)
   (with l (pending-ref lan ses)
     (when (nnull? l)
@@ -152,6 +236,56 @@
   (with t (ahash-ref plugin-started (list lan ses))
     (if t (- (texmacs-time) t) 0)))
 
+;; plugin-feed
+;; 向指定插件会话的待处理队列中追加一个新任务，若队列为空则立即开始执行。
+;;
+;; 语法
+;; ----
+;; (plugin-feed lan ses do notify next cancel args)
+;;
+;; 参数
+;; ----
+;; lan : string
+;; 插件语言名称（如 "scheme"、"llm" 等）。
+;;
+;; ses : string
+;; 会话标识字符串。
+;;
+;; do : procedure
+;; 任务开始时的执行回调，签名 (do lan ses)。
+;;
+;; notify : procedure
+;; 接收插件输出通知的回调，签名 (notify lan ses ch t)。
+;; ch 为通道名（"output"、"error"、"prompt"、"input"），t 为数据树。
+;;
+;; next : procedure
+;; 当前任务完成后的回调，签名 (next lan ses)。
+;;
+;; cancel : procedure
+;; 任务被取消时的回调，签名 (cancel lan ses dead?)。
+;; dead? 为 #t 表示插件进程已死亡，#f 表示被中断。
+;;
+;; args : list
+;; 随任务携带的附加参数列表，通常包含输入数据及相关元信息。
+;;
+;; 返回值
+;; ----
+;; #<unspecified>
+;; 无显式返回值。
+;;
+;; 逻辑
+;; ----
+;; 1. 获取当前 (lan ses) 对应的待处理队列 l。
+;; 2. 初始化 author 为 0；若 lan 不是 "scheme"，则创建新 author 并启动 slave。
+;; 3. 将 do、notify、next、cancel、author 打包为回调列表 cb。
+;; 4. 将 (cons cb args) 追加到待处理队列。
+;; 5. 若原队列 l 为空，立即调用 plugin-do 开始执行。
+;;
+;; 注意
+;; ----
+;; 此函数是插件异步执行模型的核心入口，所有向插件提交计算需求的操作
+;; 最终都通过它进入 pending 队列。回调函数的生命周期由 plugin-do、
+;; plugin-next、plugin-cancel 管理。
 (tm-define (plugin-feed lan ses do notify next cancel args)
   (with l (pending-ref lan ses)
     (with author 0

--- a/TeXmacs/progs/utils/plugins/plugin-eval.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-eval.scm
@@ -12,66 +12,89 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (utils plugins plugin-eval)
-  (:use (utils library tree)
-        (utils library cursor)))
+  (:use (utils library tree) (utils library cursor))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; evaluation + simplification of document fragments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (plugin-output-std-simplify name t)
-  ;;(display* "Simplify " t "\n")
+  ;; (display* "Simplify " t "\n")
   (cond ((or (func? t 'document 0) (func? 'concat 0)) "")
         ((or (func? t 'document 1) (func? t 'concat 1))
-         (plugin-output-simplify name (cadr t)))
-        ((and (or (func? t 'document) (func? t 'concat))
-              (in? (cadr t) '("" " " "  ")))
-         (plugin-output-simplify name (cons (car t) (cddr t))))
-        ((and (or (func? t 'document) (func? t 'concat))
-              (in? (cAr t) '("" " " "  ")))
-         (plugin-output-simplify name (cDr t)))
+         (plugin-output-simplify name (cadr t))
+        ) ;
+        ((and (or (func? t 'document) (func? t 'concat)) (in? (cadr t) '(""
+                                                                         " "
+                                                                         "  ")))
+         (plugin-output-simplify name (cons (car t) (cddr t)))
+        ) ;
+        ((and (or (func? t 'document) (func? t 'concat)) (in? (cAr t) '(""
+                                                                        " "
+                                                                        "  ")))
+         (plugin-output-simplify name (cDr t))
+        ) ;
         ((match? t '(with "mode" "math" :%1))
-         `(math ,(plugin-output-simplify name (cAr t))))
-        ((func? t 'with)
-         (rcons (cDr t) (plugin-output-simplify name (cAr t))))
-        (else t)))
+         `(math ,(plugin-output-simplify name (cAr t)))
+        ) ;
+        ((func? t 'with) (rcons (cDr t) (plugin-output-simplify name (cAr t))))
+        (else t)
+  ) ;cond
+) ;tm-define
 
 (tm-define (plugin-output-simplify name t)
-  ;;(display* "Simplify " t "\n")
-  (plugin-output-std-simplify name t))
+  ;; (display* "Simplify " t "\n")
+  (plugin-output-std-simplify name t)
+) ;tm-define
 
 (tm-define (plugin-preprocess name ses t opts)
-  ;;(display* "Preprocess " t ", " opts "\n")
-  (if (null? opts) t
-      (begin
-        (if (and (== (car opts) :math-input)
-                 (plugin-supports-math-input-ref name))
-            (set! t (plugin-math-input (list 'tuple name t))))
-        (plugin-preprocess name ses t (cdr opts)))))
+  ;; (display* "Preprocess " t ", " opts "\n")
+  (if (null? opts)
+    t
+    (begin
+      (if (and (== (car opts) :math-input) (plugin-supports-math-input-ref name))
+        (set! t (plugin-math-input (list 'tuple name t)))
+      ) ;if
+      (plugin-preprocess name ses t (cdr opts))
+    ) ;begin
+  ) ;if
+) ;tm-define
 
 (tm-define (plugin-postprocess name ses r opts)
-  ;;(display* "Postprocess " r ", " opts "\n")
-  (if (null? opts) r
-      (begin
-        (if (== (car opts) :simplify-output)
-            (set! r (plugin-output-simplify name r)))
-        (plugin-postprocess name ses r (cdr opts)))))
+  ;; (display* "Postprocess " r ", " opts "\n")
+  (if (null? opts)
+    r
+    (begin
+      (if (== (car opts) :simplify-output) (set! r (plugin-output-simplify name r)))
+      (plugin-postprocess name ses r (cdr opts))
+    ) ;begin
+  ) ;if
+) ;tm-define
 
 (tm-define (plugin-eval name ses t . opts)
-  (with u (plugin-preprocess name ses t opts)
-    ;;(display* "u= " u "\n")
-    (with r (tree->stree (connection-eval name ses u))
-      ;;(display* "r= " r "\n")
-      (plugin-postprocess name ses r (cons :simplify-output opts)))))
+  (with u
+    (plugin-preprocess name ses t opts)
+    ;; (display* "u= " u "\n")
+    (with r
+      (tree->stree (connection-eval name ses u))
+      ;; (display* "r= " r "\n")
+      (plugin-postprocess name ses r (cons :simplify-output opts))
+    ) ;with
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; New connection management
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define plugin-pending (make-ahash-table))
+
 (define plugin-started (make-ahash-table))
+
 (define plugin-prompts (make-ahash-table))
-(define plugin-author  (make-ahash-table))
+
+(define plugin-author (make-ahash-table))
 
 ;; pending-set
 ;; 设置指定插件会话的待处理任务队列。
@@ -100,8 +123,10 @@
 ;; ----
 ;; 此函数直接操作内部 plugin-pending 哈希表，覆盖指定会话的原有队列。
 ;; 通常由 plugin-feed、plugin-next、plugin-cancel 等函数调用。
+
 (define (pending-set lan ses l)
-  (ahash-set! plugin-pending (list lan ses) l))
+  (ahash-set! plugin-pending (list lan ses) l)
+) ;define
 
 ;; pending-ref
 ;; 获取指定插件会话的待处理任务队列。
@@ -128,58 +153,80 @@
 ;; 此函数不会修改内部状态，返回的列表是 plugin-pending 哈希表中
 ;; 对应键的值，或通过 or 表达式回退的空列表。
 (tm-define (pending-ref lan ses)
-  (or (ahash-ref plugin-pending (list lan ses)) '()))
+  (or (ahash-ref plugin-pending (list lan ses)) '())
+) ;tm-define
 
 (define (plugin-status lan ses)
-  (if (!= lan "scheme")
-      (connection-status lan ses)
-      2))
+  (if (!= lan "scheme") (connection-status lan ses) 2)
+) ;define
 
 (define (plugin-set-author lan ses)
-  (with l (pending-ref lan ses)
+  (with l
+    (pending-ref lan ses)
     (when (nnull? l)
-      (ahash-set! plugin-author (list lan ses) (fifth (caar l))))))
+      (ahash-set! plugin-author (list lan ses) (fifth (caar l)))
+    ) ;when
+  ) ;with
+) ;define
 
 (define (plugin-start lan ses)
   (when (!= lan "scheme")
     (plugin-set-author lan ses)
-    (connection-start lan ses)))
+    (connection-start lan ses)
+  ) ;when
+) ;define
 
 (tm-define (plugin-write lan ses t mode)
   (ahash-set! plugin-started (list lan ses) (texmacs-time))
   (if (!= lan "scheme")
-      (if (tm-func? t 'command 1)
-          (connection-write-string lan ses (cadr t))
-          (begin
-            (plugin-set-author lan ses)
-            (connection-write lan ses (stree->tree t))))
-      (delayed
-        (connection-notify-status lan ses 3)
-        (with r (scheme-eval t mode)
-          (if (not (func? r 'document))
-              (set! r (tree 'document r)))
-          (connection-notify lan ses "output" r))
-        (connection-notify-status lan ses 2))))
+    (if (tm-func? t 'command 1)
+      (connection-write-string lan ses (cadr t))
+      (begin
+        (plugin-set-author lan ses)
+        (connection-write lan ses (stree->tree t))
+      ) ;begin
+    ) ;if
+    (delayed (connection-notify-status lan ses 3)
+      (with r
+        (scheme-eval t mode)
+        (if (not (func? r 'document)) (set! r (tree 'document r)))
+        (connection-notify lan ses "output" r)
+      ) ;with
+      (connection-notify-status lan ses 2)
+    ) ;delayed
+  ) ;if
+) ;tm-define
 
 (define (plugin-do lan ses)
-  (with l (pending-ref lan ses)
+  (with l
+    (pending-ref lan ses)
     (when (nnull? l)
-      (with status (plugin-status lan ses)
+      (with status
+        (plugin-status lan ses)
         (cond ((and (> (length (car l)) 2) (== (second (car l)) :start))
-               (if (== status 0)
-                   (plugin-start lan ses)
-                   (plugin-next lan ses)))
+               (if (== status 0) (plugin-start lan ses) (plugin-next lan ses))
+              ) ;
               ((== status 0)
-               (with author 0
+               (with author
+                 0
                  (when (!= lan "scheme")
                    (set! author (new-author))
-                   (start-slave author))
-                 (with p (silent-encode :start noop '())
+                   (start-slave author)
+                 ) ;when
+                 (with p
+                   (silent-encode :start noop '())
                    (set! p (cons (rcons (car p) author) (cdr p)))
                    (pending-set lan ses (cons p l))
-                   (plugin-do lan ses))))
-              (#t
-               ((first (caar l)) lan ses)))))))
+                   (plugin-do lan ses)
+                 ) ;with
+               ) ;with
+              ) ;
+              (#t ((first (caar l)) lan ses))
+        ) ;cond
+      ) ;with
+    ) ;when
+  ) ;with
+) ;define
 
 ;; plugin-next
 ;; 当前任务完成时调用其 next 回调，并从待处理队列中移除该任务，
@@ -215,26 +262,37 @@
 ;; 此函数通常在插件连接层报告任务完成时被调用，用于推进 pending 队列。
 ;; 若队列为空，则不做任何操作。
 (tm-define (plugin-next lan ses)
-  (with l (pending-ref lan ses)
+  (with l
+    (pending-ref lan ses)
     (when (nnull? l)
       ((third (caar l)) lan ses)
       (pending-set lan ses (cdr l))
-      (plugin-do lan ses))))
+      (plugin-do lan ses)
+    ) ;when
+  ) ;with
+) ;tm-define
 
 (define (plugin-cancel lan ses dead?)
-  (with l (pending-ref lan ses)
+  (with l
+    (pending-ref lan ses)
     (when (nnull? l)
       ((fourth (caar l)) lan ses dead?)
       (pending-set lan ses (cdr l))
-      (plugin-cancel lan ses dead?))))
+      (plugin-cancel lan ses dead?)
+    ) ;when
+  ) ;with
+) ;define
 
 (tm-define (plugin-prompt lan ses)
-  (with p (ahash-ref plugin-prompts (list lan ses))
-    (if p (tree-copy p) (string-append (upcase-first lan) "] "))))
+  (with p
+    (ahash-ref plugin-prompts (list lan ses))
+    (if p (tree-copy p) (string-append (upcase-first lan) "] "))
+  ) ;with
+) ;tm-define
 
 (tm-define (plugin-timing lan ses)
-  (with t (ahash-ref plugin-started (list lan ses))
-    (if t (- (texmacs-time) t) 0)))
+  (with t (ahash-ref plugin-started (list lan ses)) (if t (- (texmacs-time) t) 0))
+) ;tm-define
 
 ;; plugin-feed
 ;; 向指定插件会话的待处理队列中追加一个新任务，若队列为空则立即开始执行。
@@ -287,57 +345,74 @@
 ;; 最终都通过它进入 pending 队列。回调函数的生命周期由 plugin-do、
 ;; plugin-next、plugin-cancel 管理。
 (tm-define (plugin-feed lan ses do notify next cancel args)
-  (with l (pending-ref lan ses)
-    (with author 0
+  (with l
+    (pending-ref lan ses)
+    (with author
+      0
       (when (!= lan "scheme")
         (set! author (new-author))
-        (start-slave author))
-      (with cb (list do notify next cancel author)
+        (start-slave author)
+      ) ;when
+      (with cb
+        (list do notify next cancel author)
         (pending-set lan ses (rcons l (cons cb args)))
-        (if (null? l) (plugin-do lan ses))))))
+        (if (null? l) (plugin-do lan ses))
+      ) ;with
+    ) ;with
+  ) ;with
+) ;tm-define
 
 (tm-define (plugin-interrupt)
-  (let* ((lan (get-env "prog-language"))
-         (ses (get-env "prog-session")))
-    (if (== (connection-status lan ses) 3)
-        (connection-interrupt lan ses))
-    (plugin-cancel lan ses #f)))
+  (let* ((lan (get-env "prog-language")) (ses (get-env "prog-session")))
+    (if (== (connection-status lan ses) 3) (connection-interrupt lan ses))
+    (plugin-cancel lan ses #f)
+  ) ;let*
+) ;tm-define
 
 (tm-define (plugin-stop)
-  (let* ((lan (get-env "prog-language"))
-         (ses (get-env "prog-session")))
-    (if (!= (connection-status lan ses) 0)
-        (connection-stop lan ses))))
+  (let* ((lan (get-env "prog-language")) (ses (get-env "prog-session")))
+    (if (!= (connection-status lan ses) 0) (connection-stop lan ses))
+  ) ;let*
+) ;tm-define
 
 (define-public-macro (with-author a . body)
-  (with old (gensym)
+  (with old
+    (gensym)
     `(if (not ,a)
-         (begin ,@body)
-         (with ,old (get-author)
-           (set-author ,a)
-           (with r (begin ,@body)
-             (commit-changes)
-             (set-author ,old)
-             r)))))
+       (begin ,@body)
+       (with ,old
+         (get-author)
+         (set-author ,a)
+         (with r (begin ,@body) (commit-changes) (set-author ,old) r)))
+  ) ;with
+) ;define-public-macro
 
 (tm-define (connection-notify lan ses ch t)
-  ;;(display* "Notify " lan ", " ses ", " ch ", " t "\n")
+  ;; (display* "Notify " lan ", " ses ", " ch ", " t "\n")
   (with-author (ahash-ref plugin-author (list lan ses))
-    (with l (pending-ref lan ses)
+    (with l
+      (pending-ref lan ses)
       (when (nnull? l)
-        (if (== ch "prompt")
-            (ahash-set! plugin-prompts (list lan ses) (tree-copy t)))
-        ((second (caar l)) lan ses ch t)))))
+        (if (== ch "prompt") (ahash-set! plugin-prompts (list lan ses) (tree-copy t)))
+        ((second (caar l)) lan ses ch t)
+      ) ;when
+    ) ;with
+  ) ;with-author
+) ;tm-define
 
 (tm-define (connection-notify-status lan ses st)
-  ;;(display* "Notify status " lan ", " ses ", " st "\n")
+  ;; (display* "Notify status " lan ", " ses ", " st "\n")
   (with-author (ahash-ref plugin-author (list lan ses))
     (when (== st 0)
       (ahash-remove! plugin-started (list lan ses))
       (ahash-remove! plugin-prompts (list lan ses))
-      (plugin-cancel lan ses #t))
+      (plugin-cancel lan ses #t)
+    ) ;when
     (when (== st 2)
-      (plugin-next lan ses))))
+      (plugin-next lan ses)
+    ) ;when
+  ) ;with-author
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Silent evaluation
@@ -345,90 +420,121 @@
 
 (define (silent-encode in return opts)
   (list (list silent-do silent-notify silent-next silent-cancel)
-        (if (tm? in) (tm->stree in) in)
-        (tree 'document)
-        (tree 'document)
-        return
-        opts))
+    (if (tm? in) (tm->stree in) in)
+    (tree 'document)
+    (tree 'document)
+    return
+    opts
+  ) ;list
+) ;define
 
 (define (silent-decode l)
-  (list (second l)
-        (third l)
-        (fourth l)
-        (fifth l)
-        (sixth l)))
+  (list (second l) (third l) (fourth l) (fifth l) (sixth l))
+) ;define
 
 (define (silent-do lan ses)
-  (with l (pending-ref lan ses)
-    (with (in out err return opts) (silent-decode (car l))
-      ;;(display* "Silent do " lan ", " ses ", " in "\n")
-      (if (tree-empty? in)
-          (plugin-next lan ses)
-          (plugin-write lan ses in :silent)))))
+  (with l
+    (pending-ref lan ses)
+    (with (in out err return opts)
+      (silent-decode (car l))
+      ;; (display* "Silent do " lan ", " ses ", " in "\n")
+      (if (tree-empty? in) (plugin-next lan ses) (plugin-write lan ses in :silent))
+    ) ;with
+  ) ;with
+) ;define
 
 (define (silent-next lan ses)
-  ;;(display* "Silent next " lan ", " ses "\n")
-  (with l (pending-ref lan ses)
-    (with (in out err return opts) (silent-decode (car l))
-      ;;(display* "Silent return " (tm->stree out) ", " (tm->stree err) "\n")
-      (return (cons (tm->stree out) (tm->stree err))))))
+  ;; (display* "Silent next " lan ", " ses "\n")
+  (with l
+    (pending-ref lan ses)
+    (with (in out err return opts)
+      (silent-decode (car l))
+      ;; (display* "Silent return " (tm->stree out) ", " (tm->stree err) "\n")
+      (return (cons (tm->stree out) (tm->stree err)))
+    ) ;with
+  ) ;with
+) ;define
 
 (define (var-tree-children t)
-  (with r (tree-children t)
-    (if (and (nnull? r) (tree-empty? (cAr r))) (cDr r) r)))
+  (with r (tree-children t) (if (and (nnull? r) (tree-empty? (cAr r))) (cDr r) r))
+) ;define
 
 (define (silent-output t u)
   (when (and (tm-func? t 'document) (tm-func? u 'document))
-    (tree-insert! t (tree-arity t) (var-tree-children u))))
+    (tree-insert! t (tree-arity t) (var-tree-children u))
+  ) ;when
+) ;define
 
 (define (silent-notify lan ses ch t)
-  ;;(display* "Silent notify " lan ", " ses ", " ch ", " t "\n")
-  (with l (pending-ref lan ses)
-    (with (in out err return opts) (silent-decode (car l))
-      (cond ((== ch "output")
-             (silent-output out t))
-            ((== ch "error")
-             (silent-output err t))))))
+  ;; (display* "Silent notify " lan ", " ses ", " ch ", " t "\n")
+  (with l
+    (pending-ref lan ses)
+    (with (in out err return opts)
+      (silent-decode (car l))
+      (cond ((== ch "output") (silent-output out t))
+            ((== ch "error") (silent-output err t))
+      ) ;cond
+    ) ;with
+  ) ;with
+) ;define
 
 (define (silent-cancel lan ses dead?)
-  ;;(display* "Silent cancel " lan ", " ses ", " dead? "\n")
-  (with l (pending-ref lan ses)
-    (with (in out err return opts) (silent-decode (car l))
-      (return (if dead? :dead :interrupted)))))
+  ;; (display* "Silent cancel " lan ", " ses ", " dead? "\n")
+  (with l
+    (pending-ref lan ses)
+    (with (in out err return opts)
+      (silent-decode (car l))
+      (return (if dead? :dead :interrupted))
+    ) ;with
+  ) ;with
+) ;define
 
 (tm-define (silent-feed lan ses in return opts)
   (set! in (plugin-preprocess lan ses in opts))
-  (with ret (lambda (x)
-              (return (if (npair? x) x
-                          (cons (plugin-postprocess lan ses (car x) opts)
-                                (plugin-postprocess lan ses (cdr x) opts)))))
-    (with x (silent-encode in ret opts)
-      (apply plugin-feed `(,lan ,ses ,@(car x) ,(cdr x))))))
+  (with ret
+    (lambda (x)
+      (return (if (npair? x)
+                x
+                (cons (plugin-postprocess lan ses (car x) opts)
+                  (plugin-postprocess lan ses (cdr x) opts)
+                ) ;cons
+              ) ;if
+      ) ;return
+    ) ;lambda
+    (with x
+      (silent-encode in ret opts)
+      (apply plugin-feed `(,lan ,ses ,@(car x) ,(cdr x)))
+    ) ;with
+  ) ;with
+) ;tm-define
 
 (tm-define (silent-feed* lan ses in return opts)
   (define (result-wrap x)
     (cond ((== x :dead) '(script-dead))
           ((== x :interrupted) '(script-interrupted))
-          ((!= (tm-arity (cdr x)) 0)
-           `(with "color" "red" ,(cdr x)))
-          (else (car x))))
- 
+          ((!= (tm-arity (cdr x)) 0) `(with ,"color" ,"red" ,(cdr x)))
+          (else (car x))
+    ) ;cond
+  ) ;define
+
   (define (result-callback x)
     (let ((r1 (result-wrap x)))
-      (if (tree? r1)
-          (return r1)
-          (return (stree->tree r1)))))
+      (if (tree? r1) (return r1) (return (stree->tree r1)))
+    ) ;let
+  ) ;define
 
-  (silent-feed lan ses in result-callback opts))
+  (silent-feed lan ses in result-callback opts)
+) ;tm-define
 
 (define (plugin-command-answer x)
-  (if (tm-func? x 'document 1) (plugin-command-answer (cadr x))
-      x))
+  (if (tm-func? x 'document 1) (plugin-command-answer (cadr x)) x)
+) ;define
 
 (tm-define (plugin-command lan ses in return opts)
   (let* ((cmd `(command ,(format-command lan in)))
-         (ret (lambda (x)
-                (and (pair? x)
-                     (return (plugin-command-answer (car x))))))
-         (x (silent-encode cmd ret opts)))
-    (apply plugin-feed `(,lan ,ses ,@(car x) ,(cdr x)))))
+         (ret (lambda (x) (and (pair? x) (return (plugin-command-answer (car x))))))
+         (x (silent-encode cmd ret opts))
+        ) ;
+    (apply plugin-feed `(,lan ,ses ,@(car x) ,(cdr x)))
+  ) ;let*
+) ;tm-define

--- a/bin/format
+++ b/bin/format
@@ -33,3 +33,4 @@ clang-format -i 3rdparty/lolly/**/*.cpp
 clang-format -i 3rdparty/lolly/**/*.hpp
 
 gf fix TeXmacs/progs/kernel
+gf fix TeXmacs/progs/utils/plugins/

--- a/devel/0133.md
+++ b/devel/0133.md
@@ -1,0 +1,50 @@
+# [0133] AI Tab 相关函数文档补充
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `TeXmacs/progs/dynamic/chat-tab-session.scm`
+- `TeXmacs/progs/dynamic/chat-adapter.scm`
+- `TeXmacs/progs/utils/plugins/plugin-eval.scm`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+# 暂无新增单元测试，现有 Scheme 测试通过即可
+```
+
+### 非确定性测试（文档验证）
+```bash
+# 验证文档注释格式正确，无语法错误
+```
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+# 确认所有修改文件已保存
+# 确认注释格式统一使用 ;; 开头
+```
+
+## What
+为 AI Tab 模块及其依赖的插件执行框架中的关键函数补充详细文档注释，统一采用 `;;` 开头的多行注释格式。
+
+1. `chat-tab-session.scm`：为 `chat-tab-session-select-model`、`chat-tab-session-send` 添加文档。
+2. `chat-adapter.scm`：为 `open-llm-chat-tab`、`chat-tab-send` 添加文档。
+3. `plugin-eval.scm`：为 `plugin-feed`、`plugin-next`、`pending-set`、`pending-ref` 添加文档。
+
+## Why
+AI Tab 是 Mogan 与 LLM 交互的核心入口，但相关函数的语义和回调机制缺乏文档，导致后续维护和理解成本较高。补充文档有助于开发者快速掌握会话生命周期、插件异步执行模型及各回调的职责。
+
+## How
+参考 `search-widgets.scm` 中的 `#|` 多行文档格式，将其转换为 `;;` 开头的等效注释，包含以下固定章节：
+
+- 函数名与一句话描述
+- 语法（调用签名）
+- 参数（名称、类型、说明）
+- 返回值（类型、含义）
+- 逻辑（执行步骤）
+- 注意（使用场景与约束）


### PR DESCRIPTION
## 概要

为 AI Tab 模块及其依赖的插件执行框架中的关键函数补充详细文档注释，并进行相关代码改进。

## 变更内容

1. **任务文档**
   - 创建 `devel/0133.md`

2. **文档补充（`;;` 开头格式）**
   - `chat-tab-session.scm`: `chat-tab-session-select-model`, `chat-tab-session-send`, `chat-tab-session-do`, `chat-tab-session-next`, `chat-tab-session-notify`, `chat-tab-session-cancel`, `chat-tab-session-encode`, `chat-tab-session-decode`, `chat-tab-session-feed`
   - `chat-adapter.scm`: `open-llm-chat-tab`, `chat-tab-send`
   - `plugin-eval.scm`: `plugin-feed`, `plugin-next`, `pending-set`, `pending-ref`

3. **代码改进**
   - 将 `chat-tab-session.scm` 中硬编码的 `"llm"` 字符串提取为 `chat-tab-session-name` 变量
   - 将 `gf fix TeXmacs/progs/utils/plugins/` 加入 `bin/format`

## 测试

- 文档注释仅影响可读性，不改变运行逻辑
- 代码改动（变量提取）保持原有行为不变

🤖 Generated with [Claude Code](https://claude.com/code)