### PR TITLE
[0163] 修复 Chat Tab 对话完成后输入框焦点丢失

### DIFF
--- a/devel/0163.md
+++ b/devel/0163.md
@@ -1,0 +1,85 @@
+# [0163] Chat Tab 输入框焦点丢失导致回车无法发送
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- src/Plugins/Qt/qt_chat_tab_widget.cpp - ChatConversationPanel::eventFilter / focusInput
+- src/Plugins/Qt/qt_chat_controller.cpp - ChatController::notifyStateChanged / onSendRequested
+- TeXmacs/progs/dynamic/chat-tab-session.scm - chat-tab-session-next / chat-tab-session-cancel
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无（UI 交互问题，需手动验证）
+
+### 3.2 非确定性测试（文档验证）
+```
+# 构建并运行
+xmake b stem && xmake r stem
+```
+1. 打开 Chat Tab
+2. 输入 "1"，按回车发送（第一次发送正常）
+3. 等待对话完成（按钮从 Stop 恢复为 Send）
+4. 输入 "2"，按回车
+5. 预期：发送消息；实际：回车在 input buffer 中另起一行，光标不可见
+
+## 4 如何提交
+
+```bash
+xmake b stem
+```
+
+## 5 What
+
+Chat Tab 中，第一次对话完成后，第二次输入时：
+- 输入内容（如 "2"）可以正常输入到 input buffer
+- 回车键不触发发送，而是在 buffer 中另起一行
+- 光标不可见
+
+## 6 Why
+
+问题根因是 **LLM 生成完成后，TeXmacs 的 current view 被切换到了 message buffer，而 input buffer 的 view 不再是 current view**。
+
+完整的事件链：
+
+1. 用户第一次输入 "1" 按回车
+2. `ChatConversationPanel::eventFilter`（qt_chat_tab_widget.cpp:362-374）拦截回车，emit `sendRequested`
+3. `ChatController::onSendRequested`（qt_chat_controller.cpp:156）调用 `chat-tab-send`（Scheme），状态设为 Generating，调用 `panel->focusInput()`
+4. `focusInput`（qt_chat_tab_widget.cpp:329-338）通过 `get_passive_view` + `set_current_view` 将 input buffer 的 view 设为 current view
+
+5. LLM 生成完成，Scheme 的 `chat-tab-session-next`（chat-tab-session.scm:706）被调用
+6. `chat-tab-session-next` 中执行 `(with-buffer msg-buf ...)` 操作 message buffer，**这会将 TeXmacs 的 current view 切换到 message buffer 的 view**
+7. `(exec-delayed (lambda () (qt-chat-tab-set-state session-id "idle")))` 通知 C++ 状态变为 Idle
+
+8. `ChatController::notifyStateChanged`（qt_chat_controller.cpp:329）收到 "idle"，切换按钮为 Send，**但没有调用 `panel->focusInput()`**
+
+9. 此时 TeXmacs 的 current view 是 message buffer 的 view，**不是 input buffer 的 view**
+
+10. 用户输入 "2"：因为 Qt 的键盘焦点仍在 input editor widget 上，文字可以输入。但 TeXmacs 内部的 current view 是 message buffer，所以 input buffer 的 editor 处于"非激活"状态
+
+11. 用户按回车：`eventFilter` 检查 `watched->property("chat_panel")` 是否等于 `this`——**这里匹配应该没问题**。但回车事件被 TeXmacs 的编辑器内部处理了（因为 current view 不对，编辑器按普通文档模式处理回车 = 另起一行），而不是被 eventFilter 拦截。
+
+**关键矛盾**：eventFilter 安装在 `QTMWidget* editor`（qt_chat_tab_widget.cpp:225-236）上，理论上应该先于编辑器内部处理。但由于 `with-buffer msg-buf` 改变了 TeXmacs 的 current view，input buffer 的 QTMWidget 内部的按键处理逻辑可能发生了变化，导致 eventFilter 的拦截时机或行为异常。
+
+另一种可能：`with-buffer` 操作触发了 view 切换，导致 QTMWidget 内部的 focus/grab 状态变化，使得 eventFilter 收不到 KeyPress 事件（事件被其他 widget 或 TeXmacs 内部截获）。
+
+## 7 How
+
+**方案 A（推荐）：在 `notifyStateChanged` 的 Idle 分支中调用 `panel->focusInput()`**
+
+在 `ChatController::notifyStateChanged`（qt_chat_controller.cpp:353-361）的 Idle 分支末尾，添加 `panel->focusInput()`，确保生成完成后 input buffer 的 view 重新成为 current view，且 Qt 焦点回到输入框。
+
+```cpp
+// Idle 状态：切换按钮为 Send，并保存会话
+else {
+  btn->setToolTip ("Send");
+  btn->setIcon (QIcon (":llm-chat/send.svg"));
+  disconnect (session->sendBtnConnection);
+  session->sendBtnConnection=
+      connect (btn, &QPushButton::clicked, this,
+               [this, sessionId] () { onSendRequested (sessionId); });
+  exportBuffer (sessionId);
+  panel->focusInput ();  // <-- 新增：恢复 input buffer 焦点
+}
+```

