### PR TITLE
[0154] 移除页面渲染中的屏幕选项

### DIFF
--- a/TeXmacs/progs/generic/document-menu.scm
+++ b/TeXmacs/progs/generic/document-menu.scm
@@ -736,7 +736,6 @@
 (menu-bind page-rendering-menu
  ("Single Page" (init-page-rendering "paper"))
  ("Continuous Scroll" (init-page-rendering "papyrus"))
- ("Screen" (init-page-rendering "automatic"))
  (assuming (in-beamer?) ("Beamer" (init-page-rendering "beamer")))
  ("Two Page" (init-page-rendering "book"))
  ("Panorama" (init-page-rendering "panorama"))

--- a/TeXmacs/progs/generic/document-widgets.scm
+++ b/TeXmacs/progs/generic/document-widgets.scm
@@ -208,8 +208,8 @@
 
 (define (page-rendering-options)
   (if (in-beamer?)
-    '("Single Page" "Continuous Scroll" "Screen" "Beamer" "Two Page" "Panorama")
-    '("Single Page" "Continuous Scroll" "Screen" "Two Page" "Panorama")
+    '("Single Page" "Continuous Scroll" "Beamer" "Two Page" "Panorama")
+    '("Single Page" "Continuous Scroll" "Two Page" "Panorama")
   ) ;if
 ) ;define
 

--- a/TeXmacs/progs/generic/format-tools.scm
+++ b/TeXmacs/progs/generic/format-tools.scm
@@ -341,12 +341,11 @@
   (if (in-beamer?)
     '("Single Page"
       "Continuous Scroll"
-      "Screen"
       "Beamer"
       "Two Page"
       "Panorama"
       "Slideshow")
-    '("Single Page" "Continuous Scroll" "Screen" "Two Page" "Panorama")
+    '("Single Page" "Continuous Scroll" "Two Page" "Panorama")
   ) ;if
 ) ;define
 

--- a/devel/0154.md
+++ b/devel/0154.md
@@ -1,0 +1,40 @@
+# [0154] 移除页面渲染中的"屏幕"选项
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/document-menu.scm`
+- `TeXmacs/progs/generic/document-widgets.scm`
+- `TeXmacs/progs/generic/format-tools.scm`
+
+## 3 如何测试
+
+### 3.1 非确定性测试（文档验证）
+编译并运行程序，验证以下位置不再出现"屏幕"选项：
+1. 菜单栏 `文档 -> 页面 -> 页面渲染 -> 类型` 下拉菜单
+2. 焦点工具栏（focus toolbar）中的页面渲染下拉框
+3. 文档设置对话框中的页面渲染选项
+
+## 4 如何提交
+
+```bash
+git add devel/0154.md
+git commit -m "[0154] 更新任务文档"
+git add TeXmacs/progs/generic/document-menu.scm TeXmacs/progs/generic/document-widgets.scm TeXmacs/progs/generic/format-tools.scm
+git commit -m "[0154] 移除页面渲染中的屏幕选项"
+git push
+```
+
+## 5 What
+从页面渲染选项中移除"屏幕"（Screen / `automatic`）选项。
+
+1. 在 `document-menu.scm` 的 `page-rendering-menu` 中删除 `"Screen"` 菜单项
+2. 在 `document-widgets.scm` 的 `page-rendering-options` 中删除 `"Screen"` 选项
+3. 在 `format-tools.scm` 的 `page-rendering-options` 中删除 `"Screen"` 选项
+
+## 6 Why
+当 `page-medium` 设置为 `automatic` 时，页面渲染显示为"屏幕"，但该功能不稳定、不靠谱，容易给用户造成困扰，因此需要从所有用户可见的选项列表中移除。
+
+## 7 How
+直接修改三个 Scheme 文件中的菜单绑定和选项列表，移除 `"Screen"` 对应的 `"automatic"` 页面渲染模式。保留底层的编码/解码映射函数，避免影响已使用 `page-medium=automatic` 的旧文档兼容性。


### PR DESCRIPTION
## 摘要
当 `page-medium` 为 `automatic` 时，页面渲染显示为"屏幕"，但该功能不稳定，容易给用户造成困扰。本 PR 从所有用户可见的选项列表中移除此选项。

## 改动范围
- `TeXmacs/progs/generic/document-menu.scm`：从 `文档 -> 页面 -> 页面渲染` 菜单中移除 `"Screen"`
- `TeXmacs/progs/generic/document-widgets.scm`：从文档设置对话框的页面渲染选项中移除 `"Screen"`
- `TeXmacs/progs/generic/format-tools.scm`：从焦点工具栏的页面渲染选项中移除 `"Screen"`
- `devel/0154.md`：新增任务文档

## 测试计划
- [ ] 编译并运行程序
- [ ] 确认菜单 `文档 -> 页面 -> 页面渲染` 中不再出现"屏幕"
- [ ] 确认焦点工具栏中不再出现"屏幕"

🤖 Generated with [Claude Code](https://claude.com/claude-code)