### PR TITLE
[0164] Chat 界面顶部显示会话标题而非模型名称

### DIFF
--- a/devel/0164.md
+++ b/devel/0164.md
@@ -1,0 +1,54 @@
+# [0164] Chat 界面顶部显示会话标题而非模型名称
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- src/Plugins/Qt/qt_chat_tab_widget.hpp - ChatConversationPanel 类定义，包含 modelLabel_ 字段
+- src/Plugins/Qt/qt_chat_tab_widget.cpp - ChatConversationPanel::setup_ui() 中创建 modelLabel_
+- src/Plugins/Qt/qt_chat_controller.cpp - Controller 中多处设置 modelLabel_ 的文本
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 打开 Chat Tab
+2. 确认空白会话顶部不显示模型名称
+3. 发送一条消息，确认标题自动提取后显示在顶部
+4. 切换到已有标题的会话，确认顶部显示该会话标题
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+将 Chat 界面顶部的模型名称标签改为显示会话标题。
+
+1. 将 `ChatConversationPanel` 中的 `modelLabel_` 重命名为 `sessionTitle_`
+2. 将 `modelLabel()` 访问器重命名为 `sessionTitle()`
+3. Controller 中设置该标签文本时，使用会话标题而非模型名称
+4. 空白会话（无标题）时隐藏该标签或显示空文本
+
+## 6 Why
+当前 Chat 界面顶部固定显示模型名称（如 "Kimi-VLM"），用户无法直观看到当前会话的主题。应该显示会话标题，与侧边栏的会话列表保持一致。
+
+## 7 How
+
+### 重命名
+1. `qt_chat_tab_widget.hpp` 中 `modelLabel_` → `sessionTitle_`，`modelLabel()` → `sessionTitle()`
+2. `qt_chat_tab_widget.cpp` 中所有 `modelLabel_` → `sessionTitle_`
+3. `qt_chat_controller.cpp` 中所有 `modelLabel()` → `sessionTitle()`
+
+### 逻辑变更
+Controller 中原来 `panel->modelLabel()->setText(to_qstring(s->model))` 改为显示会话标题：
+- `loadSessionContent`：显示 `s->title`，空标题时隐藏标签
+- `ensureNewConversation`：新会话无标题时隐藏标签
+- `onSendRequested`：标题提取后更新标签文本并显示

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -194,6 +194,15 @@ ChatController::onSendRequested (const string& sessionId) {
     string displayTitle= getSessionDisplayTitle (sessionId);
     view_->sidebar ()->updateItemTitle (sessionId, displayTitle);
     view_->sidebar ()->setActiveItem (sessionId);
+    // 更新会话标题标签
+    if (session->panel) {
+      ChatConversationPanel* p=
+          static_cast<ChatConversationPanel*> (session->panel);
+      if (p->sessionTitle ()) {
+        p->sessionTitle ()->setText (qTitle);
+        p->sessionTitle ()->show ();
+      }
+    }
   }
 
   if (!as_bool (call ("chat-tab-send", sessionId))) return;
@@ -425,9 +434,15 @@ ChatController::loadSessionContent (ChatConversationPanel* panel) {
     panel->enterConversationMode ();
   }
 
-  // 同步模型标签
-  if (panel->modelLabel () && s) {
-    panel->modelLabel ()->setText (to_qstring (s->model));
+  // 同步会话标题标签
+  if (panel->sessionTitle () && s) {
+    if (is_empty (s->title)) {
+      panel->sessionTitle ()->hide ();
+    }
+    else {
+      panel->sessionTitle ()->setText (to_qstring (s->title));
+      panel->sessionTitle ()->show ();
+    }
   }
 }
 
