### PR TITLE
[0161] 移除未使用的 -delete-server-data 和 -delete-databases 选项

### DIFF
--- a/devel/0161.md
+++ b/devel/0161.md
@@ -1,4 +1,4 @@
-# [0161] 移除 -delete-server-data 和 -delete-databases 中的 rm -rf
+# [0161] 移除未使用的 -delete-server-data 和 -delete-databases 选项
 
 ## 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
@@ -15,27 +15,28 @@ xmake b stem
 ```
 
 ### 非确定性测试（文档验证）
-启动 Mogan Research，验证 `-delete-server-data` 和 `-delete-databases` 参数仍能正常识别。
+启动 Mogan Research，确认 `-delete-server-data` 和 `-delete-databases` 参数已不在命令行选项列表中。
 
 ## 如何提交
 
 提交前执行以下最少步骤：
 
 ```bash
+bin/format
 xmake b stem
 ```
 
 ## What
 
-移除 `-delete-server-data` 和 `-delete-databases` 两个命令行选项中对 `rm -rf` 的调用，改用项目内置的 `remove` 函数。
+从代码中彻底移除 `-delete-server-data` 和 `-delete-databases` 两个命令行选项。
 
-1. 将 `system("rm -rf", url("..."))` 替换为 `remove(url("...") * url_wildcard("*"))`
-2. 保持命令行参数解析逻辑不变
+1. 从 `src/Mogan/Research/research.cpp` 中移除对应处理逻辑
+2. 从 `src/System/Boot/init_texmacs.cpp` 的参数解析列表中移除这两个选项
 
 ## Why
 
-`rm -rf` 是外部 shell 命令，存在潜在安全风险，且不符合项目编码规范。Mogan 提供了跨平台的 `remove` 函数，应优先使用项目内置的文件操作接口。
+这两个选项使用了外部 `rm -rf` 命令，存在潜在安全风险，且实际未被使用。直接移除最为安全。
 
 ## How
 
-在 `research.cpp` 中，将原本通过 `system("rm -rf", ...)` 删除目录的代码，改为使用 `remove` 函数配合 `url_wildcard("*")` 通配符来删除目录内容，与其他缓存清理选项（如 `-delete-cache`、`-delete-font-cache`）的实现方式保持一致。
+在 `research.cpp` 中删除对应的 `else if` 分支，在 `init_texmacs.cpp` 中将这两个选项从有效参数列表中剔除。

--- a/devel/0161.md
+++ b/devel/0161.md
@@ -1,0 +1,41 @@
+# [0161] 移除 -delete-server-data 和 -delete-databases 中的 rm -rf
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Mogan/Research/research.cpp`
+- `src/System/Boot/init_texmacs.cpp`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+xmake b stem
+```
+
+### 非确定性测试（文档验证）
+启动 Mogan Research，验证 `-delete-server-data` 和 `-delete-databases` 参数仍能正常识别。
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## What
+
+移除 `-delete-server-data` 和 `-delete-databases` 两个命令行选项中对 `rm -rf` 的调用，改用项目内置的 `remove` 函数。
+
+1. 将 `system("rm -rf", url("..."))` 替换为 `remove(url("...") * url_wildcard("*"))`
+2. 保持命令行参数解析逻辑不变
+
+## Why
+
+`rm -rf` 是外部 shell 命令，存在潜在安全风险，且不符合项目编码规范。Mogan 提供了跨平台的 `remove` 函数，应优先使用项目内置的文件操作接口。
+
+## How
+
+在 `research.cpp` 中，将原本通过 `system("rm -rf", ...)` 删除目录的代码，改为使用 `remove` 函数配合 `url_wildcard("*")` 通配符来删除目录内容，与其他缓存清理选项（如 `-delete-cache`、`-delete-font-cache`）的实现方式保持一致。

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -131,12 +131,6 @@ immediate_options (int argc, char** argv) {
     }
     else if (s == "-delete-plugin-cache")
       remove (get_tm_cache_path () * url ("plugin_cache.scm"));
-    else if (s == "-delete-server-data")
-      remove (url ("$TEXMACS_HOME_PATH/server") * url_wildcard ("*"));
-    else if (s == "-delete-databases") {
-      remove (url ("$TEXMACS_HOME_PATH/system/database") * url_wildcard ("*"));
-      remove (url ("$TEXMACS_HOME_PATH/users") * url_wildcard ("*"));
-    }
 #ifdef QTTEXMACS
     else if (s == "-headless") headless_mode= true;
 #endif

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -132,10 +132,10 @@ immediate_options (int argc, char** argv) {
     else if (s == "-delete-plugin-cache")
       remove (get_tm_cache_path () * url ("plugin_cache.scm"));
     else if (s == "-delete-server-data")
-      system ("rm -rf", url ("$TEXMACS_HOME_PATH/server"));
+      remove (url ("$TEXMACS_HOME_PATH/server") * url_wildcard ("*"));
     else if (s == "-delete-databases") {
-      system ("rm -rf", url ("$TEXMACS_HOME_PATH/system/database"));
-      system ("rm -rf", url ("$TEXMACS_HOME_PATH/users"));
+      remove (url ("$TEXMACS_HOME_PATH/system/database") * url_wildcard ("*"));
+      remove (url ("$TEXMACS_HOME_PATH/users") * url_wildcard ("*"));
     }
 #ifdef QTTEXMACS
     else if (s == "-headless") headless_mode= true;

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -799,8 +799,7 @@ TeXmacs_main (int argc, char** argv) {
       else if ((s == "-S") || (s == "-setup") || (s == "-delete-cache") ||
                (s == "-delete-font-cache") || (s == "-delete-style-cache") ||
                (s == "-delete-file-cache") || (s == "-delete-doc-cache") ||
-               (s == "-delete-plugin-cache") || (s == "-delete-server-data") ||
-               (s == "-delete-databases") || (s == "-headless"))
+               (s == "-delete-plugin-cache") || (s == "-headless"))
         ;
       else if (s == "-build-manual") {
         if ((++i) < argc)


### PR DESCRIPTION
## Summary
- 从命令行参数解析中彻底移除 `-delete-server-data` 和 `-delete-databases` 两个未使用选项

## Why

这两个选项使用了外部 `rm -rf` 命令，且实际未被使用，存在潜在安全风险。直接从代码中移除最为安全。

## Test plan
- [x] 构建验证 `xmake b stem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)