### PR TITLE
[0144] 为 PDF 阅读器添加矩形选框功能

### DIFF
--- a/devel/0144.md
+++ b/devel/0144.md
@@ -1,0 +1,56 @@
+# [0144] 为 PDF 阅读器添加矩形选框功能
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_pdf_reader_widget.hpp`
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp`
+- `tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b qt_pdf_reader_widget_test
+xmake r qt_pdf_reader_widget_test
+```
+
+### 3.2 非确定性测试（文档验证）
+```bash
+xmake b stem
+# 启动 Mogan，打开一个 PDF 文件，点击矩形选框按钮，拖拽选择区域，验证剪贴板中有图片
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b qt_pdf_reader_widget_test
+xmake r qt_pdf_reader_widget_test
+```
+
+## 5 What
+
+为 PDF 阅读器新增矩形选框功能：
+
+1. 在工具栏上添加一个矩形选框按钮
+2. 点击按钮后进入矩形选择模式
+3. 在 PDF 渲染区域拖拽选择矩形区域
+4. 将选中内容以图片格式存储到剪贴板
+
+## 6 Why
+
+用户需要能够快速截取 PDF 中的部分内容并复制到剪贴板，方便在其他应用中粘贴使用。
+
+## 7 How
+
+1. 在 `PDFReaderWidget` 工具栏添加矩形选框按钮，使用 `QPushButton` 并设置 `checkable`
+2. 添加 `QRubberBand` 用于显示选择框
+3. 在选择模式下，通过 `eventFilter` 拦截 `scrollArea_->viewport()` 的鼠标事件
+4. 鼠标按下记录起始点并创建 rubber band，移动时更新 rubber band 大小，释放时计算选择区域
+5. 根据鼠标位置定位到对应的页面 `QLabel`，获取其 `QPixmap`
+6. 将选择区域的坐标转换为 pixmap 坐标（考虑 DPR），使用 `QPixmap::copy()` 截取
+7. 使用 `QClipboard::setPixmap()` 将截取的图片放入系统剪贴板
+8. 使用 TDD 方式开发：先写测试，再写实现

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -8,6 +8,7 @@
 #include "qt_pdf_reader_widget.hpp"
 
 #include <QApplication>
+#include <QClipboard>
 #include <QDebug>
 #include <QFile>
 #include <QKeyEvent>
@@ -35,10 +36,12 @@ PDFReaderWidget::PDFReaderWidget (QWidget* parent)
     : QWidget (parent), scrollArea_ (nullptr), contentWidget_ (nullptr),
       pageLayout_ (nullptr), mainLayout_ (nullptr), toolBar_ (nullptr),
       zoomCombo_ (nullptr), prevPageBtn_ (nullptr), pageEdit_ (nullptr),
