### PR TITLE
[0149] 移除过大的调试日志输出

### DIFF
--- a/devel/0149.md
+++ b/devel/0149.md
@@ -1,0 +1,47 @@
+# [0149] 移除过大的调试日志输出
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0149] 启用 LIII_DEBUG 调试日志 (#3416) - 前置任务
+
+## 2 任务相关的代码文件
+- `src/Typeset/Bridge/typesetter.cpp`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+在 debug 编译模式下启动 Mogan，确认 LIII_DEBUG 日志不再输出过大内容。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+bin/format
+git add .
+git commit -m "[0149] 移除过大的调试日志输出"
+```
+
+## 5 What
+
+移除 `src/Typeset/Bridge/typesetter.cpp` 中输出内容过大的 `LIII_DEBUG` 调试日志，避免调试模式下因日志刷屏导致性能下降和日志文件膨胀。
+
+1. 移除 `typesetter_rep::insert_paragraph` 中对整棵树 `t` 的 `cout` 输出
+2. 移除 `typesetter_rep::insert_paragraph` 中对 `temp_l` 数组的循环逐项输出
+3. 移除 `notify_assign` 中对 `p` 和 `u` 的 `cout` 输出
+
+## 6 Why
+
+在 [#3416](0b8dbd61ad8cb62ebe995ceaa793f180b2f99c03) 中启用了 `LIII_DEBUG` 调试日志，但部分日志输出的是完整的树结构或页面项数组，内容量极大，导致：
+- debug 模式下终端/日志文件被刷屏，难以阅读有效信息
+- 频繁的字符串拼接和 I/O 操作影响排版性能
+- 日志文件迅速膨胀，占用磁盘空间
+
+## 7 How
+
+直接删除对应位置的 `#ifdef LIII_DEBUG ... #endif` 代码块，保留其他有意义的调试日志（如 `notify_insert`、`notify_remove`、`notify_split` 等简短日志）。

--- a/src/Typeset/Bridge/typesetter.cpp
+++ b/src/Typeset/Bridge/typesetter.cpp
@@ -51,19 +51,9 @@ typesetter_rep::insert_parunit (tree t, path ip) {
 
 void
 typesetter_rep::insert_paragraph (tree t, path ip) {
-#ifdef LIII_DEBUG
-  cout << "Typesetting " << t << ", " << ip << "\n";
-#endif
   stack_border     temp_sb;
   array<page_item> temp_l= typeset_stack (env, t, ip, a, b, temp_sb);
   insert_stack (temp_l, temp_sb);
-
-#ifdef LIII_DEBUG
-  int i, n= N (temp_l);
-  for (i= 0; i < n; i++)
-    cout << i << ", " << temp_l[i]->b->find_lip () << ", "
-         << temp_l[i]->b->find_rip () << ",\t" << temp_l[i]->b << "\n";
-#endif
 }
 
 void
@@ -228,9 +218,6 @@ typesetter_rep::typeset (SI& x1b, SI& y1b, SI& x2b, SI& y2b) {
 
 void
 notify_assign (typesetter ttt, path p, tree u) {
-#ifdef LIII_DEBUG
-  cout << "Assign " << p << ", " << u << "\n";
-#endif
   if (is_nil (p)) ttt->br= make_bridge (ttt, u, ttt->br->ip);
   else ttt->br->notify_assign (p, u);
 }


### PR DESCRIPTION
## 关联任务
[0149] 启用 LIII_DEBUG 调试日志 (#3416) 的前置清理

## 改动内容
- 新增 `devel/0149.md` 任务文档
- 移除 `src/Typeset/Bridge/typesetter.cpp` 中输出内容过大的 `LIII_DEBUG` 调试日志：
  1. `typesetter_rep::insert_paragraph` 中对整棵树 `t` 的 `cout` 输出
  2. `typesetter_rep::insert_paragraph` 中对 `temp_l` 数组的循环逐项输出
  3. `notify_assign` 中对 `p` 和 `u` 的 `cout` 输出

## Why
在 #3416 中启用了 `LIII_DEBUG`，但部分日志输出完整树结构或页面项数组，内容量极大，导致 debug 模式下终端被刷屏、日志文件膨胀，并影响排版性能。

## 如何测试
```bash
xmake b stem
```
在 debug 编译模式下启动 Mogan，确认 LIII_DEBUG 日志不再输出过大内容。