### PR TITLE
[0159] 修复 PDF 阅读器鼠标左键按下不总是生效的问题

### DIFF
--- a/devel/0159.md
+++ b/devel/0159.md
@@ -1,0 +1,50 @@
+# [0159] 修复 PDF 阅读器鼠标左键按下不总是生效的问题
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp`
+- `tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+xmake b qt_pdf_reader_widget_test
+xmake r qt_pdf_reader_widget_test
+```
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，打开一个带链接的 PDF 文件
+2. 快速连续两次点击 PDF 页面（双击）
+3. 验证第二次点击也能正常触发拖拽或链接跳转
+
+## 如何提交
+
+```bash
+xmake b qt_pdf_reader_widget_test
+xmake r qt_pdf_reader_widget_test
+```
+
+## What
+
+修复 PDF 阅读器中鼠标左键按下不是每次都生效的问题。
+
+1. 调研确认根本原因：`eventFilter` 未处理 `MouseButtonDblClick`
+2. 添加 3 个单元测试复现双击场景（TDD）
+3. 修复 `eventFilter` 使其将 `MouseButtonDblClick` 视为 `MouseButtonPress`
+
+## Why
+
+在 Qt 中，当用户快速连续两次点击时，第二次的按下事件类型是 `QEvent::MouseButtonDblClick`，而不是 `QEvent::MouseButtonPress`。原代码的 `eventFilter` 只处理了 `MouseButtonPress`，导致双击时第二次按下被完全忽略，表现为鼠标左键"不是每次都生效"。
+
+## How
+
+在 `PDFReaderWidget::eventFilter` 中做以下修改：
+
+1. 将 `QEvent::MouseButtonDblClick` 纳入鼠标事件坐标预计算（`isMouseEvent` 条件）
+2. 浏览模式（hand tool）的鼠标按下分支：同时接受 `MouseButtonPress` 和 `MouseButtonDblClick`
+3. 矩形选择模式的鼠标按下分支：同样接受 `MouseButtonDblClick`
+
+释放（`MouseButtonRelease`）分支无需修改，因为双击序列中的释放事件类型仍然是 `MouseButtonRelease`。

--- a/devel/0159.md
+++ b/devel/0159.md
@@ -16,9 +16,13 @@ xmake r qt_pdf_reader_widget_test
 ```
 
 ### 非确定性测试（文档验证）
-1. 启动 Mogan，打开一个带链接的 PDF 文件
-2. 快速连续两次点击 PDF 页面（双击）
-3. 验证第二次点击也能正常触发拖拽或链接跳转
+1. 启动 Mogan，打开一个 PDF 文件
+2. 在浏览模式下，将鼠标移到 PDF 页面上（cursor 应为松开的小手 `OpenHandCursor`）
+3. 按下鼠标左键不松开（cursor 应变回握紧的小手 `ClosedHandCursor`）
+4. 按住左键拖动页面（cursor 应保持握紧的小手 `ClosedHandCursor`）
+5. 松开鼠标左键（cursor 应变回松开的小手 `OpenHandCursor`）
+6. 快速双击 PDF 页面，验证第二次按下也能正常进入握紧状态
+7. 将鼠标移到链接上（cursor 变为手指 `PointingHandCursor`），按下左键后在链接上拖动，验证 cursor 保持握紧状态
 
 ## 如何提交
 

--- a/devel/0159.md
+++ b/devel/0159.md
@@ -29,22 +29,27 @@ xmake r qt_pdf_reader_widget_test
 
 ## What
 
-修复 PDF 阅读器中鼠标左键按下不是每次都生效的问题。
+修复 PDF 阅读器中鼠标左键按下时不是每次都生效的问题。
+
+具体表现：在浏览模式下，按下鼠标左键时 cursor 应从松开的小手（`OpenHandCursor`）变为握紧的小手（`ClosedHandCursor`），松开时才恢复。但快速连续点击（双击）时，第二次按下往往不生效，cursor 仍保持松开状态。
 
 1. 调研确认根本原因：`eventFilter` 未处理 `MouseButtonDblClick`
