### PR TITLE
[0166] 实现 AI Chat 侧边栏 Dock 模式

### DIFF
--- a/devel/0166.md
+++ b/devel/0166.md
@@ -1,28 +1,31 @@
-# [0166] 聊天会话导出功能
+# [0166] AI Chat 侧边栏 Dock 模式
 
 ## 1 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
 
 ## 2 任务相关的代码文件
-- `src/Plugins/Qt/qt_chat_tab_widget.hpp` - ChatSidebar 信号声明
-- `src/Plugins/Qt/qt_chat_tab_widget.cpp` - 侧边栏菜单项
-- `src/Plugins/Qt/qt_chat_controller.hpp` - Controller 处理函数声明
-- `src/Plugins/Qt/qt_chat_controller.cpp` - Controller 处理函数实现
-- `TeXmacs/progs/dynamic/chat-session-persist.scm` - Scheme 导出函数
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp` - ChatTabWidget 侧边栏状态控制接口
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp` - 关闭侧边栏按钮及状态切换实现
+- `src/Plugins/Qt/qt_tm_widget.hpp` - 主窗口 Dock 相关成员声明
+- `src/Plugins/Qt/qt_tm_widget.cpp` - AI Chat 侧边栏 Dock 模式同步逻辑
+- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp` - 单元测试
 
 ## 3 如何测试
 
 ### 3.1 确定性测试（单元测试）
-无
+```bash
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
 
 ### 3.2 非确定性测试（文档验证）
-1. 启动 Mogan，打开 Chat 标签页
-2. 进行一次对话（发送消息并等待回复完成）
-3. 在侧边栏点击该会话的 "..." 按钮
-4. 确认菜单中出现 "Export" 选项（位于 Rename 和 Archive 之间）
-5. 点击 Export，在文件对话框中选择保存位置和文件名
-6. 确认指定路径下生成了 .tmu 文件，内容为会话消息
-7. 确认导出的文档出现在最近文档列表中（启动页或 File → Recent 菜单可见）
+1. 启动 Mogan，确保有已创建的会话
+2. 在文档区域右上角确认出现 "Open AI Chat"（已有会话）或 "New AI Chat"（无会话）浮动按钮
+3. 点击该按钮，确认右侧弹出侧边栏 Dock，宽度约为窗口 1/4
+4. 确认编辑器或 PDF 阅读器仍然可见，聊天界面只显示对话区域（隐藏内部会话列表）
+5. 确认对话区域左上角出现关闭侧边栏按钮，点击后侧边栏收起
+6. 通过 File → Open 或工具栏打开一个 Chat 文件（`.tm` 或特定聊天文件），确认侧边栏自动收起并进入全屏聊天模式
+7. 关闭聊天文件回到编辑器，确认浮动按钮重新出现
 
 ## 4 如何提交
 
@@ -30,21 +33,26 @@
 
 ```bash
 xmake b stem
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
 ```
 
 ## 5 What
-为 AI 聊天界面的会话列表增加导出子功能。
+为 AI Chat 增加侧边栏 Dock 模式，允许在编辑或阅读 PDF 的同时侧边显示聊天界面。
 
-1. 在侧边栏会话项的 "..." 菜单中增加 "Export" 选项
-2. 点击后弹出文件保存对话框，用户选择目标路径
-3. 将会话 message buffer 以 TMU 格式保存到用户指定位置
-4. 导出后将文档加入最近文档列表
+1. 在文档区域右上角增加浮动按钮，用于打开/关闭 AI Chat 侧边栏
+2. 聊天界面以右侧 QDockWidget 形式嵌入，与编辑器/PDF 阅读器共存
+3. Dock 模式下隐藏聊天界面内部的会话列表，只显示对话区域
+4. 对话区域左上角增加关闭侧边栏按钮
+5. 全屏聊天模式（Chat Tab）与侧边栏模式互斥，切换时自动重置状态
 
 ## 6 Why
