### PR TITLE
[0135] Chat Tab 输入框支持 Shift+Enter 发送

### DIFF
--- a/devel/0135.md
+++ b/devel/0135.md
@@ -1,0 +1,37 @@
+[0135] Chat Tab 输入框支持 Shift+Enter 发送
+
+## 如何测试
+
+1. 启动 Mogan STEM，点击顶部工具栏的 AI 图标打开 Chat 标签页
+2. 在输入框中输入任意文本
+3. 按下 Shift+Enter，确认消息被发送（右侧进入会话态并显示 User/Assistant 消息）
+4. 输入多行文本，确认普通 Enter 仍可正常插入换行
+5. 切换到其他会话，确认 Shift+Enter 发送行为在各会话中均生效
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## What
+
+- 在 Chat Tab 的 `texmacs_input_widget` 输入框中，Shift+Enter 触发消息发送
+- 普通 Enter 保持原有行为（插入换行或执行编辑器默认动作）
+
+## Why
+
+- 会话里面有多行输入模式，原本的多行输入模式就是 Shift+Enter
+- 需要一种快捷方式在保持多行输入能力的同时完成发送
+
+## How
+
+- 在 `QTChatTabWidget` 上为每个输入框内部的 `QTMWidget` 安装 `eventFilter`
+- 拦截 `Shift+Return` / `Shift+Enter` 按键事件，直接调用 `handle_send()` 发送消息
+- 通过 `QObject::property` 将 `QTMWidget` 与对应的 `ChatConversationPanel` 关联，避免遍历查找
+- 事件被过滤后返回 `true`，阻止其继续传播到编辑器内部插入换行
+
+相关文档：
+- `devel/0302.md` — LLM 聊天页实现

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 #include "qt_chat_tab_widget.hpp"
+#include "QTMWidget.hpp"
 #include "new_buffer.hpp"
 #include "qt_dpi_utils.hpp"
 #include "qt_utilities.hpp"
@@ -304,6 +305,10 @@ QTChatTabWidget::create_conversation (const QString& title) {
   QWidget* inputQWidget   = concrete (panel->inputWidget)->as_qwidget ();
   panel->inputEditorWidget= inputQWidget;
   disable_scrollbars_recursively (inputQWidget);
+  if (QTMWidget* editor= inputQWidget->findChild<QTMWidget*> ()) {
+    editor->setProperty ("chat_panel", QVariant::fromValue ((void*) panel));
+    editor->installEventFilter (this);
+  }
   QWidget* inputFrame= new QWidget (topPanel);
   inputFrame->setObjectName ("chat-tab-input-frame");
   inputFrame->setStyleSheet (
@@ -497,4 +502,22 @@ QTChatTabWidget::keyReleaseEvent (QKeyEvent* event) {
 
   eval_scheme ("(key-press " * qt_scheme_quote (to_qstring (key)) * ")");
   event->accept ();
+}
+
+bool
+QTChatTabWidget::eventFilter (QObject* watched, QEvent* event) {
+  if (event->type () == QEvent::KeyPress) {
+    QKeyEvent* keyEvent= static_cast<QKeyEvent*> (event);
+    if ((keyEvent->key () == Qt::Key_Return ||
+         keyEvent->key () == Qt::Key_Enter) &&
+        (keyEvent->modifiers () & Qt::ShiftModifier)) {
+      void* ptr= watched->property ("chat_panel").value<void*> ();
+      if (ptr) {
+        ChatConversationPanel* panel= static_cast<ChatConversationPanel*> (ptr);
+        handle_send (panel);
+        return true;
+      }
+    }
+  }
+  return QWidget::eventFilter (watched, event);
 }

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -25,6 +25,7 @@ class QSpacerItem;
 class QStackedWidget;
 class QString;
 class QVBoxLayout;
+class QEvent;
 
 class QTChatTabWidget : public QWidget {
   Q_OBJECT
@@ -36,6 +37,7 @@ public:
 protected:
   void keyPressEvent (QKeyEvent* event) override;
   void keyReleaseEvent (QKeyEvent* event) override;
+  bool eventFilter (QObject* watched, QEvent* event) override;
 
 private:
   struct ChatConversationPanel;


### PR DESCRIPTION
## 摘要

- 在 Chat Tab 的 `texmacs_input_widget` 输入框中，Shift+Enter 触发消息发送
- 普通 Enter 保持原有行为（插入换行或执行编辑器默认动作）

## 实现方式

- 在 `QTChatTabWidget` 上为每个输入框内部的 `QTMWidget` 安装 `eventFilter`
- 拦截 `Shift+Return` / `Shift+Enter` 按键事件，直接调用 `handle_send()` 发送消息
- 通过 `QObject::property` 将 `QTMWidget` 与对应的 `ChatConversationPanel` 关联
- 事件被过滤后返回 `true`，阻止其继续传播到编辑器内部插入换行

## 测试计划

- [ ] 启动 Mogan STEM，打开 Chat 标签页
- [ ] 在输入框中输入文本，按下 Shift+Enter，确认消息被发送
- [ ] 输入多行文本，确认普通 Enter 仍可正常插入换行
- [ ] 切换会话，确认 Shift+Enter 发送行为在各会话中均生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)