### PR TITLE
[1030] 修复重启后 Chat Tab 会话样式丢失

### DIFF
--- a/TeXmacs/progs/dynamic/chat-session-persist.scm
+++ b/TeXmacs/progs/dynamic/chat-session-persist.scm
@@ -13,6 +13,7 @@
 (texmacs-module (dynamic chat-session-persist)
   (:use (dynamic chat-tab-session)
     (texmacs texmacs tm-files)
+    (utils library cursor)
   ) ;:use
 ) ;texmacs-module
 
@@ -198,6 +199,10 @@
              (body (tmfile-extract doc 'body)))
         (when body
           (buffer-set-body msg-buf body)
+          ;; 恢复宏包：加载时 buffer 只有默认 generic 样式，
+          ;; 需要重新添加 number-europe、language 等宏包以正确渲染
+          (with-buffer msg-buf
+            (chat-tab-add-default-style-packages!))
           (buffer-pretend-saved msg-buf)))
     ) ;when
   ) ;let

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -516,7 +516,7 @@
 
 ;;; ---------- 会话管理 ----------
 
-(define (chat-tab-add-default-style-packages!)
+(tm-define (chat-tab-add-default-style-packages!)
   ;; 偏好驱动，参考 buffer-set-default-style（tm-files.scm:130-146）
   (add-style-package "number-europe")
   (add-style-package "preview-ref")

--- a/devel/1030.md
+++ b/devel/1030.md
@@ -1,0 +1,47 @@
+# [1030] 修复重启后 Chat Tab 会话样式丢失
+
+## 1 相关文档
+- [1029.md](1029.md) - 修复重启后 Chat Tab crash 和多余 tab
+- [0219.md](0219.md) - MVC 重构主任务
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- TeXmacs/progs/dynamic/chat-session-persist.scm
+- TeXmacs/progs/dynamic/chat-tab-session.scm
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem && xmake r stem
+```
+
+### 3.2 非确定性测试（文档验证）
+在 Mogan 中执行以下场景：
+1. 打开 Chat Tab，发送消息产生有内容的会话（包含公式、编号等需要宏包渲染的内容）
+2. 重启 Mogan（切换主题或关闭重开）
+3. 重启后点击该会话，确认中文、公式、编号等样式正常渲染，未丢失
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+
+1. 将 `chat-tab-add-default-style-packages!` 从 `define` 改为 `tm-define`，使其可跨模块调用
+2. 在 `chat-persist-load-session-content` 中，加载 body 后通过 `with-buffer` 切换到目标 buffer 上下文，调用 `chat-tab-add-default-style-packages!` 恢复宏包
+3. 在模块声明中添加 `(utils library cursor)` 依赖，引入 `with-buffer` 宏
+
+## 6 Why
+
+`buffer-export` 保存 TMU 文件时会完整保存 style/packages 信息，但 `chat-persist-load-session-content` 加载时只通过 `tmfile-extract doc 'body` 提取了 body，丢弃了 style 字段。buffer 在 `texmacs_input_widget` 创建时只有默认的 `generic` 样式，缺少 `number-europe`、`preview-ref`、`chinese` 等宏包，导致重启后公式编号、中文排版等样式丢失。
+
+首次创建 buffer 时，`chat-tab-ensure-session!` 会调用 `chat-tab-add-default-style-packages!` 添加这些宏包。但重新加载时跳过了这一步。
+
+## 7 How
+
+在 `buffer-set-body` 之后，用 `with-buffer msg-buf` 切换到目标 buffer 上下文，调用 `chat-tab-add-default-style-packages!` 恢复宏包。该函数原来用 `define` 定义，是模块私有绑定，`chat-session-persist` 即使 `(:use (dynamic chat-tab-session))` 也无法访问。改为 `tm-define` 后作为公开符号可被跨模块调用。


### PR DESCRIPTION
## Summary
- 将 `chat-tab-add-default-style-packages!` 从 `define` 改为 `tm-define`，使其可跨模块调用
- 在 `chat-persist-load-session-content` 中，加载 body 后通过 `with-buffer` 调用 `chat-tab-add-default-style-packages!` 恢复宏包
- 添加 `(utils library cursor)` 模块依赖引入 `with-buffer` 宏

## Why

`buffer-export` 保存 TMU 文件时会完整保存 style/packages 信息，但 `chat-persist-load-session-content` 加载时只通过 `tmfile-extract doc 'body` 提取了 body，丢弃了 style 字段。buffer 在 `texmacs_input_widget` 创建时只有默认的 `generic` 样式，缺少 `number-europe`、`preview-ref`、`chinese` 等宏包，导致重启后公式编号、中文排版等样式丢失。

`chat-tab-add-default-style-packages!` 原来用 `define` 定义，是模块私有绑定，`chat-session-persist` 即使 `(:use (dynamic chat-tab-session))` 也无法访问（报 `unbound variable`）。改为 `tm-define` 后作为公开符号可被跨模块正常调用。

## Test plan
- [x] 打开 Chat Tab，发送消息产生有内容的会话（包含中文、公式、编号等）
- [x] 重启 Mogan
- [x] 重启后点击该会话，确认中文、公式、编号等样式正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)