--- a/devel/0163.md
+++ b/devel/0163.md
@@ -22,7 +22,7 @@ xmake b stem && xmake r stem
 2. 输入 "1"，按回车发送（第一次发送正常）
 3. 等待对话完成（按钮从 Stop 恢复为 Send）
 4. 输入 "2"，按回车
-5. 预期：发送消息；实际：回车在 input buffer 中另起一行，光标不可见
+5. 预期：光标可见，回车触发发送
 
 ## 4 如何提交
 
@@ -39,47 +39,32 @@ Chat Tab 中，第一次对话完成后，第二次输入时：
 
 ## 6 Why
 
-问题根因是 **LLM 生成完成后，TeXmacs 的 current view 被切换到了 message buffer，而 input buffer 的 view 不再是 current view**。
+问题有两层，通过调试日志逐步定位：
 
-完整的事件链：
+### 第一层：idle 时未恢复 input buffer 焦点
 
-1. 用户第一次输入 "1" 按回车
-2. `ChatConversationPanel::eventFilter`（qt_chat_tab_widget.cpp:362-374）拦截回车，emit `sendRequested`
-3. `ChatController::onSendRequested`（qt_chat_controller.cpp:156）调用 `chat-tab-send`（Scheme），状态设为 Generating，调用 `panel->focusInput()`
-4. `focusInput`（qt_chat_tab_widget.cpp:329-338）通过 `get_passive_view` + `set_current_view` 将 input buffer 的 view 设为 current view
+LLM 生成完成后，Scheme 的 `chat-tab-session-next` 通过 `(with-buffer msg-buf ...)` 操作 message buffer，这会调用 `buffer-focus` 将 TeXmacs 内部焦点切到 message buffer。但 `notifyStateChanged` 收到 idle 回调时，只切换了按钮图标，没有调用 `focusInput()` 恢复。
 
-5. LLM 生成完成，Scheme 的 `chat-tab-session-next`（chat-tab-session.scm:706）被调用
-6. `chat-tab-session-next` 中执行 `(with-buffer msg-buf ...)` 操作 message buffer，**这会将 TeXmacs 的 current view 切换到 message buffer 的 view**
-7. `(exec-delayed (lambda () (qt-chat-tab-set-state session-id "idle")))` 通知 C++ 状态变为 Idle
+修复：在 `notifyStateChanged` 的 Idle 分支末尾加 `panel->focusInput()`。
 
-8. `ChatController::notifyStateChanged`（qt_chat_controller.cpp:329）收到 "idle"，切换按钮为 Send，**但没有调用 `panel->focusInput()`**
+### 第二层：Qt 焦点已存在时 setFocus 不触发 focusInEvent
 
-9. 此时 TeXmacs 的 current view 是 message buffer 的 view，**不是 input buffer 的 view**
+加入 `focusInput()` 后，日志显示 `hasFocus=true`（Qt 认为有焦点），但 `handle_keyboard_focus` 没有被调用（光标不显示）。原因是：
 
-10. 用户输入 "2"：因为 Qt 的键盘焦点仍在 input editor widget 上，文字可以输入。但 TeXmacs 内部的 current view 是 message buffer，所以 input buffer 的 editor 处于"非激活"状态
+1. 发送消息时，Scheme 的 `with-buffer` 导致 `handle_keyboard_focus(false)` 发给 input buffer 的 `QTMWidget`
+2. Idle 后 `focusInput` 调用 `setFocus`，但此时 Qt 焦点仍在 widget 上（只是 TeXmacs 内部的 `got_focus=false`）
+3. Qt 不会对已有焦点的 widget 发送 `focusInEvent`，所以 `handle_keyboard_focus(true)` 永远不会被调用
 
-11. 用户按回车：`eventFilter` 检查 `watched->property("chat_panel")` 是否等于 `this`——**这里匹配应该没问题**。但回车事件被 TeXmacs 的编辑器内部处理了（因为 current view 不对，编辑器按普通文档模式处理回车 = 另起一行），而不是被 eventFilter 拦截。
-
-**关键矛盾**：eventFilter 安装在 `QTMWidget* editor`（qt_chat_tab_widget.cpp:225-236）上，理论上应该先于编辑器内部处理。但由于 `with-buffer msg-buf` 改变了 TeXmacs 的 current view，input buffer 的 QTMWidget 内部的按键处理逻辑可能发生了变化，导致 eventFilter 的拦截时机或行为异常。
-
-另一种可能：`with-buffer` 操作触发了 view 切换，导致 QTMWidget 内部的 focus/grab 状态变化，使得 eventFilter 收不到 KeyPress 事件（事件被其他 widget 或 TeXmacs 内部截获）。
+此外 `focusInput` 原来对 `inputEditorWidget_`（外层容器）做 `setFocus`，而 `focusInEvent` 和 eventFilter 都安装在子对象 `QTMWidget*` 上，两者不一致。
 
 ## 7 How
 
