### PR TITLE
[0623] 支持思维链折叠前的数学公式与 markdown 渲染

### DIFF
--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -476,6 +476,44 @@
   ) ;when
 ) ;define
 
+(define (chat-tab-render-last-explain! out)
+  (when (tm-func? out 'document)
+    (with i
+      (tree-arity out)
+      ;; 跳过 script-busy
+      (if (and (> i 0) (tm-func? (tree-ref out (- i 1)) 'script-busy))
+        (set! i (- i 1))
+      ) ;if
+      ;; 找到 unfolded-explain（直接子节点或在 concat 内）
+      (with ue
+        (chat-tab-find-last-unfolded-explain out i)
+        (when ue
+          (with body
+            (tree-ref ue 1)
+            ;; 在 body(with) 的子节点中搜索 document
+            (let doc-loop
+              ((j 0))
+              (when (< j (tree-arity body))
+                (if (tm-func? (tree-ref body j) 'document)
+                  (let* ((doc (tree-ref body j))
+                         (plain-text (chat-tab-tree->plain-text doc))
+                         (parsed (generic->texmacs plain-text "markdown-snippet"))
+                        ) ;let*
+                    (when (and parsed (tree? parsed))
+                      (tree-assign! doc parsed)
+                    ) ;when
+                  ) ;let*
+                  (doc-loop (+ j 1))
+                ) ;if
+              ) ;when
+            ) ;let
+          ) ;with
+        ) ;when
+      ) ;with
+    ) ;with
+  ) ;when
+) ;define
+
 (define (chat-tab-clear-input! input-buffer)
   (with-buffer input-buffer
     (buffer-set-body input-buffer '(document ""))
@@ -771,6 +809,7 @@
                         (chat-tab-append-reasoning! out text)
                         ;; 如果同时有 fold 命令，折叠
                         (when has-fold?
+                          (chat-tab-render-last-explain! out)
                           (chat-tab-fold-last-explain! out)
                         ) ;when
                       ) ;let*
@@ -780,6 +819,7 @@
                    ;; t 仅包含 fold-explain-reasoning → 直接折叠
                    ((tree-contains-label? t 'fold-explain-reasoning)
                     (with-buffer msg-buf
+                      (chat-tab-render-last-explain! out)
                       (chat-tab-fold-last-explain! out)
                       (buffer-pretend-saved msg-buf)
                     ) ;with-buffer

--- a/devel/0623.md
+++ b/devel/0623.md
@@ -1,0 +1,43 @@
+# [0623] 思维链公式与 markdown 渲染
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0221.md](0221.md) - Reasoning 流式展示与自动折叠
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/dynamic/chat-tab-session.scm` - 编辑器端会话模块
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无。
+
+### 3.2 非确定性测试（文档验证）
+1. 使用支持思维链（reasoning）的模型（如 Kimi）在 Chat Tab 中进行对话。
+2. 在思维链生成过程中，确认其以 plain text 展开态进行流式展示（例如包含 `$\frac{1}{2}$` 的原始 LaTeX/markdown 标记）。
+3. 推理（reasoning）结束自动折叠后，点击展开该推理部分，确认其内容已经排版渲染（公式、列表等 markdown 元素已正确被渲染展现，而不是原始标记）。
+4. 确保正常内容输出和多轮对话不受影响。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+# 检查本地编译与构建
+xmake b stem
+```
+
+## 5 What
+实现对思维链（Reasoning）的公式和 markdown 格式渲染。
+
+1. 在思维链流式输出阶段，保留原有的 plain text 流式拼接，避免不完整的 markdown/LaTeX 片段在解析时产生错误或崩溃。
+2. 在思维链输出结束（即触发折叠指令 `fold-explain-reasoning`）时，提取出整个思维链的 plain text 纯文本。
+3. 使用 `generic->texmacs` 接口以 `markdown-snippet` 格式对该纯文本进行 markdown/LaTeX 数学公式解析，生成 TeXmacs 渲染树。
+4. 将生成的渲染树在内存中 in-place 赋值（通过 `tree-assign!`）替换原有的 plain text 文本节点，完成完美的富文本渲染。
+
+## 6 Why
+目前思维链的输出不支持公式渲染，用户在思维链折叠区域展开后，只能看到原始的 `$...$` 或 markdown 列表原始标记，无法完美阅读模型在推理过程中的公式推导，影响学术和专业场景的使用体验。
+
+## 7 How
+在思维链完成生成并要执行折叠时，在 `chat-tab-fold-last-explain!` 之前，引入 `chat-tab-render-last-explain!`。
+该函数会在消息树中定位到当前展开的最后一个 `unfolded-explain` 节点，提取其内部 `document` 子节点的完整 plain text，通过调用 `(generic->texmacs plain-text "markdown-snippet")` 解析生成渲染树，最后通过 `(tree-assign! doc parsed)` 进行节点内容替换。随后进行的折叠和以后展开行为都会基于已渲染好的富文本树。


### PR DESCRIPTION
### 需求描述
思维链折叠时需要支持数学公式及 markdown 格式的渲染。

### 解决方案
在思维链流式拼接结束后，且在折叠之前，提取出展开状态的 explain 块下的 `document` 节点纯文本，调用 `(generic->texmacs plain-text "markdown-snippet")` 对完整文本进行渲染解析，然后再通过 `(tree-assign! doc parsed-tree)` 原地替换树节点，最后进行折叠。这样，不管是初始折叠状态展开查看，还是以后后续重组，都能呈现排版好的公式与 markdown 富文本。