### PR TITLE
[0167] no_name_x.tmu 文档的路径改为 ~/Document/LiiiSTEM/no_name/

### DIFF
--- a/devel/0167.md
+++ b/devel/0167.md
@@ -1,0 +1,18 @@
+# [0167] no_name_x.tmu 文档路径变更
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## What
+
+no_name_x.tmu 文档的路径改为 `~/文档/LiiiSTEM/no_name/`（通过 Qt 的 `QStandardPaths::DocumentsLocation` 获取本地化文档目录）。
+
+1. 默认格式从 `.tm` 改为 `.tmu`
+
+## How
+
+1. `src/Mogan/Research/research.cpp` 在 Qt 初始化后，调用 `QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)` 获取本地化 Documents 路径，写入 `TEXMACS_DOCUMENTS_PATH` 环境变量
+2. `src/System/Misc/tm_sys_utils.cpp` 新增 `get_documents_path()`，读取上述环境变量并回退到 `$HOME/Documents`
+3. `src/System/Files/tm_file.cpp` 中的 `url_scratch` 与 `is_scratch` 使用 `get_documents_path() * "LiiiSTEM/no_name"` 作为新路径
+4. `src/Texmacs/Data/new_buffer.cpp` 中的 `make_new_buffer` 与 `propose_title` 将后缀从 `.tm` 改为 `.tmu`，并同步调整标题解析偏移
+5. `url_numbered` 内部已有 `mkdir`，`LiiiSTEM/no_name` 目录会在首次创建临时文件时自动初始化

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -49,6 +49,7 @@ void mac_fix_paths ();
 #include <QCoreApplication>
 #include <QGuiApplication>
 #include <QKeySequence>
+#include <QStandardPaths>
 #endif
 
 #ifdef MACOSX_EXTENSIONS