-2. 添加 3 个单元测试复现双击场景（TDD）
+2. 添加 3 个单元测试复现双击场景
 3. 修复 `eventFilter` 使其将 `MouseButtonDblClick` 视为 `MouseButtonPress`
 
 ## Why
 
-在 Qt 中，当用户快速连续两次点击时，第二次的按下事件类型是 `QEvent::MouseButtonDblClick`，而不是 `QEvent::MouseButtonPress`。原代码的 `eventFilter` 只处理了 `MouseButtonPress`，导致双击时第二次按下被完全忽略，表现为鼠标左键"不是每次都生效"。
+在 Qt 中，当用户快速连续两次点击时，第二次的按下事件类型是 `QEvent::MouseButtonDblClick`，而不是 `QEvent::MouseButtonPress`。原代码的 `eventFilter` 只处理了 `MouseButtonPress`，导致双击时第二次按下被完全忽略，表现为鼠标左键按下不是每次都生效（cursor 不变为握紧的小手）。
 
 ## How
 
-在 `PDFReaderWidget::eventFilter` 中做以下修改：
+采用 TDD 方式开发：
 
-1. 将 `QEvent::MouseButtonDblClick` 纳入鼠标事件坐标预计算（`isMouseEvent` 条件）
-2. 浏览模式（hand tool）的鼠标按下分支：同时接受 `MouseButtonPress` 和 `MouseButtonDblClick`
-3. 矩形选择模式的鼠标按下分支：同样接受 `MouseButtonDblClick`
+1. **先写测试**：添加 `test_doubleClickStartsDrag`、`test_doubleClickInRectSelectMode`、`test_doubleClickOnLinkTriggersClick` 三个测试，验证双击时第二次按下应正确触发拖拽/选择/链接点击。运行确认测试失败。
+2. **再改代码**：在 `PDFReaderWidget::eventFilter` 中：
+   - 将 `QEvent::MouseButtonDblClick` 纳入鼠标事件坐标预计算（`isMouseEvent` 条件）
+   - 浏览模式（hand tool）的鼠标按下分支：同时接受 `MouseButtonPress` 和 `MouseButtonDblClick`
+   - 矩形选择模式的鼠标按下分支：同样接受 `MouseButtonDblClick`
+3. **验证测试**：运行全部 38 个测试，均通过。
 
 释放（`MouseButtonRelease`）分支无需修改，因为双击序列中的释放事件类型仍然是 `MouseButtonRelease`。

--- a/devel/0159.md
+++ b/devel/0159.md
@@ -31,7 +31,7 @@ xmake r qt_pdf_reader_widget_test
 
 修复 PDF 阅读器中鼠标左键按下时不是每次都生效的问题。
 
-具体表现：在浏览模式下，按下鼠标左键时 cursor 应从松开的小手（`OpenHandCursor`）变为握紧的小手（`ClosedHandCursor`），松开时才恢复。但快速连续点击（双击）时，第二次按下往往不生效，cursor 仍保持松开状态。
+具体表现：在浏览模式下，正常的鼠标状态流转应为——默认松开的小手（`OpenHandCursor`）→ 按下左键变为握紧的小手（`ClosedHandCursor`）→ 拖动过程中保持握紧 → 松开左键恢复为松开的小手。但快速连续点击（双击）时，第二次按下往往不生效，cursor 仍停留在松开状态，无法进入握紧状态。
 
 1. 调研确认根本原因：`eventFilter` 未处理 `MouseButtonDblClick`
 2. 添加 3 个单元测试复现双击场景

--- a/devel/0159.md
+++ b/devel/0159.md
@@ -31,25 +31,37 @@ xmake r qt_pdf_reader_widget_test
 
 修复 PDF 阅读器中鼠标左键按下时不是每次都生效的问题。
 