-用户需要将聊天会话内容导出为独立的 TMU 文档，以便在其他地方使用或备份。
+用户希望在使用编辑器或阅读 PDF 时，能够随时查看和继续 AI 对话，而不必切换到全屏聊天标签页。
 
 ## 7 How
-1. 在 `ChatSidebar` 添加 `exportRequested` 信号
-2. 在 `createItem` 的菜单中添加 "Export" 动作
-3. 在 `ChatController` 中实现 `onExportRequested`：使用 `QFileDialog::getSaveFileName` 获取目标路径，调用 Scheme 函数完成导出
-4. 在 `chat-session-persist.scm` 中添加 `chat-persist-export-session-to`：先 `buffer-export` 保存 buffer 到磁盘，再 `system-copy` 复制到目标路径
+1. 在 `qt_tm_widget_rep` 中增加 `chatSideDock`（QDockWidget）和 `chatSidebarToggleBtn`（浮动按钮）
+2. `sync_chat_sidebar_mode()` 控制侧边栏模式的显隐：将 `chatContentWidget` 移入/移出 Dock，同时隐藏/显示内部会话列表
+3. 在 `QTChatTabWidget` 中增加 `setSidebarVisible()`（dock 模式专用，不触发浮动按钮）和 `setCloseSidebarButtonVisible()`
+4. `update_visibility()` 中根据当前模式控制浮动按钮显隐和 tooltip（根据是否有会话动态显示 "Open AI Chat" 或 "New AI Chat"）
+5. 连接 `QTChatTabWidget::closeSidebarRequested` 信号到关闭侧边栏逻辑
+6. `sync_chat_tab_mode()` 中若之前处于侧边栏模式，先关闭以进入全屏聊天

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -1233,6 +1233,27 @@ QTChatTabWidget::setup_right_content (QHBoxLayout* mainLayout) {
 
   mainLayout->addWidget (content, 1);
 
+  // 对话区域左上角关闭侧边栏按钮（dock 模式使用）
+  closeSidebarBtn_= new QPushButton (content);
+  closeSidebarBtn_->setObjectName ("chat-tab-close-sidebar-btn");
+  closeSidebarBtn_->setFocusPolicy (Qt::NoFocus);
+  closeSidebarBtn_->setCursor (Qt::PointingHandCursor);
+  closeSidebarBtn_->setIcon (QIcon (":llm-chat/sidebar.svg"));
+  closeSidebarBtn_->setIconSize (QSize (DpiUtils::scaled (kToggleIconSize),
+                                        DpiUtils::scaled (kToggleIconSize)));
+  closeSidebarBtn_->setFixedSize (DpiUtils::scaled (kToggleBtnSize),
+                                  DpiUtils::scaled (kToggleBtnSize));
+  closeSidebarBtn_->setStyleSheet (
+      QString ("QPushButton { border: none; border-radius: %1px; "
+               "background: transparent; }"
+               "QPushButton:hover { background: rgba(0,0,0,0.08); }")
+          .arg (DpiUtils::scaled (kToggleBtnSize / 2)));
+  closeSidebarBtn_->move (DpiUtils::scaled (kFloatingBtnMarginX),
+                          DpiUtils::scaled (kFloatingBtnMarginY));
+  connect (closeSidebarBtn_, &QPushButton::clicked, this,
+           [this] () { emit closeSidebarRequested (); });
+  closeSidebarBtn_->hide ();
+
   // 浮球按钮容器
   QWidget* floatingContainer= new QWidget (this);
   floatingContainer->setObjectName ("chat-tab-floating-container");
@@ -1305,6 +1326,26 @@ QTChatTabWidget::toggle_sidebar () {
     }
     sidebarCollapsed_= true;
   }
