### PR TITLE
[0612] 新增独立的 Quiver 交换图插件与会话支持

### DIFF
--- a/TeXmacs/plugins/quiver/goldfish/tm-quiver.scm
+++ b/TeXmacs/plugins/quiver/goldfish/tm-quiver.scm
@@ -1,0 +1,255 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-quiver.scm
+;; DESCRIPTION : Quiver Binary plugin (pdflatex)
+;; COPYRIGHT   : (C) 2026  (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (scheme base)
+  (texmacs protocol)
+  (liii os)
+  (liii path)
+  (liii uuid)
+  (liii sys)
+  (liii string)
+  (liii list)
+)
+
+(define (escape-string str)
+  (string-join
+    (map (lambda (char)
+           (if (char=? char #\")
+               (string #\\ #\")
+               (if (char=? char #\\)
+                   (string #\\ #\\)
+                   (string char))))
+          (string->list str))))
+
+(define (goldfish-quote s)
+  (string-append "\"" (escape-string s) "\""))
+
+(define (quiver-welcome)
+  (flush-prompt "quiver] ")
+  (flush-verbatim "Liii STEM interface to Quiver"))
+
+(define (quiver-read-code)
+  (define (read-code code)
+    (let ((line (read-line)))
+      (if (or (eof-object? line) (string=? line "<EOF>\n"))
+          code
+          (read-code (string-append code line)))))
+  (read-code ""))
+
+(define (gen-temp-path)
+  (let ((quiver-tmpdir (string-append (os-temp-dir) "/quiver")))
+    (when (not (file-exists? quiver-tmpdir))
+      (mkdir quiver-tmpdir))
+    (string-append quiver-tmpdir "/" (uuid4))))
+
+(define (wrap-quiver-code code)
+  (let ((trimmed (string-trim-left code)))
+    (if (string-starts? trimmed "\\documentclass")
+        code
+        (let* ((lines (string-split code #\newline))
+               (library-lines
+                 (filter (lambda (line)
+                           (string-starts? (string-trim-left line) "\\usetikzlibrary"))
+                         lines))
+               (package-lines
+                 (filter (lambda (line)
+                           (string-starts? (string-trim-left line) "\\usepackage"))
+                         lines))
+               (other-lines
+                 (filter (lambda (line)
+                           (let ((trimmed-line (string-trim-left line)))
+                             (and (not (string-starts? trimmed-line "\\usetikzlibrary"))
+                                  (not (string-starts? trimmed-line "\\usepackage")))))
+                         lines))
+               (body (string-join other-lines "\n"))
+               (body-trimmed (string-trim-left body)))
+          (let* ((has-tikzcd? (string-starts? body-trimmed "\\begin{tikzcd}"))
+                 (inner-code
+                   (if (or (string-null? body-trimmed)
+                           has-tikzcd?)
+                       body
+                       (string-append "\\begin{tikzcd}\n" body "\n\\end{tikzcd}"))))
+            (string-append
+              "\\documentclass[tikz]{standalone}\n"
+              "\\usepackage{tikz-cd}\n"
+              "\\usepackage{amssymb}\n"
+              "\\usetikzlibrary{calc}\n"
+              "\\usetikzlibrary{decorations.pathmorphing}\n"
+              "\\usetikzlibrary{spath3}\n"
+              "\n"
+              "\\tikzset{curve/.style={settings={#1},to path={(\\tikztostart)\n"
+              "    .. controls ($(\\tikztostart)!\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+              "    and ($(\\tikztostart)!1-\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+              "    .. (\\tikztostart)\\tikztonodes}},\n"
+              "    settings/.code={\\tikzset{quiver/.cd,#1}\n"
+              "        \\def\\pv##1{\\pgfkeysvalueof{/tikz/quiver/##1}}},\n"
+              "    quiver/.cd,pos/.initial=0.35,height/.initial=0}\n"
+              "\n"
+              "\\tikzset{between/.style n args={2}{/tikz/execute at end to={\n"
+              "    \\tikzset{spath/split at keep middle={current}{#1}{#2}}\n"
+              "}}}\n"
+              "\n"
+              "\\tikzset{tail reversed/.code={\\pgfsetarrowsstart{tikzcd to}}}\n"
+              "\\tikzset{2tail/.code={\\pgfsetarrowsstart{Implies[reversed]}}}\n"
+              "\\tikzset{2tail reversed/.code={\\pgfsetarrowsstart{Implies}}}\n"
+              "\\tikzset{no body/.style={/tikz/dash pattern=on 0 off 1mm}}\n"
+              "\n"
+              (if (null? package-lines) "" (string-append (string-join package-lines "\n") "\n"))
+              "\\begin{document}\n"
+              (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
+              inner-code
+              "\n\\end{document}"))))))
+
+(define (parse-magic-line magic-line)
+  (let ((tokens (filter (lambda (x) (not (string-null? x)))
+                        (string-split magic-line #\space)))
+        (width "0px")
+        (height "0px"))
+    (let loop ((args (cdr tokens)))
+      (cond ((or (null? args) (null? (cdr args)))
+             (list width height))
+            ((string=? (car args) "-width")
+             (set! width (cadr args))
+             (loop (cddr args)))
+            ((string=? (car args) "-height")
+             (set! height (cadr args))
+             (loop (cddr args)))
+            (else (loop (cddr args)))))))
+
+(define (dump-tex-code code-path code)
+  (with-output-to-file code-path
+    (lambda () (display code))))
+
+(define (quiver-temp-dir)
+  (string-append (os-temp-dir) "/quiver"))
+
+(define (run-pdflatex tex-path pdflatex-bin)
+  (let* ((inner-cmd (string-append (goldfish-quote pdflatex-bin)
+                                   " --interaction=errorstopmode -halt-on-error "
+                                   (goldfish-quote tex-path)
+                                   " > /dev/null 2>&1"))
+         (cmd (string-append "sh -c " (goldfish-quote inner-cmd)))
+         (orig-dir (getcwd)))
+    (unsetenv "DYLD_LIBRARY_PATH")
+    (unsetenv "DYLD_FRAMEWORK_PATH")
+    (unsetenv "DYLD_FALLBACK_LIBRARY_PATH")
+    (unsetenv "DYLD_FALLBACK_FRAMEWORK_PATH")
+    (chdir (quiver-temp-dir))
+    (let ((result (os-call cmd)))
+      (chdir orig-dir)
+      result)))
+
+(define (image-valid? path)
+  (and (file-exists? path) (> (path-getsize path) 10)))
+
+(define (get-pdf-page-size log-path)
+  (let ((p (open-input-file log-path)))
+    (let loop ()
+      (let ((line (read-line p)))
+        (if (eof-object? line)
+            (begin (close-input-port p) #f)
+            (if (string-contains? line "papersize=")
+                (let* ((parts (string-split line #\=))
+                       (size-part (cadr parts))
+                       (dims (string-split size-part #\,))
+                       (w-str (string-remove-suffix (car dims) "pt"))
+                       (h-str (string-remove-suffix (cadr dims) "pt"))
+                       (w (string->number w-str))
+                       (h (string->number h-str)))
+                  (close-input-port p)
+                  (if (and w h)
+                      (list w h)
+                      #f))
+                (loop)))))))
+
+(define (pdf-page-empty? log-path)
+  (let ((size (get-pdf-page-size log-path)))
+    (if (not size)
+        #t
+        (let ((w (car size))
+              (h (cadr size)))
+          (and (<= w 0.1) (<= h 0.1))))))
+
+(define (flush-image path width height)
+  (if (image-valid? path)
+      (flush-file (string-append path "?" "width=" width "&" "height=" height))
+      (flush-verbatim "Failed to generate image")))
+
+(define (eval-and-print code width height)
+  (let* ((temp-path (gen-temp-path))
+         (tex-path (string-append temp-path ".tex"))
+         (pdf-path (string-append temp-path ".pdf"))
+         (log-path (string-append temp-path ".log"))
+         (wrapped-code (wrap-quiver-code code))
+         (pdflatex-bin (fourth (argv))))
+    (dump-tex-code tex-path wrapped-code)
+    (if (zero? (run-pdflatex tex-path pdflatex-bin))
+        (let ((size (get-pdf-page-size log-path)))
+          (if (or (not size) (and (<= (car size) 0.1) (<= (cadr size) 0.1)))
+              (flush-verbatim "Quiver produced an empty image (0x0 bounding box)")
+              (let ((final-width width)
+                    (final-height height))
+                (when (and (string=? width "0px") (string=? height "0px"))
+                  (if size
+                      (begin
+                        (set! final-width (string-append (number->string (car size)) "pt"))
+                        (set! final-height (string-append (number->string (cadr size)) "pt")))
+                      (begin
+                        (set! final-width "0.3par")
+                        (set! final-height "0px"))))
+                (flush-image pdf-path final-width final-height))))
+        (begin
+          (flush-verbatim "pdflatex error")
+          (flush-verbatim "")))))
+
+(define (split-code-and-magic code)
+  (if (not (string-starts? code "%"))
+      (list "" code)
+      (let ((i/false (string-index code #\newline)))
+        (if (not i/false)
+            (list code "")
+            (list (substring code 0 i/false)
+                  (substring code (+ i/false 1)))))))
+
+(define (read-eval-print)
+  (let* ((raw-code (quiver-read-code))
+         (l (split-code-and-magic raw-code))
+         (magic-line (car l))
+         (code (cadr l))
+         (parsed (if (string-null? magic-line)
+                     (list "0px" "0px")
+                     (parse-magic-line magic-line)))
+         (width (car parsed))
+         (height (cadr parsed)))
+    (if (string-null? code)
+        (flush-verbatim "No code provided!")
+        (eval-and-print code width height))))
+
+(define (safe-read-eval-print)
+  (catch #t
+    (lambda () (read-eval-print))
+    (lambda args
+      (flush-scheme
+        (string-append "(errput (document "
+                       (goldfish-quote (symbol->string (car args)))
+                       " "
+                       (if (and (>= (length args) 2) (not (null? (cadr args))))
+                           (goldfish-quote (object->string (cadr args)))
+                           "")
+                       "))")))))
+
+(define (quiver-repl)
+  (safe-read-eval-print)
+  (quiver-repl))
+
+(quiver-welcome)
+(quiver-repl)

--- a/TeXmacs/plugins/quiver/progs/code/quiver-edit.scm
+++ b/TeXmacs/plugins/quiver/progs/code/quiver-edit.scm
@@ -1,0 +1,47 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : quiver-edit.scm
+;; DESCRIPTION : Editing Quiver code
+;; COPYRIGHT   : (C) 2026 (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (code quiver-edit)
+  (:use (prog prog-edit)
+    (code quiver-mode)))
+
+(tm-define (get-tabstop)
+  (:mode in-prog-quiver?)
+  2)
+
+(define (quiver-bracket-open lbr rbr)
+  (bracket-open lbr rbr "\\"))
+
+(define (quiver-bracket-close lbr rbr)
+  (bracket-close lbr rbr "\\"))
+
+(tm-define (notify-cursor-moved status)
+  (:require prog-highlight-brackets?)
+  (:mode in-prog-quiver?)
+  (select-brackets-after-movement "([{" ")]}" "\\"))
+
+(tm-define (kbd-paste)
+  (:mode in-prog-quiver?)
+  (clipboard-paste-import "quiver" "primary"))
+
+(kbd-map
+  (:mode in-prog-quiver?)
+  ("A-tab" (insert-tabstop))
+  ("cmd S-tab" (remove-tabstop))
+  ("{" (quiver-bracket-open "{" "}"))
+  ("}" (quiver-bracket-close "{" "}"))
+  ("(" (quiver-bracket-open "(" ")"))
+  (")" (quiver-bracket-close "(" ")"))
+  ("[" (quiver-bracket-open "[" "]"))
+  ("]" (quiver-bracket-close "[" "]"))
+  ("\"" (quiver-bracket-open "\"" "\""))
+  ("'" (quiver-bracket-open "'" "'")))

--- a/TeXmacs/plugins/quiver/progs/code/quiver-lang.scm
+++ b/TeXmacs/plugins/quiver/progs/code/quiver-lang.scm
@@ -1,0 +1,102 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : quiver-lang.scm
+;; DESCRIPTION : Quiver language support for syntax highlighting
+;; COPYRIGHT   : (C) 2026 (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (code quiver-lang)
+  (:use (prog default-lang)))
+
+;;------------------------------------------------------------------------------
+;; Keywords definition
+;;
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "quiver") (== key "keyword")))
+  `(,(string->symbol key)
+    (extra_chars "_.-")
+    (constant
+      "true" "false" "none" "solid" "dashed" "dotted" "thick" "thin" "ultra" "very" "semithick"
+      "smooth" "tension")
+    (constant_identifier
+      "red" "green" "blue" "cyan" "magenta" "yellow" "black" "white" "gray" "darkgray"
+      "lightgray" "brown" "lime" "olive" "orange" "pink" "purple" "teal" "violet")
+    (constant_type
+      "circle" "rectangle" "coordinate" "ellipse" "diamond" "trapezium" "semicircle"
+      "regular polygon" "star" "cylinder")
+    (declare_function
+      "draw" "node" "path" "fill" "clip" "filldraw" "shadedraw" "shade" "select" "foreach"
+      "definecolor" "colorlet" "tikzset" "tikzstyle" "arrow" "ar")
+    (declare_module
+      "arrows" "shapes" "calc" "positioning" "fit" "intersections" "shapes.geometric" "svg.path")
+    (variable_identifier
+      "above" "below" "left" "right" "anchor" "above left" "above right" "below left" "below right"
+      "mid" "base" "inner sep" "outer sep" "minimum height" "minimum width" "minimum size"
+      "font" "node font" "text" "text width" "align" "line width" "opacity" "fill opacity"
+      "draw opacity" "text opacity" "scale" "rotate" "shift" "xshift" "yshift")
+    (keyword
+      "at" "cycle" "circle" "rectangle" "ellipse" "arc" "to" "grid" "step" "controls" "plot"
+      "coordinates" "parabola" "sin" "cos" "child" "edge")
+    (keyword_control
+      "begin" "end" "foreach" "usetikzlibrary" "tikzcd")))
+
+;;------------------------------------------------------------------------------
+;; Operators definition
+;;
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "quiver") (== key "operator")))
+  `(,(string->symbol key)
+    (operator
+      "+" "-" "*" "/" "\\" "^" "_" "=" "!" "?"
+      ";" "," ":" "&" "|" "$")
+    (operator_openclose
+      "(" ")" "[" "]" "{" "}")
+    (operator_special
+      "--" "->" "<-" "<->" "++" "+")))
+
+;;------------------------------------------------------------------------------
+;; Comments definition
+;;
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "quiver") (== key "comment")))
+  `(,(string->symbol key)
+    (inline "%")))
+
+;;------------------------------------------------------------------------------
+;; Preferences for syntax highlighting
+;;
+
+(define (notify-quiver-syntax var val)
+  (syntax-read-preferences "quiver"))
+
+(define-preferences
+  ("syntax:quiver:none" "red" notify-quiver-syntax)
+  ("syntax:quiver:comment" "brown" notify-quiver-syntax)
+  ("syntax:quiver:error" "dark red" notify-quiver-syntax)
+  ("syntax:quiver:constant" "#4040c0" notify-quiver-syntax)
+  ("syntax:quiver:constant_identifier" "#228b22" notify-quiver-syntax)
+  ("syntax:quiver:constant_type" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:constant_number" "#3030b0" notify-quiver-syntax)
+  ("syntax:quiver:constant_string" "dark grey" notify-quiver-syntax)
+  ("syntax:quiver:constant_char" "#333333" notify-quiver-syntax)
+  ("syntax:quiver:variable_identifier" "#a020f0" notify-quiver-syntax)
+  ("syntax:quiver:declare_function" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:declare_type" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:declare_module" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:declare_class" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:declare_variable" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:keyword" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:keyword_control" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:operator" "#0000c0" notify-quiver-syntax)
+  ("syntax:quiver:operator_openclose" "#000000" notify-quiver-syntax)
+  ("syntax:quiver:operator_special" "#d2691e" notify-quiver-syntax)
+  ("syntax:quiver:macro" "#c71585" notify-quiver-syntax)
+  ("syntax:quiver:matched_bracket" "#ffffc0" notify-quiver-syntax))

--- a/TeXmacs/plugins/quiver/progs/code/quiver-mode.scm
+++ b/TeXmacs/plugins/quiver/progs/code/quiver-mode.scm
@@ -1,0 +1,18 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : quiver-mode.scm
+;; DESCRIPTION : Quiver language mode
+;; COPYRIGHT   : (C) 2026 (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (code quiver-mode)
+  (:use (kernel texmacs tm-modes)))
+
+(texmacs-modes
+  (in-quiver% (== (get-env "prog-language") "quiver"))
+  (in-prog-quiver% #t in-prog% in-quiver%))

--- a/TeXmacs/plugins/quiver/progs/data/quiver.scm
+++ b/TeXmacs/plugins/quiver/progs/data/quiver.scm
@@ -1,0 +1,50 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : quiver.scm
+;; DESCRIPTION : prog format for Quiver
+;; COPYRIGHT   : (C) 2026 (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (data quiver))
+
+;;------------------------------------------------------------------------------
+;; Format definition
+;;
+
+(define-format quiver
+  (:name "Quiver source code")
+  (:suffix "quiver"))
+
+;;------------------------------------------------------------------------------
+;; Conversion functions
+;;
+
+(define (texmacs->quiver x . opts)
+  (texmacs->verbatim x (acons "texmacs->verbatim:encoding" "SourceCode" '())))
+
+(define (quiver->texmacs x . opts)
+  (code->texmacs x))
+
+(define (quiver-snippet->texmacs x . opts)
+  (code-snippet->texmacs x))
+
+;;------------------------------------------------------------------------------
+;; Converter registration
+;;
+
+(converter texmacs-tree quiver-document
+  (:function texmacs->quiver))
+
+(converter quiver-document texmacs-tree
+  (:function quiver->texmacs))
+
+(converter texmacs-tree quiver-snippet
+  (:function texmacs->quiver))
+
+(converter quiver-snippet texmacs-tree
+  (:function quiver-snippet->texmacs))

--- a/TeXmacs/plugins/quiver/progs/init-quiver.scm
+++ b/TeXmacs/plugins/quiver/progs/init-quiver.scm
@@ -1,0 +1,57 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-quiver.scm
+;; DESCRIPTION : Initialize Quiver plugin
+;; COPYRIGHT   : (C) 2026 (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-library (session quiver)
+  (import (scheme base) (liii list))
+  (export init-quiver)
+  (begin
+    (use-modules (binary pdflatex) (binary goldfish))
+
+    (define (quiver-serialize lan t)
+      (let* ((u (pre-serialize lan t))
+             (s (texmacs->code (stree->tree u) "SourceCode")))
+        (string-append s "\n<EOF>\n")
+      )
+    )
+
+    (define (quiver-launcher)
+      (string-append
+        (string-quote (url->system (find-binary-goldfish)))
+        " "
+        "load"
+        " "
+        (string-quote
+          (string-append (url->system (get-texmacs-path))
+            "/plugins/quiver/goldfish/tm-quiver.scm"
+          )
+        )
+        " "
+        (string-quote (url->system (find-binary-pdflatex)))
+      )
+    )
+
+    (define (init-quiver)
+      (plugin-configure quiver
+        (:require (and (has-binary-goldfish?)
+                       (has-binary-pdflatex?)))
+        (:launch ,(quiver-launcher))
+        (:serializer ,quiver-serialize)
+        (:session "Quiver")
+      )
+    )
+  )
+)
+
+(import (session quiver))
+(init-quiver)
+(lazy-format (data quiver) quiver)
+(use-modules (code quiver-mode) (code quiver-edit))

--- a/TeXmacs/plugins/quiver/tests/tm-quiver-test.scm
+++ b/TeXmacs/plugins/quiver/tests/tm-quiver-test.scm
@@ -1,0 +1,157 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-quiver-test.scm
+;; DESCRIPTION : Quiver Binary plugin unit tests
+;; COPYRIGHT   : (C) 2026 (Jack) Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (scheme base)
+  (liii check)
+  (liii string)
+  (liii list)
+  (liii path)
+)
+
+; Simulate the wrap-quiver-code logic from tm-quiver.scm
+(define (wrap-quiver-code code)
+  (let ((trimmed (string-trim-left code)))
+    (if (string-starts? trimmed "\\documentclass")
+        code
+        (let* ((lines (string-split code #\newline))
+               (library-lines
+                 (filter (lambda (line)
+                           (string-starts? (string-trim-left line) "\\usetikzlibrary"))
+                         lines))
+               (package-lines
+                 (filter (lambda (line)
+                           (string-starts? (string-trim-left line) "\\usepackage"))
+                         lines))
+               (other-lines
+                 (filter (lambda (line)
+                           (let ((trimmed-line (string-trim-left line)))
+                             (and (not (string-starts? trimmed-line "\\usetikzlibrary"))
+                                  (not (string-starts? trimmed-line "\\usepackage")))))
+                         lines))
+               (body (string-join other-lines "\n"))
+               (body-trimmed (string-trim-left body)))
+          (let* ((has-tikzcd? (string-starts? body-trimmed "\\begin{tikzcd}"))
+                 (inner-code
+                   (if (or (string-null? body-trimmed)
+                           has-tikzcd?)
+                       body
+                       (string-append "\\begin{tikzcd}\n" body "\n\\end{tikzcd}"))))
+            (string-append
+              "\\documentclass[tikz]{standalone}\n"
+              "\\usepackage{tikz-cd}\n"
+              "\\usepackage{amssymb}\n"
+              "\\usetikzlibrary{calc}\n"
+              "\\usetikzlibrary{decorations.pathmorphing}\n"
+              "\\usetikzlibrary{spath3}\n"
+              "\n"
+              "\\tikzset{curve/.style={settings={#1},to path={(\\tikztostart)\n"
+              "    .. controls ($(\\tikztostart)!\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+              "    and ($(\\tikztostart)!1-\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+              "    .. (\\tikztostart)\\tikztonodes}},\n"
+              "    settings/.code={\\tikzset{quiver/.cd,#1}\n"
+              "        \\def\\pv##1{\\pgfkeysvalueof{/tikz/quiver/##1}}},\n"
+              "    quiver/.cd,pos/.initial=0.35,height/.initial=0}\n"
+              "\n"
+              "\\tikzset{between/.style n args={2}{/tikz/execute at end to={\n"
+              "    \\tikzset{spath/split at keep middle={current}{#1}{#2}}\n"
+              "}}}\n"
+              "\n"
+              "\\tikzset{tail reversed/.code={\\pgfsetarrowsstart{tikzcd to}}}\n"
+              "\\tikzset{2tail/.code={\\pgfsetarrowsstart{Implies[reversed]}}}\n"
+              "\\tikzset{2tail reversed/.code={\\pgfsetarrowsstart{Implies}}}\n"
+              "\\tikzset{no body/.style={/tikz/dash pattern=on 0 off 1mm}}\n"
+              "\n"
+              (if (null? package-lines) "" (string-append (string-join package-lines "\n") "\n"))
+              "\\begin{document}\n"
+              (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
+              inner-code
+              "\n\\end{document}"))))))
+
+(check
+  (wrap-quiver-code "\\documentclass{article}\n\\begin{document}\n\\end{document}")
+  =>
+  "\\documentclass{article}\n\\begin{document}\n\\end{document}"
+)
+
+(check
+  (wrap-quiver-code "A \\arrow[r] & B")
+  =>
+  (string-append
+    "\\documentclass[tikz]{standalone}\n"
+    "\\usepackage{tikz-cd}\n"
+    "\\usepackage{amssymb}\n"
+    "\\usetikzlibrary{calc}\n"
+    "\\usetikzlibrary{decorations.pathmorphing}\n"
+    "\\usetikzlibrary{spath3}\n"
+    "\n"
+    "\\tikzset{curve/.style={settings={#1},to path={(\\tikztostart)\n"
+    "    .. controls ($(\\tikztostart)!\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+    "    and ($(\\tikztostart)!1-\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+    "    .. (\\tikztostart)\\tikztonodes}},\n"
+    "    settings/.code={\\tikzset{quiver/.cd,#1}\n"
+    "        \\def\\pv##1{\\pgfkeysvalueof{/tikz/quiver/##1}}},\n"
+    "    quiver/.cd,pos/.initial=0.35,height/.initial=0}\n"
+    "\n"
+    "\\tikzset{between/.style n args={2}{/tikz/execute at end to={\n"
+    "    \\tikzset{spath/split at keep middle={current}{#1}{#2}}\n"
+    "}}}\n"
+    "\n"
+    "\\tikzset{tail reversed/.code={\\pgfsetarrowsstart{tikzcd to}}}\n"
+    "\\tikzset{2tail/.code={\\pgfsetarrowsstart{Implies[reversed]}}}\n"
+    "\\tikzset{2tail reversed/.code={\\pgfsetarrowsstart{Implies}}}\n"
+    "\\tikzset{no body/.style={/tikz/dash pattern=on 0 off 1mm}}\n"
+    "\n"
+    "\\begin{document}\n"
+    "\\begin{tikzcd}\n"
+    "A \\arrow[r] & B\n"
+    "\\end{tikzcd}\n"
+    "\\end{document}"
+  )
+)
+
+(check
+  (wrap-quiver-code "\\begin{tikzcd}\nA \\arrow[r] & B\n\\end{tikzcd}")
+  =>
+  (string-append
+    "\\documentclass[tikz]{standalone}\n"
+    "\\usepackage{tikz-cd}\n"
+    "\\usepackage{amssymb}\n"
+    "\\usetikzlibrary{calc}\n"
+    "\\usetikzlibrary{decorations.pathmorphing}\n"
+    "\\usetikzlibrary{spath3}\n"
+    "\n"
+    "\\tikzset{curve/.style={settings={#1},to path={(\\tikztostart)\n"
+    "    .. controls ($(\\tikztostart)!\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+    "    and ($(\\tikztostart)!1-\\pv{pos}!(\\tikztotarget)!\\pv{height}!270:(\\tikztotarget)$)\n"
+    "    .. (\\tikztostart)\\tikztonodes}},\n"
+    "    settings/.code={\\tikzset{quiver/.cd,#1}\n"
+    "        \\def\\pv##1{\\pgfkeysvalueof{/tikz/quiver/##1}}},\n"
+    "    quiver/.cd,pos/.initial=0.35,height/.initial=0}\n"
+    "\n"
+    "\\tikzset{between/.style n args={2}{/tikz/execute at end to={\n"
+    "    \\tikzset{spath/split at keep middle={current}{#1}{#2}}\n"
+    "}}}\n"
+    "\n"
+    "\\tikzset{tail reversed/.code={\\pgfsetarrowsstart{tikzcd to}}}\n"
+    "\\tikzset{2tail/.code={\\pgfsetarrowsstart{Implies[reversed]}}}\n"
+    "\\tikzset{2tail reversed/.code={\\pgfsetarrowsstart{Implies}}}\n"
+    "\\tikzset{no body/.style={/tikz/dash pattern=on 0 off 1mm}}\n"
+    "\n"
+    "\\begin{document}\n"
+    "\\begin{tikzcd}\n"
+    "A \\arrow[r] & B\n"
+    "\\end{tikzcd}\n"
+    "\\end{document}"
+  )
+)
+
+(check-report "Quiver plugin unit tests")

--- a/TeXmacs/plugins/tikz/goldfish/tm-tikz.scm
+++ b/TeXmacs/plugins/tikz/goldfish/tm-tikz.scm
@@ -67,16 +67,31 @@
                    (or has-chemfig?
                        (string-contains? body "\\chem")
                        (string-contains? body "\\scheme")))
+                 (has-quiver? (string-starts? body-trimmed "\\begin{tikzcd}"))
+                 (need-quiver-package?
+                   (or has-quiver?
+                       (string-contains? body "\\begin{tikzcd}")
+                       (string-contains? body "\\arrow")))
                  (extra-packages
-                   (if (and need-chemfig-package?
-                            (null? (filter (lambda (line) (string-contains? line "chemfig"))
-                                           package-lines)))
-                       '("\\usepackage{chemfig}")
-                       '()))
+                   (let ((pkgs '()))
+                     (when (and need-chemfig-package?
+                                (null? (filter (lambda (line) (string-contains? line "chemfig"))
+                                               package-lines)))
+                       (set! pkgs (append pkgs '("\\usepackage{chemfig}"))))
+                     (when (and need-quiver-package?
+                                (null? (filter (lambda (line) (string-contains? line "tikz-cd"))
+                                               package-lines)))
+                       (set! pkgs (append pkgs '("\\usepackage{tikz-cd}"))))
+                     (when (and need-quiver-package?
+                                (null? (filter (lambda (line) (string-contains? line "quiver"))
+                                               package-lines)))
+                       (set! pkgs (append pkgs '("\\usepackage{quiver}"))))
+                     pkgs))
                  (inner-code
                    (if (or (string-null? body-trimmed)
                            (string-starts? body-trimmed "\\begin{tikzpicture}")
-                           has-chemfig?)
+                           has-chemfig?
+                           has-quiver?)
                        body
                        (string-append "\\begin{tikzpicture}\n" body "\n\\end{tikzpicture}"))))
             (string-append

--- a/TeXmacs/plugins/tikz/tests/tm-tikz-test.scm
+++ b/TeXmacs/plugins/tikz/tests/tm-tikz-test.scm
@@ -45,16 +45,31 @@
                  (or has-chemfig?
                      (string-contains? body "\\chem")
                      (string-contains? body "\\scheme")))
+               (has-quiver? (string-starts? body-trimmed "\\begin{tikzcd}"))
+               (need-quiver-package?
+                 (or has-quiver?
+                     (string-contains? body "\\begin{tikzcd}")
+                     (string-contains? body "\\arrow")))
                (extra-packages
-                 (if (and need-chemfig-package?
-                          (null? (filter (lambda (line) (string-contains? line "chemfig"))
-                                         package-lines)))
-                     '("\\usepackage{chemfig}")
-                     '()))
+                 (let ((pkgs '()))
+                   (when (and need-chemfig-package?
+                              (null? (filter (lambda (line) (string-contains? line "chemfig"))
+                                             package-lines)))
+                     (set! pkgs (append pkgs '("\\usepackage{chemfig}"))))
+                   (when (and need-quiver-package?
+                              (null? (filter (lambda (line) (string-contains? line "tikz-cd"))
+                                             package-lines)))
+                     (set! pkgs (append pkgs '("\\usepackage{tikz-cd}"))))
+                   (when (and need-quiver-package?
+                              (null? (filter (lambda (line) (string-contains? line "quiver"))
+                                             package-lines)))
+                     (set! pkgs (append pkgs '("\\usepackage{quiver}"))))
+                   pkgs))
                (inner-code
                  (if (or (string-null? body-trimmed)
                          (string-starts? body-trimmed "\\begin{tikzpicture}")
-                         has-chemfig?)
+                         has-chemfig?
+                         has-quiver?)
                    body
                    (string-append "\\begin{tikzpicture}\n" body "\n\\end{tikzpicture}")
                  ) ;if
@@ -302,6 +317,28 @@
 (check (pdf-page-empty? test-log-vertical-path) => #f)
 (check (pdf-page-empty? test-log-horizontal-path) => #f)
 (check (pdf-page-empty? test-log-point-path) => #f)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for Quiver support
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(check
+  (wrap-tikz-code "\\begin{tikzcd}\nA \\arrow[r] & B\n\\end{tikzcd}")
+  =>
+  "\\documentclass[tikz]{standalone}\n\\usepackage{tikz-cd}\n\\usepackage{quiver}\n\\begin{document}\n\\begin{tikzcd}\nA \\arrow[r] & B\n\\end{tikzcd}\n\\end{document}"
+)
+
+(check
+  (wrap-tikz-code "\\usepackage{tikz-cd}\n\\usepackage{quiver}\n\\begin{tikzcd}\nA \\arrow[r] & B\n\\end{tikzcd}")
+  =>
+  "\\documentclass[tikz]{standalone}\n\\usepackage{tikz-cd}\n\\usepackage{quiver}\n\\begin{document}\n\\begin{tikzcd}\nA \\arrow[r] & B\n\\end{tikzcd}\n\\end{document}"
+)
+
+(check
+  (wrap-tikz-code "\\node (diagram) at (0,0) {\\begin{tikzcd} A \\arrow[r] & B \\end{tikzcd}};\n\\draw (0,0) -- (1,1);")
+  =>
+  "\\documentclass[tikz]{standalone}\n\\usepackage{tikz-cd}\n\\usepackage{quiver}\n\\begin{document}\n\\begin{tikzpicture}\n\\node (diagram) at (0,0) {\\begin{tikzcd} A \\arrow[r] & B \\end{tikzcd}};\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
+)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Run all tests

--- a/devel/0612.md
+++ b/devel/0612.md
@@ -495,3 +495,51 @@ pdflatex 编译报错，输出 `pdflatex error`。
 - `TeXmacs/plugins/tikz/goldfish/tm-tikz.scm`
 - `TeXmacs/plugins/tikz/tests/tm-tikz-test.scm`
 - `TeXmacs/tests/tmu/0612.tmu`
+
+## 15 增加对 quiver 的支持
+
+### 15.1 问题与需求分析
+
+Quiver 是一个优秀的交换图编辑器，能将绘制的交换图转换为 LaTeX 的 `tikz-cd` 及 `quiver` 宏包代码（通常最外层包裹在 `\begin{tikzcd}` 中）。
+为了在 TikZ 插件中无缝支持 quiver 生成的交换图代码：
+1. **自动引入包**：检测到代码包含 `\begin{tikzcd}` 或 `\arrow` 等 quiver 标记时，在 LaTeX 文档前置区（Preamble）自动引入 `\usepackage{tikz-cd}` 与 `\usepackage{quiver}` 宏包。
+2. **避免重复包裹**：如果代码以 `\begin{tikzcd}` 开头，则无需将其包裹在最外层的 `\begin{tikzpicture} ... \end{tikzpicture}` 环境中，因为 `tikzcd` 是其自身的顶级环境。而如果 `tikzcd` 嵌套在其他节点中（如 `\node`），则依然保留外层包裹。
+
+### 15.2 修复/实现方案
+
+在 `tm-tikz.scm` 的 `wrap-tikz-code` 函数中：
+1. 定义检测变量 `has-quiver?` 以判断代码最外层是否以 `\begin{tikzcd}` 开头：
+   ```scheme
+   (has-quiver? (string-starts? body-trimmed "\\begin{tikzcd}"))
+   ```
+2. 定义检测变量 `need-quiver-package?` 以判定正文中是否包含 `\begin{tikzcd}` 或 `\arrow` 关键字：
+   ```scheme
+   (need-quiver-package?
+     (or has-quiver?
+         (string-contains? body "\\begin{tikzcd}")
+         (string-contains? body "\\arrow")))
+   ```
+3. 在 `extra-packages` 判定中，如果需要 quiver 并且 `package-lines` 未包含对应的引入指令，自动添加：
+   ```scheme
+   (when (and need-quiver-package?
+              (null? (filter (lambda (line) (string-contains? line "tikz-cd"))
+                             package-lines)))
+     (set! pkgs (append pkgs '("\\usepackage{tikz-cd}"))))
+   (when (and need-quiver-package?
+              (null? (filter (lambda (line) (string-contains? line "quiver"))
+                             package-lines)))
+     (set! pkgs (append pkgs '("\\usepackage{quiver}"))))
+   ```
+4. 将 `has-quiver?` 作为绕过 `tikzpicture` 环境包裹的过滤条件之一。
+
+### 15.3 测试覆盖
+
+在 `tm-tikz-test.scm` 单元测试中同步更新测试辅助的 `wrap-tikz-code` 函数，并新增 3 个测试用例：
+1. `\begin{tikzcd}` 开头代码 -> 自动前置引入 `tikz-cd` 与 `quiver` 宏包，并且不重复包裹 `tikzpicture`；
+2. 已经手动声明 `\usepackage` 的情况下 -> 不重复注入宏包；
+3. `\begin{tikzcd}` 嵌套在 `\node` 中 -> 自动前置引入宏包，但依然对最外层包裹 `tikzpicture` 环境。
+
+### 15.4 相关文件
+
+- `TeXmacs/plugins/tikz/goldfish/tm-tikz.scm`
+- `TeXmacs/plugins/tikz/tests/tm-tikz-test.scm`

--- a/devel/0612_quiver.md
+++ b/devel/0612_quiver.md
@@ -1,0 +1,53 @@
+# [0612] 新增独立的 Quiver 交换图插件与会话支持
+
+## 1 相关文档
+- [0612.md](0612.md) - TikZ 插件基础开发与重构任务文档
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/quiver/progs/init-quiver.scm` — 插件初始化与会话注册
+- `TeXmacs/plugins/quiver/progs/data/quiver.scm` — 注册 `quiver` 格式与转换器
+- `TeXmacs/plugins/quiver/progs/code/quiver-mode.scm` — Quiver 编辑模式检测
+- `TeXmacs/plugins/quiver/progs/code/quiver-edit.scm` — Quiver 编辑器特性、快捷键、括号配对
+- `TeXmacs/plugins/quiver/progs/code/quiver-lang.scm` — Quiver 词法着色与语法高亮
+- `TeXmacs/plugins/quiver/goldfish/tm-quiver.scm` — Quiver 核心编译、包注入逻辑
+- `TeXmacs/plugins/quiver/tests/tm-quiver-test.scm` — Quiver 单元测试用例
+
+## 3 如何测试
+
+### 3.1 单元测试（确定性测试）
+1. 构建 Goldfish Scheme 解释器：
+   ```bash
+   xmake b goldfish
+   ```
+2. 运行 Quiver 插件单元测试：
+   ```bash
+   TeXmacs/plugins/goldfish/bin/goldfish load TeXmacs/plugins/quiver/tests/tm-quiver-test.scm
+   ```
+
+### 3.2 会话与文档验证（非确定性测试）
+1. 构建并运行 Mogan STEM：
+   ```bash
+   xmake b stem
+   xmake r stem
+   ```
+2. 手动验证：通过菜单 `Insert -> Session -> Quiver` 插入 Quiver 交换图会话：
+   - 验证可以正常输入交换图代码（如 `A \arrow[r] & B`）并自适应生成正确的 PDF 预览。
+   - 验证语法高亮是否正常染色（如 `arrow`, `begin`, `end`, `tikzcd` 等关键词着色）。
+   - 验证括号、括号配对和自动对齐功能是否正常。
+
+## 4 What
+实现一个高内聚、低耦合、完全独立的 `quiver` 交换图插件：
+1. 采用与 `tikz` 插件一致的现代 Goldfish Scheme 架构进行开发。
+2. 在 `Insert -> Session` 菜单中新增专属的 `Quiver` 会话入口。
+3. 自动注入完整的、自包含的 quiver 支持宏定义及 TikZ 依赖库（`tikz-cd`, `amssymb`, `calc`, `spath3` 等），使用户在无需安装 `quiver.sty` 本地库的机器上亦能渲染包含高级 quiver 属性（如 curve，between 比例缩短等）的精美图表。
+4. 保证在代码最外层不是 `tikzcd` 时能自动完成环境包裹，是 `tikzcd` 时能绕过 `tikzpicture` 环境，以实现无痛渲染。
+
+## 5 Why
+1. **职责分离（Separation of Concerns）**：Quiver 虽然生成的是 TikZ/tikz-cd 代码，但它代表了一个独特的“交换图编辑/呈现”领域，拥有自己特定的宏包依赖、样式集及最顶层环境。将其与基础 TikZ 绘图混在一起，不仅会让 TikZ 的代码膨胀，还会增加对无关图表的干扰风险。
+2. **完美的用户体验**：作为一个单独的插件注册，让用户能直接插入 `Quiver` 会话。
+3. **独立测试与演进**：有了单独的测试集和代码文件，后期针对 Quiver 的快捷键优化、宏包升级都更加安全和便利。
+
+## 6 How
+1. **测试驱动开发 (TDD)**：先实现 `tm-quiver-test.scm` 以验证 `wrap-quiver-code` 的自动包注入和环境自适应逻辑，确认测试失败后再在 `tm-quiver.scm` 中写出最终实现，保证其 100% 运行通过。
+2. **注册独立会话**：在 `init-quiver.scm` 中，通过 `(plugin-configure quiver ... (:session "Quiver"))` 完成高层会话绑定与命令启动。
+3. **语言解析与语法高亮**：创建 `quiver-lang.scm` 词法文件，定义对 `arrow`, `tikzcd`, `begin`, `end` 等特有结构的着色支持。


### PR DESCRIPTION
## Summary
- **独立高内聚插件**：在 `TeXmacs/plugins/quiver` 目录下实现了一个全新的、高内聚低耦合的 `quiver` 交换图插件，使 `quiver` 与基础 `tikz` 插件完全解耦分离。
- **添加 Quiver 专属会话**：在 Mogan STEM 的会话菜单中新增了独立的 `Quiver` 会话（注册为 `(:session "Quiver")`）。
- **一键自包含包注入**：当用户输入交换图代码（如 `A \arrow[r] & B`）时，插件能自动前置引入 `tikz-cd`、`amssymb`、以及 `calc`、`decorations.pathmorphing`、`spath3` 等依赖的 TikZ 库，并内置注入完整的 `curve`、`between` 等 quiver 专属样式。这保证了用户在本地没有安装 `quiver.sty` 宏包的情况下，依然能无痛且像素级精准地渲染高级 Quiver 图表。
- **环境自适应绕过**：最外层是以 `\begin{tikzcd}` 开头的代码会自动绕过外层 `tikzpicture` 环境包裹，避免嵌套编译报错；如果非最外层开头（如嵌套在 `\node` 里），则能自适应保留外层包裹，功能兼容性极佳。
- **全方位高亮与高级编辑支持**：为 Quiver 新建了 `quiver-lang.scm`、`quiver-mode.scm`、`quiver-edit.scm`、`quiver.scm`，提供了完整的语法高亮（对 `arrow`, `tikzcd`, `begin`, `end` 等进行染色）、括号匹配、括号高亮以及专属快捷键。
- **TDD 开发**：编写了 `tm-quiver-test.scm` 单元测试包，3 项测试用例全数通过。