-具体表现：在浏览模式下，正常的鼠标状态流转应为——默认松开的小手（`OpenHandCursor`）→ 按下左键变为握紧的小手（`ClosedHandCursor`）→ 拖动过程中保持握紧 → 松开左键恢复为松开的小手。但快速连续点击（双击）时，第二次按下往往不生效，cursor 仍停留在松开状态，无法进入握紧状态。
+具体表现：在浏览模式下，正常的鼠标状态流转应为——默认松开的小手（`OpenHandCursor`）→ 按下左键变为握紧的小手（`ClosedHandCursor`）→ 拖动过程中保持握紧 → 松开左键恢复为松开的小手。实际存在两个问题导致这一状态流转不总是生效：
 
-1. 调研确认根本原因：`eventFilter` 未处理 `MouseButtonDblClick`
-2. 添加 3 个单元测试复现双击场景
+1. **双击时第二次按下不生效**：快速连续点击（双击）时，第二次按下被 Qt 发送为 `MouseButtonDblClick` 而非 `MouseButtonPress`，`eventFilter` 未处理该事件类型，导致 cursor 仍停留在松开状态。
+2. **按下后微移时 cursor 提前恢复松开**：按下左键后、移动距离未超过拖拽阈值前，`updateLinkCursor` 会在鼠标不在链接上时将 cursor 错误地改回 `OpenHandCursor`，违背了"拖动过程中保持握紧"的状态要求。
+
+修复工作：
+1. 调研确认两个根本原因
+2. 添加 4 个单元测试复现问题场景（TDD）
 3. 修复 `eventFilter` 使其将 `MouseButtonDblClick` 视为 `MouseButtonPress`
+4. 修复 `MouseMove` 分支中 `updateLinkCursor` 错误覆盖 cursor 的问题
 
 ## Why
 
-在 Qt 中，当用户快速连续两次点击时，第二次的按下事件类型是 `QEvent::MouseButtonDblClick`，而不是 `QEvent::MouseButtonPress`。原代码的 `eventFilter` 只处理了 `MouseButtonPress`，导致双击时第二次按下被完全忽略，表现为鼠标左键按下不是每次都生效（cursor 不变为握紧的小手）。
+存在两个独立的问题：
+
+1. **双击事件被忽略**：Qt 中快速连续两次点击时，第二次的按下事件类型是 `QEvent::MouseButtonDblClick`，而不是 `QEvent::MouseButtonPress`。原代码的 `eventFilter` 只处理了 `MouseButtonPress`，导致双击时第二次按下被完全忽略。
+
+2. **`updateLinkCursor` 错误覆盖 cursor**：在 `browseDragging_` 为 true 但 `browseDragActive_` 为 false（即按下后、超过拖拽阈值前）的 `MouseMove` 处理中，代码调用了 `updateLinkCursor` 来更新链接状态。当鼠标不在链接上时，`updateLinkCursor` 会把 cursor 设回 `OpenHandCursor`，覆盖了 Press 时设置的 `ClosedHandCursor`，导致按下后稍微移动鼠标 cursor 就提前恢复为松开状态。
 
 ## How
 
 采用 TDD 方式开发：
 
