### PR TITLE
[0147] 添加 tmu_to_tree 解析性能基准测试

### DIFF
--- a/src/Data/Convert/Mogan/from_tmu.cpp
+++ b/src/Data/Convert/Mogan/from_tmu.cpp
@@ -19,6 +19,7 @@
 #include <lolly/data/unicode.hpp>
 #include <moebius/drd/drd_std.hpp>
 #include <moebius/vars.hpp>
+#include "tm_debug.hpp"
 
 using lolly::data::decode_from_utf8;
 using lolly::data::from_hex;
@@ -334,14 +335,20 @@ tmu_reader::read (bool skip_flag) {
 
 tree
 tmu_to_tree (string s) {
+  bench_start ("tmu_to_tree");
   tmu_reader tmr (s);
-  return tmr.read (true);
+  tree t= tmr.read (true);
+  bench_end ("tmu_to_tree");
+  return t;
 }
 
 tree
 tmu_to_tree (string s, string version) {
+  bench_start ("tmu_to_tree");
   tmu_reader tmr (s, version);
-  return tmr.read (true);
+  tree t= tmr.read (true);
+  bench_end ("tmu_to_tree");
+  return t;
 }
 
 /******************************************************************************


### PR DESCRIPTION
## Summary
- 在 `tmu_to_tree` 的两个重载函数中添加 `bench_start`/`bench_end`，测量 TMU 格式解析的整体耗时

## 性能对比

基于 `bench_tmu_to_tree` 分支（main 基线）测量的 `tmu_to_tree` 耗时：

| 版本 | tmu_to_tree 耗时 |
|------|-----------------|
| main（优化前） | **310 ms** |
| da/0147/big_doc（优化后） | **238 ms** |

优化幅度：**23%**（减少 72ms）

优化内容（da/0147/big_doc 分支）：
- `decode` 函数：无转义字符时直接返回原字符串，避免不必要的复制
- `read_next` 函数：普通字符的 fast path，减少临时字符串创建

## Test plan
- [x] `xmake b stem` 编译通过
- [x] `xmake r stem` 运行后 `grep tmu_to_tree` 可观察到性能日志

🤖 Generated with [Claude Code](https://claude.com/claude-code)