@@ -231,6 +232,15 @@ main (int argc, char** argv) {
   // initialize the Qt application infrastructure
   if (headless_mode) qtmcoreapp= new QTMCoreApplication (argc, argv);
   else qtmapp= new QTMApplication (argc, argv);
+
+  // Set documents path for scratch files
+  {
+    QString docsDir=
+        QStandardPaths::writableLocation (QStandardPaths::DocumentsLocation);
+    if (docsDir.isEmpty ())
+      docsDir= QStandardPaths::writableLocation (QStandardPaths::HomeLocation);
+    set_env ("TEXMACS_DOCUMENTS_PATH", from_qstring_utf8 (docsDir));
+  }
 
   // before startup login dialog
   init_texmacs_path (argc, argv);

--- a/src/System/Files/tm_file.cpp
+++ b/src/System/Files/tm_file.cpp
@@ -18,6 +18,7 @@
 #include "lolly/system/subprocess.hpp"
 #include "scheme.hpp"
 #include "sys_utils.hpp"
+#include "tm_sys_utils.hpp"
 #include "tm_timer.hpp"
 #include "tmfs_url.hpp"
 #include "tree_helper.hpp"
@@ -104,13 +105,13 @@ url_numbered (url dir, string prefix, string postfix, int i) {
 
 url
 url_scratch (string prefix, string postfix, int i) {
-  url dir ("$TEXMACS_HOME_PATH/texts/scratch");
+  url dir= get_documents_path () * "LiiiSTEM/no_name";
   return url_numbered (dir, prefix, postfix, i);
 }
 
 bool
 is_scratch (url u) {
-  return head (u) == url ("$TEXMACS_HOME_PATH/texts/scratch");
+  return head (u) == get_documents_path () * "LiiiSTEM/no_name";
 }
 
 string

--- a/src/System/Files/tm_file.hpp
+++ b/src/System/Files/tm_file.hpp
@@ -46,9 +46,9 @@ eval_system (string which, url u1, url u2) {
                       escape_sh (concretize (u2)));
 }
 
-url    url_numbered (url dir, string prefix, string postfix, int i= 1);
-url    url_scratch (string prefix= "no_name_", string postfix= ".tm", int i= 1);
-bool   is_scratch (url u);
+url  url_numbered (url dir, string prefix, string postfix, int i= 1);
+url  url_scratch (string prefix= "no_name_", string postfix= ".tmu", int i= 1);
+bool is_scratch (url u);
 string file_format (url u);
 
 /**

--- a/src/System/Misc/tm_sys_utils.cpp
+++ b/src/System/Misc/tm_sys_utils.cpp
@@ -136,6 +136,13 @@ init_texmacs_home_path () {
 }
 
 url
+get_documents_path () {
+  string docs= get_env ("TEXMACS_DOCUMENTS_PATH");
+  if (!is_empty (docs)) return url_system (docs);
+  return url_system (get_env ("HOME") * "/Documents");
+}
+
+url
 get_tm_cache_path () {
 #if defined(OS_WIN) || defined(OS_MINGW)
   return url (string ("$LOCALAPPDATA/") * CACHE_NAME * "/system/cache/" *

--- a/src/System/Misc/tm_sys_utils.hpp
+++ b/src/System/Misc/tm_sys_utils.hpp
@@ -29,6 +29,7 @@ string check_stderr (string s);
 url  get_texmacs_path ();
 url  get_texmacs_home_path ();
 void init_texmacs_home_path ();
+url  get_documents_path ();
 url  get_tm_cache_path ();
 url  get_tm_preference_path ();
 

--- a/src/Texmacs/Data/new_buffer.cpp
+++ b/src/Texmacs/Data/new_buffer.cpp
@@ -211,7 +211,7 @@ url
 make_new_buffer () {
   int i= 1;
   while (true) {
-    url name= url_scratch ("no_name_", ".tm", i);
+    url name= url_scratch ("no_name_", ".tmu", i);
     if (is_nil (concrete_buffer (name))) {
       set_buffer_tree (name, tree (DOCUMENT));
       return name;
@@ -232,14 +232,14 @@ buffer_has_name (url name) {
 string
 propose_title (string old_title, url u, tree doc) {
   string name= as_string (tail (u));
-  if (starts (name, "no_name_") && ends (name, ".tm")) {
+  if (starts (name, "no_name_") && ends (name, ".tmu")) {
     string no_name= translate ("No name");
     for (int i= 0; i < N (no_name); i++)
       if (((unsigned char) (no_name[i])) >= (unsigned char) 128) {
         no_name= "No name";
         break;
       }
-    name= no_name * " [" * name (8, N (name) - 3) * "]";
+    name= no_name * " [" * name (8, N (name) - 4) * "]";
   }
   if ((name == "") || (name == ".")) name= as_string (tail (u * url_parent ()));
   if ((name == "") || (name == ".")) name= as_string (u);

--- a/tests/Data/view_type_test.cpp
+++ b/tests/Data/view_type_test.cpp
@@ -27,7 +27,8 @@ private slots:
 
 void
 Test_view_type::test_normal_cases () {
-  string normal_url_1= "tmfs://view/1/default/Users/texts/scratch/no_name_5.tm";
+  string normal_url_1=
+      "tmfs://view/1/default/Users/texts/scratch/no_name_5.tmu";
   string normal_url_2=
       "tmfs://view/2/default/Users/jimzhou/Downloads/user_guide.tmu";
   string normal_url_114514= "tmfs://view/114514/default/Users/Documents/A.tmu";
@@ -62,10 +63,11 @@ Test_view_type::test_live_cases () {
 
 void
 Test_view_type::test_broken_cases () {
-  string broken_url_1= "ntfs://view/1/default/Users/texts/scratch/no_name_5.tm";
+  string broken_url_1=
+      "ntfs://view/1/default/Users/texts/scratch/no_name_5.tmu";
   string broken_url_2= "tmfs://view//tmfs/aux/edit-strong";
   string broken_url_3=
-      "tmfs://view/<number>/default/Users/texts/scratch/no_name_5.tm";
+      "tmfs://view/<number>/default/Users/texts/scratch/no_name_5.tmu";
   string broken_url_4= "tmfs://view/abc/tmfs/aux/edit-strong";
   QCOMPARE (is_tmfs_view_type (broken_url_1, "default"), false);
   QCOMPARE (is_tmfs_view_type (broken_url_2, "aux"), false);


### PR DESCRIPTION
将未命名临时文档的存储路径改为 Documents/LiiiSTEM/no_name，并将默认后缀从 .tm 改为 .tmu。

- 使用 Qt 的 QStandardPaths::DocumentsLocation 获取本地化 Documents 路径
- url_scratch 与 is_scratch 路径同步更新
- make_new_buffer 与 propose_title 后缀同步更新
- 相关测试同步更新