### PR TITLE
[0136] Chat Tab 支持菜单栏、模式工具栏和焦点工具栏

### DIFF
--- a/devel/0136.md
+++ b/devel/0136.md
@@ -1,0 +1,53 @@
+# [0136] Chat Tab 支持菜单栏、模式工具栏和焦点工具栏
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+
+## 3 如何测试
+
+### 3.1 非确定性测试（文档验证）
+
+1. 启动 Mogan STEM，切换到 Chat Tab
+2. 点击底部输入框获取焦点
+3. 应能看到顶部显示菜单栏、模式工具栏、焦点工具栏
+4. 在输入框中输入不同内容时，焦点工具栏应随之更新
+
+## 4 如何提交
+
+```bash
+xmake b stem
+xmake b qt_chat_tab_widget_test  # 如有单元测试
+```
+
+## 5 What
+
+`qt_chat_tab_widget.cpp` 和 `qt_chat_tab_widget.hpp` 需要显示菜单栏、模式工具栏、焦点工具栏。
+
+1. 在 `QTChatTabWidget` 中集成菜单栏（menu toolbar）、模式工具栏（mode toolbar）和焦点工具栏（focus toolbar）
+2. 确保底部输入区域（`texmacs_input_widget`）获取焦点时，工具栏内容正确更新
+3. 保持现有 UI 布局不变，工具栏显示在聊天内容区域的合适位置
+
+## 6 Why
+
+Chat Tab 底部的输入区域使用 `texmacs_input_widget` 实现，它是一个内嵌的 TeXmacs 编辑器 widget。该编辑器依赖菜单栏、模式工具栏和焦点工具栏提供上下文相关的编辑功能和操作入口。当前 `QTChatTabWidget` 没有这些工具栏，导致输入区域的部分编辑功能无法正常使用。
+
+## 7 How
+
+参考 `qt_tm_widget_rep` 中工具栏的创建和管理方式：
+
+- `qt_tm_widget.cpp:562-565` 创建 `menuToolBar`、`modeToolBar`、`focusToolBar`
+- `qt_tm_widget.cpp:1641-1680` 通过 `SLOT_MODE_ICONS` 和 `SLOT_FOCUS_ICONS` 更新工具栏按钮
+- `qt_tm_widget.cpp:1020-1100` `update_visibility` 控制工具栏可见性
+
+在 `QTChatTabWidget` 中：
+
+1. 在 `ChatConversationPanel` 或 `QTChatTabWidget` 中添加 `QToolBar*` 成员用于菜单栏、模式工具栏、焦点工具栏
+2. 在 `setup_right_content` 或 `create_conversation` 中创建并布局这些工具栏
+3. 通过 TeXmacs widget 系统接收并安装菜单栏和工具栏内容（类似 `qt_tm_widget_rep::install_main_menu` 和 `replaceButtons`）
+4. 当输入框获取焦点时，确保工具栏可见性正确同步

--- a/devel/0136.md
+++ b/devel/0136.md
@@ -45,9 +45,16 @@ Chat Tab 底部的输入区域使用 `texmacs_input_widget` 实现，它是一�
 - `qt_tm_widget.cpp:1641-1680` 通过 `SLOT_MODE_ICONS` 和 `SLOT_FOCUS_ICONS` 更新工具栏按钮
 - `qt_tm_widget.cpp:1020-1100` `update_visibility` 控制工具栏可见性
 
-在 `QTChatTabWidget` 中：
+### 实现步骤
 
