### PR TITLE
[0151] PDF 阅读器选框模式支持 ESC 退出

### DIFF
--- a/devel/0151.md
+++ b/devel/0151.md
@@ -1,0 +1,53 @@
+# [0151] PDF 阅读器选框模式支持 ESC 退出
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp` - `PDFReaderWidget` 的 `keyPressEvent` 和 `eventFilter` 函数
+- `tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp` - 单元测试
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```
+xmake b qt_pdf_reader_widget_test && xmake r qt_pdf_reader_widget_test
+```
+
+### 非确定性测试（交互验证）
+```
+xmake r stem
+```
+
+打开后确认：
+1. 打开任意 PDF 文档（文件 -> 打开 -> 选择 PDF）
+2. 点击工具栏的选框按钮（截图图标）进入选框模式
+3. 按 ESC 键，确认退出选框模式，光标恢复为箭头
+4. 再次进入选框模式，按住左键开始拖拽选框
+5. 拖拽过程中按 ESC 键，确认取消当前拖拽但保持选框模式
+6. 再按一次 ESC，确认完全退出选框模式
+
+## What
+
+为 PDF 阅读器的矩形选框模式添加 ESC 键退出支持。
+
+1. 在 `keyPressEvent` 中处理 `Qt::Key_Escape`
+2. 在 `eventFilter` 中处理视口的 `KeyPress` ESC 事件
+3. 拖拽中按 ESC 取消当前拖拽（隐藏 rubber band，停止拖拽）
+4. 选框模式下按 ESC 退出选框模式（取消按钮选中状态）
+5. 添加单元测试 `test_rectSelectEscExitsMode` 和 `test_rectSelectEscCancelsDrag`
+
+## Why
+
+PDF 阅读器的矩形选框模式（用于截图复制到剪贴板）在开启后，用户只能通过再次点击工具栏按钮来退出。这不符合大多数图形应用中「按 ESC 取消/退出当前模式」的交互惯例，用户体验不直观。
+
+## How
+
+在 `PDFReaderWidget` 的两个键盘事件入口统一处理 ESC：
+
+- `keyPressEvent`：处理 Widget 本身获得焦点时的 ESC 按键
+- `eventFilter`（`QEvent::KeyPress` on viewport）：处理视口获得焦点时的 ESC 按键
+
+ESC 处理优先级：
+1. 如果正在拖拽 (`rectSelectDragging_`)，则取消拖拽（隐藏 rubber band，重置标志位），但保持选框模式
+2. 如果处于选框模式 (`rectSelectMode_`)，则取消 `rectSelectBtn_` 的选中状态，触发 `onRectSelectToggled(false)` 完成模式退出

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -940,6 +940,20 @@ PDFReaderWidget::keyPressEvent (QKeyEvent* event) {
     return;
   }
 
+  if (event->key () == Qt::Key_Escape) {
+    if (rectSelectDragging_) {
+      rectSelectDragging_= false;
+      if (rubberBand_) rubberBand_->hide ();
+      event->accept ();
+      return;
+    }
+    if (rectSelectMode_) {
+      rectSelectBtn_->setChecked (false);
+      event->accept ();
+      return;
+    }
+  }
+
   if (event->key () == Qt::Key_J || event->key () == Qt::Key_K) {
     QScrollBar* vbar= scrollArea_->verticalScrollBar ();
     if (vbar) {
@@ -1007,6 +1021,17 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
           vbar->setValue (vbar->value () + direction * vbar->singleStep ());
         }
         return true;
+      }
+      if (keyEvent->key () == Qt::Key_Escape) {
+        if (rectSelectDragging_) {
+          rectSelectDragging_= false;
+          if (rubberBand_) rubberBand_->hide ();
+          return true;
+        }
+        if (rectSelectMode_) {
+          rectSelectBtn_->setChecked (false);
+          return true;
+        }
       }
     }
     else if (event->type () == QEvent::Resize) {

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -313,6 +313,82 @@ private slots:
     QVERIFY (clipboard->mimeData ()->hasImage ());
     delete widget;
   }
+
+  void test_rectSelectEscExitsMode () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+
+    QApplication::processEvents ();
+
+    QToolButton* rectBtn=
+        widget->findChild<QToolButton*> ("pdf-screenshot-btn");
+    QVERIFY (rectBtn != nullptr);
+    rectBtn->click ();
+    QApplication::processEvents ();
+    QVERIFY (widget->isRectSelectMode ());
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+    vp->setFocus ();
+    QTest::keyClick (vp, Qt::Key_Escape);
+    QApplication::processEvents ();
+
+    QVERIFY (!widget->isRectSelectMode ());
+    QCOMPARE (vp->cursor ().shape (), Qt::ArrowCursor);
+    delete widget;
+  }
+
+  void test_rectSelectEscCancelsDrag () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+
+    QApplication::processEvents ();
+
+    QToolButton* rectBtn=
+        widget->findChild<QToolButton*> ("pdf-screenshot-btn");
+    QVERIFY (rectBtn != nullptr);
+    rectBtn->click ();
+    QApplication::processEvents ();
+    QVERIFY (widget->isRectSelectMode ());
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+
+    // 开始拖拽
+    QPoint start (50, 50);
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, start);
+    QApplication::processEvents ();
+
+    // 按下 ESC 取消拖拽
+    vp->setFocus ();
+    QTest::keyClick (vp, Qt::Key_Escape);
+    QApplication::processEvents ();
+
+    // 选框模式仍然开启
+    QVERIFY (widget->isRectSelectMode ());
+    QCOMPARE (vp->cursor ().shape (), Qt::CrossCursor);
+
+    // 再次按下 ESC 退出选框模式
+    QTest::keyClick (vp, Qt::Key_Escape);
+    QApplication::processEvents ();
+
+    QVERIFY (!widget->isRectSelectMode ());
+    QCOMPARE (vp->cursor ().shape (), Qt::ArrowCursor);
+
+    delete widget;
+  }
 };
 
 QTEST_MAIN (TestPdfReaderWidget)


### PR DESCRIPTION
## Summary
- PDF 阅读器进入矩形选框模式后，按下 ESC 键可退出选框模式
- 拖拽选框过程中按下 ESC 键可取消当前拖拽，但保持选框模式
- 在 `keyPressEvent` 和 `eventFilter` 中统一处理 ESC 按键，确保视口和 Widget 获得焦点时都能响应
- 新增两个单元测试验证 ESC 行为

## Test plan
- [x] `xmake b qt_pdf_reader_widget_test && xmake r qt_pdf_reader_widget_test` 全部通过（17/17）
- [ ] 交互验证：打开 PDF，进入选框模式，按 ESC 退出
- [ ] 交互验证：拖拽选框时按 ESC 取消拖拽

🤖 Generated with [Claude Code](https://claude.com/claude-code)