+}
+
+void
+QTChatTabWidget::setSidebarCollapsed (bool collapsed) {
+  if (sidebarCollapsed_ == collapsed) return;
+  toggle_sidebar ();
+}
+
+void
+QTChatTabWidget::setSidebarVisible (bool visible) {
+  if (!sidebarWidget_) return;
+  sidebarWidget_->setVisible (visible);
+  sidebarCollapsed_= !visible;
+  // dock 模式下不需要浮动按钮，始终隐藏
+  if (floatingBtnContainer_) floatingBtnContainer_->hide ();
+}
+
+void
+QTChatTabWidget::setCloseSidebarButtonVisible (bool visible) {
+  if (closeSidebarBtn_) closeSidebarBtn_->setVisible (visible);
 }
 
 /******************************************************************************

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -312,14 +312,30 @@ public:
   ChatSidebar* sidebar () const { return sidebar_; }
   QPushButton* newChatButton () const { return newChatButton_; }
   QPushButton* floatingNewChatButton () const { return floatingNewChatBtn_; }
+  QPushButton* closeSidebarButton () const { return closeSidebarBtn_; }
   QList<ChatConversationPanel*>& conversations () { return conversations_; }
   ChatConversationPanel*         activeConversation () const {
     return activeConversation_;
   }
+  void setSidebarCollapsed (bool collapsed);
+  bool isSidebarCollapsed () const { return sidebarCollapsed_; }
+  bool isSidebarWidgetVisible () const {
+    return sidebarWidget_ != nullptr && sidebarWidget_->isVisible ();
+  }
+  bool isFloatingContainerVisible () const {
+    return floatingBtnContainer_ != nullptr &&
+           floatingBtnContainer_->isVisible ();
+  }
+  /**
+   * @brief 直接设置内部侧边栏显隐（dock 模式使用，不触发浮动按钮）。
+   */
+  void setSidebarVisible (bool visible);
+  void setCloseSidebarButtonVisible (bool visible);
 
 signals:
   void cancelRequested (const string& sessionId);
   void newChatRequested ();
+  void closeSidebarRequested ();
 
 protected:
   /// 键盘事件处理（Ctrl+N 新建会话等）
@@ -347,6 +363,7 @@ private:
   QPushButton*    floatingNewChatBtn_  = nullptr; ///< 浮动新建按钮
   QWidget*        floatingBtnContainer_= nullptr; ///< 浮动按钮容器
   QPushButton*    newChatButton_       = nullptr; ///< 侧边栏新建按钮
+  QPushButton*    closeSidebarBtn_     = nullptr; ///< 对话区域关闭侧边栏按钮
   QWidget*        sidebarNormalContent_= nullptr; ///< 侧边栏常规内容区
   QStackedWidget* conversationStack_   = nullptr; ///< 会话面板堆栈
 

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -182,7 +182,9 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
       m_memberType (""), m_currentScmNotificationItem (""),
       startupContentWidget (nullptr), startupTabMode (false),
       pdfViewerWidget (nullptr), pdfTabMode (false), currentPdfPath (""),
