### PR TITLE
[0171] 修复模板预览对话框的内存泄漏

### DIFF
--- a/devel/0171.md
+++ b/devel/0171.md
@@ -3,6 +3,7 @@
 ## 任务相关的代码文件
 - `src/Plugins/Qt/qt_picture.cpp`
 - `src/Plugins/MuPDF/mupdf_picture.cpp`
+- `src/Plugins/Qt/QTMTemplatePage.cpp`
 
 ## What
 
@@ -10,14 +11,20 @@
 
 2. 修复 `mupdf_load_image` 函数中的 `fz_buffer` 内存泄漏问题。当加载 XPM 格式图片且存在更高分辨率的 PNG 替代文件时，函数通过 `return mupdf_load_image(png_equiv)` 提前返回，但未释放已经通过 `mupdf_read_from_url` 分配的 `fz_buffer`，导致每次加载此类 XPM 文件都会泄漏一个 `fz_buffer`。
 
+3. 修复 `QTMTemplatePage::showTemplatePreview` 函数中的 QDialog 内存泄漏。该函数通过 `new QDialog(this)` 创建预览对话框，调用 `dialog->exec()` 后直接返回，未释放对话框对象，导致每次预览模板都会泄漏整个对话框及其所有子控件。
+
 ## Why
 
 1. `qt_load_svg_icon` 用于将 SVG 文件渲染为 `QPixmap` 图标。其内部实现先创建一个 `QImage` 作为渲染目标，使用 `QPainter` 将 SVG 渲染到该图像上，然后将图像转换为 `QPixmap` 返回。由于返回的是 `QPixmap`（已完成深拷贝），临时的 `QImage` 应当被释放。
 
 2. `mupdf_load_image` 在函数开头通过 `mupdf_read_from_url` 将 URL 对应的文件读入 `fz_buffer`，在函数末尾统一调用 `fz_drop_buffer` 释放。但 XPM 分支中检测到存在 PNG 替代文件时直接 `return` 跳过了末尾的释放逻辑。
 
+3. `showTemplatePreview` 使用模态对话框展示模板预览，`exec()` 返回后对话框不再使用，但从未调用 `delete`。
+
 ## How
 
 1. 在 `return icon;` 之前添加 `delete pm;` 语句，释放临时分配的 `QImage`。
 
 2. 在 XPM 分支的三个提前返回之前，分别添加 `fz_drop_buffer(ctx, buffer)` 释放已分配的缓冲区。
+
+3. 在 `dialog->exec()` 之后添加 `delete dialog;` 释放对话框。

--- a/src/Plugins/Qt/QTMTemplatePage.cpp
+++ b/src/Plugins/Qt/QTMTemplatePage.cpp
@@ -473,6 +473,7 @@ QTMTemplatePage::showTemplatePreview (const QString& templateId) {
   layout->addLayout (btnLayout);
 
   dialog->exec ();
+  delete dialog;
 }
 
 void


### PR DESCRIPTION
## Summary
- 修复 `QTMTemplatePage::showTemplatePreview` 中 `new QDialog` 在 `exec()` 后未 `delete` 的内存泄漏
- 每次用户点击模板预览，整个对话框及其子控件（PDF 预览、标签、按钮等）都会泄漏

## Test plan
- [ ] 打开启动页，点击模板中心
- [ ] 点击某个模板卡片触发预览对话框
- [ ] 关闭对话框后重复多次，观察内存占用是否稳定（不再持续增长）

🤖 Generated with [Claude Code](https://claude.com/claude-code)