### PR TITLE
[1029] 修复切换主题重启后 Chat Tab crash 和多余 tab

### DIFF
--- a/TeXmacs/progs/dynamic/chat-session-persist.scm
+++ b/TeXmacs/progs/dynamic/chat-session-persist.scm
@@ -191,11 +191,14 @@
       (display "[chat-persist] load-session-content: sid=")
       (display session-id)
       (newline)
-      (let ((file-url (system->url msg-path)))
-        (buffer-load file-url)
-        (buffer-set-body msg-buf (buffer-get-body file-url))
-        (buffer-pretend-saved msg-buf)
-      ) ;let
+      ;; 用 tree-import 读取文件内容，不经过 buffer 系统
+      ;; 避免 buffer-load 创建临时文件 buffer 导致多余 tab
+      ;; 避免 buffer-set-body 对已有嵌入式 editor 触发 assign 导致 crash
+      (let* ((doc (tree-import (system->url msg-path) "generic"))
+             (body (tmfile-extract doc 'body)))
+        (when body
+          (buffer-set-body msg-buf body)
+          (buffer-pretend-saved msg-buf)))
     ) ;when
   ) ;let
 ) ;tm-define

--- a/devel/1029.md
+++ b/devel/1029.md
@@ -1,0 +1,51 @@
+# [1029] 修复切换主题重启后 Chat Tab 相关 buffer 导致 crash 和多余 tab
+
+## 1 相关文档
+- [0219.md](0219.md) - MVC 重构主任务
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- src/Texmacs/Server/tm_server.cpp
+- TeXmacs/progs/dynamic/chat-session-persist.scm
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem && xmake r stem
+```
+
+### 3.2 非确定性测试（文档验证）
+在 Mogan 中执行以下场景：
+1. 打开 Chat Tab，发送消息产生有内容的会话
+2. 切换主题（触发 restart），确认重启后不 crash
+3. 重启后 tab 栏不出现 `message.tmu` 等多余文件 tab
+4. 重启后点击 Chat Tab，确认会话列表正常显示，消息内容正常加载
+5. 在 Chat Tab 中切换不同会话，确认不 crash
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+
+1. 修改 `tm_server_rep::restart()`：在传递 buffer 列表给新进程时，用 `is_rooted_tmfs()` 过滤掉所有 `tmfs://` 虚拟 buffer（包括 `tmfs://chat-tab`、`tmfs://chat-message-*`、`tmfs://chat-input-*`、`tmfs://startup-tab` 等）
+2. 修改 `chat-persist-load-session-content`：用 `tree-import` + `tmfile-extract` 替代 `buffer-load` + `buffer-get-body`，避免创建临时文件 buffer
+
+## 6 Why
+
+`restart()` 通过 `get_all_buffers()` 收集所有 buffer 并作为命令行参数传给新进程。这导致两个问题：
+
+- **crash**：新进程启动后，命令行参数中的 `tmfs://chat-tab` 触发 `switch_to_buffer` → `sync_chat_tab_mode()` → 创建 `QTChatTabWidget` → 恢复会话时创建多个 `texmacs_input_widget`（每个都创建子 window/view），在启动初期竞争全局状态导致卡死或 crash。即使不经过 restart，`load-session-content` 中 `buffer-load` 创建的临时文件 buffer 也可能触发 `assign` 对已有嵌入式 editor 的 observer 通知，导致 "invalid modification" crash。
+
+- **多余 tab**：`buffer-load` 将 `message.tmu` 文件加载为独立 buffer，这个文件 buffer 被 `get_all_buffers()` 收集后传给新进程，新进程将其作为普通文档打开，在 tab 栏出现多余的文件 tab。
+
+## 7 How
+
+- **restart 过滤**：在 `tm_server.cpp` 的 `restart()` 中，引入 `tmfs_url.hpp`，遍历 buffer 列表时调用 `is_rooted_tmfs(buffers[i])` 跳过所有 `tmfs://` 虚拟 buffer。这些 buffer 是内部 UI 组件（chat tab、startup tab）使用的虚拟 buffer，不应作为用户文件传递给新进程，它们会由新进程在用户点击时按需创建。
+
+- **load-session-content 改用 tree-import**：在 Scheme 中使用 `(tree-import url "generic")` 直接从文件解析 TeXmacs 文档树，再用 `(tmfile-extract doc 'body)` 提取 body 内容，最后用 `buffer-set-body` 写入目标 buffer。这样完全不经过 `buffer-load`，不创建临时文件 buffer，避免了多余 tab 和潜在的 assign 冲突。

--- a/src/Texmacs/Server/tm_server.cpp
+++ b/src/Texmacs/Server/tm_server.cpp
@@ -30,6 +30,7 @@
 #include "tm_configure.hpp"
 #include "tm_link.hpp"
 #include "tm_sys_utils.hpp"
+#include "tmfs_url.hpp"
 #include <moebius/drd/drd_std.hpp>
 #include <s7_tm.hpp>
 
@@ -334,8 +335,8 @@ tm_server_rep::restart () {
   if (!args.isEmpty ()) args.removeFirst ();
 
   for (int i= 0; i < N (buffers); i++) {
-    string file_path= as_string (buffers[i]);
-    args << to_qstring (file_path);
+    if (is_rooted_tmfs (buffers[i])) continue;
+    args << to_qstring (as_string (buffers[i]));
   }
 
   QProcess::startDetached (QApplication::applicationFilePath (), args);


### PR DESCRIPTION
## Summary
- `restart()` 用 `is_rooted_tmfs()` 过滤 `tmfs://` 虚拟 buffer，避免 chat tab 相关 buffer 传给新进程导致 crash
- `chat-persist-load-session-content` 用 `tree-import` + `tmfile-extract` 替代 `buffer-load`，避免创建临时文件 buffer 导致多余 tab 和 assign crash

## Test plan
- [ ] 打开 Chat Tab，发送消息产生有内容的会话
- [ ] 切换主题触发 restart，确认重启后不 crash
- [ ] 确认 tab 栏不出现 `message.tmu` 等多余文件 tab
- [ ] 重启后点击 Chat Tab，确认会话列表和消息内容正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)