### PR TITLE
[0166] Chat 会话列表增加导出子功能

### DIFF
--- a/TeXmacs/progs/dynamic/chat-session-persist.scm
+++ b/TeXmacs/progs/dynamic/chat-session-persist.scm
@@ -351,6 +351,40 @@
   ) ;let
 ) ;tm-define
 
+;;; ---------- 导出会话到指定路径 ----------
+
+;; chat-persist-export-session-to
+;; 将指定会话的消息内容保存到用户选择的目标路径（TMU 格式）。
+;; 先 buffer-save 保证 buffer 内容已写入磁盘，再 system-copy 到目标路径。
+;;
+;; 语法
+;; ----
+;; (chat-persist-export-session-to session-id target-path)
+;;
+;; 参数
+;; ----
+;; session-id : string
+;;   会话 UUID。
+;; target-path : string
+;;   目标文件路径（系统路径，以 .tmu 结尾）。
+
+(tm-define (chat-persist-export-session-to session-id target-path)
+  (let ((msg-buf (chat-tab-session->message-buffer session-id))
+        (msg-path (chat-persist-message-path session-id))
+       ) ;
+    ;; 确保 buffer 内容已写入磁盘
+    (chat-persist-ensure-dir! (chat-persist-parent-dir msg-path))
+    (buffer-export msg-buf (system->url msg-path) "tmu")
+    ;; 复制到用户指定路径
+    (when (file-exists? msg-path)
+      (chat-persist-ensure-dir! (chat-persist-parent-dir target-path))
+      (system-copy (system->url msg-path) (system->url target-path))
+      ;; 加入最近文档列表
+      (startup-tab-add-recent-doc target-path)
+    ) ;when
+  ) ;let
+) ;tm-define
+
 ;;; ---------- 注册恢复后的会话 ----------
 
 (tm-define (chat-persist-register-session session-id model)

--- a/devel/0166.md
+++ b/devel/0166.md
@@ -1,0 +1,50 @@
+# [0166] 聊天会话导出功能
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp` - ChatSidebar 信号声明
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp` - 侧边栏菜单项
+- `src/Plugins/Qt/qt_chat_controller.hpp` - Controller 处理函数声明
+- `src/Plugins/Qt/qt_chat_controller.cpp` - Controller 处理函数实现
+- `TeXmacs/progs/dynamic/chat-session-persist.scm` - Scheme 导出函数
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无
+
+### 3.2 非确定性测试（文档验证）
+1. 启动 Mogan，打开 Chat 标签页
+2. 进行一次对话（发送消息并等待回复完成）
+3. 在侧边栏点击该会话的 "..." 按钮
+4. 确认菜单中出现 "Export" 选项（位于 Rename 和 Archive 之间）
+5. 点击 Export，在文件对话框中选择保存位置和文件名
+6. 确认指定路径下生成了 .tmu 文件，内容为会话消息
+7. 确认导出的文档出现在最近文档列表中（启动页或 File → Recent 菜单可见）
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+为 AI 聊天界面的会话列表增加导出子功能。
+
+1. 在侧边栏会话项的 "..." 菜单中增加 "Export" 选项
+2. 点击后弹出文件保存对话框，用户选择目标路径
+3. 将会话 message buffer 以 TMU 格式保存到用户指定位置
+4. 导出后将文档加入最近文档列表
+
+## 6 Why
+用户需要将聊天会话内容导出为独立的 TMU 文档，以便在其他地方使用或备份。
+
+## 7 How
+1. 在 `ChatSidebar` 添加 `exportRequested` 信号
+2. 在 `createItem` 的菜单中添加 "Export" 动作
+3. 在 `ChatController` 中实现 `onExportRequested`：使用 `QFileDialog::getSaveFileName` 获取目标路径，调用 Scheme 函数完成导出
+4. 在 `chat-session-persist.scm` 中添加 `chat-persist-export-session-to`：先 `buffer-export` 保存 buffer 到磁盘，再 `system-copy` 复制到目标路径

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -17,6 +17,7 @@
 #include "scheme.hpp"
 
 #include <QApplication>
+#include <QFileDialog>
 #include <QLabel>
 #include <QPushButton>
 
@@ -85,6 +86,8 @@ ChatController::createView (QWidget* parent, qt_tm_widget_rep* tm) {
              });
     connect (sb, &ChatSidebar::restoreRequested, this,
              &ChatController::onRestoreRequested);