-1. 在 `ChatConversationPanel` 或 `QTChatTabWidget` 中添加 `QToolBar*` 成员用于菜单栏、模式工具栏、焦点工具栏
-2. 在 `setup_right_content` 或 `create_conversation` 中创建并布局这些工具栏
-3. 通过 TeXmacs widget 系统接收并安装菜单栏和工具栏内容（类似 `qt_tm_widget_rep::install_main_menu` 和 `replaceButtons`）
-4. 当输入框获取焦点时，确保工具栏可见性正确同步
+1. **`qt_chat_tab_widget.hpp/cpp`**：
+   - 在 `QTChatTabWidget` 中添加 `chatMenuToolBar_`、`chatModeToolBar_`、`chatFocusToolBar_` 三个 `QToolBar*` 成员
+   - 在 `setup_right_content` 中将三个工具栏插入到 `contentLayout` 顶部（`conversationStack_` 上方）
+   - 添加公共接口 `install_chat_menu_bar`、`set_chat_mode_icons`、`set_chat_focus_icons`
+   - 接口实现复用 `qt_tm_widget.cpp` 中 `install_main_menu` 和 `replaceButtons` 的逻辑
+
+2. **`qt_tm_widget.cpp`**：
+   - 修改 `qt_tm_embedded_widget_rep::write`
+   - 当接收到 `SLOT_MAIN_MENU`、`SLOT_MODE_ICONS`、`SLOT_FOCUS_ICONS` 时，遍历 `qwid` 的父 widget 链查找 `QTChatTabWidget`
+   - 若找到则转发给 `QTChatTabWidget` 的对应接口，否则保持原有忽略行为
+   - `qt_tm_widget_rep::update_visibility` 在 chat tab 模式下已隐藏主窗口的 menu/mode/focus 工具栏，无需额外修改

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -25,11 +25,14 @@
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QMenuBar>
 #include <QPropertyAnimation>
 #include <QPushButton>
 #include <QScrollBar>
 #include <QSpacerItem>
 #include <QStackedWidget>
+#include <QToolBar>
+#include <QToolButton>
 #include <QVBoxLayout>
 #include <QVariantAnimation>
 
@@ -196,7 +199,8 @@ QTChatTabWidget::QTChatTabWidget (QWidget* parent)
       conversationCountLabel_ (nullptr), conversationListWidget_ (nullptr),
       conversationListLayout_ (nullptr), newChatButton_ (nullptr),
       conversationStack_ (nullptr), activeConversation_ (nullptr),