-1. **先写测试**：添加 `test_doubleClickStartsDrag`、`test_doubleClickInRectSelectMode`、`test_doubleClickOnLinkTriggersClick` 三个测试，验证双击时第二次按下应正确触发拖拽/选择/链接点击。运行确认测试失败。
-2. **再改代码**：在 `PDFReaderWidget::eventFilter` 中：
-   - 将 `QEvent::MouseButtonDblClick` 纳入鼠标事件坐标预计算（`isMouseEvent` 条件）
-   - 浏览模式（hand tool）的鼠标按下分支：同时接受 `MouseButtonPress` 和 `MouseButtonDblClick`
-   - 矩形选择模式的鼠标按下分支：同样接受 `MouseButtonDblClick`
-3. **验证测试**：运行全部 38 个测试，均通过。
+1. **先写测试**：
+   - 添加 `test_doubleClickStartsDrag`、`test_doubleClickInRectSelectMode`、`test_doubleClickOnLinkTriggersClick` 三个测试，验证双击时第二次按下应正确触发拖拽/选择/链接点击。运行确认测试失败。
+   - 添加 `test_dragKeepsClosedHandBeforeThreshold`，验证按下左键后、移动未超过阈值前 cursor 应保持 `ClosedHandCursor`。运行确认测试失败。
+2. **再改代码**：
+   - 在 `PDFReaderWidget::eventFilter` 中将 `QEvent::MouseButtonDblClick` 纳入鼠标事件坐标预计算（`isMouseEvent` 条件）。
+   - 浏览模式（hand tool）的鼠标按下分支：同时接受 `MouseButtonPress` 和 `MouseButtonDblClick`。
+   - 矩形选择模式的鼠标按下分支：同样接受 `MouseButtonDblClick`。
+   - 在 `MouseMove` 分支中，当 `!browseDragActive_` 调用 `updateLinkCursor` 后，若 `!overLink_` 则将 cursor 恢复为 `ClosedHandCursor`，确保左键按下期间 cursor 不会提前变回松开状态。
+3. **验证测试**：运行全部 39 个测试，均通过。
 
 释放（`MouseButtonRelease`）分支无需修改，因为双击序列中的释放事件类型仍然是 `MouseButtonRelease`。

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -1427,7 +1427,8 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
     QPoint viewportPos, contentPos;
     bool   isMouseEvent= (event->type () == QEvent::MouseMove ||
                         event->type () == QEvent::MouseButtonPress ||
-                        event->type () == QEvent::MouseButtonRelease);
+                        event->type () == QEvent::MouseButtonRelease ||
+                        event->type () == QEvent::MouseButtonDblClick);
     if (isMouseEvent) {
       QMouseEvent* me= static_cast<QMouseEvent*> (event);
       viewportPos    = me->pos ();
@@ -1505,7 +1506,9 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
     // ============================================================
     // Browse (hand) tool: default drag-to-scroll behavior
     // ============================================================
-    else if (!rectSelectMode_ && event->type () == QEvent::MouseButtonPress) {
+    else if (!rectSelectMode_ &&
+             (event->type () == QEvent::MouseButtonPress ||
+              event->type () == QEvent::MouseButtonDblClick)) {
       QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
       if (mouseEvent->button () == Qt::LeftButton) {
         browseDragging_    = true;
@@ -1553,7 +1556,9 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
     // ============================================================
     // Rectangular selection mode
     // ============================================================
-    else if (rectSelectMode_ && event->type () == QEvent::MouseButtonPress) {
+    else if (rectSelectMode_ &&
+             (event->type () == QEvent::MouseButtonPress ||
+              event->type () == QEvent::MouseButtonDblClick)) {
       QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
       if (mouseEvent->button () == Qt::LeftButton) {
         rectSelectDragging_= true;

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -1532,6 +1532,9 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
       }
       if (!browseDragActive_) {
         updateLinkCursor (contentPos);
+        if (!overLink_) {
+          scrollArea_->viewport ()->setCursor (Qt::ClosedHandCursor);
+        }
       }
       scroller_->handleInput (QScroller::InputMove, viewportPos,
                               mouseEvent->timestamp ());

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -522,8 +522,7 @@ private slots:
     QCOMPARE (vp->cursor ().shape (), Qt::ClosedHandCursor);
 
     // Move a tiny distance (below drag threshold) and not over a link
-    QPoint smallMove (
-        start.x () + 1, start.y () + 1);
+    QPoint smallMove (start.x () + 1, start.y () + 1);
     QTest::mouseMove (vp, smallMove);
     QApplication::processEvents ();
 
@@ -1197,8 +1196,9 @@ private slots:
     // QTest::mouseDClick sends dblclick+release; release hides the band,
     // so we send only the dblclick event to verify the press path.
     {
-      QMouseEvent dblClickEvent (QEvent::MouseButtonDblClick, pos, Qt::LeftButton,
-                                 Qt::LeftButton, Qt::NoModifier);
+      QMouseEvent dblClickEvent (QEvent::MouseButtonDblClick, pos,
+                                 Qt::LeftButton, Qt::LeftButton,
+                                 Qt::NoModifier);
       QApplication::sendEvent (vp, &dblClickEvent);
     }
     QApplication::processEvents ();
@@ -1256,7 +1256,8 @@ private slots:
     // Simulate only the dblclick event (the second press of a double-click)
     {
       QMouseEvent dblClickEvent (QEvent::MouseButtonDblClick, QPoint (50, 50),
-                                 Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+                                 Qt::LeftButton, Qt::LeftButton,
+                                 Qt::NoModifier);
       QApplication::sendEvent (vp, &dblClickEvent);
     }
     QApplication::processEvents ();

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -1078,6 +1078,162 @@ private slots:
 
     delete widget;
   }
+
+  // ============================================================
+  // Double-click tests (TDD for mouse-left-button-not-always-working)
+  // ============================================================
+
+  void test_doubleClickStartsDrag () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+    QApplication::processEvents ();
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+    QCOMPARE (vp->cursor ().shape (), Qt::OpenHandCursor);
+
+    // Simulate a double-click: press, release, dblclick, release
+    QPoint pos (100, 100);
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, pos);
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::ClosedHandCursor);
+
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, pos);
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::OpenHandCursor);
+
+    // Now the second click of the double-click sequence
+    QTest::mouseDClick (vp, Qt::LeftButton, Qt::NoModifier, pos);
+    QApplication::processEvents ();
+
+    // After the dblclick event the cursor must be ClosedHandCursor,
+    // proving the second press was handled.
+    QCOMPARE (vp->cursor ().shape (), Qt::ClosedHandCursor);
+
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, pos);
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::OpenHandCursor);
+
+    delete widget;
+  }
+
+  void test_doubleClickInRectSelectMode () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+    QApplication::processEvents ();
+
+    QToolButton* rectBtn=
+        widget->findChild<QToolButton*> ("pdf-screenshot-btn");
+    QVERIFY (rectBtn != nullptr);
+    rectBtn->click ();
+    QApplication::processEvents ();
+    QVERIFY (widget->isRectSelectMode ());
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+
+    QPoint pos (50, 50);
+
+    // First click starts rubber band
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, pos);
+    QApplication::processEvents ();
+
+    QRubberBand* rb= widget->findChild<QRubberBand*> ();
+    QVERIFY (rb != nullptr);
+    QVERIFY (rb->isVisible ());
+
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, pos);
+    QApplication::processEvents ();
+
+    // Second click of a double-click must also start rubber band.
+    // QTest::mouseDClick sends dblclick+release; release hides the band,
+    // so we send only the dblclick event to verify the press path.
+    {
+      QMouseEvent dblClickEvent (QEvent::MouseButtonDblClick, pos, Qt::LeftButton,
+                                 Qt::LeftButton, Qt::NoModifier);
+      QApplication::sendEvent (vp, &dblClickEvent);
+    }
+    QApplication::processEvents ();
+    QVERIFY (rb->isVisible ());
+
+    delete widget;
+  }
+
+  void test_doubleClickOnLinkTriggersClick () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (!is_regular (pdfUrl)) {
+      delete widget;
+      return;
+    }
+    widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    QApplication::processEvents ();
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+
+    QString capturedUri;
+    connect (widget, &PDFReaderWidget::linkClicked,
+             [&capturedUri] (const QString& uri) { capturedUri= uri; });
+
+    QVector<PdfLink> links;
+    PdfLink          link;
+    link.rect= QRectF (0.0, 0.0, 0.5, 0.5);
+    link.uri = "https://example.com";
+    links.append (link);
+    widget->setTestLinks (0, links);
+
+    // Hover to set overLink_
+    {
+      QMouseEvent moveEvent (QEvent::MouseMove, QPoint (50, 50), Qt::NoButton,
+                             Qt::NoButton, Qt::NoModifier);
+      QApplication::sendEvent (vp, &moveEvent);
+    }
+    QApplication::processEvents ();
+    QVERIFY (widget->isOverLink ());
+
+    // First click
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, QPoint (50, 50));
+    QApplication::processEvents ();
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, QPoint (50, 50));
+    QApplication::processEvents ();
+
+    // Verify first click worked, then reset
+    QCOMPARE (capturedUri, QString ("https://example.com"));
+    capturedUri.clear ();
+
+    // Simulate only the dblclick event (the second press of a double-click)
+    {
+      QMouseEvent dblClickEvent (QEvent::MouseButtonDblClick, QPoint (50, 50),
+                                 Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+      QApplication::sendEvent (vp, &dblClickEvent);
+    }
+    QApplication::processEvents ();
+
+    // Release after dblclick
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, QPoint (50, 50));
+    QApplication::processEvents ();
+
+    // The dblclick-release should have triggered the link click
+    QCOMPARE (capturedUri, QString ("https://example.com"));
+
+    delete widget;
+  }
 };
 
 QTEST_MAIN (TestPdfReaderWidget)

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -501,6 +501,42 @@ private slots:
     delete widget;
   }
 