@@ -469,8 +484,8 @@ ChatController::ensureNewConversation () {
       ChatConversationPanel* p= static_cast<ChatConversationPanel*> (s->panel);
       if (p && !p->conversationMode ()) {
         sessionManager_.setModel (sid, currentModel);
-        if (p->modelLabel ()) {
-          p->modelLabel ()->setText (to_qstring (currentModel));
+        if (p->sessionTitle ()) {
+          p->sessionTitle ()->hide ();
         }
         view_->sidebar ()->setActiveItem (sid);
         view_->activatePanel (p);
@@ -489,8 +504,8 @@ ChatController::ensureNewConversation () {
 
   call ("chat-tab-sync-dark-style!", sid);
 
-  if (panel->modelLabel ()) {
-    panel->modelLabel ()->setText (to_qstring (currentModel));
+  if (panel->sessionTitle ()) {
+    panel->sessionTitle ()->hide ();
   }
 
   // 连接 Panel 的信号

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -143,17 +143,17 @@ ChatConversationPanel::setup_ui () {
   DpiUtils::applyScaledFont (welcomeTitle_, kWelcomeFontPx);
   topLayout->addWidget (welcomeTitle_);
 
-  // Model label
-  modelLabel_= new QLabel ("", topPanel);
-  modelLabel_->setObjectName ("chat-tab-model-label");
-  modelLabel_->setAlignment (Qt::AlignCenter);
-  DpiUtils::applyScaledFont (modelLabel_, kNavButtonFontPx);
-  modelLabel_->setStyleSheet (
+  // Session title label
+  sessionTitle_= new QLabel ("", topPanel);
+  sessionTitle_->setObjectName ("chat-tab-model-label");
+  sessionTitle_->setAlignment (Qt::AlignCenter);
+  DpiUtils::applyScaledFont (sessionTitle_, kNavButtonFontPx);
+  sessionTitle_->setStyleSheet (
       QString ("padding: 2px %1px; border-radius: %2px;")
           .arg (DpiUtils::scaled (kNavButtonPadX))
           .arg (DpiUtils::scaled (kModelLabelRadius)));
-  modelLabel_->setMinimumHeight (DpiUtils::scaled (kModelLabelMinHeight));
-  topLayout->addWidget (modelLabel_, 0, Qt::AlignHCenter);
+  sessionTitle_->setMinimumHeight (DpiUtils::scaled (kModelLabelMinHeight));
+  topLayout->addWidget (sessionTitle_, 0, Qt::AlignHCenter);
 
   // Message area
   url msgBufUrl = ChatSessionManager::messageBufferUrl (sessionId_);

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -74,7 +74,7 @@ public:
   tree readInputMessage () const;
 
   QPushButton*  sendButton () const { return sendButton_; }
-  QLabel*       modelLabel () const { return modelLabel_; }
+  QLabel*       sessionTitle () const { return sessionTitle_; }
   const string& sessionId () const { return sessionId_; }
   bool          conversationMode () const { return conversationMode_; }
 
@@ -109,7 +109,7 @@ private:
   string       sessionId_;                  ///< 所属会话 ID
   bool         conversationMode_ = false;   ///< 是否已进入对话模式
   QLabel*      welcomeTitle_     = nullptr; ///< 欢迎页标题
-  QLabel*      modelLabel_       = nullptr; ///< 模型名称标签
+  QLabel*      sessionTitle_     = nullptr; ///< 会话标题标签
   QWidget*     messageFrame_     = nullptr; ///< 消息区域容器
   QWidget*     inputEditorWidget_= nullptr; ///< 输入编辑器容器
   QWidget*     inputQTMWidget_   = nullptr; ///< 输入区 QTMWidget

--- a/tests/Plugins/Qt/qt_chat_session_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_session_test.cpp
@@ -60,6 +60,11 @@ private slots:
   // === messageBufferUrl / inputBufferUrl ===
   void test_messageBufferUrl ();
   void test_inputBufferUrl ();
+
+  // === 会话标题可见性判断 ===
+  void test_title_empty_for_new_session ();
+  void test_title_nonempty_after_set ();
+  void test_title_preserved_across_archive_restore ();
 };
 
 /******************************************************************************
@@ -376,3 +381,46 @@ TestChatSession::test_inputBufferUrl () {
 
 QTEST_MAIN (TestChatSession)
 #include "qt_chat_session_test.moc"
+
+/******************************************************************************
+ * 会话标题可见性判断
+ *
+ * 验证 Controller 用来决定 sessionTitle 标签显隐的 is_empty(s->title) 判断：
+ * - 新会话 title 为空 → 标签应隐藏
+ * - 设置 title 后非空 → 标签应显示
+ * - 归档/恢复后 title 保持 → 标签应保持显示
+ ******************************************************************************/
+
+void
+TestChatSession::test_title_empty_for_new_session () {
+  ChatSessionManager mgr;
+  string             sid= mgr.createSession ();
+  ChatSession*       s  = mgr.getSession (sid);
+  QVERIFY (s != nullptr);
+  QVERIFY (is_empty (s->title));
+}
+
+void
+TestChatSession::test_title_nonempty_after_set () {
+  ChatSessionManager mgr;
+  string             sid= mgr.createSession ();
+  mgr.setTitle (sid, "测试标题");
+  ChatSession* s= mgr.getSession (sid);
+  QVERIFY (s != nullptr);
+  QVERIFY (!is_empty (s->title));
+  QVERIFY (s->title == string ("测试标题"));
+}
+
+void
+TestChatSession::test_title_preserved_across_archive_restore () {
+  ChatSessionManager mgr;
+  string             sid= mgr.createSession ();
+  mgr.setTitle (sid, "My Session");
+  mgr.archiveSession (sid);
+  mgr.restoreSession (sid);
+  ChatSession* s= mgr.getSession (sid);
+  QVERIFY (s != nullptr);
+  QVERIFY (!s->archived);
+  QVERIFY (!is_empty (s->title));
+  QVERIFY (s->title == string ("My Session"));
+}


### PR DESCRIPTION
## Summary
- 将 `modelLabel_` 重命名为 `sessionTitle_`，显示会话标题而非模型名称
- 空白会话时隐藏标签，有标题时显示标题
- 标题提取后更新并显示标签

## Test plan
- [x] `xmake b stem` 编译通过
- [x] `xmake r qt_chat_session_test` 29 个测试全部通过
- [ ] 手动验证：打开 Chat Tab，空白会话顶部无标签，发送消息后显示提取的标题

🤖 Generated with [Claude Code](https://claude.com/claude-code)