-      nextConversationTitleId_ (1) {
+      nextConversationTitleId_ (1), chatMenuToolBar_ (nullptr),
+      chatModeToolBar_ (nullptr), chatFocusToolBar_ (nullptr) {
   setFocusPolicy (Qt::StrongFocus);
 
   QHBoxLayout* mainLayout= new QHBoxLayout (this);
@@ -312,6 +316,25 @@ QTChatTabWidget::setup_right_content (QHBoxLayout* mainLayout) {
   QVBoxLayout* contentLayout= new QVBoxLayout (content);
   contentLayout->setContentsMargins (0, 0, 0, 0);
   contentLayout->setSpacing (0);
+
+  chatMenuToolBar_= new QToolBar ("chat menu toolbar", content);
+  chatMenuToolBar_->setObjectName ("chat-menu-tool-bar");
+  chatMenuToolBar_->setMovable (false);
+  chatMenuToolBar_->setVisible (false);
+  contentLayout->addWidget (chatMenuToolBar_);
+
+  chatModeToolBar_= new QToolBar ("chat mode toolbar", content);
+  chatModeToolBar_->setObjectName ("chat-mode-tool-bar");
+  chatModeToolBar_->setMovable (false);
+  chatModeToolBar_->setVisible (false);
+  contentLayout->addWidget (chatModeToolBar_);
+
+  chatFocusToolBar_= new QToolBar ("chat focus toolbar", content);
+  chatFocusToolBar_->setObjectName ("chat-focus-tool-bar");
+  chatFocusToolBar_->setMovable (false);
+  chatFocusToolBar_->setVisible (false);
+  contentLayout->addWidget (chatFocusToolBar_);
+
   conversationStack_= new QStackedWidget (content);
   conversationStack_->setObjectName ("chat-tab-conversation-stack");
   contentLayout->addWidget (conversationStack_, 1);
@@ -637,4 +660,110 @@ QTChatTabWidget::eventFilter (QObject* watched, QEvent* event) {
     }
   }
   return QWidget::eventFilter (watched, event);
+}
+
+void
+QTChatTabWidget::install_chat_menu_bar (widget menuWidget) {
+  if (!chatMenuToolBar_) return;
+  qt_widget_rep*   menu_rep= concrete (menuWidget);
+  QList<QAction*>* src     = menu_rep->get_qactionlist ();
+  if (!src) return;
+
+  QMenuBar* dest= new QMenuBar ();
+  double    scale= DpiUtils::scaleFactor ();
+  int       h= DpiUtils::scaled (108);
+  dest->setFixedHeight (h);
+  if (tm_style_sheet == "") dest->setStyle (qtmstyle ());
+  dest->setNativeMenuBar (false);
+
+  dest->clear ();
+  for (int i= 0; i < src->count (); i++) {
+    QAction* a= (*src)[i];
+    if (a->menu ()) {
+      a->menu ()->addAction ("native menubar trick");
+      dest->addAction (a->menu ()->menuAction ());
+      QObject::connect (a->menu (), SIGNAL (aboutToShow ()),
+                        the_gui->gui_helper, SLOT (aboutToShowMainMenu ()));
+      QObject::connect (a->menu (), SIGNAL (aboutToHide ()),
+                        the_gui->gui_helper, SLOT (aboutToHideMainMenu ()));
+    }
+  }
+
+  QList<QWidget*> widgets= chatMenuToolBar_->findChildren<QWidget*> ();
+  for (QWidget* w : widgets) {
+    w->setParent (nullptr);
+  }
+  chatMenuToolBar_->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Fixed);
+  if (chatMenuToolBar_->layout ()) {
+    chatMenuToolBar_->layout ()->setContentsMargins (2, 0, 2, 0);
+    chatMenuToolBar_->layout ()->setSpacing (4);
+  }
+  chatMenuToolBar_->addWidget (dest);
+  chatMenuToolBar_->setVisible (true);
+}
+
+void
+QTChatTabWidget::set_chat_mode_icons (widget modeWidget) {
+  if (!chatModeToolBar_) return;
+  qt_widget_rep*   mode_rep= concrete (modeWidget);
+  QList<QAction*>* src     = mode_rep->get_qactionlist ();
+  if (!src) return;
+
+  chatModeToolBar_->setUpdatesEnabled (false);
+  bool visible= chatModeToolBar_->isVisible ();
+  if (visible) chatModeToolBar_->hide ();
+
+  QList<QAction*> actions= chatModeToolBar_->actions ();
+  for (int i= 0; i < actions.count (); i++) {
+    chatModeToolBar_->removeAction (actions[i]);
+  }
+  for (int i= 0; i < src->count (); i++) {
+    chatModeToolBar_->addAction ((*src)[i]);
+  }
+
+  QList<QObject*> list= chatModeToolBar_->children ();
+  for (int i= 0; i < list.count (); ++i) {
+    QToolButton* button= qobject_cast<QToolButton*> (list[i]);
+    if (button) {
+      button->setPopupMode (QToolButton::InstantPopup);
+      if (tm_style_sheet == "") button->setStyle (qtmstyle ());
+    }
+  }
+
+  if (visible) chatModeToolBar_->show ();
+  chatModeToolBar_->setUpdatesEnabled (true);
+  chatModeToolBar_->setVisible (true);
+}
+
+void
+QTChatTabWidget::set_chat_focus_icons (widget focusWidget) {
+  if (!chatFocusToolBar_) return;
+  qt_widget_rep*   focus_rep= concrete (focusWidget);
+  QList<QAction*>* src      = focus_rep->get_qactionlist ();
+  if (!src) return;
+
+  chatFocusToolBar_->setUpdatesEnabled (false);
+  bool visible= chatFocusToolBar_->isVisible ();
+  if (visible) chatFocusToolBar_->hide ();
+
+  QList<QAction*> actions= chatFocusToolBar_->actions ();
+  for (int i= 0; i < actions.count (); i++) {
+    chatFocusToolBar_->removeAction (actions[i]);
+  }
+  for (int i= 0; i < src->count (); i++) {
+    chatFocusToolBar_->addAction ((*src)[i]);
+  }
+
+  QList<QObject*> list= chatFocusToolBar_->children ();
+  for (int i= 0; i < list.count (); ++i) {
+    QToolButton* button= qobject_cast<QToolButton*> (list[i]);
+    if (button) {
+      button->setPopupMode (QToolButton::InstantPopup);
+      if (tm_style_sheet == "") button->setStyle (qtmstyle ());
+    }
+  }
+
+  if (visible) chatFocusToolBar_->show ();
+  chatFocusToolBar_->setUpdatesEnabled (true);
+  chatFocusToolBar_->setVisible (true);
 }

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -10,9 +10,12 @@
  ******************************************************************************/
 
 #include "qt_chat_tab_widget.hpp"
