### PR TITLE
[1036] 将 Chat 发送按钮样式迁移至 CSS

### DIFF
--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -1433,6 +1433,7 @@ QWidget#centralWidget QWidget#chat-tab-input-frame:hover {
 /* 发送按钮 */
 QWidget#centralWidget QPushButton#chat-tab-send-btn {
   background-color: transparent;
+  border: none;
 }
 QWidget#centralWidget QPushButton#chat-tab-send-btn:hover {
   background-color: #f0f0f0;

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -1355,6 +1355,7 @@ QWidget#chat-tab-input-frame:hover {
 /* 发送按钮 */
 QPushButton#chat-tab-send-btn {
   background-color: transparent;
+  border: none;
 }
 QPushButton#chat-tab-send-btn:hover {
   background-color: #f0f0f0;

--- a/devel/1036.md
+++ b/devel/1036.md
@@ -1,0 +1,43 @@
+# [1036] 将 Chat 发送按钮样式迁移至 CSS
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- src/Plugins/Qt/qt_chat_tab_widget.cpp
+- TeXmacs/misc/themes/liii.css
+- TeXmacs/misc/themes/liii-night.css
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+# UI 样式改动，无对应单元测试
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+xmake b stem && xmake r stem
+# 在 Chat tab 中检查发送按钮样式是否正常显示
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+将 Chat 发送按钮的 `border`、`background-color` 样式从 C++ 代码中的 `setStyleSheet` 迁移至 CSS 主题文件，C++ 端仅保留 `border-radius`。
+
+1. 在 liii.css 和 liii-night.css 中为 `#chat-tab-send-btn` 添加 `border: none`
+2. 从 qt_chat_tab_widget.cpp 的 `setStyleSheet` 调用中移除 `border: none` 和 `background-color: transparent`
+3. 将发送按钮图标尺寸从 24 调整为 30，使其与按钮大小更匹配
+
+## 6 Why
+发送按钮的样式硬编码在 C++ 代码中，导致 CSS 主题文件中的样式无法正确覆盖。Qt 的样式优先级使得 C++ 端 `setStyleSheet` 设置的属性优先级高于外部 CSS，造成 CSS 中定义的按钮样式不生效。将样式统一迁移至 CSS 文件后，主题可以完整控制按钮外观。
+
+## 7 How
+在 CSS 文件的 `QPushButton#chat-tab-send-btn` 规则中添加 `border: none`，同时将 C++ 代码中的 `setStyleSheet` 简化为仅设置动态计算的 `border-radius`（需要根据 DPI 缩放值动态生成，不适合放在静态 CSS 中）。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -98,7 +98,7 @@ constexpr int kMessageMinHeight      = 240;
 constexpr int kTransitionDurationMs  = 220;
 constexpr int kModelLabelMinHeight   = 20;
 constexpr int kModelLabelRadius      = 4;
-constexpr int kSendIconSize          = 24;
+constexpr int kSendIconSize          = 30;
 constexpr int kSendButtonSize        = 36;
 constexpr int kSendButtonRadius      = 18;
 constexpr int kConversationBtnRadius = 6;
@@ -251,8 +251,7 @@ ChatConversationPanel::setup_ui () {
   sendButton_->setFixedSize (DpiUtils::scaled (kSendButtonSize),
                              DpiUtils::scaled (kSendButtonSize));
   sendButton_->setStyleSheet (
-      QString ("QPushButton { border: none; border-radius: %1px; "
-               "            background-color: transparent; }")
+      QString ("QPushButton { border-radius: %1px; }")
           .arg (DpiUtils::scaled (kSendButtonRadius)));
   connect (sendButton_, &QPushButton::clicked, this,
            [this] () { emit sendRequested (sessionId_); });

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -250,9 +250,8 @@ ChatConversationPanel::setup_ui () {
   sendButton_->setIconSize (QSize (sendIconSize, sendIconSize));
   sendButton_->setFixedSize (DpiUtils::scaled (kSendButtonSize),
                              DpiUtils::scaled (kSendButtonSize));
-  sendButton_->setStyleSheet (
-      QString ("QPushButton { border-radius: %1px; }")
-          .arg (DpiUtils::scaled (kSendButtonRadius)));
+  sendButton_->setStyleSheet (QString ("QPushButton { border-radius: %1px; }")
+                                  .arg (DpiUtils::scaled (kSendButtonRadius)));
   connect (sendButton_, &QPushButton::clicked, this,
            [this] () { emit sendRequested (sessionId_); });
   btnLayout->addWidget (sendButton_);


### PR DESCRIPTION
## Summary
- 将 Chat 发送按钮的 `border`、`background-color` 样式从 C++ `setStyleSheet` 迁移至 CSS 主题文件（liii.css、liii-night.css）
- C++ 端仅保留动态计算的 `border-radius`
- 调整发送按钮图标尺寸 24 → 30，与按钮大小更匹配

## Test plan
- [ ] `xmake b stem` 编译通过
- [ ] 启动后在 Chat tab 中检查发送按钮样式正常显示（无边框、透明背景、圆角）

🤖 Generated with [Claude Code](https://claude.com/claude-code)