+  void test_dragKeepsClosedHandBeforeThreshold () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+    QApplication::processEvents ();
+
+    QWidget* vp= widget->viewport ();
+    QVERIFY (vp != nullptr);
+    QCOMPARE (vp->cursor ().shape (), Qt::OpenHandCursor);
+
+    QPoint start (100, 100);
+    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, start);
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::ClosedHandCursor);
+
+    // Move a tiny distance (below drag threshold) and not over a link
+    QPoint smallMove (
+        start.x () + 1, start.y () + 1);
+    QTest::mouseMove (vp, smallMove);
+    QApplication::processEvents ();
+
+    // Cursor must remain ClosedHandCursor because left button is still pressed
+    QCOMPARE (vp->cursor ().shape (), Qt::ClosedHandCursor);
+
+    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, smallMove);
+    QApplication::processEvents ();
+    QCOMPARE (vp->cursor ().shape (), Qt::OpenHandCursor);
+
+    delete widget;
+  }
+
   void test_releaseRestoresOpenHand () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     widget->resize (400, 300);


### PR DESCRIPTION
## 问题描述

PDF 阅读器中鼠标左键按下不是每次都生效，cursor 状态流转不稳定。

## 修复内容

### 问题 1：双击时第二次按下不生效
- 根本原因：`eventFilter` 未处理 `MouseButtonDblClick`
- 修复：将 `MouseButtonDblClick` 视为 `MouseButtonPress` 处理

### 问题 2：按下后微移时 cursor 提前恢复松开
- 根本原因：`updateLinkCursor` 在拖动中错误覆盖 cursor
- 修复：调用 `updateLinkCursor` 后，若 `!overLink_` 则将 cursor 恢复为 `ClosedHandCursor`

## TDD 过程

新增 4 个单元测试复现问题：
- `test_doubleClickStartsDrag`
- `test_doubleClickInRectSelectMode`
- `test_doubleClickOnLinkTriggersClick`
- `test_dragKeepsClosedHandBeforeThreshold`

全部 39 个测试通过。

## 提交历史

- `[0159] 添加任务文档`
- `[0159] 修复 PDF 阅读器鼠标左键按下不总是生效的问题`
- `[0159] 更新任务文档`
- `[0159] 更新任务文档，补充鼠标状态流转描述`
- `[0159] 更新任务文档，补充第二个问题及 TDD 过程`
- `[0159] 修复按下后微移时 cursor 错误恢复为松开状态的问题`