-      lastLoadedPdfPath (""), chatContentWidget (nullptr), chatTabMode (false) {
+      lastLoadedPdfPath (""), chatContentWidget (nullptr), chatTabMode (false),
+      chatSideDock (nullptr), chatSidebarToggleBtn (nullptr),
+      chatSidebarMode (false) {
   type= texmacs_widget;
 
   main_widget= concrete (::glue_widget (true, true, 1, 1));
@@ -772,6 +774,78 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
   // auxiliaryWidget->setTitleBarWidget (new QWidget ()); // Disables title bar
   mw->addDockWidget (Qt::RightDockWidgetArea, auxiliaryWidget);
 
+  // AI 聊天侧边栏 Dock
+  chatSideDock= new QDockWidget ("AI Chat Sidebar", mw);
+  chatSideDock->setObjectName ("chatSideDock");
+  chatSideDock->setAllowedAreas (Qt::RightDockWidgetArea);
+  chatSideDock->setFeatures (QDockWidget::DockWidgetClosable);
+  chatSideDock->setFloating (false);
+  chatSideDock->setTitleBarWidget (new QWidget ()); // 禁用标题栏
+  chatSideDock->setMinimumWidth (DpiUtils::scaled (320));
+  chatSideDock->setVisible (false);
+  mw->addDockWidget (Qt::RightDockWidgetArea, chatSideDock);
+
+  QObject::connect (chatSideDock, &QDockWidget::visibilityChanged,
+                    [this] (bool visible) {
+                      if (!visible && chatSidebarMode) {
+                        chatSidebarMode= false;
+                        if (chatContentWidget && chatSideDock &&
+                            chatSideDock->widget () == chatContentWidget) {
+                          chatSideDock->setWidget (nullptr);
+                          chatContentWidget->setParent (centralwidget ());
+                          chatContentWidget->hide ();
+                        }
+                        update_visibility ();
+                      }
+                    });
+
+  // 文档区域右上角浮动新建对话按钮
+  chatSidebarToggleBtn= new QPushButton (cw);
+  chatSidebarToggleBtn->setObjectName ("chat-sidebar-toggle-btn");
+  chatSidebarToggleBtn->setFocusPolicy (Qt::NoFocus);
+  chatSidebarToggleBtn->setCursor (Qt::PointingHandCursor);
+  chatSidebarToggleBtn->setIcon (QIcon (":llm-chat/addchat.svg"));
+  int toggleIconSize= DpiUtils::scaled (24);
+  chatSidebarToggleBtn->setIconSize (QSize (toggleIconSize, toggleIconSize));
+  int toggleBtnSize= DpiUtils::scaled (40);
+  chatSidebarToggleBtn->setFixedSize (toggleBtnSize, toggleBtnSize);
+  chatSidebarToggleBtn->setStyleSheet (
+      QString ("QPushButton { border-radius: %1px; "
+               "background: rgba(255,255,255,0.9); "
+               "border: 1px solid rgba(0,0,0,0.12); }"
+               "QPushButton:hover { background: rgba(255,255,255,1.0); "
+               "border: 1px solid rgba(0,0,0,0.2); }")
+          .arg (toggleBtnSize / 2));
+  chatSidebarToggleBtn->hide ();
+
+  // 使用 QObject 辅助类处理 central widget 的 resize 事件以更新按钮位置
+  class ChatSidebarBtnPositioner : public QObject {
+  public:
+    ChatSidebarBtnPositioner (QPushButton* btn, QWidget* parent)
+        : QObject (parent), button_ (btn), parent_ (parent) {}
+    bool eventFilter (QObject* obj, QEvent* event) override {
+      if (obj == parent_ && event->type () == QEvent::Resize) {
+        int margin = DpiUtils::scaled (12);
+        int btnSize= button_->width ();
+        int x      = parent_->width () - btnSize - margin;
+        int y      = margin;
+        button_->move (x, y);
+      }
+      return QObject::eventFilter (obj, event);
+    }
+
+  private:
+    QPushButton* button_;
+    QWidget*     parent_;
+  };
+  cw->installEventFilter (
+      new ChatSidebarBtnPositioner (chatSidebarToggleBtn, cw));
+
+  QObject::connect (chatSidebarToggleBtn, &QPushButton::clicked, [this] () {
+    chatSidebarMode= !chatSidebarMode;
+    sync_chat_sidebar_mode ();
+  });
+
   // FIXME? add DockWidgetClosable and connect the close signal
   // to the scheme code
   //  QObject::connect(sideDock, SIGNAL(closeEvent()),
@@ -797,6 +871,9 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
   QColor   bgcol= to_qcolor (tm_background);
   pal.setColor (QPalette::Mid, bgcol);
   mainwindow ()->setPalette (pal);
+
+  // 强制刷新一次可见性状态，确保浮动按钮等控件初始状态正确
+  update_visibility ();
 
   // 连接登录状态变化信号
   if (is_server_started ()) {
@@ -850,6 +927,10 @@ qt_tm_widget_rep::~qt_tm_widget_rep () {
   // delete pdf viewer widget
   if (pdfViewerWidget) {
     delete pdfViewerWidget;
+  }
+  /// 清理聊天侧边栏 dock 中的 widget 引用，避免悬垂
+  if (chatSideDock) {
+    chatSideDock->setWidget (nullptr);
   }
   /// delete chat content widget
   if (chatContentWidget) {
@@ -996,6 +1077,24 @@ qt_tm_widget_rep::sync_chat_tab_mode () {
 
   if (chatTabMode) {
     // Show Chat tab view
+    // 如果之前处于侧边栏模式，先关闭
+    if (chatSidebarMode) {
+      chatSidebarMode= false;
+      if (chatSideDock && chatContentWidget &&
+          chatSideDock->widget () == chatContentWidget) {
+        chatSideDock->setWidget (nullptr);
+        chatContentWidget->setParent (centralwidget ());
+        // 恢复内部对话列表显示（全屏模式需要）
+        QTChatTabWidget* chatWidget=
+            qobject_cast<QTChatTabWidget*> (chatContentWidget);
+        if (chatWidget) {
+          chatWidget->setSidebarVisible (true);
+          chatWidget->setCloseSidebarButtonVisible (false);
+        }
+      }
+      if (chatSideDock) chatSideDock->hide ();
+    }
+
     hide_widget_from_layout (editorWidget, layout);
     hide_widget_from_layout (startupContentWidget, layout);
     hide_widget_from_layout (pdfViewerWidget, layout);
@@ -1024,6 +1123,121 @@ qt_tm_widget_rep::sync_chat_tab_mode () {
       if (!is_none (currentView)) send_keyboard_focus (abstract (main_widget));
     }
   }
+}
+
+void
+qt_tm_widget_rep::position_chat_sidebar_button () {
+  if (!chatSidebarToggleBtn || !centralwidget ()) return;
+  QWidget* cw     = centralwidget ();
+  int      margin = DpiUtils::scaled (12);
+  int      btnSize= chatSidebarToggleBtn->width ();
+  int      cwW    = cw->width ();
+  int      cwH    = cw->height ();
+  if (cwW <= 0 || cwH <= 0) return; // 窗口尚未就绪
+  int x= cwW - btnSize - margin;
+  int y= margin;
+  chatSidebarToggleBtn->move (x, y);
+}
+
+/**
+ * @brief 同步 AI 聊天侧边栏模式的可见性。
+ *
+ * 当 \ref chatSidebarMode 激活时，将 \ref chatContentWidget 放入右侧
+ * Dock 中显示，同时保持编辑器或 PDF 阅读器可见。
+ * 与 \ref chatTabMode 互斥。
+ */
+void
+qt_tm_widget_rep::sync_chat_sidebar_mode () {
+  QWidget* editorWidget= main_widget->qwid;
+  QLayout* layout      = centralwidget ()->layout ();
+  if (!layout) return;
+
+  if (chatSidebarMode) {
+    // 确保不与全屏聊天模式同时存在
+    if (chatTabMode) {
+      chatTabMode= false;
+      sync_chat_tab_mode ();
+    }
+
+    // 确保聊天控件已创建
+    if (!chatContentWidget) {
+      chatContentWidget=
+          get_chat_controller ()->createView (centralwidget (), this);
+    }
+
+    // 如果控件当前在中央布局中，先移除
+    if (layout->indexOf (chatContentWidget) >= 0) {
+      hide_widget_from_layout (chatContentWidget, layout);
+    }
+
+    // 放入侧边栏 dock
+    if (chatSideDock->widget () != chatContentWidget) {
+      chatContentWidget->setParent (chatSideDock);
+      chatSideDock->setWidget (chatContentWidget);
+    }
+
+    // 侧边栏模式：只显示对话区域，隐藏内部对话列表
+    QTChatTabWidget* chatWidget=
+        qobject_cast<QTChatTabWidget*> (chatContentWidget);
+    if (chatWidget) {
+      chatWidget->setSidebarVisible (false);
+      chatWidget->setCloseSidebarButtonVisible (true);
+      // 连接关闭按钮信号
+      QObject::connect (chatWidget, &QTChatTabWidget::closeSidebarRequested,
+                        [this] () {
+                          chatSidebarMode= false;
+                          sync_chat_sidebar_mode ();
+                        });
+    }
+
+    chatSideDock->show ();
+    chatContentWidget->show ();
+    chatContentWidget->setFocus (Qt::OtherFocusReason);
+
+    // 设置 dock 宽度为屏幕宽度的 1/4
+    QMainWindow* mw= mainwindow ();
+    if (mw) {
+      int dockWidth= qMax (DpiUtils::scaled (280), mw->width () / 4);
+      mw->resizeDocks ({chatSideDock}, {dockWidth}, Qt::Horizontal);
+    }
+
+    // 确保编辑器或 PDF 阅读器可见
+    if (startupTabMode) {
+      hide_widget_from_layout (editorWidget, layout);
+      hide_widget_from_layout (pdfViewerWidget, layout);
+    }
+    else if (pdfTabMode) {
+      hide_widget_from_layout (editorWidget, layout);
+      show_widget_in_layout (pdfViewerWidget, layout);
+    }
+    else {
+      hide_widget_from_layout (pdfViewerWidget, layout);
+      show_widget_in_layout (editorWidget, layout);
+    }
+  }
+  else {
+    // 隐藏侧边栏 dock
+    if (chatSideDock) chatSideDock->hide ();
+
+    // 如果控件在 dock 中，先移回中央 widget（隐藏状态）
+    if (chatContentWidget && chatSideDock &&
+        chatSideDock->widget () == chatContentWidget) {
+      chatSideDock->setWidget (nullptr);
+      chatContentWidget->setParent (centralwidget ());
+      // 不加入布局，保持隐藏
+      chatContentWidget->hide ();
+
+      // 恢复内部对话列表显示（全屏模式需要）
+      QTChatTabWidget* chatWidget=
+          qobject_cast<QTChatTabWidget*> (chatContentWidget);
+      if (chatWidget) {
+        chatWidget->setSidebarVisible (true);
+        chatWidget->setCloseSidebarButtonVisible (false);
+      }
+    }
+  }
+
+  update_visibility ();
 }
 
 void
@@ -1133,6 +1347,22 @@ qt_tm_widget_rep::update_visibility () {
     windowAgent->titleBar ()->setVisible (new_titleVisibility);
   if (XOR (old_statusVisibility, new_statusVisibility))
     mainwindow ()->statusBar ()->setVisible (new_statusVisibility);
+
+  // AI 聊天侧边栏浮动按钮可见性
+  if (chatSidebarToggleBtn) {
+    bool shouldShow= !chatTabMode && !chatSidebarMode && !startupTabMode;
+    chatSidebarToggleBtn->setVisible (shouldShow);
+    if (shouldShow) {
+      chatSidebarToggleBtn->raise ();
+      position_chat_sidebar_button ();
+      // 动态 tooltip：已有会话时显示 "Open AI Chat"，否则显示 "New AI Chat"
+      ChatController* ctrl= get_chat_controller ();
+      bool hasSessions= !ctrl->sessionManager ().getAllSessionIds ().empty ();
+      chatSidebarToggleBtn->setToolTip (hasSessions
+                                            ? qt_translate ("Open AI Chat")
+                                            : qt_translate ("New AI Chat"));
+    }
+  }
 
 // #if 0
 #ifdef UNIFIED_TOOLBAR
@@ -1356,14 +1586,16 @@ qt_tm_widget_rep::send (slot s, blackbox val) {
     string file= open_box<string> (val);
     if (DEBUG_QT_WIDGETS) debug_widgets << "\tFile: " << file << LF;
     mainwindow ()->setWindowFilePath (utf8_to_qstring (file));
-    startupTabMode= is_startup_tab_file (file);
-    pdfTabMode    = is_pdf_tab_file (file);
+    currentEditorFile= file;
+    startupTabMode   = is_startup_tab_file (file);
+    pdfTabMode       = is_pdf_tab_file (file);
     if (pdfTabMode) {
       currentPdfPath= utf8_to_qstring (file);
     }
     chatTabMode= is_chat_tab_file (file);
     sync_startup_tab_mode ();
     sync_chat_tab_mode ();
+    sync_chat_sidebar_mode ();
   } break;
   case SLOT_POSITION: {
     check_type<coord2> (val, s);

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -79,6 +79,7 @@ class qt_tm_widget_rep : public qt_window_widget_rep {
   QDockWidget*            leftTools;
   QDockWidget*            bottomTools;
   QDockWidget*            extraTools;
+  QDockWidget*            chatSideDock; ///< AI 聊天侧边栏 Dock
   QTMTabPageContainer*    tabPageContainer;
   QTMAuxiliaryWidget*     auxiliaryWidget;
   QWK::WidgetWindowAgent* windowAgent;
@@ -93,6 +94,7 @@ class qt_tm_widget_rep : public qt_window_widget_rep {
   QLabel*                 membershipTitleLabel;
   QPushButton*            loginActionButton;
   QPushButton*            logoutButton;
+  QPushButton* chatSidebarToggleBtn; ///< 文档区域右上角的新建对话浮动按钮
 
   // 更新提示区域控件
   QWidget*     m_updateSection     = nullptr;
@@ -152,6 +154,8 @@ private:
   void showNotLoggedInDialog (const QString& errorMessage);
   void updateVipButtonVisibility (bool isLoggedIn, const QString& memberType);
   void logout ();
+  void sync_chat_sidebar_mode ();
+  void position_chat_sidebar_button ();
 
   // Version update notification
   void    checkVersionUpdate ();
@@ -182,6 +186,8 @@ private:
   QString          currentPdfPath;    ///\< 当前显示的 PDF 路径。
   QString          lastLoadedPdfPath; ///\< 上次加载的 PDF 路径。
   bool             chatTabMode;       ///\< 聊天标签页视图是否激活。
+  bool             chatSidebarMode;   ///\< AI 聊天侧边栏模式是否激活。
+  string           currentEditorFile; ///\< 当前编辑器打开的文件路径。
 
 public:
   qt_tm_widget_rep (int mask, command _quit);

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -7,6 +7,8 @@
 
 #include "Qt/qt_chat_tab_widget.hpp"
 #include "base.hpp"
+#include <QPushButton>
+#include <QSignalSpy>
 #include <QtTest/QtTest>
 
 using namespace moebius;
@@ -68,6 +70,120 @@ private slots:
   void test_is_empty_document_body_multiple_paragraphs () {
     tree doc= tree (DOCUMENT, "para1", "para2");
     QVERIFY (!ChatConversationPanel::is_empty_document_body (doc));
+  }
+
+  // === setSidebarCollapsed / isSidebarCollapsed ===
+  void test_setSidebarCollapsed_expand () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.setSidebarCollapsed (false);
+    QVERIFY (!widget.isSidebarCollapsed ());
+  }
+
+  void test_setSidebarCollapsed_collapse () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.setSidebarCollapsed (true);
+    QVERIFY (widget.isSidebarCollapsed ());
+  }
+
+  void test_setSidebarCollapsed_toggle () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    bool                      initial= widget.isSidebarCollapsed ();
+    widget.setSidebarCollapsed (!initial);
+    QCOMPARE (widget.isSidebarCollapsed (), !initial);
+    widget.setSidebarCollapsed (initial);
+    QCOMPARE (widget.isSidebarCollapsed (), initial);
+  }
+
+  void test_setSidebarCollapsed_idempotent () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.setSidebarCollapsed (true);
+    widget.setSidebarCollapsed (true);
+    QVERIFY (widget.isSidebarCollapsed ());
+    widget.setSidebarCollapsed (false);
+    widget.setSidebarCollapsed (false);
+    QVERIFY (!widget.isSidebarCollapsed ());
+  }
+
+  void test_setSidebarCollapsed_affects_widget_visibility () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show (); // 必须 show 才能检查实际 Qt 可见性
+    // 默认侧边栏可见，浮动按钮隐藏
+    QVERIFY (widget.isSidebarWidgetVisible ());
+    QVERIFY (!widget.isFloatingContainerVisible ());
+
+    widget.setSidebarCollapsed (true);
+    QVERIFY (!widget.isSidebarWidgetVisible ());
+    QVERIFY (widget.isFloatingContainerVisible ());
+
+    widget.setSidebarCollapsed (false);
+    QVERIFY (widget.isSidebarWidgetVisible ());
+    QVERIFY (!widget.isFloatingContainerVisible ());
+  }
+
+  // === setSidebarVisible (dock 模式专用) ===
+  void test_setSidebarVisible_hide () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+    widget.setSidebarVisible (false);
+    QVERIFY (!widget.isSidebarWidgetVisible ());
+    QVERIFY (!widget.isFloatingContainerVisible ());
+  }
+
+  void test_setSidebarVisible_show () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+    widget.setSidebarVisible (false);
+    widget.setSidebarVisible (true);
+    QVERIFY (widget.isSidebarWidgetVisible ());
+    QVERIFY (!widget.isFloatingContainerVisible ());
+  }
+
+  void test_setSidebarVisible_does_not_show_floating_buttons () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+    widget.setSidebarCollapsed (true); // 正常折叠会显示浮动按钮
+    QVERIFY (widget.isFloatingContainerVisible ());
+
+    widget.setSidebarVisible (false); // dock 模式隐藏，不显示浮动按钮
+    QVERIFY (!widget.isSidebarWidgetVisible ());
+    QVERIFY (!widget.isFloatingContainerVisible ());
+  }
+
+  // === close sidebar 按钮 ===
+  void test_closeSidebarButton_visible () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+    QVERIFY (widget.closeSidebarButton () != nullptr);
+    widget.setCloseSidebarButtonVisible (true);
+    QVERIFY (widget.closeSidebarButton ()->isVisible ());
+  }
+
+  void test_closeSidebarButton_hidden () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+    widget.setCloseSidebarButtonVisible (true);
+    widget.setCloseSidebarButtonVisible (false);
+    QVERIFY (!widget.closeSidebarButton ()->isVisible ());
+  }
+
+  void test_closeSidebarButton_emits_signal () {
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+    QSignalSpy spy (&widget, &QTChatTabWidget::closeSidebarRequested);
+    widget.setCloseSidebarButtonVisible (true);
+    QTest::mouseClick (widget.closeSidebarButton (), Qt::LeftButton);
+    QCOMPARE (spy.count (), 1);
   }
 };
 


### PR DESCRIPTION
## Summary
- 在文档区域右上角增加浮动按钮，用于打开/关闭 AI Chat 侧边栏
- 聊天界面以右侧 QDockWidget 形式嵌入，与编辑器/PDF 阅读器共存
- Dock 模式下隐藏聊天界面内部的会话列表，只显示对话区域
- 对话区域左上角增加关闭侧边栏按钮
- 全屏聊天模式（Chat Tab）与侧边栏模式互斥，切换时自动重置状态
- 增加单元测试覆盖新 API

## Test plan
- [x] `xmake b qt_chat_tab_widget_test && xmake r qt_chat_tab_widget_test` 通过
- [ ] 启动 Mogan，确认文档区域右上角出现浮动按钮
- [ ] 点击浮动按钮，确认右侧弹出侧边栏 Dock
- [ ] 确认编辑器或 PDF 阅读器仍然可见
- [ ] 确认对话区域左上角出现关闭按钮，点击后收起侧边栏
- [ ] 打开 Chat 文件进入全屏聊天模式，确认侧边栏自动收起

🤖 Generated with [Claude Code](https://claude.com/claude-code)