-      pageTotalLabel_ (nullptr), nextPageBtn_ (nullptr), pageCount_ (0),
-      hasError_ (false), targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0),
-      pageAspectRatio_ (0.0), pageBaseWidthPts_ (0.0),
-      zoomDebounceTimer_ (nullptr), resizeDebounceTimer_ (nullptr) {
+      pageTotalLabel_ (nullptr), nextPageBtn_ (nullptr), zoomInBtn_ (nullptr),
+      rectSelectBtn_ (nullptr), rubberBand_ (nullptr), rectSelectMode_ (false),
+      rectSelectDragging_ (false), pageCount_ (0), hasError_ (false),
+      targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0), pageAspectRatio_ (0.0),
+      pageBaseWidthPts_ (0.0), zoomDebounceTimer_ (nullptr),
+      resizeDebounceTimer_ (nullptr) {
 
   mainLayout_= new QVBoxLayout (this);
   mainLayout_->setContentsMargins (0, 0, 0, 0);
@@ -152,6 +155,16 @@ PDFReaderWidget::setupToolBar () {
   toolBar_->addWidget (pageEdit_);
   toolBar_->addWidget (pageTotalLabel_);
   toolBar_->addWidget (nextPageBtn_);
+
+  rectSelectBtn_= new QPushButton ("□", toolBar_);
+  rectSelectBtn_->setObjectName ("rectSelectBtn");
+  rectSelectBtn_->setFixedWidth (30);
+  rectSelectBtn_->setCheckable (true);
+  connect (rectSelectBtn_, &QPushButton::toggled, this,
+           &PDFReaderWidget::onRectSelectToggled);
+
+  toolBar_->addSeparator ();
+  toolBar_->addWidget (rectSelectBtn_);
 
   mainLayout_->insertWidget (0, toolBar_);
 }
@@ -309,6 +322,97 @@ void
 PDFReaderWidget::onNextPage () {
   int page= currentPage () + 1;
   if (page <= pageCount_) goToPage (page);
+}
+
+bool
+PDFReaderWidget::isRectSelectMode () const {
+  return rectSelectMode_;
+}
+
+void
+PDFReaderWidget::onRectSelectToggled (bool checked) {
+  rectSelectMode_= checked;
+  if (scrollArea_ && scrollArea_->viewport ()) {
+    scrollArea_->viewport ()->setMouseTracking (rectSelectMode_);
+  }
+  if (!rectSelectMode_ && rubberBand_) {
+    rubberBand_->hide ();
+    delete rubberBand_;
+    rubberBand_= nullptr;
+  }
+  rectSelectDragging_= false;
+}
+
+void
+PDFReaderWidget::finishRectSelect (const QPoint& viewportPos) {
+  if (!rubberBand_ || !contentWidget_) return;
+
+  QRect rubberRect= rubberBand_->geometry ();
+  rubberBand_->hide ();
+
+  // 将 rubber band 的 geometry（contentWidget_ 坐标）转换为内容坐标
+  QPoint contentTopLeft= rubberRect.topLeft ();
+  QPoint contentBottomRight= rubberRect.bottomRight ();
+
+  QRect contentRect (contentTopLeft, contentBottomRight);
+  if (contentRect.width () <= 0 || contentRect.height () <= 0) return;
+
+  QLabel* label= findPageLabelAt (contentRect.center ());
+  if (!label) return;
+
+  QPixmap selected= extractSelectionPixmap (label, contentRect);
+  if (selected.isNull ()) return;
+
+  QClipboard* clipboard= QApplication::clipboard ();
+  if (clipboard) {
+    clipboard->setPixmap (selected);
+  }
+}
+
+QLabel*
+PDFReaderWidget::findPageLabelAt (const QPoint& contentPos) const {
+  int childCount= pageLayout_->count ();
+  for (int i= 0; i < childCount; ++i) {
+    QLayoutItem* item= pageLayout_->itemAt (i);
+    if (!item) continue;
+    QWidget* w= item->widget ();
+    if (!w) continue;
+    QLabel* label= qobject_cast<QLabel*> (w);
+    if (!label) continue;
+    if (label->geometry ().contains (contentPos)) {
+      return label;
+    }
+  }
+  return nullptr;
+}
+
+QPixmap
+PDFReaderWidget::extractSelectionPixmap (QLabel* label,
+                                         const QRect& contentRect) const {
+  if (!label) return QPixmap ();
+
+  QPixmap pm= label->pixmap ();
+  if (pm.isNull ()) return QPixmap ();
+
+  // 计算选择区域相对于 label 的坐标
+  QRect labelRect= label->geometry ();
+  QRect intersect = contentRect.intersected (labelRect);
+  if (intersect.isEmpty ()) return QPixmap ();
+
+  int relX= intersect.x () - labelRect.x ();
+  int relY= intersect.y () - labelRect.y ();
+  int relW= intersect.width ();
+  int relH= intersect.height ();
+
+  qreal dpr = pm.devicePixelRatio ();
+  int   srcX= qRound (relX * dpr);
+  int   srcY= qRound (relY * dpr);
+  int   srcW= qRound (relW * dpr);
+  int   srcH= qRound (relH * dpr);
+
+  QPixmap copied= pm.copy (srcX, srcY, srcW, srcH);
+  copied.setDevicePixelRatio (1.0);
+  return copied;
 }
 
 void
@@ -823,6 +927,46 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
     else if (event->type () == QEvent::Resize) {
       if (!pdfData_.isEmpty () && pageCount_ > 0) {
         resizeDebounceTimer_->start ();
+      }
+    }
+    else if (rectSelectMode_ && event->type () == QEvent::MouseButtonPress) {
+      QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
+      if (mouseEvent->button () == Qt::LeftButton) {
+        rectSelectDragging_= true;
+        rectSelectStart_   = scrollArea_->viewport ()->mapToGlobal (
+            mouseEvent->pos ());
+        rectSelectStart_=
+            contentWidget_->mapFromGlobal (rectSelectStart_);
+        if (!rubberBand_) {
+          rubberBand_=
+              new QRubberBand (QRubberBand::Rectangle, contentWidget_);
+        }
+        rubberBand_->setGeometry (QRect (rectSelectStart_, QSize ()));
+        rubberBand_->show ();
+        mouseEvent->accept ();
+        return true;
+      }
+    }
+    else if (rectSelectMode_ && rectSelectDragging_ &&
+             event->type () == QEvent::MouseMove) {
+      QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
+      QPoint currentPos=
+          contentWidget_->mapFromGlobal (
+              scrollArea_->viewport ()->mapToGlobal (mouseEvent->pos ()));
+      QRect rect (rectSelectStart_, currentPos);
+      rect= rect.normalized ();
+      rubberBand_->setGeometry (rect);
+      mouseEvent->accept ();
+      return true;
+    }
+    else if (rectSelectMode_ && rectSelectDragging_ &&
+             event->type () == QEvent::MouseButtonRelease) {
+      QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
+      if (mouseEvent->button () == Qt::LeftButton) {
+        rectSelectDragging_= false;
+        finishRectSelect (mouseEvent->pos ());
+        mouseEvent->accept ();
+        return true;
       }
     }
   }

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -38,7 +38,8 @@ PDFReaderWidget::PDFReaderWidget (QWidget* parent)
       zoomCombo_ (nullptr), prevPageBtn_ (nullptr), pageEdit_ (nullptr),
       pageTotalLabel_ (nullptr), nextPageBtn_ (nullptr), zoomInBtn_ (nullptr),
       rectSelectBtn_ (nullptr), rubberBand_ (nullptr), rectSelectMode_ (false),
