### PR TITLE
[0625] 修复 HTML 和 MathML 导出时分段函数的显示错误

### DIFF
--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -219,7 +219,7 @@
                 ".fill-out { text-decoration: underline dotted; } "
               ) ;string-append
         ) ;html
-        (mathml "math { font-family: cmr, times, verdana } ")
+        (mathml "math { font-family: \"Latin Modern Math\", \"Cambria Math\", \"STIX Two Math\", \"Noto Sans Math\", \"STIXGeneral\", cmr, times, verdana, serif } ")
        ) ;
     (if tmhtml-mathml? (string-append html mathml) html)
   ) ;let

--- a/TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm
+++ b/TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm
@@ -249,6 +249,18 @@
 
 (define (tmmath-noop l) "")
 
+(define (tmmath-hspace l)
+  (let* ((len (if (null? l) "1em" (car l)))
+         (s (cond ((string? len) len)
+                  ((symbol? len) (symbol->string len))
+                  (else (object->string len))))
+         (s* (cond ((string-ends? s "*p*t") (string-append (substring s 0 (- (string-length s) 4)) "pt"))
+                   ((string-ends? s "*e*m") (string-append (substring s 0 (- (string-length s) 4)) "em"))
+                   ((string-ends? s "*e*x") (string-append (substring s 0 (- (string-length s) 4)) "ex"))
+                   ((string->number s) (string-append s "em"))
+                   (else s))))
+    `(m:mspace (@ (width ,s*)))))
+
 (define (tmmath-first l)
   (tmmath (car l)))
 
@@ -364,6 +376,9 @@
   (block* tmmath-first)
 
   ;; Other markup
+  (space tmmath-hspace)
+  (hspace tmmath-hspace)
+  (htab tmmath-hspace)
   (document tmmath-concat)
   (para tmmath-concat)
   (surround tmmath-surround)

--- a/TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm
+++ b/TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm
@@ -80,9 +80,9 @@
   (with y (logic-ref tm->mathml-large% x)
     (if y y (cork->utf8 x))))
 
-(define (tmmath-left l) `(m:mo (@ (form "prefix")) ,(tmmath-large (car l))))
-(define (tmmath-mid l) `(m:mo ,(tmmath-large (car l))))
-(define (tmmath-right l) `(m:mo (@ (form "postfix")) ,(tmmath-large (car l))))
+(define (tmmath-left l) `(m:mo (@ (form "prefix") (stretchy "true")) ,(tmmath-large (car l))))
+(define (tmmath-mid l) `(m:mo (@ (stretchy "true")) ,(tmmath-large (car l))))
+(define (tmmath-right l) `(m:mo (@ (form "postfix") (stretchy "true")) ,(tmmath-large (car l))))
 
 (define (tmmath-big l)
   (cond ((== (car l) ".") "")

--- a/TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm
+++ b/TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm
@@ -251,14 +251,8 @@
 
 (define (tmmath-hspace l)
   (let* ((len (if (null? l) "1em" (car l)))
-         (s (cond ((string? len) len)
-                  ((symbol? len) (symbol->string len))
-                  (else (object->string len))))
-         (s* (cond ((string-ends? s "*p*t") (string-append (substring s 0 (- (string-length s) 4)) "pt"))
-                   ((string-ends? s "*e*m") (string-append (substring s 0 (- (string-length s) 4)) "em"))
-                   ((string-ends? s "*e*x") (string-append (substring s 0 (- (string-length s) 4)) "ex"))
-                   ((string->number s) (string-append s "em"))
-                   (else s))))
+         (s (string-replace (if (string? len) len (object->string len)) "*" ""))
+         (s* (if (string->number s) (string-append s "em") s)))
     `(m:mspace (@ (width ,s*)))))
 
 (define (tmmath-first l)

--- a/TeXmacs/tests/0625.scm
+++ b/TeXmacs/tests/0625.scm
@@ -24,7 +24,10 @@
     (display* "Exported HTML length: " (string-length html-content) "\n")
     ;; In MathML mode, the <space|1em> should be exported as `<mspace width="1em"/>` or `<m:mspace width="1em"/>`!
     (check (string-contains? html-content "mspace") => #t)
-    (check (string-contains? html-content "width=\"1em\"") => #t)))
+    (check (string-contains? html-content "width=\"1em\"") => #t)
+    
+    ;; Also verify that the left brace of the piecewise choice block has stretchy="true" to scale vertically!
+    (check (string-contains? html-content "stretchy=\"true\"") => #t)))
 
 (tm-define (test_0625)
   (test-math-space-export-integration)

--- a/TeXmacs/tests/0625.scm
+++ b/TeXmacs/tests/0625.scm
@@ -10,7 +10,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(import (liii check))
+(import (liii check)
+        (liii path))
 
 (check-set-mode! 'report-failed)
 
@@ -21,6 +22,7 @@
          (dummy (load-buffer tmu-path))
          (dummy2 (buffer-export tmu-path tmp-html "html"))
          (html-content (string-load tmp-html)))
+    (path-write-text "0625_out.html" html-content)
     (display* "Exported HTML length: " (string-length html-content) "\n")
     ;; In MathML mode, the <space|1em> should be exported as `<mspace width="1em"/>` or `<m:mspace width="1em"/>`!
     (check (string-contains? html-content "mspace") => #t)

--- a/TeXmacs/tests/0625.scm
+++ b/TeXmacs/tests/0625.scm
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0625.scm
+;; DESCRIPTION : Unit and Integration tests for MathML/HTML export of space/hspace in math mode
+;; COPYRIGHT   : (C) 2026 Sisyphus
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(define (test-math-space-export-integration)
+  (display "Verifying end-to-end HTML/MathML export with space/hspace in math mode...\n")
+  (let* ((tmu-path "$TEXMACS_PATH/tests/tmu/0625_piecewise.tmu")
+         (tmp-html (url-temp))
+         (dummy (load-buffer tmu-path))
+         (dummy2 (buffer-export tmu-path tmp-html "html"))
+         (html-content (string-load tmp-html)))
+    (display* "Exported HTML length: " (string-length html-content) "\n")
+    ;; In MathML mode, the <space|1em> should be exported as `<mspace width="1em"/>` or `<m:mspace width="1em"/>`!
+    (check (string-contains? html-content "mspace") => #t)
+    (check (string-contains? html-content "width=\"1em\"") => #t)))
+
+(tm-define (test_0625)
+  (test-math-space-export-integration)
+  (check-report))

--- a/TeXmacs/tests/tmu/0625_piecewise.tmu
+++ b/TeXmacs/tests/tmu/0625_piecewise.tmu
@@ -1,0 +1,16 @@
+<TMU|<tuple|1.1.0|2026.2.7-rc6>>
+
+<style|<tuple|generic|number-europe|preview-ref>>
+
+<\body>
+  <\equation*>
+    <choice|<tformat|<table|<row|<cell|<around*|\<langle\>|T|\<rangle\>>=-E<rsub|n>>|<cell|if<space|1em>x\<gtr\>0>>|<row|<cell|<around*|\<langle\>|V|\<rangle\>>=2E<rsub|n>>|<cell|if<space|1em>x\<less\>0>>|<row|<cell|<around*|\<langle\>|V<rsup|2>|\<rangle\>>=<around*|(|<frac|e<rsup|2>|4\<pi\>\<epsilon\><rsub|0>>|)><rsup|2><around*|\<langle\>|<frac|1|r<rsup|2>>|\<rangle\>>=<frac|1|<around*|(|\<ell\>+<frac|1|2>|)>n<rsup|3>a<rsup|2>>>|<cell|if<space|1em>x=0>>>>>.
+  </equation*>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|3106D53A-25DC-4D10-8327-C9F53D26CE30>
+  </collection>
+</initial>

--- a/devel/0625.md
+++ b/devel/0625.md
@@ -1,0 +1,47 @@
+# [0625] 修复 HTML 和 MathML 导出时公式内部的 <space> 等水平间距被静默丢弃的问题
+
+当 Mogan 导出包含 `<space>`（例如 `if<space|1em>x`）或 `<hspace>` 的数学公式为 HTML/MathML 时，公式内部的这些水平间距节点在导出的 MathML 文档中会被静默丢弃，导致相邻单词连在一起（例如显示为 `ifx > 0` ）。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm`
+- `TeXmacs/tests/0625.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+运行单元测试验证 `space`, `hspace`, `htab` 节点被正确转换为 MathML `<mspace width="..."/>` 并完整导出：
+```bash
+xmake r 0625
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 在 Mogan 中打开随本 PR 提交的测试文件 `TeXmacs/tests/tmu/0625_piecewise.tmu`。
+2. 导出为 HTML，验证生成的 HTML 中分段函数的 `if` 与其后的变量之间包含标准的 MathML `<mspace width="1em"/>` 节点，并且渲染出的字句不再挤压相连（显示为健康的 `if x` ）。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+1. 运行确定性测试，确保输出 `*** checks *** : 2 correct, 0 failed.`：
+   ```bash
+   xmake r 0625
+   ```
+
+## 5 What
+1. 修复了数学模式（公式）下包含 `<space>`、`<hspace>` 及 `<htab>` 等水平间距在导出为 HTML/MathML 时被静默丢弃、导致渲染出的数学公式文本（如 `if x`）严重挤压相连（如 `ifx`）的问题。
+2. 在 MathML 导出引擎（`tmmath.scm`）中添加了对 `space` / `hspace` / `htab` 的语义化翻译支持，将它们统一编译为标准的 MathML `<m:mspace>` 节点，并保留其精确的 `width` 属性。
+3. 编写了完整的端到端集成测试 `TeXmacs/tests/0625.scm`。
+
+## 6 Why
+在原先的 `tmmath.scm` 中，其 `tmmath-primitives%` 分发器中并没有为 `space`、`hspace` 或 `htab` 注册任何处理器。
+这导致在 `mode="math"` 的 MathML 导出过程中，分发器无法找到它们的映射关系，从而默认将它们退化回空字符串 `""` 丢弃。而标准 HTML 导出引擎 `tmhtml.scm` 会优先选择 MathML 进行公式序列化，从而使得这些本应保留的公式内间距在输出的成果物中被彻底吞掉，发生了严重的代码缺失。
+
+## 7 How
+在 `tmmath.scm` 中实现并定义通用的水平间距节点转换函数 `tmmath-hspace`。
+该函数接收水平间距参数，清洗多余的后缀（如将 `*p*t` 等转换为 MathML 标准的 `pt`，非数值单位自适应补上 `em` 等），然后输出语义化的 `((m:mspace (@ (width ,s*))))` 节点树。
+并在 MathML 分发器 `tmmath-primitives%` 中注册以下三个间距标签的映射，使它们在数学模式导出时能完美支持：
+* `(space tmmath-hspace)`
+* `(hspace tmmath-hspace)`
+* `(htab tmmath-hspace)`

--- a/devel/0625.md
+++ b/devel/0625.md
@@ -1,6 +1,6 @@
-# [0625] 修复 HTML 和 MathML 导出时公式内部的 <space> 等水平间距被静默丢弃的问题
+# [0625] 修复 HTML 和 MathML 导出时公式内部的 <space> 等水平间距被静默丢弃，及大括号无法纵向自适应拉伸的问题
 
-当 Mogan 导出包含 `<space>`（例如 `if<space|1em>x`）或 `<hspace>` 的数学公式为 HTML/MathML 时，公式内部的这些水平间距节点在导出的 MathML 文档中会被静默丢弃，导致相邻单词连在一起（例如显示为 `ifx > 0` ）。
+当 Mogan 导出包含 `<space>`（例如 `if<space|1em>x`）或 `<hspace>` 的数学公式为 HTML/MathML 时，公式内部的这些水平间距节点在导出的 MathML 文档中会被静默丢弃，导致相邻单词连在一起（例如显示为 `ifx > 0`）。同时，分段函数（例如 `choice` / `around` / `left` / `right`）左边的大括号 `{` 渲染得极其矮小，无法根据表格内容的高度进行自适应的纵向拉伸（Stretchy）。
 
 ## 1 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
@@ -12,7 +12,7 @@
 ## 3 如何测试
 
 ### 3.1 确定性测试（单元测试）
-运行单元测试验证 `space`, `hspace`, `htab` 节点被正确转换为 MathML `<mspace width="..."/>` 并完整导出：
+运行单元测试验证 `space` / `hspace` / `htab` 节点被正确转换为 MathML `<mspace width="..."/>`，且 `left` / `mid` / `right` 左/中/右大括号/括号均被赋予 `stretchy="true"` 属性并完整导出：
 ```bash
 xmake r 0625
 ```
@@ -20,28 +20,34 @@ xmake r 0625
 ### 3.2 非确定性测试（文档验证）
 1. 在 Mogan 中打开随本 PR 提交的测试文件 `TeXmacs/tests/tmu/0625_piecewise.tmu`。
 2. 导出为 HTML，验证生成的 HTML 中分段函数的 `if` 与其后的变量之间包含标准的 MathML `<mspace width="1em"/>` 节点，并且渲染出的字句不再挤压相连（显示为健康的 `if x` ）。
+3. 验证分段函数左边的大括号 `{` 拥有 `stretchy="true"` 属性，并且大括号在浏览器中渲染时能够根据分段公式的高度进行美观的纵向拉伸，不再显得极其矮小。
 
 ## 4 如何提交
 
 提交前执行以下最少步骤：
-1. 运行确定性测试，确保输出 `*** checks *** : 2 correct, 0 failed.`：
+1. 运行确定性测试，确保输出 `*** checks *** : 3 correct, 0 failed.`：
    ```bash
    xmake r 0625
    ```
 
 ## 5 What
 1. 修复了数学模式（公式）下包含 `<space>`、`<hspace>` 及 `<htab>` 等水平间距在导出为 HTML/MathML 时被静默丢弃、导致渲染出的数学公式文本（如 `if x`）严重挤压相连（如 `ifx`）的问题。
-2. 在 MathML 导出引擎（`tmmath.scm`）中添加了对 `space` / `hspace` / `htab` 的语义化翻译支持，将它们统一编译为标准的 MathML `<m:mspace>` 节点，并保留其精确的 `width` 属性。
-3. 编写了完整的端到端集成测试 `TeXmacs/tests/0625.scm`。
+2. 修复了分段公式左边大括号极其矮小的问题。为所有通过 `left` / `mid` / `right` 导出的前缀、中缀、后缀数学算子/围栏符号加上了标准的 `stretchy="true"` 属性，使它们在 MathML 渲染时能自适应拉伸。
+3. 在 MathML 导出引擎（`tmmath.scm`）中添加了对 `space` / `hspace` / `htab` 的语义化翻译支持，将它们统一编译为标准的 MathML `<m:mspace>` 节点，并保留其精确的 `width` 属性。
+4. 编写了完整的端到端集成测试 `TeXmacs/tests/0625.scm`。
 
 ## 6 Why
-在原先的 `tmmath.scm` 中，其 `tmmath-primitives%` 分发器中并没有为 `space`、`hspace` 或 `htab` 注册任何处理器。
-这导致在 `mode="math"` 的 MathML 导出过程中，分发器无法找到它们的映射关系，从而默认将它们退化回空字符串 `""` 丢弃。而标准 HTML 导出引擎 `tmhtml.scm` 会优先选择 MathML 进行公式序列化，从而使得这些本应保留的公式内间距在输出的成果物中被彻底吞掉，发生了严重的代码缺失。
+* **间距丢失原因**：在原先的 `tmmath.scm` 中，其 `tmmath-primitives%` 分发器中并没有为 `space`、`hspace` 或 `htab` 注册任何处理器。这导致在 `mode="math"` 的 MathML 导出过程中，分发器无法找到它们的映射关系，从而默认将它们退化回空字符串 `""` 丢弃。
+* **大括号矮小原因**：MathML 规范中，大括号 `{` 等前/后缀操作符（`<mo>`）的高度默认是不拉伸的。在主流浏览器/渲染器中，必须明确为 `<mo>` 围栏符号指定 `stretchy="true"` 属性，它才会自适应子元素或所属表格（`<mtable>`）的高度进行纵向拉伸，否则就会保持极其矮小的原生单行高。
 
 ## 7 How
-在 `tmmath.scm` 中实现并定义通用的水平间距节点转换函数 `tmmath-hspace`。
-该函数接收水平间距参数，清洗多余的后缀（如将 `*p*t` 等转换为 MathML 标准的 `pt`，非数值单位自适应补上 `em` 等），然后输出语义化的 `((m:mspace (@ (width ,s*))))` 节点树。
-并在 MathML 分发器 `tmmath-primitives%` 中注册以下三个间距标签的映射，使它们在数学模式导出时能完美支持：
-* `(space tmmath-hspace)`
-* `(hspace tmmath-hspace)`
-* `(htab tmmath-hspace)`
+1. 在 `tmmath.scm` 中实现并定义通用的水平间距节点转换函数 `tmmath-hspace`。该函数接收水平间距参数，输出标准的 `(m:mspace (@ (width ,s*)))` 节点。并在 MathML 分发器 `tmmath-primitives%` 中注册以下三个间距标签的映射：
+   * `(space tmmath-hspace)`
+   * `(hspace tmmath-hspace)`
+   * `(htab tmmath-hspace)`
+2. 修改 `tmmath-left`、`tmmath-mid`、`tmmath-right` 函数，为它们输出的 MathML 算子节点（`<m:mo>`）增加 `stretchy="true"` 属性，以启用大括号及其他围栏符号（如括号、竖线、中括号等）的纵向自适应拉伸：
+   ```scheme
+   (define (tmmath-left l) `(m:mo (@ (form "prefix") (stretchy "true")) ,(tmmath-large (car l))))
+   (define (tmmath-mid l) `(m:mo (@ (stretchy "true")) ,(tmmath-large (car l))))
+   (define (tmmath-right l) `(m:mo (@ (form "postfix") (stretchy "true")) ,(tmmath-large (car l))))
+   ```


### PR DESCRIPTION
# [0625] 修复 HTML 和 MathML 导出时公式内部的 <space> 等水平间距被静默丢弃，及大括号无法纵向自适应拉伸的问题

当 Mogan 导出包含 `<space>`（例如 `if<space|1em>x`）或 `<hspace>` 的数学公式为 HTML/MathML 时，公式内部的这些水平间距节点在导出的 MathML 文档中会被静默丢弃，导致相邻单词连在一起（例如显示为 `ifx > 0`）。同时，分段函数（例如 `choice` / `around` / `left` / `right`）左边的大括号 `{` 渲染得极其矮小，无法根据表格内容的高度进行自适应的纵向拉伸（Stretchy）。

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `TeXmacs/plugins/html/progs/convert/mathml/tmmath.scm`
- `TeXmacs/tests/0625.scm`

## 3 如何测试

### 3.1 确定性测试（单元测试）
运行单元测试验证 `space` / `hspace` / `htab` 节点被正确转换为 MathML `<mspace width="..."/>`，且 `left` / `mid` / `right` 左/中/右大括号/括号均被赋予 `stretchy="true"` 属性并完整导出：
```bash
xmake r 0625
```

### 3.2 非确定性测试（文档验证）
1. 在 Mogan 中打开随本 PR 提交的测试文件 `TeXmacs/tests/tmu/0625_piecewise.tmu`。
2. 导出为 HTML，验证生成的 HTML 中分段函数的 `if` 与其后的变量之间包含标准的 MathML `<mspace width="1em"/>` 节点，并且渲染出的字句不再挤压相连（显示为健康的 `if x` ）。
3. 验证分段函数左边的大括号 `{` 拥有 `stretchy="true"` 属性，并且大括号在浏览器中渲染时能够根据分段公式的高度进行美观的纵向拉伸，不再显得极其矮小。

## 4 如何提交

提交前执行以下最少步骤：
1. 运行确定性测试，确保输出 `*** checks *** : 3 correct, 0 failed.`：
   ```bash
   xmake r 0625
   ```

## 5 What
1. 修复了数学模式（公式）下包含 `<space>`、`<hspace>` 及 `<htab>` 等水平间距在导出为 HTML/MathML 时被静默丢弃、导致渲染出的数学公式文本（如 `if x`）严重挤压相连（如 `ifx`）的问题。
2. 修复了分段公式左边大括号极其矮小的问题。为所有通过 `left` / `mid` / `right` 导出的前缀、中缀、后缀数学算子/围栏符号加上了标准的 `stretchy="true"` 属性，使它们在 MathML 渲染时能自适应拉伸。
3. 在 MathML 导出引擎（`tmmath.scm`）中添加了对 `space` / `hspace` / `htab` 的语义化翻译支持，将它们统一编译为标准的 MathML `<m:mspace>` 节点，并保留其精确的 `width` 属性。
4. 编写了完整的端到端集成测试 `TeXmacs/tests/0625.scm`。

## 6 Why
* **间距丢失原因**：在原先的 `tmmath.scm` 中，其 `tmmath-primitives%` 分发器中并没有为 `space`、`hspace` 或 `htab` 注册任何处理器。这导致在 `mode="math"` 的 MathML 导出过程中，分发器无法找到它们的映射关系，从而默认将它们退化回空字符串 `""` 丢弃。
* **大括号矮小原因**：MathML 规范中，大括号 `{` 等前/后缀操作符（`<mo>`）的高度默认是不拉伸的。在主流浏览器/渲染器中，必须明确为 `<mo>` 围栏符号指定 `stretchy="true"` 属性，它才会自适应子元素或所属表格（`<mtable>`）的高度进行纵向拉伸，否则就会保持极其矮小的原生单行高。

## 7 How
1. 在 `tmmath.scm` 中实现并定义通用的水平间距节点转换函数 `tmmath-hspace`。该函数接收水平间距参数，输出标准的 `(m:mspace (@ (width ,s*)))` 节点。并在 MathML 分发器 `tmmath-primitives%` 中注册以下三个间距标签的映射：
   * `(space tmmath-hspace)`
   * `(hspace tmmath-hspace)`
   * `(htab tmmath-hspace)`
2. 修改 `tmmath-left`、`tmmath-mid`、`tmmath-right` 函数，为它们输出的 MathML 算子节点（`<m:mo>`）增加 `stretchy="true"` 属性，以启用大括号及其他围栏符号（如括号、竖线、中括号等）的纵向自适应拉伸：
   ```scheme
   (define (tmmath-left l) `(m:mo (@ (form "prefix") (stretchy "true")) ,(tmmath-large (car l))))
   (define (tmmath-mid l) `(m:mo (@ (stretchy "true")) ,(tmmath-large (car l))))
   (define (tmmath-right l) `(m:mo (@ (form "postfix") (stretchy "true")) ,(tmmath-large (car l))))
   ```