### PR TITLE
[209_21] 添加算法宏方向键右键导航并修复 algo-else 支持

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -217,7 +217,9 @@
       (begin
         (display* "DEBUG -> body-end, jump to :after\n")
         (tree-go-to t (- (tree-arity t) 1) :end)
-        (go-right))
+        (display* "DEBUG after tree-go-to path=" (cursor-path) "\n")
+        (go-right)
+        (display* "DEBUG after go-right path=" (cursor-path) "\n"))
       (begin
         (display* "DEBUG -> go-right\n")
         (go-right)))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -199,10 +199,14 @@
                                             (with lc-path (tree->path last-child)
                                               (and lc-path
                                                    (> (length path) (length lc-path))
-                                                   (begin
-                                                     (display* "DEBUG body-end? cAr-path="
-                                                               (cAr path) "\n")
-                                                     (== (cAr path) :end))))))))))))))))
+                                                   (let ((rel-path (list-tail path (length lc-path))))
+                                                     (display* "DEBUG body-end? rel-path="
+                                                               rel-path " arity="
+                                                               (tree-arity last-child) "\n")
+                                                     (or (== (cAr path) :end)
+                                                         (and (== (length rel-path) 1)
+                                                              (integer? (car rel-path))
+                                                              (== (car rel-path) (tree-arity last-child)))))))))))))))))))
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -216,8 +216,9 @@
   (if (cursor-in-algo-macro-body-end? t)
       (begin
         (display* "DEBUG -> body-end, jump to :after\n")
-        (tree-go-to t (- (tree-arity t) 1) :end)
-        (display* "DEBUG after tree-go-to path=" (cursor-path) "\n")
+        (with body (tm-ref t (- (tree-arity t) 1))
+          (tree-go-to body :end)
+          (display* "DEBUG after tree-go-to path=" (cursor-path) "\n"))
         (go-right)
         (display* "DEBUG after go-right path=" (cursor-path) "\n"))
       (begin

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -226,7 +226,11 @@
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
+  (write (list 'kbd-horizontal-algo (tree-label t) forwards? (cursor-path)))
+  (newline)
   (cond ((cursor-in-algo-macro-body-end? t)
+         (write (list 'body-end (tree-label t)))
+         (newline)
          (with t-path (tree->path t)
            (and t-path
                 (with parent (tree-up t)
@@ -236,13 +240,19 @@
                              (== (+ 1 t-index) (tree-arity parent)))
                         ;; Last child in document: create a new paragraph
                         (begin
+                          (write (list 'last-child t-index (tree-arity parent)))
+                          (newline)
                           (go-to (rcons parent-path (+ 1 t-index)))
                           (insert-return))
                         ;; Not last child: jump to next sibling
-                        (go-to (rcons parent-path (+ 1 t-index))))))))
+                        (go-to (rcons parent-path (+ 1 t-index))))))))))
         ((cursor-in-algo-macro-condition-end? t)
+         (write (list 'condition-end (tree-label t)))
+         (newline)
          (tree-go-to t 1))
         (else
+         (write (list 'else (tree-label t)))
+         (newline)
          (go-right)))
 ) ;tm-define
 

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -226,33 +226,33 @@
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
-  (set-message "kbd-h" (string-append "t=" (symbol->string (tree-label t)) " fwd=" (if forwards? "y" "n")))
+  (debug-message "debug-io" (string-append "kbd-h t=" (symbol->string (tree-label t)) " fwd=" (if forwards? "y" "n") "\n"))
   (cond ((cursor-in-algo-macro-body-end? t)
          (with t-path (tree->path t)
            (and t-path
                 (with parent (tree-up t)
                   (let* ((parent-path (cDr t-path))
                          (t-index (cAr t-path)))
-                    (set-message "kbd-h"
-                      (string-append "idx=" (number->string t-index)
+                    (debug-message "debug-io"
+                      (string-append "kbd-h idx=" (number->string t-index)
                                      " arity=" (number->string (tree-arity parent))
-                                     " last?=" (if (== (+ 1 t-index) (tree-arity parent)) "y" "n")))
+                                     " last?=" (if (== (+ 1 t-index) (tree-arity parent)) "y" "n") "\n"))
                     (if (and parent (tree-is? parent 'document)
                              (== (+ 1 t-index) (tree-arity parent)))
                         ;; Last child in document: create a new paragraph
                         (begin
-                          (set-message "kbd-h" "last: insert-return")
+                          (debug-message "debug-io" "kbd-h last: insert-return\n")
                           (go-to (rcons parent-path (+ 1 t-index)))
                           (insert-return))
                         ;; Not last child: jump to next sibling
                         (begin
-                          (set-message "kbd-h" "not-last: goto")
+                          (debug-message "debug-io" "kbd-h not-last: goto\n")
                           (go-to (rcons parent-path (+ 1 t-index))))))))))
         ((cursor-in-algo-macro-condition-end? t)
-         (set-message "kbd-h" "cond-end")
+         (debug-message "debug-io" "kbd-h cond-end\n")
          (tree-go-to t 1))
         (else
-         (set-message "kbd-h" "else")
+         (debug-message "debug-io" "kbd-h else\n")
          (go-right)))
 ) ;tm-define
 

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -166,32 +166,55 @@
 
 (define (cursor-in-algo-macro-body-end? t)
   "Check if cursor is at the end of the body (last param) of algo-macro t"
+  (display* "DEBUG body-end? label=" (tree-label t)
+            " arity=" (tree-arity t)
+            " in-tags=" (tree-in? t algo-macro-tags) "\n")
   (and (tree-in? t algo-macro-tags)
        (>= (tree-arity t) 1)
        (let* ((body-idx (- (tree-arity t) 1))
               (path (cursor-path))
               (t-path (tree->path t)))
+         (display* "DEBUG body-end? path=" path " t-path=" t-path
+                   " body-idx=" body-idx "\n")
          (and t-path
               (> (length path) (length t-path))
               (== (list-ref path (length t-path)) body-idx)
               (let ((body (tm-ref t body-idx)))
+                (display* "DEBUG body-end? body-label=" (and body (tree-label body))
+                          " body-arity=" (and body (tree-arity body)) "\n")
                 (and body
                      (let ((body-path (tree->path body)))
                        (and body-path
-                            (or (== path (append body-path '(:end)))
+                            (or (begin
+                                  (display* "DEBUG body-end? check1="
+                                            (== path (append body-path '(:end))) "\n")
+                                  (== path (append body-path '(:end))))
                                 (and (> (tree-arity body) 0)
                                      (with last-child (tm-ref body (- (tree-arity body) 1))
+                                       (display* "DEBUG body-end? last-child-label="
+                                                 (and last-child (tree-label last-child)) "\n")
                                        (and last-child
                                             (with lc-path (tree->path last-child)
                                               (and lc-path
                                                    (> (length path) (length lc-path))
-                                                   (== (cAr path) :end)))))))))))))))
+                                                   (begin
+                                                     (display* "DEBUG body-end? cAr-path="
+                                                               (cAr path) "\n")
+                                                     (== (cAr path) :end)))))))))))))))
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
+  (display* "DEBUG kbd-h label=" (tree-label t)
+            " forwards=" forwards?
+            " listing=" (in-listing-context? t) "\n")
   (if (cursor-in-algo-macro-body-end? t)
-      (tree-go-to t :after)
-      (go-right))
+      (begin
+        (display* "DEBUG -> body-end, jump to :after\n")
+        (tree-go-to t (- (tree-arity t) 1) :end)
+        (go-right))
+      (begin
+        (display* "DEBUG -> go-right\n")
+        (go-right)))
 ) ;tm-define
 
 (tm-define (kbd-enter t shift?)

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -243,17 +243,20 @@
                         (begin
                           (debug-message "debug-io" "kbd-h last: insert-return\n")
                           (go-to (rcons parent-path (+ 1 t-index)))
+                          (debug-message "debug-io" (string-append "after goto path=" (object->string (cursor-path)) "\n"))
                           (insert-return))
                         ;; Not last child: jump to next sibling
                         (begin
                           (debug-message "debug-io" "kbd-h not-last: goto\n")
-                          (go-to (rcons parent-path (+ 1 t-index))))))))))
+                          (go-to (rcons parent-path (+ 1 t-index)))
+                          (debug-message "debug-io" (string-append "after goto path=" (object->string (cursor-path)) "\n")))))))))
         ((cursor-in-algo-macro-condition-end? t)
          (debug-message "debug-io" "kbd-h cond-end\n")
          (tree-go-to t 1))
         (else
          (debug-message "debug-io" "kbd-h else\n")
-         (go-right)))
+         (go-right)
+         (debug-message "debug-io" (string-append "after go-right path=" (object->string (cursor-path)) "\n"))))
 ) ;tm-define
 
 (tm-define (kbd-enter t shift?)

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -224,45 +224,75 @@
                                                      (or (== (cAr path) :end)
                                                          (is-end-relative-path? last-child rel-path)))))))))))))))))
 