-      rectSelectDragging_ (false), pageCount_ (0), hasError_ (false),
+      rectSelectDragging_ (false), hintLabel_ (nullptr), pageCount_ (0),
+      hasError_ (false),
       targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0), pageAspectRatio_ (0.0),
       pageBaseWidthPts_ (0.0), zoomDebounceTimer_ (nullptr),
       resizeDebounceTimer_ (nullptr) {
@@ -343,6 +344,30 @@ PDFReaderWidget::onRectSelectToggled (bool checked) {
     rubberBand_= nullptr;
   }
   rectSelectDragging_= false;
+
+  if (rectSelectMode_) {
+    if (!hintLabel_) {
+      hintLabel_= new QLabel (contentWidget_);
+      hintLabel_->setObjectName ("rectSelectHint");
+      hintLabel_->setStyleSheet (
+          "QLabel { background-color: rgba(0, 0, 0, 180); color: white; "
+          "padding: 4px 8px; border-radius: 4px; font-size: 12px; }");
+    }
+#ifdef Q_OS_MACOS
+    QString shortcut= "Cmd+Shift+v";
+#else
+    QString shortcut= "Ctrl+Shift+v";
+#endif
+    hintLabel_->setText (
+        QString ("Draw a rectangle and use %1 to magic paste!")
+            .arg (shortcut));
+    hintLabel_->adjustSize ();
+    hintLabel_->move (PAGE_MARGIN, PAGE_MARGIN);
+    hintLabel_->show ();
+  }
+  else if (hintLabel_) {
+    hintLabel_->hide ();
+  }
 }
 
 void