+#include "QTMGuiHelper.hpp"
+#include "QTMStyle.hpp"
 #include "QTMWidget.hpp"
 #include "new_buffer.hpp"
 #include "qt_dpi_utils.hpp"
+#include "qt_gui.hpp"
 #include "qt_utilities.hpp"
 #include "qt_widget.hpp"
 #include "s7_tm.hpp"
@@ -665,8 +668,7 @@ QTChatTabWidget::eventFilter (QObject* watched, QEvent* event) {
 void
 QTChatTabWidget::install_chat_menu_bar (widget menuWidget) {
   if (!chatMenuToolBar_) return;
-  qt_widget_rep*   menu_rep= concrete (menuWidget);
-  QList<QAction*>* src     = menu_rep->get_qactionlist ();
+  QList<QAction*>* src= concrete (menuWidget)->get_qactionlist ();
   if (!src) return;
 
   QMenuBar* dest= new QMenuBar ();
@@ -705,8 +707,7 @@ QTChatTabWidget::install_chat_menu_bar (widget menuWidget) {
 void
 QTChatTabWidget::set_chat_mode_icons (widget modeWidget) {
   if (!chatModeToolBar_) return;
-  qt_widget_rep*   mode_rep= concrete (modeWidget);
-  QList<QAction*>* src     = mode_rep->get_qactionlist ();
+  QList<QAction*>* src= concrete (modeWidget)->get_qactionlist ();
   if (!src) return;
 
   chatModeToolBar_->setUpdatesEnabled (false);
@@ -738,8 +739,7 @@ QTChatTabWidget::set_chat_mode_icons (widget modeWidget) {
 void
 QTChatTabWidget::set_chat_focus_icons (widget focusWidget) {
   if (!chatFocusToolBar_) return;
-  qt_widget_rep*   focus_rep= concrete (focusWidget);
-  QList<QAction*>* src      = focus_rep->get_qactionlist ();
+  QList<QAction*>* src= concrete (focusWidget)->get_qactionlist ();
   if (!src) return;
 
   chatFocusToolBar_->setUpdatesEnabled (false);

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -671,9 +671,9 @@ QTChatTabWidget::install_chat_menu_bar (widget menuWidget) {
   QList<QAction*>* src= concrete (menuWidget)->get_qactionlist ();
   if (!src) return;
 
-  QMenuBar* dest= new QMenuBar ();
+  QMenuBar* dest = new QMenuBar ();
   double    scale= DpiUtils::scaleFactor ();
-  int       h= DpiUtils::scaled (108);
+  int       h    = DpiUtils::scaled (108);
   dest->setFixedHeight (h);
   if (tm_style_sheet == "") dest->setStyle (qtmstyle ());
   dest->setNativeMenuBar (false);

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -163,10 +163,10 @@ private:
   QStackedWidget* conversationStack_;                ///< 会话页面的堆叠控件。
   QList<ChatConversationPanel*> conversations_;      ///< 所有会话面板的列表。
   ChatConversationPanel*        activeConversation_; ///< 当前激活的会话。
-  int nextConversationTitleId_; ///< 自动生成会话标题的 ID 计数器。
-  QToolBar*       chatMenuToolBar_;                  ///< Chat Tab 的菜单工具栏。
-  QToolBar*       chatModeToolBar_;                  ///< Chat Tab 的模式工具栏。
-  QToolBar*       chatFocusToolBar_;                 ///< Chat Tab 的焦点工具栏。
+  int       nextConversationTitleId_; ///< 自动生成会话标题的 ID 计数器。
+  QToolBar* chatMenuToolBar_;         ///< Chat Tab 的菜单工具栏。
+  QToolBar* chatModeToolBar_;         ///< Chat Tab 的模式工具栏。
+  QToolBar* chatFocusToolBar_;        ///< Chat Tab 的焦点工具栏。
 };
 
 #endif // QT_CHAT_TAB_WIDGET_HPP

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -24,6 +24,7 @@ class QPushButton;
 class QSpacerItem;
 class QStackedWidget;
 class QString;
+class QToolBar;
 class QVBoxLayout;
 class QEvent;
 
@@ -133,6 +134,25 @@ private:
    */
   void focus_input_editor (ChatConversationPanel* panel);
 
+public:
+  /**
+   * @brief 为 Chat Tab 安装主菜单栏内容。
+   * @param menuWidget 菜单 widget。
+   */
+  void install_chat_menu_bar (widget menuWidget);
+
+  /**
+   * @brief 设置 Chat Tab 的模式工具栏内容。
+   * @param modeWidget 模式图标 widget。
+   */
+  void set_chat_mode_icons (widget modeWidget);
+
+  /**
+   * @brief 设置 Chat Tab 的焦点工具栏内容。
+   * @param focusWidget 焦点图标 widget。
+   */
+  void set_chat_focus_icons (widget focusWidget);
+
 private:
   QWidget*        sidebarWidget_;                    ///< 左侧边栏容器。
   QWidget*        contentWidget_;                    ///< 右侧内容区容器。
@@ -144,6 +164,9 @@ private:
   QList<ChatConversationPanel*> conversations_;      ///< 所有会话面板的列表。
   ChatConversationPanel*        activeConversation_; ///< 当前激活的会话。
   int nextConversationTitleId_; ///< 自动生成会话标题的 ID 计数器。
+  QToolBar*       chatMenuToolBar_;                  ///< Chat Tab 的菜单工具栏。
+  QToolBar*       chatModeToolBar_;                  ///< Chat Tab 的模式工具栏。
+  QToolBar*       chatFocusToolBar_;                 ///< Chat Tab 的焦点工具栏。
 };
 
 #endif // QT_CHAT_TAB_WIDGET_HPP

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -2041,9 +2041,22 @@ qt_tm_embedded_widget_rep::write (slot s, blackbox index, widget w) {
   } break;
     /// FIXME: decide what to do with these for embedded widgets
   case SLOT_MAIN_MENU:
-  case SLOT_MAIN_ICONS:
   case SLOT_MODE_ICONS:
-  case SLOT_FOCUS_ICONS:
+  case SLOT_FOCUS_ICONS: {
+    if (!qwid) as_qwidget ();
+    QWidget* p= qwid;
+    while (p) {
+      if (QTChatTabWidget* chat= qobject_cast<QTChatTabWidget*> (p)) {
+        if (s == SLOT_MAIN_MENU) chat->install_chat_menu_bar (w);
+        else if (s == SLOT_MODE_ICONS) chat->set_chat_mode_icons (w);
+        else if (s == SLOT_FOCUS_ICONS) chat->set_chat_focus_icons (w);
+        return;
+      }
+      p= p->parentWidget ();
+    }
+    qt_widget_rep::write (s, index, w);
+  } break;
+  case SLOT_MAIN_ICONS:
   case SLOT_USER_ICONS:
   case SLOT_SIDE_TOOLS:
   case SLOT_LEFT_TOOLS:


### PR DESCRIPTION
## Summary
1. 在 `QTChatTabWidget` 中新增菜单栏、模式工具栏、焦点工具栏
2. 修改 `qt_tm_embedded_widget_rep::write`，将内嵌编辑器的工具栏 slot 转发到 `QTChatTabWidget`
3. `qt_tm_widget_rep::update_visibility` 在 chat tab 模式下已自动隐藏主窗口工具栏，避免重复显示

## 改动文件
- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
- `src/Plugins/Qt/qt_tm_widget.cpp`
- `devel/0136.md`

## 测试
- [x] `xmake b stem` 构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)