### PR TITLE
[0149] 启用 LIII_DEBUG 调试日志

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,27 @@
 3. **容器不支持现代 C++ 特性**：自定义容器（如 `rectangles`、`list`）不支持范围 for 循环（range-based for），需使用传统的迭代器或 `is_nil()`/`next` 遍历。
 4. **类型转换使用项目函数**：自定义类型（如 `path`）没有标准 `operator<<` 重载，输出前需先用 `as_string()` 转换。
 
+### 调试日志
+
+1. **临时调试**：使用 `#ifdef LIII_DEBUG` / `#endif` 包裹全局 `cout`（`tm_ostream` 类型）。该宏仅在 debug 编译模式下定义，release 模式下整段代码会被编译器剔除，避免影响性能：
+   ```cpp
+   #ifdef LIII_DEBUG
+   cout << "Assign " << p << ", " << u << " in " << st << "\n";
+   #endif
+   ```
+
+2. **标准调试流**：使用项目预定义的调试输出流（如 `debug_std`、`debug_typeset`、`debug_boot`、`debug_edit` 等），配合 `DEBUG_STD`、`DEBUG_AUTO` 等宏开关，可通过外部配置启用/禁用：
+   ```cpp
+   if (DEBUG_STD) debug_boot << "Loading welcome message...\n";
+   ```
+
+3. **性能调试**：使用 `bench_start`、`bench_end` 等函数进行性能计时：
+   ```cpp
+   bench_start ("my_task");
+   // ... 代码 ...
+   bench_end ("my_task");
+   ```
+
 ## 分支命名规则
 
 分支格式：`username/200_27/xxx`

--- a/src/System/config.h.xmake
+++ b/src/System/config.h.xmake
@@ -21,6 +21,9 @@ ${define HAVE_STDINT_H}
 /* Enable timestamps in debug messages */
 ${define DEBUG_WITH_TIMESTAMP}
 
+/* Enable LIII debug logging in debug and releasedbg modes */
+${define LIII_DEBUG}
+
 ${define USE_PLUGIN_GS}
 
 /* Define to 1 if you have the <inttypes.h> header file. */

