### PR TITLE
[0620] 解决局部导入/粘贴 LaTeX 包含 preamble 渲染错误的问题

### DIFF
--- a/TeXmacs/tests/0620.scm
+++ b/TeXmacs/tests/0620.scm
@@ -16,9 +16,13 @@
 
 (check-set-mode! 'report-failed)
 
+(define (load-latex path)
+  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path) "\r\n" "\n")))
+
 (define (test-latex-snippet-preamble-filter)
   (display "Testing preamble filtering for selective LaTeX paste/snippet...\n")
-  (let* ((latex-content "\\documentclass{article}\n\\usepackage{amsmath}\n\\begin{document}\na+b\n\\end{document}")
+  (let* ((latex-content (load-latex "0620_selective_paste_test.tex"))
          (parsed (parse-latex latex-content))
          (texmacs-tree (latex->texmacs parsed))
          (st (tree->stree texmacs-tree))

--- a/TeXmacs/tests/0620.scm
+++ b/TeXmacs/tests/0620.scm
@@ -1,0 +1,34 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0620.scm
+;; DESCRIPTION : Integration tests for PR 0620 LaTeX selective paste preamble filtering
+;; COPYRIGHT   : (C) 2026 Sisyphus
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/progs/convert/latex/init-latex.scm")
+
+(check-set-mode! 'report-failed)
+
+(define (test-latex-snippet-preamble-filter)
+  (display "Testing preamble filtering for selective LaTeX paste/snippet...\n")
+  (let* ((latex-content "\\documentclass{article}\n\\usepackage{amsmath}\n\\begin{document}\na+b\n\\end{document}")
+         (parsed (parse-latex latex-content))
+         (texmacs-tree (latex->texmacs parsed))
+         (st (tree->stree texmacs-tree))
+         (st-str (object->string st)))
+    (display* "LaTeX Snippet converted tree stree: " st-str "\n")
+    ;; The resulting stree should NOT contain 'documentclass, 'usepackage, or 'begin with 'document
+    (check (string-contains? st-str "documentclass") => #f)
+    (check (string-contains? st-str "usepackage") => #f)
+    (check (string-contains? st-str "begin") => #f)))
+
+(tm-define (test_0620)
+  (test-latex-snippet-preamble-filter)
+  (check-report))

--- a/TeXmacs/tests/tex/0620_selective_paste_test.tex
+++ b/TeXmacs/tests/tex/0620_selective_paste_test.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{amsmath}
+\begin{document}
+a+b
+\end{document}

--- a/TeXmacs/tests/tex/0620_selective_paste_test.tex
+++ b/TeXmacs/tests/tex/0620_selective_paste_test.tex
@@ -1,5 +1,10 @@
 \documentclass{article}
 \usepackage{amsmath}
 \begin{document}
-a+b
+
+Text here
+\begin{equation}
+    \alpha \neq \beta
+\end{equation}
+
 \end{document}

--- a/devel/0620.md
+++ b/devel/0620.md
@@ -15,6 +15,13 @@
 xmake r 0620
 ```
 
+### 3.2 非确定性测试（手动验证）
+1. 用任何外部文本编辑器（如 VS Code / 记事本）打开 `TeXmacs/tests/tex/0620_selective_paste_test.tex`。
+2. 复制该文件中的所有文本内容（该内容完整包含了 `\documentclass`, `\usepackage`, `\begin{document}` 等指令）。
+3. 打开已编译好的 Mogan STEM 应用程序。
+4. 创建或打开任意普通文档，在主编辑区中使用菜单 **编辑 -> 粘贴来源 -> LaTeX**（或使用 **魔法粘贴 / Magic Paste** 快捷键）。
+5. **预期结果**: 编辑区中应该仅正确渲染插入了 `a+b`，没有任何红色的、作为 raw LaTeX 渲染出错的 `\documentclass`、`\usepackage` 或 `\begin{document}` 标签块残留在正文中。
+
 ## 4 如何提交
 
 提交前执行以下最少步骤：

--- a/devel/0620.md
+++ b/devel/0620.md
@@ -1,0 +1,43 @@
+# [0620] 解决局部导入/粘贴 LaTeX 包含 preamble 渲染错误的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Tex/fromtex_post.cpp` - LaTeX 转换后处理与 `latex_to_tree` 接口
+- `TeXmacs/tests/0620.scm` - 集成测试文件
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake r 0620
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+git add devel/0620.md
+git commit -m "[0620] Add task document for LaTeX selective paste bug fix"
+# 然后修改代码、运行测试并进行第二次提交
+```
+
+## 5 What
+解决当局部复制/粘贴 LaTeX 段落（选择性粘贴）时，如果粘贴的内容包含了 `\documentclass`、`\usepackage` 或 `\begin{document}` 等 preamble/文档头部指令，转换结果中仍会包含这些指令，导致显示为 raw LaTeX 错误渲染的 bug。
+
+1. 编写集成测试 `TeXmacs/tests/0620.scm` 验证包含文档头指令的 LaTeX snippet 粘贴转换。
+2. 在 `latex_to_tree` 阶段，对非完整文件（`is_document` 为 false）也运行 `finalize_preamble`，以过滤去除这些 preamble 指令，确保转换为干净的 body tree。
+3. 验证测试通过，确保对整文件导入和正常公式粘贴无任何负面影响。
+
+## 6 Why
+目前，整文件导入 LaTeX 时，解析结果包裹在 `!file` 结点中，`is_document` 为 true，代码会依次执行 `filter_preamble` 和 `finalize_preamble` 清除 preamble 级别命令（如 `\documentclass`、`\usepackage`）。
+然而，如果是选择性粘贴、局部导入 LaTeX，解析流程走的是 `latex-snippet` 分支，返回的解析树没有 `!file` 包裹，`is_document` 为 false。这导致 preamble 命令未被过滤，最终混在正文中以 raw LaTeX 格式渲染展示，极大地影响了公式粘贴的健壮性和用户体验。
+
+## 7 How
+在 `src/Plugins/Tex/fromtex_post.cpp` 文件的 `latex_to_tree` 中，原逻辑是：
+```cpp
+tree t5= is_document ? finalize_preamble (t4, style) : t4;
+```
+如果我们在 `is_document` 为 false（即局部粘贴）时，也对 `t4` 运行 `finalize_preamble(t4, style)`，由于 `finalize_preamble` 在面对没有 preamble 命令的普通表达式时是一个恒等变换，而在存在 preamble 命令（如 `\documentclass`）时会自动将其过滤移除，因而这能够非常自然且安全地滤掉 snippet 中混入的 preamble 指令。

--- a/devel/0620.md
+++ b/devel/0620.md
@@ -6,6 +6,7 @@
 ## 2 任务相关的代码文件
 - `src/Plugins/Tex/fromtex_post.cpp` - LaTeX 转换后处理与 `latex_to_tree` 接口
 - `TeXmacs/tests/0620.scm` - 集成测试文件
+- `TeXmacs/tests/tex/0620_selective_paste_test.tex` - 测试 LaTeX 文档数据
 
 ## 3 如何测试
 

--- a/src/Plugins/Tex/fromtex_post.cpp
+++ b/src/Plugins/Tex/fromtex_post.cpp
@@ -2396,7 +2396,7 @@ latex_to_tree (tree t0) {
   // cout << "\n\nt3= " << t3 << "\n\n";
   tree t4= finalize_document (t3);
   // cout << "\n\nt4= " << t4 << "\n\n";
-  tree t5= is_document ? finalize_preamble (t4, style) : t4;
+  tree t5= finalize_preamble (t4, style);
   // cout << "\n\nt5= " << t5 << "\n\n";
   tree t6= handle_matches (t5);
   // cout << "\n\nt6= " << t6 << "\n\n";


### PR DESCRIPTION
此 PR 修复了在局部复制/选择性粘贴 LaTeX 片段（例如含有 `\documentclass` 或 `\usepackage` 等 preamble 指令的代码块）到当前文档时，这些头部指令会残留混在正文中并作为错误 raw LaTeX 渲染展示的 bug。

### 修复方案
在 `src/Plugins/Tex/fromtex_post.cpp` 的 `latex_to_tree` 接口中，针对局部粘贴模式（`is_document` 为 `false`）无条件引入 `finalize_preamble` 清洗器。
- `finalize_preamble` 在没有 preamble 命令的普通表达式中执行的是**恒等变换**，不会带来副作用。
- 如果代码片段中混入了 `\documentclass`、`\usepackage`、`\begin{document}`、`\end{document}` 等元数据级命令，它将自顶向下递归剔除，仅在 TeXmacs 正文中保留和渲染干净的正文节点。

### 自动化与手动测试验证
1. 新建 LaTeX 测试资产 `TeXmacs/tests/tex/0620_selective_paste_test.tex`。
2. 新建 Scheme 集成测试 `TeXmacs/tests/0620.scm` 并注册测试靶，已通过 `xmake r 0620` 验证通过。
3. 文档中也已增加了详尽的 QA 手动测试指引（见 `devel/0620.md`）。