### PR TITLE
[0613] 增加使用外部 PDF 阅读器预览的选项

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -2550,6 +2550,7 @@
 ("use blackboard bold font" "")
 ("use bold font series" "")
 ("use calligraphical font" "")
+("Use external pdf viewer" "使用外部 PDF 阅读器")
 ("use fonts in texlive" "使用texlive中的字体")
 ("use footnote font size" "")
 ("use fraktur font" "")

--- a/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
@@ -627,7 +627,10 @@ pretty-val : string
   (aligned
     (meti (hlist // (text "Expand beamer slides"))
       (toggle (set-boolean-preference "texmacs->pdf:expand slides" answer)
-              (get-boolean-preference "texmacs->pdf:expand slides"))))
+              (get-boolean-preference "texmacs->pdf:expand slides")))
+    (meti (hlist // (text "Use external pdf viewer"))
+      (toggle (set-boolean-preference "use external pdf viewer" answer)
+              (get-boolean-preference "use external pdf viewer"))))
   (assuming (supports-native-pdf?)
     (aligned
       (item (text "Pdf version number:")

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1582,14 +1582,17 @@
 (tm-define (load-pdf-buffer u)
   (when (not (url-rooted? u))
     (set! u (url-relative (current-buffer) u)))
-  (if (buffer-exists? u)
-      (switch-to-buffer u)
+  (if (get-boolean-preference "use external pdf viewer")
+      (load-external u)
       (begin
-        (buffer-set u '(document))
-        (buffer-set-title u (url->system (url-tail u)))
-        (switch-to-buffer u)))
-  (buffer-notify-recent u)
-  (remember-file-dialog-directory u))
+        (if (buffer-exists? u)
+            (switch-to-buffer u)
+            (begin
+              (buffer-set u '(document))
+              (buffer-set-title u (url->system (url-tail u)))
+              (switch-to-buffer u)))
+        (buffer-notify-recent u)
+        (remember-file-dialog-directory u))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Loading buffers

--- a/TeXmacs/progs/texmacs/texmacs/tm-print.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-print.scm
@@ -70,6 +70,7 @@
 (define-preferences
   ("texmacs->pdf:expand slides" "on" noop)
   ("preview command" "default" notify-preview-command)
+  ("use external pdf viewer" "off" noop)
   ("printing command" (get-default-printing-command) notify-printing-command)
   ("paper type" (get-default-paper-size) notify-paper-type)
   ("printer dpi" "1200" notify-printer-dpi))

--- a/devel/0613.md
+++ b/devel/0613.md
@@ -1,0 +1,48 @@
+# [0613] 增加使用外部 PDF 阅读器预览的选项
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`
+- `TeXmacs/progs/texmacs/menus/preferences-widgets.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无新增单元测试。
+
+### 3.2 非确定性测试（文档验证）
+1. 启动 Mogan，进入 `Edit -> Preferences -> Convert -> Pdf`。
+2. 确认存在 `Use external pdf viewer` 选项，且默认未勾选。
+3. 导出一个 PDF 文件（`File -> Export -> Pdf`）并选择打开，确认在内部标签页打开。
+4. 勾选 `Use external pdf viewer`，再次导出并打开，确认使用系统默认的外部 PDF 阅读器打开。
+5. 直接在文件浏览器中双击打开一个 PDF 文件，确认使用外部 PDF 阅读器打开。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+# 检查修改的文件
+git diff --stat
+
+# 编译并运行（确保 Scheme 语法正确）
+xmake b stem
+```
+
+## 5 What
+为 PDF 预览功能增加一个选项，允许用户选择使用外部 PDF 阅读器进行预览。
+
+1. 在 Preferences -> Convert -> Pdf 中新增 `Use external pdf viewer` 复选框，默认关闭。
+2. 新增用户偏好设置 `use external pdf viewer`，默认值为 `off`。
+3. 修改 `load-pdf-buffer` 函数，当偏好设置为开启时，调用 `load-external` 使用系统默认的外部程序打开 PDF。
+
+## 6 Why
+Mogan 目前默认使用内部标签页预览 PDF，但部分用户习惯使用外部 PDF 阅读器（如 Acrobat Reader、Preview 等）进行预览。此前 Mogan 曾支持外部预览，后被内部预览取代。本任务在保留内部预览作为默认行为的同时，给予用户自主选择预览方式的权利。
+
+## 7 How
+1. **偏好设置定义**：在 `tm-print.scm` 的 `define-preferences` 中注册 `"use external pdf viewer"` 布尔偏好设置，默认 `"off"`。
+2. **修改加载逻辑**：在 `tm-files.scm` 的 `load-pdf-buffer` 函数中，优先检查 `get-boolean-preference "use external pdf viewer"`。若为真，则调用 `load-external`（进而调用 `open-url` 使用系统默认程序打开）；否则保持原有的内部标签页打开逻辑。
+3. **UI 入口**：在 `preferences-widgets.scm` 的 `pdf-preferences-widget` 中新增一个 `toggle` 控件，绑定到上述偏好设置。


### PR DESCRIPTION
## Summary
为 PDF 预览功能增加一个选项，允许用户选择使用外部 PDF 阅读器进行预览。默认保持内部预览不变。

## Changes
1. 在 `Preferences -> Convert -> Pdf` 中新增 `Use external pdf viewer` 复选框，默认关闭。
2. 新增用户偏好设置 `use external pdf viewer`，默认值为 `off`。
3. 修改 `load-pdf-buffer` 函数，当偏好设置为开启时，调用 `load-external` 使用系统默认的外部程序打开 PDF。

## Test plan
- [ ] 启动 Mogan，进入 `Edit -> Preferences -> Convert -> Pdf`，确认存在 `Use external pdf viewer` 选项且默认未勾选。
- [ ] 导出一个 PDF 并选择打开，确认在内部标签页打开。
- [ ] 勾选 `Use external pdf viewer`，再次导出并打开，确认使用系统默认的外部 PDF 阅读器打开。
- [ ] 直接在文件浏览器中双击打开一个 PDF 文件，确认使用外部 PDF 阅读器打开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)