@@ -368,6 +393,11 @@ PDFReaderWidget::finishRectSelect (const QPoint& viewportPos) {
   QClipboard* clipboard= QApplication::clipboard ();
   if (clipboard) {
     clipboard->setPixmap (selected);
+  }
+
+  if (hintLabel_) {
+    hintLabel_->setText ("Copied to Clipboard!");
+    hintLabel_->adjustSize ();
   }
 }
 

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -333,7 +333,9 @@ void
 PDFReaderWidget::onRectSelectToggled (bool checked) {
   rectSelectMode_= checked;
   if (scrollArea_ && scrollArea_->viewport ()) {
-    scrollArea_->viewport ()->setMouseTracking (rectSelectMode_);
+    QWidget* vp= scrollArea_->viewport ();
+    vp->setMouseTracking (rectSelectMode_);
+    vp->setCursor (rectSelectMode_ ? Qt::CrossCursor : Qt::ArrowCursor);
   }
   if (!rectSelectMode_ && rubberBand_) {
     rubberBand_->hide ();

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -39,10 +39,9 @@ PDFReaderWidget::PDFReaderWidget (QWidget* parent)
       pageTotalLabel_ (nullptr), nextPageBtn_ (nullptr), zoomInBtn_ (nullptr),
       rectSelectBtn_ (nullptr), rubberBand_ (nullptr), rectSelectMode_ (false),
       rectSelectDragging_ (false), hintLabel_ (nullptr), pageCount_ (0),
-      hasError_ (false),
-      targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0), pageAspectRatio_ (0.0),
-      pageBaseWidthPts_ (0.0), zoomDebounceTimer_ (nullptr),
-      resizeDebounceTimer_ (nullptr) {
+      hasError_ (false), targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0),
+      pageAspectRatio_ (0.0), pageBaseWidthPts_ (0.0),
+      zoomDebounceTimer_ (nullptr), resizeDebounceTimer_ (nullptr) {
 
   mainLayout_= new QVBoxLayout (this);
   mainLayout_->setContentsMargins (0, 0, 0, 0);
@@ -359,8 +358,7 @@ PDFReaderWidget::onRectSelectToggled (bool checked) {
     QString shortcut= "Ctrl+Shift+v";
 #endif
     hintLabel_->setText (
-        QString ("Draw a rectangle and use %1 to magic paste!")
-            .arg (shortcut));
+        QString ("Draw a rectangle and use %1 to magic paste!").arg (shortcut));
     hintLabel_->adjustSize ();
     hintLabel_->move (PAGE_MARGIN, PAGE_MARGIN);
     hintLabel_->show ();
@@ -378,7 +376,7 @@ PDFReaderWidget::finishRectSelect (const QPoint& viewportPos) {
   rubberBand_->hide ();
 
   // 将 rubber band 的 geometry（contentWidget_ 坐标）转换为内容坐标
-  QPoint contentTopLeft= rubberRect.topLeft ();
+  QPoint contentTopLeft    = rubberRect.topLeft ();
   QPoint contentBottomRight= rubberRect.bottomRight ();
 
   QRect contentRect (contentTopLeft, contentBottomRight);
@@ -419,7 +417,7 @@ PDFReaderWidget::findPageLabelAt (const QPoint& contentPos) const {
 }
 
 QPixmap
-PDFReaderWidget::extractSelectionPixmap (QLabel* label,
+PDFReaderWidget::extractSelectionPixmap (QLabel*      label,
                                          const QRect& contentRect) const {
   if (!label) return QPixmap ();
 
@@ -428,7 +426,7 @@ PDFReaderWidget::extractSelectionPixmap (QLabel* label,
 
   // 计算选择区域相对于 label 的坐标
   QRect labelRect= label->geometry ();
-  QRect intersect = contentRect.intersected (labelRect);
+  QRect intersect= contentRect.intersected (labelRect);
   if (intersect.isEmpty ()) return QPixmap ();
 
   int relX= intersect.x () - labelRect.x ();
@@ -965,13 +963,11 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
       QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
       if (mouseEvent->button () == Qt::LeftButton) {
         rectSelectDragging_= true;
-        rectSelectStart_   = scrollArea_->viewport ()->mapToGlobal (
-            mouseEvent->pos ());
         rectSelectStart_=
-            contentWidget_->mapFromGlobal (rectSelectStart_);
+            scrollArea_->viewport ()->mapToGlobal (mouseEvent->pos ());
+        rectSelectStart_= contentWidget_->mapFromGlobal (rectSelectStart_);
         if (!rubberBand_) {
-          rubberBand_=
-              new QRubberBand (QRubberBand::Rectangle, contentWidget_);
+          rubberBand_= new QRubberBand (QRubberBand::Rectangle, contentWidget_);
         }
         rubberBand_->setGeometry (QRect (rectSelectStart_, QSize ()));
         rubberBand_->show ();
@@ -982,9 +978,8 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
     else if (rectSelectMode_ && rectSelectDragging_ &&
              event->type () == QEvent::MouseMove) {
       QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
-      QPoint currentPos=
-          contentWidget_->mapFromGlobal (
-              scrollArea_->viewport ()->mapToGlobal (mouseEvent->pos ()));
+      QPoint       currentPos= contentWidget_->mapFromGlobal (
+          scrollArea_->viewport ()->mapToGlobal (mouseEvent->pos ()));
       QRect rect (rectSelectStart_, currentPos);
       rect= rect.normalized ();
       rubberBand_->setGeometry (rect);

--- a/src/Plugins/Qt/qt_pdf_reader_widget.hpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.hpp
@@ -113,6 +113,7 @@ private:
   bool         rectSelectMode_;
   QPoint       rectSelectStart_;
   bool         rectSelectDragging_;
+  QLabel*      hintLabel_;
 
   QByteArray pdfData_;
   int        pageCount_;

--- a/src/Plugins/Qt/qt_pdf_reader_widget.hpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.hpp
@@ -83,14 +83,15 @@ private slots:
   void keyPressEvent (QKeyEvent* event) override;
 
 private:
-  bool renderPageToLabel (int pageNumber, QLabel* label, int targetWidth);
-  void rebuildPages ();
-  int  pageWidth () const;
-  void setupToolBar ();
-  void updateZoomDisplay ();
-  void finishRectSelect (const QPoint& viewportPos);
+  bool    renderPageToLabel (int pageNumber, QLabel* label, int targetWidth);
+  void    rebuildPages ();
+  int     pageWidth () const;
+  void    setupToolBar ();
+  void    updateZoomDisplay ();
+  void    finishRectSelect (const QPoint& viewportPos);
   QLabel* findPageLabelAt (const QPoint& contentPos) const;
-  QPixmap extractSelectionPixmap (QLabel* label, const QRect& contentRect) const;
+  QPixmap extractSelectionPixmap (QLabel*      label,
+                                  const QRect& contentRect) const;
 
   bool eventFilter (QObject* watched, QEvent* event) override;
 

--- a/src/Plugins/Qt/qt_pdf_reader_widget.hpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.hpp
@@ -13,6 +13,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QRubberBand>
 #include <QScrollArea>
 #include <QTimer>
 #include <QToolBar>
@@ -69,12 +70,15 @@ public:
   QWidget*    viewport () const;
   QScrollBar* verticalScrollBar () const;
 
+  bool isRectSelectMode () const;
+
 private slots:
   void onZoomChanged (int index);
   void onPrevPage ();
   void onNextPage ();
   void onPageEditingFinished ();
   void updatePageNavigation ();
+  void onRectSelectToggled (bool checked);
 
   void keyPressEvent (QKeyEvent* event) override;
 
@@ -84,6 +88,9 @@ private:
   int  pageWidth () const;
   void setupToolBar ();
   void updateZoomDisplay ();
+  void finishRectSelect (const QPoint& viewportPos);
+  QLabel* findPageLabelAt (const QPoint& contentPos) const;
+  QPixmap extractSelectionPixmap (QLabel* label, const QRect& contentRect) const;
 
   bool eventFilter (QObject* watched, QEvent* event) override;
 
@@ -100,6 +107,12 @@ private:
   QLabel*      pageTotalLabel_;
   QPushButton* nextPageBtn_;
   QPushButton* zoomInBtn_;
+  QPushButton* rectSelectBtn_;
+
+  QRubberBand* rubberBand_;
+  bool         rectSelectMode_;
+  QPoint       rectSelectStart_;
+  bool         rectSelectDragging_;
 
   QByteArray pdfData_;
   int        pageCount_;

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -164,6 +164,65 @@ private slots:
     QCOMPARE (widget->currentPage (), 1);
     delete widget;
   }
+
+  void test_rectSelectButtonExists () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    QPushButton*     rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
+    QVERIFY (rectBtn != nullptr);
+    delete widget;
+  }
+
+  void test_rectSelectModeToggle () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    QPushButton*     rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
+    QVERIFY (rectBtn != nullptr);
+
+    QVERIFY (!widget->isRectSelectMode ());
+    rectBtn->click ();
+    QVERIFY (widget->isRectSelectMode ());
+    rectBtn->click ();
+    QVERIFY (!widget->isRectSelectMode ());
+    delete widget;
+  }
+
+  void test_rectSelectClipboard () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+
+    QApplication::processEvents ();
+
+    // 清空剪贴板
+    QClipboard* clipboard= QApplication::clipboard ();
+    clipboard->clear ();
+    QApplication::processEvents ();
+
+    // 进入选择模式
+    QPushButton* rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
+    QVERIFY (rectBtn != nullptr);
+    rectBtn->click ();
+    QApplication::processEvents ();
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+
+    // 模拟拖拽选择
+    QPoint start (50, 50);
+    QPoint end (150, 150);
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, start);
+    QTest::mouseMove (vp, end);
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, end);
+    QApplication::processEvents ();
+
+    // 验证剪贴板有图片
+    QVERIFY (clipboard->mimeData ()->hasImage ());
+    delete widget;
+  }
 };
 
 QTEST_MAIN (TestPdfReaderWidget)

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -185,6 +185,27 @@ private slots:
     delete widget;
   }
 
