### PR TITLE
[1027] 修复对话页面无法添加空白文档的问题

### DIFF
--- a/devel/1027.md
+++ b/devel/1027.md
@@ -1,0 +1,52 @@
+# [1027] 修复对话页面无法添加空白文档的问题
+
+任务编号使用 0000 到 9999 的四位数字格式。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0219.md](0219.md) - chat tab C++ 部分重构
+
+## 2 任务相关的代码文件
+- src/Texmacs/Data/new_window.cpp - `switch_to_parent_window` 函数
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 打开 Mogan，进入 Chat Tab
+2. 在 Chat Tab 中点击新建空白文档
+3. 验证能正常创建空白文档并切换到新文档
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+修复 Chat Tab 中无法新建空白文档的问题。
+
+1. 在 `switch_to_parent_window` 函数中补充视图同步逻辑
+
+## 6 Why
+`switch_to_parent_window` 函数在切换到父窗口后，只调用了 `switch_to_window(parent)` 同步了窗口状态，但没有调用 `set_current_view` 同步 Scheme 层的当前视图指针。
+
+Chat Tab 是一个非 default 类型的子视图，新建文档时会经过 `with-default-view` -> `ensure-default-view` -> `switch_to_parent_window` 的调用链。由于视图未同步，后续的 `new-buffer` 等操作仍基于旧的 chat 子视图上下文执行，导致创建失败。
+
+其他 tab（如 startup tab）本身就在 default 视图中操作，`is-view-type?` 检查返回 true，不会触发 `switch_to_parent_window`，因此不受影响。
+
+## 7 How
+在 `switch_to_window(parent)` 之后，补充两行代码：
+
+```cpp
+url parent_view= window_to_view (parent);
+if (!is_none (parent_view)) set_current_view (parent_view);
+```
+
+通过 `window_to_view` 获取父窗口关联的视图，再用 `set_current_view` 将 Scheme 层的当前视图指针更新为该视图，确保窗口切换和视图切换保持一致。

--- a/src/Texmacs/Data/new_window.cpp
+++ b/src/Texmacs/Data/new_window.cpp
@@ -251,6 +251,8 @@ switch_to_parent_window () {
   if (parent == url_none ()) return;
   if (parent == get_current_window ()) return;
   switch_to_window (parent);
+  url parent_view= window_to_view (parent);
+  if (!is_none (parent_view)) set_current_view (parent_view);
 }
 
 /******************************************************************************


### PR DESCRIPTION
## Summary
- 修复 Chat Tab 中无法新建空白文档的问题
- `switch_to_parent_window` 在切换窗口后未同步视图指针，导致后续操作上下文错误

## Test plan
- [x] 打开 Mogan，进入 Chat Tab
- [ ] 在 Chat Tab 中点击新建空白文档
- [ ] 验证能正常创建空白文档

🤖 Generated with [Claude Code](https://claude.com/claude-code)