+    connect (sb, &ChatSidebar::exportRequested, this,
+             &ChatController::onExportRequested);
     connect (sb, &ChatSidebar::newChatRequested, this,
              &ChatController::onNewChatRequested);
     connect (sb, &ChatSidebar::renameRequested, this,
@@ -318,6 +321,23 @@ ChatController::onRestoreRequested (const string& sessionId) {
   updateManifest (sessionId);
   view_->sidebar ()->moveFromArchive (sessionId);
   activateSession (sessionId);
+}
+
+void
+ChatController::onExportRequested (const string& sessionId) {
+  ChatSession* s= sessionManager_.getSession (sessionId);
+  if (!s) return;
+
+  QString defaultName= is_empty (s->title)
+                           ? QString ("export.tmu")
+                           : to_qstring (s->title) + ".tmu";
+  QString targetPath= QFileDialog::getSaveFileName (
+      nullptr, qt_translate ("Export Conversation"), defaultName,
+      qt_translate ("TMU Files (*.tmu)"));
+  if (targetPath.isEmpty ()) return;
+
+  call ("chat-persist-export-session-to", sessionId,
+        from_qstring_utf8 (targetPath));
 }
 
 void

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -328,10 +328,9 @@ ChatController::onExportRequested (const string& sessionId) {
   ChatSession* s= sessionManager_.getSession (sessionId);
   if (!s) return;
 
-  QString defaultName= is_empty (s->title)
-                           ? QString ("export.tmu")
-                           : to_qstring (s->title) + ".tmu";
-  QString targetPath= QFileDialog::getSaveFileName (
+  QString defaultName= is_empty (s->title) ? QString ("export.tmu")
+                                           : to_qstring (s->title) + ".tmu";
+  QString targetPath = QFileDialog::getSaveFileName (
       nullptr, qt_translate ("Export Conversation"), defaultName,
       qt_translate ("TMU Files (*.tmu)"));
   if (targetPath.isEmpty ()) return;

--- a/src/Plugins/Qt/qt_chat_controller.hpp
+++ b/src/Plugins/Qt/qt_chat_controller.hpp
@@ -91,6 +91,12 @@ public:
   void onRestoreRequested (const string& sessionId);
 
   /**
+   * @brief 导出指定会话的消息 buffer 到用户选择的路径（TMU 格式）。
+   * @param sessionId 要导出的会话 ID
+   */
+  void onExportRequested (const string& sessionId);
+
+  /**
    * @brief 创建新会话或复用空白会话。
    */
   void onNewChatRequested ();

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -852,6 +852,7 @@ ChatSidebar::createItem (const string& sessionId) {
         }
         else {
           QAction* renameAction = menu.addAction (qt_translate ("Rename"));
+          QAction* exportAction= menu.addAction (qt_translate ("Export"));
           QAction* archiveAction= menu.addAction (
               archived ? qt_translate ("Restore") : qt_translate ("Archive"));
           QAction* deleteAction= menu.addAction (qt_translate ("Delete"));
@@ -862,6 +863,9 @@ ChatSidebar::createItem (const string& sessionId) {
               menu.exec (btn->mapToGlobal (btn->rect ().bottomLeft ()));
           if (chosen == renameAction) {
             emit renameRequested (sid, "");
+          }
+          else if (chosen == exportAction) {
+            emit exportRequested (sid);
           }
           else if (chosen == archiveAction) {
             if (archived) emit restoreRequested (sid);

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -852,7 +852,7 @@ ChatSidebar::createItem (const string& sessionId) {
         }
         else {
           QAction* renameAction = menu.addAction (qt_translate ("Rename"));
-          QAction* exportAction= menu.addAction (qt_translate ("Export"));
+          QAction* exportAction = menu.addAction (qt_translate ("Export"));
           QAction* archiveAction= menu.addAction (
               archived ? qt_translate ("Restore") : qt_translate ("Archive"));
           QAction* deleteAction= menu.addAction (qt_translate ("Delete"));

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -223,6 +223,7 @@ signals:
   void restoreRequested (const string& sessionId);
   void renameRequested (const string& sessionId, const string& newTitle);
   void newChatRequested ();
+  void exportRequested (const string& sessionId);
   void multiDeleteRequested (const QList<string>& sessionIds);
   void multiArchiveRequested (const QList<string>& sessionIds);
 


### PR DESCRIPTION
## Summary
- 在侧边栏会话 "..." 菜单中增加 Export 选项（单会话，不支持多选）
- 点击后弹出文件保存对话框，选择路径后将会话 message buffer 以 TMU 格式导出
- 导出后自动加入最近文档列表

## Test plan
- [ ] 打开 Chat 标签页，进行一次对话
- [ ] 点击会话 "..." 菜单，确认 Export 选项存在（位于 Rename 和 Archive 之间）
- [ ] 点击 Export，选择保存路径，确认生成 .tmu 文件且内容正确
- [ ] 确认导出的文档出现在最近文档列表中

🤖 Generated with [Claude Code](https://claude.com/claude-code)