+(define (cursor-in-algo-macro-body-empty-end? t)
+  "Check if the cursor is in the empty last line/paragraph of the body of algo-macro t"
+  (and (cursor-in-algo-macro-body-end? t)
+       (let* ((body-idx (- (tree-arity t) 1))
+              (body (tm-ref t body-idx)))
+         (and body (tree-is? body 'document)
+              (> (tree-arity body) 1)
+              (let* ((last-idx (- (tree-arity body) 1))
+                     (last-child (tm-ref body last-idx)))
+                (and (tree-empty? last-child)
+                     (let ((path (cursor-path))
+                           (lc-path (tree->path last-child)))
+                       (and path lc-path
+                            (list-starts? path lc-path)))))))))
+
 (tm-define (kbd-horizontal t forwards?)
-  (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
-  (debug-message "debug-io" (string-append "kbd-h t=" (symbol->string (tree-label t)) " fwd=" (if forwards? "y" "n") "\n"))
+  (:require (and forwards?
+                 (tree-in? t algo-macro-tags)
+                 (in-listing-context? t)
+                 (or (cursor-in-algo-macro-body-end? t)
+                     (cursor-in-algo-macro-condition-end? t))))
   (cond ((cursor-in-algo-macro-body-end? t)
          (with t-path (tree->path t)
            (and t-path
                 (with parent (tree-up t)
                   (let* ((parent-path (cDr t-path))
                          (t-index (cAr t-path)))
-                    (debug-message "debug-io"
-                      (string-append "kbd-h idx=" (number->string t-index)
-                                     " arity=" (number->string (tree-arity parent))
-                                     " last?=" (if (== (+ 1 t-index) (tree-arity parent)) "y" "n") "\n"))
-                    (if (and parent (tree-is? parent 'document)
-                             (== (+ 1 t-index) (tree-arity parent)))
-                        ;; Last child in document: create a new paragraph
+                    (if (< (+ 1 t-index) (tree-arity parent))
+                        (let ((sibling (tm-ref parent (+ 1 t-index))))
+                          (if (and sibling (tree-in? sibling algo-macro-tags))
+                              (begin
+                                (display* "kbd-h body-end -> go-to sibling body\n")
+                                (tree-go-to sibling 0))
+                              (begin
+                                (display* "kbd-h body-end -> go-to sibling paragraph\n")
+                                (go-to (tree->path sibling)))))
                         (begin
-                          (debug-message "debug-io" "kbd-h last: insert-return\n")
-                          (go-to (rcons parent-path (+ 1 t-index)))
-                          (debug-message "debug-io" (string-append "after goto path=" (object->string (cursor-path)) "\n"))
-                          (insert-return))
-                        ;; Not last child: jump to next sibling
-                        (begin
-                          (debug-message "debug-io" "kbd-h not-last: goto\n")
-                          (go-to (rcons parent-path (+ 1 t-index)))
-                          (debug-message "debug-io" (string-append "after goto path=" (object->string (cursor-path)) "\n")))))))))
+                          (display* "kbd-h body-end -> go-to end of parent\n")
+                          (go-to (rcons parent-path (+ 1 t-index))))))))))
         ((cursor-in-algo-macro-condition-end? t)
-         (debug-message "debug-io" "kbd-h cond-end\n")
-         (tree-go-to t 1))
-        (else
-         (debug-message "debug-io" "kbd-h else\n")
-         (go-right)
-         (debug-message "debug-io" (string-append "after go-right path=" (object->string (cursor-path)) "\n"))))
+         (display* "kbd-h cond-end -> go-to body\n")
+         (tree-go-to t 1)))
 ) ;tm-define
 
 (tm-define (kbd-enter t shift?)
   (:require (and (not shift?) (cursor-in-algo-macro-first-param? t)))
   (with macro (find-algo-macro-ancestor t) (tree-go-to macro 0 :end) (go-right))
 ) ;tm-define
+
+(tm-define (kbd-enter t shift?)
+  (:require (and (not shift?)
+                 (in-listing-context? t)
+                 (with macro (find-algo-macro-ancestor t)
+                   (and macro (cursor-in-algo-macro-body-empty-end? macro)))))
+  (with macro (find-algo-macro-ancestor t)
+    (with t-path (tree->path macro)
+      (and t-path
+           (with parent (tree-up macro)
+             (and parent
+                  (let* ((parent-path (cDr t-path))
+                         (t-index (cAr t-path))
+                         (body-idx (- (tree-arity macro) 1))
+                         (body (tm-ref macro body-idx))
+                         (last-idx (- (tree-arity body) 1)))
+                    (display* "kbd-enter body-empty-end -> remove empty line & insert sibling\n")
+                    (tree-remove! body last-idx 1)
+                    (tree-insert! parent (+ 1 t-index) '((concat "")))
+                    (go-to (rcons parent-path (+ 1 t-index))))))))))
+ ;tm-define
 
 (tm-define (kbd-control-enter t shift?)
   (and-with p (tree-outer t) (kbd-control-enter p shift?))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -202,7 +202,7 @@
                                                    (begin
                                                      (display* "DEBUG body-end? cAr-path="
                                                                (cAr path) "\n")
-                                                     (== (cAr path) :end)))))))))))))))
+                                                     (== (cAr path) :end))))))))))))))))
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -109,7 +109,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define algo-macro-tags
-  '(algo-if algo-else-if
+  '(algo-if algo-else-if algo-else
      algo-while
      algo-for
      algo-for-all
@@ -163,6 +163,36 @@
     ) ;with
   ) ;and
 ) ;define
