### PR TITLE
[0171] 修复 mupdf_load_image 中 XPM 分支的 fz_buffer 内存泄漏

### DIFF
--- a/devel/0171.md
+++ b/devel/0171.md
@@ -1,16 +1,23 @@
-# [0171] 修复 Qt SVG 图标加载中的内存泄漏
+# [0171] 修复内存泄漏
 
 ## 任务相关的代码文件
 - `src/Plugins/Qt/qt_picture.cpp`
+- `src/Plugins/MuPDF/mupdf_picture.cpp`
 
 ## What
 
-修复 `qt_load_svg_icon` 函数中的内存泄漏问题。该函数在加载 SVG 图标时通过 `new QImage` 分配了一个临时 `QImage` 对象，但在函数返回前没有释放，导致每次加载 SVG 图标都会泄漏内存。
+1. 修复 `qt_load_svg_icon` 函数中的内存泄漏问题。该函数在加载 SVG 图标时通过 `new QImage` 分配了一个临时 `QImage` 对象，但在函数返回前没有释放，导致每次加载 SVG 图标都会泄漏内存。
+
+2. 修复 `mupdf_load_image` 函数中的 `fz_buffer` 内存泄漏问题。当加载 XPM 格式图片且存在更高分辨率的 PNG 替代文件时，函数通过 `return mupdf_load_image(png_equiv)` 提前返回，但未释放已经通过 `mupdf_read_from_url` 分配的 `fz_buffer`，导致每次加载此类 XPM 文件都会泄漏一个 `fz_buffer`。
 
 ## Why
 
-`qt_load_svg_icon` 用于将 SVG 文件渲染为 `QPixmap` 图标。其内部实现先创建一个 `QImage` 作为渲染目标，使用 `QPainter` 将 SVG 渲染到该图像上，然后将图像转换为 `QPixmap` 返回。由于返回的是 `QPixmap`（已完成深拷贝），临时的 `QImage` 应当被释放。
+1. `qt_load_svg_icon` 用于将 SVG 文件渲染为 `QPixmap` 图标。其内部实现先创建一个 `QImage` 作为渲染目标，使用 `QPainter` 将 SVG 渲染到该图像上，然后将图像转换为 `QPixmap` 返回。由于返回的是 `QPixmap`（已完成深拷贝），临时的 `QImage` 应当被释放。
+
+2. `mupdf_load_image` 在函数开头通过 `mupdf_read_from_url` 将 URL 对应的文件读入 `fz_buffer`，在函数末尾统一调用 `fz_drop_buffer` 释放。但 XPM 分支中检测到存在 PNG 替代文件时直接 `return` 跳过了末尾的释放逻辑。
 
 ## How
 
-在 `return icon;` 之前添加 `delete pm;` 语句，释放临时分配的 `QImage`。
+1. 在 `return icon;` 之前添加 `delete pm;` 语句，释放临时分配的 `QImage`。
+
+2. 在 XPM 分支的三个提前返回之前，分别添加 `fz_drop_buffer(ctx, buffer)` 释放已分配的缓冲区。

--- a/src/Plugins/MuPDF/mupdf_picture.cpp
+++ b/src/Plugins/MuPDF/mupdf_picture.cpp
@@ -341,14 +341,17 @@ mupdf_load_image (url u) {
     // try to load higher definition png equivalent if available
     url png_equiv= glue (unglue (u, 4), "_x4.png");
     if (exists (png_equiv)) {
+      fz_drop_buffer (ctx, buffer);
       return mupdf_load_image (png_equiv);
     }
     png_equiv= glue (unglue (u, 4), "_x2.png");
     if (exists (png_equiv)) {
+      fz_drop_buffer (ctx, buffer);
       return mupdf_load_image (png_equiv);
     }
     png_equiv= glue (unglue (u, 4), ".png");
     if (exists (png_equiv)) {
+      fz_drop_buffer (ctx, buffer);
       return mupdf_load_image (png_equiv);
     }
     // ok, try to load the xpm finally


### PR DESCRIPTION
## Summary
- 修复 `mupdf_load_image` 函数中 XPM 分支的 `fz_buffer` 内存泄漏
- 当加载 XPM 文件且存在更高分辨率的 PNG 替代文件时，函数通过 `return mupdf_load_image(png_equiv)` 提前返回，但未释放已分配的 `fz_buffer`

## Test plan
- [ ] 验证加载 XPM 图标（存在 `_x4.png`、`_x2.png` 或 `.png` 替代文件时）不再泄漏 `fz_buffer`
- [ ] 验证 XPM 图标仍能正确显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)