### PR TITLE
[0171] 修复 Qt SVG 图标加载中的内存泄漏

### DIFF
--- a/devel/0171.md
+++ b/devel/0171.md
@@ -1,0 +1,16 @@
+# [0171] 修复 Qt SVG 图标加载中的内存泄漏
+
+## 任务相关的代码文件
+- `src/Plugins/Qt/qt_picture.cpp`
+
+## What
+
+修复 `qt_load_svg_icon` 函数中的内存泄漏问题。该函数在加载 SVG 图标时通过 `new QImage` 分配了一个临时 `QImage` 对象，但在函数返回前没有释放，导致每次加载 SVG 图标都会泄漏内存。
+
+## Why
+
+`qt_load_svg_icon` 用于将 SVG 文件渲染为 `QPixmap` 图标。其内部实现先创建一个 `QImage` 作为渲染目标，使用 `QPainter` 将 SVG 渲染到该图像上，然后将图像转换为 `QPixmap` 返回。由于返回的是 `QPixmap`（已完成深拷贝），临时的 `QImage` 应当被释放。
+
+## How
+
+在 `return icon;` 之前添加 `delete pm;` 语句，释放临时分配的 `QImage`。

--- a/src/Plugins/Qt/qt_picture.cpp
+++ b/src/Plugins/Qt/qt_picture.cpp
@@ -463,6 +463,7 @@ qt_load_svg_icon (url file_name) {
 
   QPixmap icon (pm->size ());
   icon.convertFromImage (*pm);
+  delete pm;
   return icon;
 }
 


### PR DESCRIPTION
## 摘要

修复 `qt_load_svg_icon` 函数中的内存泄漏问题。

## 问题描述

在 `src/Plugins/Qt/qt_picture.cpp` 的 `qt_load_svg_icon` 函数中，加载 SVG 图标时通过 `new QImage` 分配了一个临时 `QImage` 对象用于渲染，但在将图像转换为 `QPixmap` 并返回之前，没有释放该临时对象，导致每次加载 SVG 图标都会泄漏内存。

## 修复方式

在 `return icon;` 之前添加 `delete pm;` 语句，释放临时分配的 `QImage`。

## 测试

- [x] 代码审查确认修复位置正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)