-**方案 A（推荐）：在 `notifyStateChanged` 的 Idle 分支中调用 `panel->focusInput()`**
+三处改动：
 
-在 `ChatController::notifyStateChanged`（qt_chat_controller.cpp:353-361）的 Idle 分支末尾，添加 `panel->focusInput()`，确保生成完成后 input buffer 的 view 重新成为 current view，且 Qt 焦点回到输入框。
+1. **qt_chat_tab_widget.hpp**：新增 `inputQTMWidget_` 成员，保存 `QTMWidget*` 指针
 
-```cpp
-// Idle 状态：切换按钮为 Send，并保存会话
-else {
-  btn->setToolTip ("Send");
-  btn->setIcon (QIcon (":llm-chat/send.svg"));
-  disconnect (session->sendBtnConnection);
-  session->sendBtnConnection=
-      connect (btn, &QPushButton::clicked, this,
-               [this, sessionId] () { onSendRequested (sessionId); });
-  exportBuffer (sessionId);
-  panel->focusInput ();  // <-- 新增：恢复 input buffer 焦点
-}
-```
+2. **qt_chat_tab_widget.cpp**：
+   - `setup_ui`：在找到 `QTMWidget* editor` 后保存到 `inputQTMWidget_`
+   - `focusInput`：先 `set_current_view` 恢复 TeXmacs view，再对 `inputQTMWidget_` 做 `clearFocus()` + `setFocus()` 强制触发 `focusInEvent`
+
+3. **qt_chat_controller.cpp**：`notifyStateChanged` 的 Idle 分支末尾调用 `panel->focusInput()`

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -359,6 +359,7 @@ ChatController::notifyStateChanged (const string& sessionId,
         connect (btn, &QPushButton::clicked, this,
                  [this, sessionId] () { onSendRequested (sessionId); });
     exportBuffer (sessionId);
+    panel->focusInput ();
   }
 }
 

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -234,6 +234,7 @@ ChatConversationPanel::setup_ui () {
       }
       editor->setProperty ("chat_panel", QVariant::fromValue ((void*) this));
       editor->installEventFilter (this);
+      inputQTMWidget_= editor;
     }
   }
 
@@ -327,14 +328,15 @@ ChatConversationPanel::enterConversationMode () {
 
 void
 ChatConversationPanel::focusInput () {
-  if (inputEditorWidget_) {
-    inputEditorWidget_->setFocus (Qt::OtherFocusReason);
-    url inBufUrl= ChatSessionManager::inputBufferUrl (sessionId_);
-    url vw      = get_passive_view (inBufUrl);
-    if (!is_none (vw)) {
-      set_current_view (vw);
-      call ("update-menus");
-    }
+  url inBufUrl= ChatSessionManager::inputBufferUrl (sessionId_);
+  url vw      = get_passive_view (inBufUrl);
+  if (!is_none (vw)) {
+    set_current_view (vw);
+    call ("update-menus");
+  }
+  if (inputQTMWidget_) {
+    inputQTMWidget_->clearFocus ();
+    inputQTMWidget_->setFocus (Qt::OtherFocusReason);
   }
 }
 

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -112,6 +112,7 @@ private:
   QLabel*      modelLabel_       = nullptr; ///< 模型名称标签
   QWidget*     messageFrame_     = nullptr; ///< 消息区域容器
   QWidget*     inputEditorWidget_= nullptr; ///< 输入编辑器容器
+  QWidget*     inputQTMWidget_   = nullptr; ///< 输入区 QTMWidget
   QPushButton* sendButton_       = nullptr; ///< 发送/停止按钮
   QSpacerItem* topSpacer_        = nullptr; ///< 欢迎页顶部弹性空间
   widget       messageWidget_;              ///< 消息区 TeXmacs widget


### PR DESCRIPTION
## Summary
- 修复 Chat Tab 中 LLM 对话完成后，input buffer 光标不可见、回车无法发送消息的问题
- 根因：Scheme 的 `with-buffer` 导致 `handle_keyboard_focus(false)` 发给 input buffer，而 Qt 不会对已有焦点的 widget 重发 `focusInEvent`
- 在 `notifyStateChanged` idle 时调用 `focusInput`，且 `focusInput` 直接对 `QTMWidget` 做 `clearFocus+setFocus` 强制恢复光标

## Test plan
- [x] 打开 Chat Tab，输入第一条消息发送正常
- [x] 等待 LLM 回复完成，输入第二条消息按回车 → 光标可见，回车触发发送
- [x] 连续多轮对话均正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)