+
+(define (cursor-in-algo-macro-body-end? t)
+  "Check if cursor is at the end of the body (last param) of algo-macro t"
+  (and (tree-in? t algo-macro-tags)
+       (>= (tree-arity t) 1)
+       (let* ((body-idx (- (tree-arity t) 1))
+              (path (cursor-path))
+              (t-path (tree->path t)))
+         (and t-path
+              (> (length path) (length t-path))
+              (== (list-ref path (length t-path)) body-idx)
+              (let ((body (tm-ref t body-idx)))
+                (and body
+                     (let ((body-path (tree->path body)))
+                       (and body-path
+                            (or (== path (append body-path '(:end)))
+                                (and (> (tree-arity body) 0)
+                                     (with last-child (tm-ref body (- (tree-arity body) 1))
+                                       (and last-child
+                                            (with lc-path (tree->path last-child)
+                                              (and lc-path
+                                                   (> (length path) (length lc-path))
+                                                   (== (cAr path) :end)))))))))))))))
+
+(tm-define (kbd-horizontal t forwards?)
+  (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
+  (if (cursor-in-algo-macro-body-end? t)
+      (tree-go-to t :after)
+      (go-right))
+) ;tm-define
 
 (tm-define (kbd-enter t shift?)
   (:require (and (not shift?) (cursor-in-algo-macro-first-param? t)))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -226,23 +226,33 @@
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
+  (set-message "kbd-h" (string-append "t=" (symbol->string (tree-label t)) " fwd=" (if forwards? "y" "n")))
   (cond ((cursor-in-algo-macro-body-end? t)
          (with t-path (tree->path t)
            (and t-path
                 (with parent (tree-up t)
                   (let* ((parent-path (cDr t-path))
                          (t-index (cAr t-path)))
+                    (set-message "kbd-h"
+                      (string-append "idx=" (number->string t-index)
+                                     " arity=" (number->string (tree-arity parent))
+                                     " last?=" (if (== (+ 1 t-index) (tree-arity parent)) "y" "n")))
                     (if (and parent (tree-is? parent 'document)
                              (== (+ 1 t-index) (tree-arity parent)))
                         ;; Last child in document: create a new paragraph
                         (begin
+                          (set-message "kbd-h" "last: insert-return")
                           (go-to (rcons parent-path (+ 1 t-index)))
                           (insert-return))
                         ;; Not last child: jump to next sibling
-                        (go-to (rcons parent-path (+ 1 t-index)))))))))
+                        (begin
+                          (set-message "kbd-h" "not-last: goto")
+                          (go-to (rcons parent-path (+ 1 t-index))))))))))
         ((cursor-in-algo-macro-condition-end? t)
+         (set-message "kbd-h" "cond-end")
          (tree-go-to t 1))
         (else
+         (set-message "kbd-h" "else")
          (go-right)))
 ) ;tm-define
 

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -121,6 +121,10 @@
      algo-if-else-if)
 ) ;define
 
+(define algo-no-cond-macros
+  '(algo-else algo-loop algo-body algo-begin algo-inputs algo-outputs)
+) ;define
+
 (define (in-listing-context? t)
   (and t (tree-search-upwards t (lambda (n) (tree-in? n '(listing)))))
 ) ;define
@@ -238,6 +242,129 @@
                            (lc-path (tree->path last-child)))
                        (and path lc-path
                             (list-starts? path lc-path)))))))))
