### PR TITLE
[0152] 修复 PDF 阅读器小手拖动单元测试

### DIFF
--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -437,6 +437,9 @@ private slots:
     QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, end);
     QApplication::processEvents ();
 
+    // QScroller 的滚动更新是异步的，给一点时间让动画生效
+    QTest::qWait (100);
+
     int newPos= vbar->value ();
     QVERIFY (newPos < initialPos);
     delete widget;


### PR DESCRIPTION
## 问题
`TestPdfReaderWidget::test_dragScrollsDown` 单元测试失败，因为 `QScroller` 在 QTest 环境中的滚动更新是异步的，单次 `QApplication::processEvents()` 不足以让动画生效。

## 修复
在 `mouseRelease` 后增加 `QTest::qWait(100)`，给 `QScroller` 一点时间处理滚动动画。

## 测试
- [x] `xmake r qt_pdf_reader_widget_test` 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)