### PR TITLE
[0150] 插入表格时默认开启表格分页

### DIFF
--- a/devel/0150.md
+++ b/devel/0150.md
@@ -50,3 +50,53 @@ xmake r stem TeXmacs/tests/tmu/0145.tmu
 - 否则 → 同页相邻 → 正常执行 `correct_adjacent`
 
 这与 0113 中子表格内部的处理思路类似——都是避免在不应该绘制辅助线的位置生成矩形。
+
+---
+
+# [0150] 插入表格时默认开启表格分页
+
+## 相关文档
+- [0119.md](0119.md) - 插入表格时默认开启所有单元格的 cell-hyphen
+
+## 任务相关的代码文件
+- `src/Edit/Modify/edit_table.cpp`
+
+## 如何测试
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，新建一个空白文档
+2. 通过菜单或快捷键插入一个表格（如 `cmd+t` 插入 tabular）
+3. 在表格中输入多行内容，直到内容跨页
+4. 观察表格是否在分页处自动断开（应显示为多页，不再被限制在单页内）
+
+## What
+
+修改表格插入逻辑，使得新插入的表格默认开启 `table-hyphen`（表格分页）。
+
+## Why
+
+当前插入表格时，`table-hyphen` 默认为关闭（`"n"`）。这导致当表格内容较长时，表格不会跨页断开，而是被压缩或溢出页面。用户需要手动为表格开启 `table-hyphen`，体验较差。
+
+此前 [0150] 已修复跨页表格分页处的细线问题，为默认开启分页提供了前提。
+
+## How
+
+在 `src/Edit/Modify/edit_table.cpp` 中：
+
+`default_table_tree` 函数构造默认表格树时，在 `TFORMAT` 中额外添加 `table-hyphen` 为 `"y"` 的 `twith` 节点：
+
+```cpp
+tree
+default_table_tree (int nr_rows, int nr_cols) {
+  tree T= empty_table (nr_rows, nr_cols);
+  tree format_T (TFORMAT);
+  tree with (CWITH, "1", "-1", "1", "-1", "cell-hyphen", "t");
+  format_T << with;
+  tree hyphen_with (TWITH, "table-hyphen", "y");
+  format_T << hyphen_with;
+  format_T << T;
+  return format_T;
+}
+```
+
+这样所有通过 `make_table` 和 `make_subtable` 插入的表格都会默认开启分页。

--- a/src/Edit/Modify/edit_table.cpp
+++ b/src/Edit/Modify/edit_table.cpp
@@ -62,6 +62,8 @@ default_table_tree (int nr_rows, int nr_cols) {
   tree format_T (TFORMAT);
   tree with (CWITH, "1", "-1", "1", "-1", "cell-hyphen", "t");
   format_T << with;
+  tree hyphen_with (TWITH, "table-hyphen", "y");
+  format_T << hyphen_with;
   format_T << T;
   return format_T;
 }


### PR DESCRIPTION
## Summary

- 修改 `src/Edit/Modify/edit_table.cpp` 中的 `default_table_tree`，在 `TFORMAT` 中默认添加 `table-hyphen: y`
- 新插入的表格（包括 `make_table` 和 `make_subtable`）默认支持跨页分页

## Test plan

- [ ] 启动 Mogan，新建空白文档
- [ ] 插入表格（如 `cmd+t`）
- [ ] 输入多行内容直到跨页，确认表格在分页处自动断开

🤖 Generated with [Claude Code](https://claude.com/claude-code)