--- a/src/Typeset/Bridge/bridge_argument.cpp
+++ b/src/Typeset/Bridge/bridge_argument.cpp
@@ -40,7 +40,9 @@ bridge_argument_rep::bridge_argument_rep (typesetter ttt, tree st, path ip)
 
 void
 bridge_argument_rep::initialize (string name2, path pf, tree b_t, path b_ip) {
-  // cout << "Initialize arg: " << name2 << ", " << pf << ": " << b_t << "\n";
+#ifdef LIII_DEBUG
+  cout << "Initialize arg: " << name2 << ", " << pf << ": " << b_t << "\n";
+#endif
   if ((!valid) || (name != name2) || (prefix != pf) || (body->st != b_t) ||
       (body->ip != b_ip)) {
     valid = true;

--- a/src/Typeset/Bridge/bridge_docrange.cpp
+++ b/src/Typeset/Bridge/bridge_docrange.cpp
@@ -55,7 +55,9 @@ public:
 bridge
 bridge_docrange (typesetter ttt, tree st, path ip, array<bridge>& brs,
                  int begin, int end, bool divide= false) {
-  // cout << "Make range: " << begin << " -- " << end << "\n";
+#ifdef LIII_DEBUG
+  cout << "Make range: " << begin << " -- " << end << "\n";
+#endif
   return tm_new<bridge_docrange_rep> (ttt, st, ip, brs, begin, end, divide);
 }
 
@@ -90,9 +92,11 @@ bridge_docrange_rep::rebalance () {
       while ((i < n - 1) && ((mid[i + 2] == mid[start + 1]) ||
                              (mid[i + 2] - mid[start] <= ACC_THRESHOLD)))
         i++;
-      // cout << "  Compactify " << i-start << " at " << start << ", ";
-      // if (mid[i+1] == mid[start+1]) cout << "suppress\n";
-      // else cout << "compress\n";
+#ifdef LIII_DEBUG
+      cout << "  Compactify " << i - start << " at " << start << ", ";
+      if (mid[i + 1] == mid[start + 1]) cout << "suppress\n";
+      else cout << "compress\n";
+#endif
       if (mid[i + 1] == mid[start + 1]) acc2 << acc[start];
       else acc2 << bridge_docrange (ttt, st, ip, brs, mid[start], mid[i + 1]);
       mid2 << mid[start];
@@ -101,7 +105,9 @@ bridge_docrange_rep::rebalance () {
     // Expand?
     else if (mid[i + 1] - mid[i] > (7 * ACC_THRESHOLD / 4)) {
       int j, k= (mid[i + 1] - mid[i] - 1) / ACC_THRESHOLD + 1;
-      // cout << "  Expand " << k << " at " << i << "\n";
+#ifdef LIII_DEBUG
+      cout << "  Expand " << k << " at " << i << "\n";
+#endif
       for (j= 0; j < k; j++) {
         int b= mid[i] + j * ACC_THRESHOLD;
         int e= min (b + ACC_THRESHOLD, mid[i + 1]);
@@ -118,7 +124,9 @@ bridge_docrange_rep::rebalance () {
   }
 
   mid2 << end;
-  // if (mid2 != mid) cout << mid << " -> " << mid2 << "\n";
+#ifdef LIII_DEBUG
+  if (mid2 != mid) cout << mid << " -> " << mid2 << "\n";
+#endif
   acc= acc2;
   mid= mid2;
 }
@@ -141,8 +149,10 @@ bridge_docrange_rep::notify_assign (path p, tree u) {
 
 void
 bridge_docrange_rep::notify_insert (path p, tree u) {
-  // cout << "Notify insert " << p << ", " << N(u)
-  //      << " [ " << begin << "--" << end << " ]\n";
+#ifdef LIII_DEBUG
+  cout << "Notify insert " << p << ", " << N (u) << " [ " << begin << "--"
+       << end << " ]\n";
+#endif
   ASSERT (!is_nil (p), "erroneous nil path");
   if (p->item > end) {
     failed_error << "Notify insert " << u << " at " << p << "\n";
@@ -161,16 +171,22 @@ bridge_docrange_rep::notify_insert (path p, tree u) {
       acc[i]->notify_insert (p, u);
       mid[i + 1]+= N (u);
     }
-    // cout << "mid[ins,0]= " << mid << "\n";
+#ifdef LIII_DEBUG
+    cout << "mid[ins,0]= " << mid << "\n";
+#endif
     rebalance ();
-    // cout << "mid[ins,1]= " << mid << "\n";
+#ifdef LIII_DEBUG
+    cout << "mid[ins,1]= " << mid << "\n";
+#endif
   }
 }
 
 void
 bridge_docrange_rep::notify_remove (path p, int nr) {
-  // cout << "Notify insert " << p << ", " << nr
-  //      << " [ " << begin << "--" << end << " ]\n";
+#ifdef LIII_DEBUG
+  cout << "Notify insert " << p << ", " << nr << " [ " << begin << "--" << end
+       << " ]\n";
+#endif
   ASSERT (!is_nil (p), "erroneous nil path");
   ASSERT (p->item < end, "out of range");
   if (p->item + nr > begin) {
@@ -191,9 +207,13 @@ bridge_docrange_rep::notify_remove (path p, int nr) {
       acc[i]->notify_remove (p, nr);
       mid[i + 1]= max (mid[i + 1] - nr, p->item);
     }
-    // cout << "mid[rem,0]= " << mid << "\n";
+#ifdef LIII_DEBUG
+    cout << "mid[rem,0]= " << mid << "\n";
+#endif
     rebalance ();
-    // cout << "mid[rem,1]= " << mid << "\n";
+#ifdef LIII_DEBUG
+    cout << "mid[rem,1]= " << mid << "\n";
+#endif
   }
 }
 

--- a/src/Typeset/Bridge/bridge_eval.cpp
+++ b/src/Typeset/Bridge/bridge_eval.cpp
@@ -54,21 +54,26 @@ bridge_eval (typesetter ttt, tree st, path ip) {
 
 void
 bridge_eval_rep::notify_assign (path p, tree u) {
-  // cout << "Assign " << p << ", " << u << " in " << st << "\n";
+#ifdef LIII_DEBUG
+  cout << "Assign " << p << ", " << u << " in " << st << "\n";
+#endif
   status= CORRUPTED;
   st    = substitute (st, p, u);
 }
 
 bool
 bridge_eval_rep::notify_macro (int tp, string v, int l, path p, tree u) {
-  // cout << "Macro argument " << v << " [action=" << tp
-  //<< ", level=" << l << "] " << p << ", " << u << " in " << st << "\n";
-  // cout << "  Body= " << bt << "\n";
+#ifdef LIII_DEBUG
+  cout << "Macro argument " << v << " [action=" << tp << ", level=" << l << "] "
+       << p << ", " << u << " in " << st << "\n";
+#endif
   (void) tp;
   (void) p;
   (void) u;
   bool flag= env->depends (st, v, l);
-  // cout << "  Flag= " << flag << "\n";
+#ifdef LIII_DEBUG
+  cout << "  Flag= " << flag << "\n";
+#endif
   if (flag) {
     status= CORRUPTED;
     body->notify_macro (tp, v, l, p, u);

--- a/src/Typeset/Bridge/bridge_formatting.cpp
+++ b/src/Typeset/Bridge/bridge_formatting.cpp
@@ -58,7 +58,9 @@ bridge_formatting (typesetter ttt, tree st, path ip, string v) {
 
 void
 bridge_formatting_rep::notify_assign (path p, tree u) {
-  // cout << "Assign " << p << ", " << u << " in " << st << "\n";
+#ifdef LIII_DEBUG
+  cout << "Assign " << p << ", " << u << " in " << st << "\n";
+#endif
   ASSERT (!is_nil (p) || is_func (u, TFORMAT), "nil path");
   if (is_nil (p)) {
     st= u;

--- a/src/Typeset/Bridge/typesetter.cpp
+++ b/src/Typeset/Bridge/typesetter.cpp
@@ -51,19 +51,19 @@ typesetter_rep::insert_parunit (tree t, path ip) {
 
 void
 typesetter_rep::insert_paragraph (tree t, path ip) {
-  // cout << "Typesetting " << t << ", " << ip << "\n";
+#ifdef LIII_DEBUG
+  cout << "Typesetting " << t << ", " << ip << "\n";
+#endif
   stack_border     temp_sb;
   array<page_item> temp_l= typeset_stack (env, t, ip, a, b, temp_sb);
   insert_stack (temp_l, temp_sb);
 
-  /*
-  int i, n= N(temp_l);
-  for (i=0; i<n; i++)
-    cout << i << ", "
-         << temp_l[i]->b->find_lip () << ", "
-         << temp_l[i]->b->find_rip () << ",\t"
-         << temp_l[i]->b << "\n";
-  */
+#ifdef LIII_DEBUG
+  int i, n= N (temp_l);
+  for (i= 0; i < n; i++)
+    cout << i << ", " << temp_l[i]->b->find_lip () << ", "
+         << temp_l[i]->b->find_rip () << ",\t" << temp_l[i]->b << "\n";
+#endif
 }
 
 void
@@ -228,38 +228,50 @@ typesetter_rep::typeset (SI& x1b, SI& y1b, SI& x2b, SI& y2b) {
 
 void
 notify_assign (typesetter ttt, path p, tree u) {
-  // cout << "Assign " << p << ", " << u << "\n";
+#ifdef LIII_DEBUG
+  cout << "Assign " << p << ", " << u << "\n";
+#endif
   if (is_nil (p)) ttt->br= make_bridge (ttt, u, ttt->br->ip);
   else ttt->br->notify_assign (p, u);
 }
 
 void
 notify_insert (typesetter ttt, path p, tree u) {
-  // cout << "Insert " << p << ", " << u << "\n";
+#ifdef LIII_DEBUG
+  cout << "Insert " << p << ", " << u << "\n";
+#endif
   ttt->br->notify_insert (p, u);
 }
 
 void
 notify_remove (typesetter ttt, path p, int nr) {
-  // cout << "Remove " << p << ", " << nr << "\n";
+#ifdef LIII_DEBUG
+  cout << "Remove " << p << ", " << nr << "\n";
+#endif
   ttt->br->notify_remove (p, nr);
 }
 
 void
 notify_split (typesetter ttt, path p) {
-  // cout << "Split " << p << "\n";
+#ifdef LIII_DEBUG
+  cout << "Split " << p << "\n";
+#endif
   ttt->br->notify_split (p);
 }
 
 void
 notify_join (typesetter ttt, path p) {
-  // cout << "Join " << p << "\n";
+#ifdef LIII_DEBUG
+  cout << "Join " << p << "\n";
+#endif
   ttt->br->notify_join (p);
 }
 
 void
 notify_assign_node (typesetter ttt, path p, tree_label op) {
-  // cout << "Assign node " << p << ", " << as_string (op) << "\n";
+#ifdef LIII_DEBUG
+  cout << "Assign node " << p << ", " << as_string (op) << "\n";
+#endif
   tree t= subtree (ttt->br->st, p);
   int  i, n= N (t);
   tree r (op, n);
@@ -271,7 +283,9 @@ notify_assign_node (typesetter ttt, path p, tree_label op) {
 
 void
 notify_insert_node (typesetter ttt, path p, tree t) {
-  // cout << "Insert node " << p << ", " << t << "\n";
+#ifdef LIII_DEBUG
+  cout << "Insert node " << p << ", " << t << "\n";
+#endif
   int  i, pos= last_item (p), n= N (t);
   tree r (t, n + 1);
   for (i= 0; i < pos; i++)
@@ -285,7 +299,9 @@ notify_insert_node (typesetter ttt, path p, tree t) {
 
 void
 notify_remove_node (typesetter ttt, path p) {
-  // cout << "Remove node " << p << "\n";
+#ifdef LIII_DEBUG
+  cout << "Remove node " << p << "\n";
+#endif
   tree t= subtree (ttt->br->st, p);
   if (is_nil (path_up (p))) ttt->br= make_bridge (ttt, t, ttt->br->ip);
   else ttt->br->notify_assign (path_up (p), t);

--- a/src/Typeset/Page/columns_breaker.cpp
+++ b/src/Typeset/Page/columns_breaker.cpp
@@ -63,7 +63,9 @@ new_breaker_rep::break_uniform (path b1, path b2) {
     path        key= b1 * path (-1, b2);
     array<path> r  = cache_uniform[key];
     if (N (r) != 0) return r;
-    // cout << "Break uniform " << b1 << ", " << b2 << LF;
+#ifdef LIII_DEBUG
+    cout << "Break uniform " << b1 << ", " << b2 << LF;
+#endif
     int  i1= b1->item, i2= b2->item;
     path bm;
     if (i1 < i2 && i1 < col_same[i2 - 1])
@@ -79,7 +81,9 @@ new_breaker_rep::break_uniform (path b1, path b2) {
     r->resize (N (r) - 1);
     r << break_uniform (bm, b2);
     cache_uniform (key)= r;
-    // cout << "Break uniform " << b1 << ", " << b2 << " ~> " << r << LF;
+#ifdef LIII_DEBUG
+    cout << "Break uniform " << b1 << ", " << b2 << " ~> " << r << LF;
+#endif
     return r;
   }
 }
@@ -203,17 +207,22 @@ new_breaker_rep::search_rightwards (path b1, path b2, path b, double fr) {
 path
 new_breaker_rep::break_columns_at (path b1, path b2, double fr) {
   if (b1 == b2) return b1;
-  // cout << "Break " << b1 << ", " << b2 << " at " << h << LF;
+#ifdef LIII_DEBUG
+  cout << "Break " << b1 << ", " << b2 << " at " << fr << LF;
+#endif
   path bm= break_columns_ansatz (b1, b2, b1, b2, fr);
-  // cout << "Ansatz " << bm << LF;
-  // if (b1 == path (0) && b2 == path (16))
-  //   cout << "Ansatz ~> " << bm << LF;
+#ifdef LIII_DEBUG
+  cout << "Ansatz " << bm << LF;
+  if (b1 == path (0) && b2 == path (16)) cout << "Ansatz ~> " << bm << LF;
+#endif
   path bl= search_leftwards (b1, b2, bm, fr);
-  // if (b1 == path (0) && b2 == path (16))
-  //   cout << "Left ~> " << bl << LF;
+#ifdef LIII_DEBUG
+  if (b1 == path (0) && b2 == path (16)) cout << "Left ~> " << bl << LF;
+#endif
   path br= search_rightwards (b1, b2, bm, fr);
-  // if (b1 == path (0) && b2 == path (16))
-  //   cout << "Right ~> " << br << LF;
+#ifdef LIII_DEBUG
+  if (b1 == path (0) && b2 == path (16)) cout << "Right ~> " << br << LF;
+#endif
   int penl= compute_penalty (bl);
   int penr= compute_penalty (br);
   if (penl == HYPH_INVALID) return br;
@@ -248,13 +257,17 @@ new_breaker_rep::break_columns (path b1, path b2) {
     array<path> r  = cache_colbreaks[key];
     if (N (r) != 0) return r;
     r= array<path> ();
-    // cout << "Breaking " << b1 << ", " << b2 << LF << INDENT;
+#ifdef LIII_DEBUG
+    cout << "Breaking " << b1 << ", " << b2 << LF << INDENT;
+#endif
     r << b1;
     for (int k= 1; k < cols; k++)
       r << break_columns_at (b1, b2, (1.0 * k) / cols);
     r << b2;
     cache_colbreaks (key)= r;
-    // cout << UNINDENT << "Broke " << b1 << ", " << b2 << " ~> " << r << LF;
+#ifdef LIII_DEBUG
+    cout << UNINDENT << "Broke " << b1 << ", " << b2 << " ~> " << r << LF;
+#endif
     return r;
   }
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -657,6 +657,11 @@ target("libmogan") do
     set_configvar("GS_EXE", "/usr/bin/gs")
 
     set_configvar("PDFHUMMUS_NO_TIFF", true)
+
+    if is_mode("debug") or is_mode("releasedbg") then
+        set_configvar("LIII_DEBUG", 1)
+    end
+
     add_configfiles(
         "src/System/config.h.xmake", {
             filename = "config.h",


### PR DESCRIPTION
## Summary
- 在 debug/releasedbg 模式下通过 xmake 定义 LIII_DEBUG 宏
- 将 Typeset/Bridge 和 Page 中注释掉的调试日志恢复为 #ifdef LIII_DEBUG 包裹
- 更新 CLAUDE.md 调试日志规范

## Test plan
- [ ] 本地构建通过
- [ ] debug 模式下 LIII_DEBUG 宏生效
- [ ] release 模式下调试日志被剔除

🤖 Generated with [Claude Code](https://claude.com/claude-code)