+  void test_rectSelectCursor () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->show ();
+    QApplication::processEvents ();
+
+    QPushButton* rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
+    QVERIFY (rectBtn != nullptr);
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+
+    QCOMPARE (vp->cursor ().shape (), Qt::ArrowCursor);
+    rectBtn->click ();
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::CrossCursor);
+    rectBtn->click ();
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::ArrowCursor);
+    delete widget;
+  }
+
   void test_rectSelectClipboard () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     widget->resize (400, 300);

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -206,6 +206,51 @@ private slots:
     delete widget;
   }
 
+  void test_rectSelectHint () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+
+    QApplication::processEvents ();
+
+    QPushButton* rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
+    QVERIFY (rectBtn != nullptr);
+
+    // 进入选择模式后显示提示
+    rectBtn->click ();
+    QApplication::processEvents ();
+
+    QLabel* hint= widget->findChild<QLabel*> ("rectSelectHint");
+    QVERIFY (hint != nullptr);
+    QVERIFY (hint->isVisible ());
+    QVERIFY (hint->text ().contains ("Draw a rectangle"));
+
+    // 模拟拖拽选择
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+    QPoint start (50, 50);
+    QPoint end (150, 150);
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, start);
+    QTest::mouseMove (vp, end);
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, end);
+    QApplication::processEvents ();
+
+    // 选择完成后提示变为 Copied to Clipboard!
+    QCOMPARE (hint->text (), QString ("Copied to Clipboard!"));
+
+    // 退出选择模式后隐藏提示
+    rectBtn->click ();
+    QApplication::processEvents ();
+    QVERIFY (!hint->isVisible ());
+
+    delete widget;
+  }
+
   void test_rectSelectClipboard () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     widget->resize (400, 300);

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -166,14 +166,14 @@ private slots:
   }
 
   void test_rectSelectButtonExists () {
-    PDFReaderWidget* widget= new PDFReaderWidget ();
+    PDFReaderWidget* widget = new PDFReaderWidget ();
     QPushButton*     rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
     QVERIFY (rectBtn != nullptr);
     delete widget;
   }
 
   void test_rectSelectModeToggle () {
-    PDFReaderWidget* widget= new PDFReaderWidget ();
+    PDFReaderWidget* widget = new PDFReaderWidget ();
     QPushButton*     rectBtn= widget->findChild<QPushButton*> ("rectSelectBtn");
     QVERIFY (rectBtn != nullptr);
 


### PR DESCRIPTION
## 功能描述
为 PDF 阅读器新增矩形选框功能，支持截取 PDF 页面中的任意区域并复制到剪贴板。

## 改动内容
- 在 PDF 阅读器工具栏添加矩形选框按钮（□）
- 点击按钮进入矩形选择模式，鼠标变为十字形状
- 支持在 PDF 渲染区域拖拽选择矩形区域
- 进入选择模式后在左上角显示操作提示（支持 macOS / Linux / Windows 快捷键区分）
- 选中完成后提示 Copied to Clipboard!
- 将选中内容截取为图片并存储到系统剪贴板

## 测试
- 新增 5 个单元测试，全部通过
  - test_rectSelectButtonExists
  - test_rectSelectModeToggle
  - test_rectSelectCursor
  - test_rectSelectHint
  - test_rectSelectClipboard

## 使用方式
1. 打开 PDF 文件
2. 点击工具栏上的 □ 按钮进入矩形选框模式
3. 在页面上拖拽选择需要截取的区域
4. 选中内容自动复制到剪贴板，可粘贴到其他应用

🤖 Generated with [Claude Code](https://claude.com/claude-code)