### PR TITLE
[0169] 修复 autoFitWidth 单元测试匹配半屏贴靠检测逻辑

### DIFF
--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -1275,9 +1275,10 @@ private slots:
   void test_autoFitWidth_whenSnappedLeftHalf () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     QScreen*         screen= QApplication::primaryScreen ();
-    QRect  screenGeo       = screen ? screen->availableGeometry () : QRect (0, 0, 1920, 1080);
-    int    screenW          = screenGeo.width ();
-    int    screenH          = screenGeo.height ();
+    QRect            screenGeo=
+        screen ? screen->availableGeometry () : QRect (0, 0, 1920, 1080);
+    int screenW= screenGeo.width ();
+    int screenH= screenGeo.height ();
     // 模拟左半屏贴靠：宽度=屏幕一半，高度=屏幕高度，左边缘对齐
     widget->resize (screenW / 2, screenH);
     widget->move (screenGeo.x (), screenGeo.y ());
@@ -1298,9 +1299,10 @@ private slots:
   void test_noAutoFitWidth_whenNotSnapped () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     QScreen*         screen= QApplication::primaryScreen ();
-    QRect  screenGeo       = screen ? screen->availableGeometry () : QRect (0, 0, 1920, 1080);
-    int    screenW          = screenGeo.width ();
-    int    screenH          = screenGeo.height ();
+    QRect            screenGeo=
+        screen ? screen->availableGeometry () : QRect (0, 0, 1920, 1080);
+    int screenW= screenGeo.width ();
+    int screenH= screenGeo.height ();
     // 窗口宽度远超屏幕一半，不满足半屏贴靠条件
     widget->resize (screenW * 2 / 3, screenH);
     widget->move (screenGeo.x (), screenGeo.y ());

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -1272,11 +1272,15 @@ private slots:
     delete widget;
   }
 
-  void test_autoFitWidth_whenNarrow () {
+  void test_autoFitWidth_whenSnappedLeftHalf () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     QScreen*         screen= QApplication::primaryScreen ();
-    int screenWidth        = screen ? screen->availableSize ().width () : 1920;
-    widget->resize (screenWidth / 4, 300);
+    QRect  screenGeo       = screen ? screen->availableGeometry () : QRect (0, 0, 1920, 1080);
+    int    screenW          = screenGeo.width ();
+    int    screenH          = screenGeo.height ();
+    // 模拟左半屏贴靠：宽度=屏幕一半，高度=屏幕高度，左边缘对齐
+    widget->resize (screenW / 2, screenH);
+    widget->move (screenGeo.x (), screenGeo.y ());
     widget->show ();
 
     url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
@@ -1286,16 +1290,20 @@ private slots:
     QVERIFY (result);
     QApplication::processEvents ();
 
-    // 当 widget 宽度不超过屏幕一半时，应自动触发 Fit Width
+    // 当窗口贴靠到左半屏时，应自动触发 Fit Width
     QVERIFY (widget->zoomFactor () != 1.0);
     delete widget;
   }
 
-  void test_noAutoFitWidth_whenWide () {
+  void test_noAutoFitWidth_whenNotSnapped () {
     PDFReaderWidget* widget= new PDFReaderWidget ();
     QScreen*         screen= QApplication::primaryScreen ();
-    int screenWidth        = screen ? screen->availableSize ().width () : 1920;
-    widget->resize (screenWidth * 2 / 3, 800);
+    QRect  screenGeo       = screen ? screen->availableGeometry () : QRect (0, 0, 1920, 1080);
+    int    screenW          = screenGeo.width ();
+    int    screenH          = screenGeo.height ();
+    // 窗口宽度远超屏幕一半，不满足半屏贴靠条件
+    widget->resize (screenW * 2 / 3, screenH);
+    widget->move (screenGeo.x (), screenGeo.y ());
     widget->show ();
 
     url pdfUrl= url_system ("$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf");
@@ -1305,7 +1313,7 @@ private slots:
     QVERIFY (result);
     QApplication::processEvents ();
 
-    // 当 widget 宽度超过屏幕一半时，应保持默认 100% 缩放
+    // 不满足半屏贴靠条件，应保持默认 100% 缩放
     QCOMPARE (widget->zoomFactor (), 1.0);
     delete widget;
   }


### PR DESCRIPTION
## Summary
- 修复 `test_autoFitWidth_whenNarrow` 和 `test_noAutoFitWidth_whenWide` 两个单元测试
- 原始测试用 `width=screenWidth/4` 触发 autoFitWidth，但实现已改为精确检测左/右半屏贴靠（宽度=屏幕一半、高度=屏幕高度、边缘对齐），导致测试不匹配
- 更新测试模拟真实的半屏贴靠场景（左边缘对齐、宽度=屏幕一半、高度=屏幕高度）

## Test plan
- [x] `xmake b qt_pdf_reader_widget_test` 构建通过
- [x] `xmake r qt_pdf_reader_widget_test` 全部 41 个测试通过，0 失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)