### PR TITLE
[0160] 修复 0612.tmu 导出 PDF 后第一页出现竖直细线的问题

### DIFF
--- a/devel/0160.md
+++ b/devel/0160.md
@@ -1,0 +1,42 @@
+# [0160] 修复 0612.tmu 导出 PDF 后第一页出现竖直细线的问题
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Plugins/Pdf/pdf_hummus_renderer.cpp`
+- `TeXmacs/tests/tmu/0612.tmu`
+
+## 如何测试
+
+### 非确定性测试（文档验证）
+1. 启动 Mogan，打开 `TeXmacs/tests/tmu/0612.tmu`
+2. 执行导出 PDF 操作（文件 -> 导出 -> PDF）
+3. 用 PDF 阅读器打开导出的 PDF，检查第一页
+4. 验证第一页是否还有从顶部向下延伸的竖直细线
+
+## What
+
+修复 `0612.tmu` 导出 PDF 后，第一页出现竖直细线的问题。
+
+具体表现：该文件在 Mogan 中正常渲染时无此细线；导出为 PDF 后，第一页会出现一条从页面顶部开始、竖直向下延伸至"第二节交互式会话测试"之后的细线（长度约为单页高度的 1/3）。
+
+## Why
+
+该细线仅在 PDF 导出后出现，Mogan 内部渲染无此问题，说明是 PDFHummus 渲染器在将文档内容输出为 PDF 时引入了不该存在的图形元素。
+
+## How
+
+### 根因分析
+
+`0612.tmu` 包含 tikz 会话生成的内联 PDF 图片（ramdisc URL）。这些 PDF 尺寸极小（如 `0.4x0.4pt` 或 `0.4x28.85pt`）。`pdf_hummus_renderer_rep::image()` 在嵌入 PDF 为 Form XObject 时，需要知道原始 PDF 的宽高来计算变换矩阵 `cm(w/im->w, 0, 0, h/im->h, ...)`。
+
+`image_size()` 对 PDF 后缀的文件会调用 `pdf_image_size()`，但对 ramdisc URL 会回退到 `qt_image_size()`，后者通过 `QImage::loadFromData()` 加载。Qt 对极小的 PDF 返回 `1x1` 像素，导致 `im->w = 1`、`im->h = 1` 被缓存到 `pdf_image_rep`。
+
+当嵌入一个高度为 28.85pt（约 240 像素）的 PDF 线条时，`cm()` 的 y 方向缩放系数变为 `h / 1 ≈ 240`。这个极端的纵向拉伸把 PDF 中原本极细的线条渲染成了页面上肉眼可见的竖直细线。
+
+### 修复方案
+
+在 `pdf_hummus_renderer_rep::image()` 中，当检测到 `im->w <= 1 || im->h <= 1`（即 `image_size` 返回了不可靠的尺寸）时，放弃 Form XObject 嵌入路径，改为通过 `load_scalable_image()` 将 PDF 栅格化后再绘制。这样避开了极端缩放矩阵导致的图形伪影。
+
+修改文件：`src/Plugins/Pdf/pdf_hummus_renderer.cpp`

--- a/src/Plugins/Pdf/pdf_hummus_renderer.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_renderer.cpp
@@ -1656,6 +1656,17 @@ pdf_hummus_renderer_rep::image (url u, double w, double h, SI x, SI y,
 
   if (is_nil (im)) return;
 
+  // For tiny PDFs where image_size returns unreliable dimensions (e.g. 1x1
+  // from Qt's QImage loader), fallback to rasterization to avoid extreme
+  // scaling that produces spurious lines.
+  if (im->w <= 1 || im->h <= 1) {
+    scalable sim=
+        load_scalable_image (u, (SI) (w * pixel), (SI) (h * pixel), tree (),
+                             pixel);
+    renderer_rep::draw_scalable (sim, x, y, alpha);
+    return;
+  }
+
   end_text ();
 
   contentContext->q ();

--- a/src/Plugins/Pdf/pdf_hummus_renderer.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_renderer.cpp
@@ -1660,9 +1660,8 @@ pdf_hummus_renderer_rep::image (url u, double w, double h, SI x, SI y,
   // from Qt's QImage loader), fallback to rasterization to avoid extreme
   // scaling that produces spurious lines.
   if (im->w <= 1 || im->h <= 1) {
-    scalable sim=
-        load_scalable_image (u, (SI) (w * pixel), (SI) (h * pixel), tree (),
-                             pixel);
+    scalable sim= load_scalable_image (u, (SI) (w * pixel), (SI) (h * pixel),
+                                       tree (), pixel);
     renderer_rep::draw_scalable (sim, x, y, alpha);
     return;
   }


### PR DESCRIPTION
## 问题描述

`0612.tmu` 导出 PDF 后，第一页会出现一条从顶部向下延伸的竖直细线（长度约为单页高度的 1/3）。该文件在 Mogan 内部渲染时无此细线。

## 根因分析

`0612.tmu` 包含 tikz 会话生成的内联 PDF 图片（ramdisc URL），这些 PDF 尺寸极小（如 `0.4x28.85pt`）。`pdf_hummus_renderer_rep::image()` 嵌入 PDF 为 Form XObject 时，依赖 `image_size()` 返回的原始尺寸计算变换矩阵 `cm(w/im->w, 0, 0, h/im->h, ...)`。

`image_size()` 对 ramdisc URL 回退到 `qt_image_size()`，后者通过 `QImage::loadFromData()` 加载。Qt 对极小的 PDF 返回 `1x1` 像素，导致 `im->w = 1`、`im->h = 1`。当嵌入高度为 28.85pt（约 240 像素）的 PDF 线条时，`cm()` 的 y 方向缩放系数变为 `h / 1 ≈ 240`，极端的纵向拉伸把原本极细的线条渲染成了页面上肉眼可见的竖直细线。

## 修复方案

在 `pdf_hummus_renderer_rep::image()` 中，当检测到 `im->w <= 1 || im->h <= 1`（即 `image_size` 返回了不可靠的尺寸）时，放弃 Form XObject 嵌入路径，改为通过 `load_scalable_image()` 将 PDF 栅格化后再绘制，避开极端缩放矩阵导致的图形伪影。

## 测试

- 导出 `TeXmacs/tests/tmu/0612.tmu` 为 PDF
- 验证第一页不再出现竖直细线