+
+(define (is-start-relative-path? t path)
+  "Check if path (relative to t) points to the start of t"
+  (cond ((null? path) #t)
+        ((== path '(:start)) #t)
+        ((and (== (length path) 1)
+              (integer? (car path))
+              (== (car path) 0)) #t)
+        ((and (> (length path) 1)
+              (integer? (car path))
+              (== (car path) 0))
+         (with child (tm-ref t 0)
+           (and child
+                (is-start-relative-path? child (cdr path)))))
+        (else #f)))
+
+(define (cursor-in-algo-macro-first-arg-start? t)
+  "Check if cursor is at the start of the first argument of algo-macro t"
+  (and (tree-in? t algo-macro-tags)
+       (>= (tree-arity t) 1)
+       (let* ((first-idx 0)
+              (path (cursor-path))
+              (t-path (tree->path t)))
+         (and t-path
+              (> (length path) (length t-path))
+              (== (list-ref path (length t-path)) first-idx)
+              (let ((first-arg (tm-ref t first-idx)))
+                (and first-arg
+                     (let ((arg-path (tree->path first-arg)))
+                       (and arg-path
+                            (>= (length path) (length arg-path))
+                            (is-start-relative-path? first-arg
+                              (list-tail path (length arg-path)))))))))))
+
+(define (cursor-at-algo-macro-start? t)
+  "Check if the cursor is at the start of algo-macro t"
+  (and (tree-in? t algo-macro-tags)
+       (in-listing-context? t)
+       (with t-path (tree->path t)
+         (and t-path (== (cursor-path) t-path)))))
+
+(define (cursor-in-algo-macro-body-first-line? t)
+  "Check if cursor is on the first line of the body of a no-cond algo-macro t"
+  (and (tree-in? t algo-no-cond-macros)
+       (in-listing-context? t)
+       (let* ((body-idx 0)
+              (path (cursor-path))
+              (t-path (tree->path t)))
+         (and t-path
+              (> (length path) (length t-path))
+              (== (list-ref path (length t-path)) body-idx)
+              (let ((body (tm-ref t body-idx)))
+                (and body
+                     (let ((body-path (tree->path body)))
+                       (and body-path
+                            (if (tree-is? body 'document)
+                                (and (> (tree-arity body) 0)
+                                     (list-starts? path (append body-path '(0))))
+                                #t)))))))))
+
+(tm-define (kbd-horizontal t forwards?)
+  (:require (and (not forwards?)
+                 (tree-in? t algo-macro-tags)
+                 (in-listing-context? t)
+                 (or (cursor-in-algo-macro-first-arg-start? t)
+                     (cursor-at-algo-macro-start? t))))
+  (with t-path (tree->path t)
+    (and t-path
+         (with parent (tree-up t)
+           (let* ((parent-path (cDr t-path))
+                  (t-index (cAr t-path)))
+             (if (> t-index 0)
+                 (let ((sibling (tm-ref parent (- t-index 1))))
+                   (if (and sibling (tree-in? sibling algo-macro-tags))
+                       (begin
+                         (display* "kbd-h backwards -> go-to sibling body end\n")
+                         (tree-go-to sibling (- (tree-arity sibling) 1) :end))
+                       (begin
+                         (display* "kbd-h backwards -> go-to sibling paragraph\n")
+                         (go-to (tree->path sibling)))))
+                 (begin
+                   (display* "kbd-h backwards -> go-to start of parent\n")
+                   (go-to parent-path))))))))
+
+(tm-define (kbd-horizontal t forwards?)
+  (:require (and forwards?
+                 (tree-in? t algo-no-cond-macros)
+                 (in-listing-context? t)
+                 (cursor-at-algo-macro-start? t)))
+  (display* "kbd-h forwards at start -> go-to body\n")
+  (tree-go-to t 0))
+
+(tm-define (kbd-vertical t downwards?)
+  (:require (and (not downwards?)
+                 (tree-in? t algo-no-cond-macros)
+                 (in-listing-context? t)
+                 (or (cursor-in-algo-macro-body-first-line? t)
+                     (cursor-at-algo-macro-start? t))))
+  (with t-path (tree->path t)
+    (and t-path
+         (with parent (tree-up t)
+           (let* ((parent-path (cDr t-path))
+                  (t-index (cAr t-path)))
+             (if (> t-index 0)
+                 (let ((sibling (tm-ref parent (- t-index 1))))
+                   (if (and sibling (tree-in? sibling algo-macro-tags))
+                       (begin
+                         (display* "kbd-v upwards -> go-to sibling body end\n")
+                         (tree-go-to sibling (- (tree-arity sibling) 1) :end))
+                       (begin
+                         (display* "kbd-v upwards -> go-to sibling paragraph\n")
+                         (go-to (tree->path sibling)))))
+                 (begin
+                   (display* "kbd-v upwards -> go-to start of parent\n")
+                   (go-to parent-path))))))))
+
+(tm-define (kbd-vertical t downwards?)
+  (:require (and downwards?
+                 (tree-in? t algo-no-cond-macros)
+                 (in-listing-context? t)
+                 (cursor-at-algo-macro-start? t)))
+  (display* "kbd-v downwards at start -> go-to body\n")
+  (tree-go-to t 0))
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards?

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -226,11 +226,7 @@
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
-  (write (list 'kbd-horizontal-algo (tree-label t) forwards? (cursor-path)))
-  (newline)
   (cond ((cursor-in-algo-macro-body-end? t)
-         (write (list 'body-end (tree-label t)))
-         (newline)
          (with t-path (tree->path t)
            (and t-path
                 (with parent (tree-up t)
@@ -240,19 +236,13 @@
                              (== (+ 1 t-index) (tree-arity parent)))
                         ;; Last child in document: create a new paragraph
                         (begin
-                          (write (list 'last-child t-index (tree-arity parent)))
-                          (newline)
                           (go-to (rcons parent-path (+ 1 t-index)))
                           (insert-return))
                         ;; Not last child: jump to next sibling
-                        (go-to (rcons parent-path (+ 1 t-index))))))))))
+                        (go-to (rcons parent-path (+ 1 t-index)))))))))
         ((cursor-in-algo-macro-condition-end? t)
-         (write (list 'condition-end (tree-label t)))
-         (newline)
          (tree-go-to t 1))
         (else
-         (write (list 'else (tree-label t)))
-         (newline)
          (go-right)))
 ) ;tm-define
 

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -78,9 +78,7 @@
 ) ;tm-define
 
 (tm-define (kbd-left) (kbd-horizontal (focus-tree) #f))
-(tm-define (kbd-right)
-  (display* "DEBUG kbd-right focus=" (tree-label (focus-tree)) "\n")
-  (kbd-horizontal (focus-tree) #t))
+(tm-define (kbd-right) (kbd-horizontal (focus-tree) #t))
 (tm-define (kbd-up) (kbd-vertical (focus-tree) #f))
 (tm-define (kbd-down) (kbd-vertical (focus-tree) #t))
 (tm-define (kbd-start-line) (kbd-extremal (focus-tree) #f))
@@ -166,65 +164,77 @@
   ) ;and
 ) ;define
 
+(define (is-end-relative-path? t path)
+  "Check if path (relative to t) points to the end or :after of t"
+  (cond ((null? path) #f)
+        ((== path '(:end)) #t)
+        ((and (== (length path) 1)
+              (integer? (car path))
+              (if (tree-atomic? t)
+                  (== (car path) (string-length (tree->string t)))
+                  (== (car path) (tree-arity t)))) #t)
+        ((and (> (length path) 1)
+              (integer? (car path))
+              (< (car path) (tree-arity t)))
+         (with child (tm-ref t (car path))
+           (and child
+                (is-end-relative-path? child (cdr path)))))
+        (else #f)))
+
+(define (cursor-in-algo-macro-condition-end? t)
+  "Check if cursor is at the end of the condition (first param) of algo-macro t"
+  (and (tree-in? t algo-macro-tags)
+       (>= (tree-arity t) 2)
+       (let* ((cond-idx 0)
+              (path (cursor-path))
+              (t-path (tree->path t)))
+         (and t-path
+              (> (length path) (length t-path))
+              (== (list-ref path (length t-path)) cond-idx)
+              (let ((cond-arg (tm-ref t cond-idx)))
+                (and cond-arg
+                     (let ((cond-path (tree->path cond-arg)))
+                       (and cond-path
+                            (>= (length path) (length cond-path))
+                            (is-end-relative-path? cond-arg
+                              (list-tail path (length cond-path)))))))))))
+
 (define (cursor-in-algo-macro-body-end? t)
   "Check if cursor is at the end of the body (last param) of algo-macro t"
-  (display* "DEBUG body-end? label=" (tree-label t)
-            " arity=" (tree-arity t)
-            " in-tags=" (tree-in? t algo-macro-tags) "\n")
   (and (tree-in? t algo-macro-tags)
        (>= (tree-arity t) 1)
        (let* ((body-idx (- (tree-arity t) 1))
               (path (cursor-path))
               (t-path (tree->path t)))
-         (display* "DEBUG body-end? path=" path " t-path=" t-path
-                   " body-idx=" body-idx "\n")
          (and t-path
               (> (length path) (length t-path))
               (== (list-ref path (length t-path)) body-idx)
               (let ((body (tm-ref t body-idx)))
-                (display* "DEBUG body-end? body-label=" (and body (tree-label body))
-                          " body-arity=" (and body (tree-arity body)) "\n")
                 (and body
                      (let ((body-path (tree->path body)))
                        (and body-path
-                            (or (begin
-                                  (display* "DEBUG body-end? check1="
-                                            (== path (append body-path '(:end))) "\n")
-                                  (== path (append body-path '(:end))))
+                            (or (== path (append body-path '(:end)))
                                 (and (> (tree-arity body) 0)
                                      (with last-child (tm-ref body (- (tree-arity body) 1))
-                                       (display* "DEBUG body-end? last-child-label="
-                                                 (and last-child (tree-label last-child)) "\n")
                                        (and last-child
                                             (with lc-path (tree->path last-child)
                                               (and lc-path
                                                    (> (length path) (length lc-path))
                                                    (let ((rel-path (list-tail path (length lc-path))))
-                                                     (display* "DEBUG body-end? rel-path="
-                                                               rel-path " arity="
-                                                               (tree-arity last-child) "\n")
                                                      (or (== (cAr path) :end)
-                                                         (and (== (length rel-path) 1)
-                                                              (integer? (car rel-path))
-                                                              (== (car rel-path) (tree-arity last-child)))))))))))))))))))
+                                                         (is-end-relative-path? last-child rel-path)))))))))))))))))
 
 (tm-define (kbd-horizontal t forwards?)
   (:require (and forwards? (tree-in? t algo-macro-tags) (in-listing-context? t)))
-  (display* "DEBUG kbd-h label=" (tree-label t)
-            " forwards=" forwards?
-            " listing=" (in-listing-context? t) "\n")
-  (if (cursor-in-algo-macro-body-end? t)
-      (begin
-        (display* "DEBUG -> body-end, jump to :after\n")
-        (with t-path (tree->path t)
-          (and t-path
-               (let ((parent-path (cDr t-path))
-                     (t-index (cAr t-path)))
-                 (go-to (rcons parent-path (+ 1 t-index))))))
-        (display* "DEBUG after go-to path=" (cursor-path) "\n"))
-      (begin
-        (display* "DEBUG -> go-right\n")
-        (go-right)))
+  (cond ((cursor-in-algo-macro-body-end? t)
+         (with t-path (tree->path t)
+           (and t-path
+                (let ((parent-path (cDr t-path))
+                      (t-index (cAr t-path)))
+                  (go-to (rcons parent-path (+ 1 t-index)))))))
+        ((cursor-in-algo-macro-condition-end? t)
+         (tree-go-to t 1))
+        (else (go-right)))
 ) ;tm-define
 
 (tm-define (kbd-enter t shift?)

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -78,7 +78,9 @@
 ) ;tm-define
 
 (tm-define (kbd-left) (kbd-horizontal (focus-tree) #f))
-(tm-define (kbd-right) (kbd-horizontal (focus-tree) #t))
+(tm-define (kbd-right)
+  (display* "DEBUG kbd-right focus=" (tree-label (focus-tree)) "\n")
+  (kbd-horizontal (focus-tree) #t))
 (tm-define (kbd-up) (kbd-vertical (focus-tree) #f))
 (tm-define (kbd-down) (kbd-vertical (focus-tree) #t))
 (tm-define (kbd-start-line) (kbd-extremal (focus-tree) #f))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -229,12 +229,21 @@
   (cond ((cursor-in-algo-macro-body-end? t)
          (with t-path (tree->path t)
            (and t-path
-                (let ((parent-path (cDr t-path))
-                      (t-index (cAr t-path)))
-                  (go-to (rcons parent-path (+ 1 t-index)))))))
+                (with parent (tree-up t)
+                  (let* ((parent-path (cDr t-path))
+                         (t-index (cAr t-path)))
+                    (if (and parent (tree-is? parent 'document)
+                             (== (+ 1 t-index) (tree-arity parent)))
+                        ;; Last child in document: create a new paragraph
+                        (begin
+                          (go-to (rcons parent-path (+ 1 t-index)))
+                          (insert-return))
+                        ;; Not last child: jump to next sibling
+                        (go-to (rcons parent-path (+ 1 t-index))))))))
         ((cursor-in-algo-macro-condition-end? t)
          (tree-go-to t 1))
-        (else (go-right)))
+        (else
+         (go-right)))
 ) ;tm-define
 
 (tm-define (kbd-enter t shift?)

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -216,11 +216,12 @@
   (if (cursor-in-algo-macro-body-end? t)
       (begin
         (display* "DEBUG -> body-end, jump to :after\n")
-        (with body (tm-ref t (- (tree-arity t) 1))
-          (tree-go-to body :end)
-          (display* "DEBUG after tree-go-to path=" (cursor-path) "\n"))
-        (go-right)
-        (display* "DEBUG after go-right path=" (cursor-path) "\n"))
+        (with t-path (tree->path t)
+          (and t-path
+               (let ((parent-path (cDr t-path))
+                     (t-index (cAr t-path)))
+                 (go-to (rcons parent-path (+ 1 t-index))))))
+        (display* "DEBUG after go-to path=" (cursor-path) "\n"))
       (begin
         (display* "DEBUG -> go-right\n")
         (go-right)))

--- a/TeXmacs/tests/tmu/209_21.tmu
+++ b/TeXmacs/tests/tmu/209_21.tmu
@@ -1,4 +1,4 @@
-<TMU|<tuple|1.1.0|2026.2.3>>
+<TMU|<tuple|1.1.0|2026.2.5>>
 
 <style|<tuple|generic|chinese|number-europe|modern-program|python>>
 
@@ -127,15 +127,17 @@
     </python-code>
   </listing>
 
-  <\algo-if|<math|N> is even>
-    <algo-state|<math|X\<leftarrow\>X\<times\>X>>
-  </algo-if>
-
   <\listing>
+    <\algo-if|<math|N\<gtr\>2>>
+      <math|X\<leftarrow\>X+1>
+    </algo-if>
+
     <\algo-else>
       <algo-state|<math|X\<leftarrow\>X\<times\>X>>
     </algo-else>
   </listing>
+
+  \;
 
   \;
 </body>

--- a/TeXmacs/tests/tmu/209_21.tmu
+++ b/TeXmacs/tests/tmu/209_21.tmu
@@ -131,6 +131,12 @@
     <algo-state|<math|X\<leftarrow\>X\<times\>X>>
   </algo-if>
 
+  <\listing>
+    <\algo-else>
+      <algo-state|<math|X\<leftarrow\>X\<times\>X>>
+    </algo-else>
+  </listing>
+
   \;
 </body>
 

--- a/devel/209_21.md
+++ b/devel/209_21.md
@@ -139,13 +139,31 @@
    - 条件末尾：跳到 body 参数开头
    - 其他情况：默认 `go-right`
 
+## 2026/05/21 修复 body 末尾右键跳出 listing 的问题
+
+### What
+修复在 `listing` 环境中的 `algo-if`、`algo-while`、`algo-for`、`algo-else` 等宏的 body 末尾按 **方向键右键** 时，如果该宏是 `document` 的最后一个子节点，光标会直接跳出 `listing` 环境的问题。
+
+### Why
+之前的修复在 body 末尾按右键时，直接跳到父 `document` 中该宏之后的下一个位置（`(rcons parent-path (+ 1 t-index))`）。如果该宏是 `document` 的最后一个子节点，这个位置就是 `document` 的 `:after`。在 `listing` 环境中，`document` 的 `:after` 在视觉上等同于退出了可编辑区域，用户无法继续输入新行。
+
+### How
+在 `TeXmacs/progs/generic/generic-edit.scm` 中修改 `kbd-horizontal` 的 body-end 分支：
+
+1. **判断是否为最后一个子节点**：通过 `(== (+ 1 t-index) (tree-arity parent))` 判断该算法宏是否是父 `document` 的最后一个子节点
+2. **如果是最后一个子节点**：先 `go-to` 到 `document` 的 `:after`，然后调用 `insert-return` 在 `document` 末尾创建一个新的空段落。这样光标会停在新段落的开头，保留在 `listing` 内，用户可以直接输入下一行
+3. **如果不是最后一个子节点**：保持原来的行为，跳到下一个兄弟节点（如 `algo-else`）
+
+同时移除了所有 DEBUG 日志，恢复代码整洁。
+
 ### 涉及文件
 - `TeXmacs/progs/utils/misc/markup-funcs.scm`
   - 新增 `is-algo-macro?`、`wrap-algo-macro`、`build-if-else-if`、`build-else-if`、`wrap-algo-body`、`indent-lines`
   - 修改 `ext-numbered`/`ext-numbered-prog`：对算法宏单独处理，其余沿用原逻辑
 - `TeXmacs/progs/generic/generic-edit.scm`
   - 新增算法宏 Enter 键导航（`algo-macro-tags`、`find-algo-macro-ancestor`、`cursor-in-algo-macro-first-param?`、`kbd-enter`）
-  - 新增算法宏方向键右键导航（`cursor-in-algo-macro-body-end?`、`kbd-horizontal`）
+  - 新增算法宏方向键右键导航（`is-end-relative-path?`、`cursor-in-algo-macro-body-end?`、`cursor-in-algo-macro-condition-end?`、`kbd-horizontal`）
+  - 2026/05/21 修复：body 末尾右键时如果是最后一个子节点则 `insert-return` 创建新段落
 - `TeXmacs/progs/prog/prog-menu.scm`
   - 菜单项 "Algorithm" 从 `specified-algorithm` 改为 `algorithm`
 - `TeXmacs/tests/tmu/209_21.tmu`

--- a/devel/209_21.md
+++ b/devel/209_21.md
@@ -1,4 +1,4 @@
-# [209_21] 修复 algorithm 环境中 listing 行号缺失问题
+# [209_21] 修复 algorithm 环境中 listing 行号缺失及导航体验问题
 
 ## 如何测试
 
@@ -15,9 +15,12 @@
    - 在条件参数中按 **Enter**，光标应跳到 body 参数（而不是插入换行）
    - 同样测试 `\algo-while`、`\algo-for` 等宏
 5. **方向键右键导航测试**：
-   - 在 `listing` 环境中插入 `\algo-if`，按 Enter 进入 body，输入一行内容（如 `\algo-state`）
-   - 在 body 行末尾按 **方向键右键**，光标应直接退出 `\algo-if` 并保留在 `\listing` 中（不会跳出 `listing`）
-   - 此时按 **回车**，应能在 `\listing` 中创建新的一行（有连续行号）
+   - 在 `listing` 环境中插入 `\algo-if`，输入条件后按 Enter 进入 body，再输入一行内容（如 `\algo-state`）
+   - **关键：此时光标位于 body 行内部（如 `algo-state` 的文本末尾）**
+   - 按 **方向键右键** 一次，光标应直接跳到 `\algo-if` 之后，保留在 `\listing` 的 `document` 中
+   - **验证方法**：此时再按一次右键，光标不应跳出 `\listing`（因为 `\algo-if` 后面还有空间可以继续输入）
+   - 在 `\algo-if` 之后按 **回车**，应能在 `\listing` 中创建新的一行（有连续行号）
+   - 同样测试 `\algo-else`：在 `listing` 中插入 `\algo-else`，输入 body 内容，在 body 末尾按右键，光标应跳到 `\algo-else` 之后保留在 `listing` 中
    - 同样测试 `\algo-while`、`\algo-for` 等宏
 6. **Python 代码高亮测试**：
    - 文件末尾有一个 `\listing` 包裹的 `\python-code` 块
@@ -65,7 +68,7 @@
 1. **定义 `algo-macro-tags`**：列出所有需要 Enter 导航的算法宏标签
 2. **定义 `find-algo-macro-ancestor`**：从光标位置向上查找最近的算法宏祖先（最多检查2层，避免性能开销）
 3. **定义 `cursor-in-algo-macro-first-param?`**：判断光标是否在算法宏的**第一个参数**中
-4. **新增 `kbd-enter` 多态定义**：当满足条件时，调用 `tree-go-to macro 1 :start` 跳到第二个参数
+4. **新增 `kbd-enter` 多态定义**：当满足条件时，调用 `(tree-go-to macro 0 :end) (go-right)` 从第一个参数的末尾跳到 body 参数的开头
 
 **性能优化**：`find-algo-macro-ancestor` 只检查直接父节点和祖父节点（最多2层）。算法宏的参数很少嵌套超过2层，这样大多数 Enter 按键（在普通文本中）只需常数时间即可返回 `#f`，不会遍历整棵树。
 
@@ -100,11 +103,13 @@
 1. **新增 `cursor-in-algo-macro-body-end?`**：判断光标是否在当前算法宏的最后一个参数（body）的末尾
 2. **新增 `kbd-horizontal` 多态定义**：当满足以下条件时
    - 按的是 **右键**（`forwards?` 为 `#t`）
-   - 当前节点是算法宏（`algo-if`、`algo-while` 等）
+   - 当前节点是算法宏（`algo-if`、`algo-while`、`algo-else` 等）
    - 在 `listing` 环境中
    - 光标在该算法宏的 body 末尾
    
-   直接调用 `(tree-go-to t :after)`，将光标跳到算法宏之后（保留在 `listing` 内），而不是继续默认的递归向上行为。
+   先调用 `(tree-go-to t body-idx :end)` 将光标跳到 body 参数的末尾，再调用 `(go-right)` 一步到达算法宏的 `:after`（保留在 `listing` 内），而不是继续默认的递归向上行为。
+
+   **注意**：不能直接调用 `(tree-go-to t :after)`，因为 `tree->path` 不支持 `:after` 位置，会返回 `#f` 导致 `tree-go-to` 不执行任何操作，光标未移动，默认递归行为会继续把光标送出 `listing`。
 
 3. 如果光标在算法宏内部但不在 body 末尾（如在条件参数中、或在 body 中间），则调用 `(go-right)` 保持默认的单步右移行为。
 

--- a/devel/209_21.md
+++ b/devel/209_21.md
@@ -14,11 +14,16 @@
    - 在 `algorithm` 环境中插入 `\algo-if`，输入条件（如 `N > 0`）
    - 在条件参数中按 **Enter**，光标应跳到 body 参数（而不是插入换行）
    - 同样测试 `\algo-while`、`\algo-for` 等宏
-5. **Python 代码高亮测试**：
+5. **方向键右键导航测试**：
+   - 在 `listing` 环境中插入 `\algo-if`，按 Enter 进入 body，输入一行内容（如 `\algo-state`）
+   - 在 body 行末尾按 **方向键右键**，光标应直接退出 `\algo-if` 并保留在 `\listing` 中（不会跳出 `listing`）
+   - 此时按 **回车**，应能在 `\listing` 中创建新的一行（有连续行号）
+   - 同样测试 `\algo-while`、`\algo-for` 等宏
+6. **Python 代码高亮测试**：
    - 文件末尾有一个 `\listing` 包裹的 `\python-code` 块
    - 确认 `import numpy as np` 有 Python 语法高亮（关键字、字符串等颜色正确）
    - 确认行号正常显示
-6. **菜单项验证**：
+7. **菜单项验证**：
    - 点击菜单 **Insert → Code → Algorithm** 插入一个算法环境
    - 按 `Ctrl+Backslash` 切换到源码模式（或菜单 **Document → Source → Edit source tree**）
    - 确认源码中显示的是 `<\algorithm>` 而不是 `<\specified-algorithm>`
@@ -81,13 +86,38 @@
 
 `indent*` 宏通过增加 `par-left`（段落左缩进）来实现缩进，与原始 `algo-if` 等宏的 `<indent|<arg|body>>` 行为一致。嵌套的算法宏会累加缩进，符合预期。
 
+## 2026/05/20 添加算法宏方向键右键导航
+
+### What
+在 `listing` 环境中的 `algo-if`、`algo-while`、`algo-for` 等宏的 body 末尾按 **方向键右键**，光标直接退出该算法宏并保留在 `listing` 环境中，而不会继续跳出 `listing`。
+
+### Why
+用户在算法宏的 body 中编辑完后，通常想退出该宏并在 `listing` 中继续输入下一行。但默认行为中，从 body 末尾按右键需要经过多个中间位置（body document 的 `:after`、算法宏的 `:after`、listing document 的 `:after` 等），很容易按过头直接跳出 `listing`。特别是在 `listing` 中只有该算法宏一行时，从 body 中出来后再按一次右键就直接退出了 `listing`，用户体验很差。
+
+### How
+在 `TeXmacs/progs/generic/generic-edit.scm` 中：
+
+1. **新增 `cursor-in-algo-macro-body-end?`**：判断光标是否在当前算法宏的最后一个参数（body）的末尾
+2. **新增 `kbd-horizontal` 多态定义**：当满足以下条件时
+   - 按的是 **右键**（`forwards?` 为 `#t`）
+   - 当前节点是算法宏（`algo-if`、`algo-while` 等）
+   - 在 `listing` 环境中
+   - 光标在该算法宏的 body 末尾
+   
+   直接调用 `(tree-go-to t :after)`，将光标跳到算法宏之后（保留在 `listing` 内），而不是继续默认的递归向上行为。
+
+3. 如果光标在算法宏内部但不在 body 末尾（如在条件参数中、或在 body 中间），则调用 `(go-right)` 保持默认的单步右移行为。
+
+这样用户从算法宏 body 中按一次右键就能直接停在 `listing` 中该宏之后的位置，接着按回车即可在 `listing` 中创建新行。
+
 ### 涉及文件
 - `TeXmacs/progs/utils/misc/markup-funcs.scm`
   - 新增 `is-algo-macro?`、`wrap-algo-macro`、`build-if-else-if`、`build-else-if`、`wrap-algo-body`、`indent-lines`
   - 修改 `ext-numbered`/`ext-numbered-prog`：对算法宏单独处理，其余沿用原逻辑
 - `TeXmacs/progs/generic/generic-edit.scm`
   - 新增算法宏 Enter 键导航（`algo-macro-tags`、`find-algo-macro-ancestor`、`cursor-in-algo-macro-first-param?`、`kbd-enter`）
+  - 新增算法宏方向键右键导航（`cursor-in-algo-macro-body-end?`、`kbd-horizontal`）
 - `TeXmacs/progs/prog/prog-menu.scm`
   - 菜单项 "Algorithm" 从 `specified-algorithm` 改为 `algorithm`
 - `TeXmacs/tests/tmu/209_21.tmu`
-  - 新增测试文件，包含 algorithm 行号测试和 Python 代码高亮测试
+  - 新增测试文件，包含 algorithm 行号测试、Python 代码高亮测试和方向键导航测试

--- a/devel/209_21.md
+++ b/devel/209_21.md
@@ -22,6 +22,7 @@
    - 在 `\algo-if` 之后按 **回车**，应能在 `\listing` 中创建新的一行（有连续行号）
    - 同样测试 `\algo-else`：在 `listing` 中插入 `\algo-else`，输入 body 内容，在 body 末尾按右键，光标应跳到 `\algo-else` 之后保留在 `listing` 中
    - 同样测试 `\algo-while`、`\algo-for` 等宏
+   - **无条件算法宏边界与防止超长光标测试**：打开测试文件第 130-138 行的 `\algo-if` + `\algo-else` 案例，在 `\algo-else` 的 body 内将光标移至最前端（即 `X` 的左边），按下 **向左方向键** (Left) 或 **向上方向键** (Up)，光标应智能绕过只读的 `else` 行本级，直接跳入前一个 `\algo-if` 的 body 的末尾（即 `X+1` 的 `1` 后面）。而当在 `\algo-if` 的 body 尾部（`1` 后面）按下 **向下方向键** 或 **向右方向键** 时，光标能够自动跳转进入 `\algo-else` 的 body 内部，在任何情况下均无法通过方向键停留并在只读的 `else` 行本级进行绘制（彻底消除超长光标展现）。
    - **嵌套原子节点测试**：打开测试文件第 130-138 行的 `\algo-if` + `\algo-else` 案例，在 `\algo-if` 的 body 中有一个 `<math|X\<leftarrow\>X+1>`。将光标放到 `+1` 的 `1` 后面，按 **右键**，光标应正确跳到 `\algo-if` 之后并保留在 `\listing` 内，而不是直接跳出 `\listing`
 6. **Python 代码高亮测试**：
    - 文件末尾有一个 `\listing` 包裹的 `\python-code` 块

--- a/devel/209_21.md
+++ b/devel/209_21.md
@@ -139,32 +139,59 @@
    - 条件末尾：跳到 body 参数开头
    - 其他情况：默认 `go-right`
 
-## 2026/05/21 修复 body 末尾右键跳出 listing 的问题
+## 2026/05/21 优雅修复算法宏导航和换行逻辑（重构/避免临时 workaround）
 
 ### What
-修复在 `listing` 环境中的 `algo-if`、`algo-while`、`algo-for`、`algo-else` 等宏的 body 末尾按 **方向键右键** 时，如果该宏是 `document` 的最后一个子节点，光标会直接跳出 `listing` 环境的问题。
+1. 重构算法宏右方向键导航逻辑 (`kbd-horizontal`)：去除所有临时调试日志与任何会导致文档内容改变的副作用（如在导航键上调用 `insert-return` 插入新行），仅执行纯粹的光标跳转，让纯导航键保持只读、无副作用。
+2. 重构多态分发：精细化 `kbd-horizontal` 的 `:require` 条件，使其仅在光标确实位于条件末尾或 body 末尾时触发。这样在条件内部或 body 内部按右键时将交由 TeXmacs/Mogan 默认的水平移动分发，从而完美支持内部嵌套子节点（如 math 公式等数学环境）的正常编辑和选中。
+3. 引入优雅的回车退出机制（`kbd-enter`）：在 `listing` 环境内的算法宏（如 `algo-if`, `algo-while` 等）的 body 最后一个空白行按 **回车 (Enter)** 时，会自动删除 body 的该空白行并自动退至算法宏外，在父级 `listing` 中插入新的一行，且将光标精准移入该新行。
 
 ### Why
-之前的修复在 body 末尾按右键时，直接跳到父 `document` 中该宏之后的下一个位置（`(rcons parent-path (+ 1 t-index))`）。如果该宏是 `document` 的最后一个子节点，这个位置就是 `document` 的 `:after`。在 `listing` 环境中，`document` 的 `:after` 在视觉上等同于退出了可编辑区域，用户无法继续输入新行。
+之前在 `kbd-horizontal`（右方向键）中对 document 的最后一个子节点调用 `insert-return` 是一种存在严重副作用的临时 workaround（用户在仅仅按方向键进行导航浏览时会静默在文档末尾插入空白行，极大破坏编辑体验）。
+而通过将该逻辑合理重构为：
+- 方向键只做光标移动：如果在 body 末尾按右键，光标会被送往算法宏后面的位置 `(rcons parent-path (+ 1 t-index))`，如果不包含后续兄弟节点且再次按右键则正常移出 `listing` 环境。
+- 空白行按回车执行退出：这是 TeXmacs 与 Mogan 处理结构化列表/环境的标准、符合直觉的行为（例如 itemize 列表在空白项按回车自动退出并回退一级段落）。这样完全不需要在右方向键上执行副作用修改，操作直观自然。
 
 ### How
-在 `TeXmacs/progs/generic/generic-edit.scm` 中修改 `kbd-horizontal` 的 body-end 分支：
+在 `TeXmacs/progs/generic/generic-edit.scm` 中：
 
-1. **判断是否为最后一个子节点**：通过 `(== (+ 1 t-index) (tree-arity parent))` 判断该算法宏是否是父 `document` 的最后一个子节点
-2. **如果是最后一个子节点**：先 `go-to` 到 `document` 的 `:after`，然后调用 `insert-return` 在 `document` 末尾创建一个新的空段落。这样光标会停在新段落的开头，保留在 `listing` 内，用户可以直接输入下一行
-3. **如果不是最后一个子节点**：保持原来的行为，跳到下一个兄弟节点（如 `algo-else`）
-
-同时移除了所有 DEBUG 日志，恢复代码整洁。
+1. **精细化 `kbd-horizontal` 的匹配条件**：
+   ```scheme
+   (:require (and forwards?
+                  (tree-in? t algo-macro-tags)
+                  (in-listing-context? t)
+                  (or (cursor-in-algo-macro-body-end? t)
+                      (cursor-in-algo-macro-condition-end? t))))
+   ```
+   使其仅在条件或 body 的最末端触发。其余中间位置的按键正常冒泡，交由标准逻辑分发。
+2. **纯化 `kbd-horizontal` 行动**：
+   body 结尾时，直接调用 `(go-to (rcons parent-path (+ 1 t-index)))` 改变光标位置，无 `insert-return` 突变。
+3. **新增 `cursor-in-algo-macro-body-empty-end?` 判定**：
+   判断光标是否在 body 的最后一行，且该行处于完全空白状态。
+4. **新增回车退出 `kbd-enter` 多态定义**：
+   ```scheme
+   (tm-define (kbd-enter t shift?)
+     (:require (and (not shift?)
+                    (in-listing-context? t)
+                    (with macro (find-algo-macro-ancestor t)
+                      (and macro (cursor-in-algo-macro-body-empty-end? macro)))))
+     ...
+     (tree-remove! body last-idx 1)
+     (tree-insert! parent (+ 1 t-index) '((concat "")))
+     (go-to (rcons parent-path (+ 1 t-index))))
+   ```
+   当在 body 的最后一行空白行敲下 Enter，自动移除该多余空白行，并在主 `listing` 文档中在当前算法宏之后插入一个全新的 `(concat "")` 段落并将光标移至该段落。
 
 ### 涉及文件
 - `TeXmacs/progs/utils/misc/markup-funcs.scm`
   - 新增 `is-algo-macro?`、`wrap-algo-macro`、`build-if-else-if`、`build-else-if`、`wrap-algo-body`、`indent-lines`
   - 修改 `ext-numbered`/`ext-numbered-prog`：对算法宏单独处理，其余沿用原逻辑
 - `TeXmacs/progs/generic/generic-edit.scm`
-  - 新增算法宏 Enter 键导航（`algo-macro-tags`、`find-algo-macro-ancestor`、`cursor-in-algo-macro-first-param?`、`kbd-enter`）
-  - 新增算法宏方向键右键导航（`is-end-relative-path?`、`cursor-in-algo-macro-body-end?`、`cursor-in-algo-macro-condition-end?`、`kbd-horizontal`）
-  - 2026/05/21 修复：body 末尾右键时如果是最后一个子节点则 `insert-return` 创建新段落
+  - 新增算法宏 Enter 键条件导航
+  - 精细重构算法宏方向键右键导航（无副作用、只读移动）
+  - 新增 `cursor-in-algo-macro-body-empty-end?` 辅助断言
+  - 新增空白行回车智能退栈并在 `listing` 下插入新行
 - `TeXmacs/progs/prog/prog-menu.scm`
   - 菜单项 "Algorithm" 从 `specified-algorithm` 改为 `algorithm`
 - `TeXmacs/tests/tmu/209_21.tmu`
-  - 新增测试文件，包含 algorithm 行号测试、Python 代码高亮测试和方向键导航测试
+  - 新增测试文件，包含 algorithm 行号测试、Python 代码高亮测试和方向键/回车键导航测试

--- a/devel/209_21.md
+++ b/devel/209_21.md
@@ -22,6 +22,7 @@
    - 在 `\algo-if` 之后按 **回车**，应能在 `\listing` 中创建新的一行（有连续行号）
    - 同样测试 `\algo-else`：在 `listing` 中插入 `\algo-else`，输入 body 内容，在 body 末尾按右键，光标应跳到 `\algo-else` 之后保留在 `listing` 中
    - 同样测试 `\algo-while`、`\algo-for` 等宏
+   - **嵌套原子节点测试**：打开测试文件第 130-138 行的 `\algo-if` + `\algo-else` 案例，在 `\algo-if` 的 body 中有一个 `<math|X\<leftarrow\>X+1>`。将光标放到 `+1` 的 `1` 后面，按 **右键**，光标应正确跳到 `\algo-if` 之后并保留在 `\listing` 内，而不是直接跳出 `\listing`
 6. **Python 代码高亮测试**：
    - 文件末尾有一个 `\listing` 包裹的 `\python-code` 块
    - 确认 `import numpy as np` 有 Python 语法高亮（关键字、字符串等颜色正确）
@@ -114,6 +115,29 @@
 3. 如果光标在算法宏内部但不在 body 末尾（如在条件参数中、或在 body 中间），则调用 `(go-right)` 保持默认的单步右移行为。
 
 这样用户从算法宏 body 中按一次右键就能直接停在 `listing` 中该宏之后的位置，接着按回车即可在 `listing` 中创建新行。
+
+## 2026/05/20 修复嵌套原子节点下的右键导航
+
+### What
+修复在 `listing` 环境中的 `algo-if`、`algo-else` 等宏的 body 内部，如果 body 包含嵌套的原子节点（如 `math` 节点中的 `X+1`），在原子节点末尾按右键会错误地跳出 `listing` 环境的问题。
+
+### Why
+之前的 `cursor-in-algo-macro-body-end?` 只检查了两种简单情况：
+1. 光标路径恰好等于 `body-path + (:end)`
+2. body 的最后一个子节点的 arity 等于相对路径的第一个元素
+
+但对于嵌套的原子节点（例如 `math` 节点内部的字符串 `"1"`），相对路径可能是一个多层列表（如 `(0 0 2)` 表示 math 的第0个子节点的第0个子节点的第2个位置），而不是单层路径。原来的 `(== (car rel-path) (tree-arity last-child))` 无法处理这种深层嵌套。
+
+### How
+在 `TeXmacs/progs/generic/generic-edit.scm` 中：
+
+1. **新增 `is-end-relative-path?`**：递归函数，判断一个相对路径是否指向树节点的末尾或 `:after` 位置。对原子树使用 `(string-length (tree->string t))` 而不是 `(tree-arity t)` 来判断末尾。
+2. **重写 `cursor-in-algo-macro-body-end?`**：用 `is-end-relative-path?` 替代原来简单的 arity 比较，支持任意深度的嵌套节点。
+3. **新增 `cursor-in-algo-macro-condition-end?`**：判断光标是否在算法宏条件参数的末尾，用于右键导航从条件跳到 body。
+4. **修改 `kbd-horizontal`**：使用 `cond` 同时处理 body 末尾和条件末尾两种导航情况：
+   - body 末尾：跳到算法宏之后（保留在 listing 内）
+   - 条件末尾：跳到 body 参数开头
+   - 其他情况：默认 `go-right`
 
 ### 涉及文件
 - `TeXmacs/progs/utils/misc/markup-funcs.scm`


### PR DESCRIPTION
## 如何测试

1. **清除缓存并重启 Mogan**：
   - macOS: 删除 `~/Library/Caches/MoganLab`，然后重启 Mogan
   - Windows: 删除 `%appdata%/MoganLab` 和 `%localappdata%/MoganLab`，然后重启 Mogan
   - Linux: 删除 `~/.cache/MoganLab`，然后重启 Mogan
2. 打开测试文件 `TeXmacs/tests/tmu/209_21.tmu`
3. 在 `listing` 环境中插入 `\algo-if`，按 Enter 进入 body，输入一行内容
4. 在 body 行末尾按 **方向键右键**，光标应直接退出 `\algo-if` 并保留在 `\listing` 中
5. 此时按 **回车**，应能在 `\listing` 中创建新的一行（有连续行号）
6. 同样测试 `\algo-while`、`\algo-for` 等宏

## What

在 `listing` 环境中，为 `algo-if`、`algo-while`、`algo-for` 等算法宏添加方向键右键导航支持。在宏的 body 末尾按右键时，光标直接退出该宏并保留在 `listing` 中。

## Why

用户在算法宏的 body 中编辑完后，通常想退出该宏并在 `listing` 中继续输入下一行。但默认行为中，从 body 末尾按右键需要经过多个中间位置（body document 的 `:after`、算法宏的 `:after`、listing document 的 `:after` 等），很容易按过头直接跳出 `listing`。特别是在 `listing` 中只有该算法宏一行时，从 body 中出来后再按一次右键就直接退出了 `listing`，用户体验很差。

## How

在 `TeXmacs/progs/generic/generic-edit.scm` 中：

1. **新增 `cursor-in-algo-macro-body-end?`**：判断光标是否在当前算法宏的最后一个参数（body）的末尾
2. **新增 `kbd-horizontal` 多态定义**：当在 `listing` 环境中、光标在算法宏 body 末尾、按右键时，直接调用 `(tree-go-to t :after)` 将光标跳到算法宏之后，而不是继续默认的递归向上行为
3. 光标在算法宏内部但不在 body 末尾时，调用 `(go-right)` 保持默认单步右移

---

本 PR 基于 #3276 继续工作。