### PR TITLE
[0171] 修复 checkNetworkAvailable 中 QNetworkAccessManager 内存泄漏

### DIFF
--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -3037,12 +3037,14 @@ qt_tm_widget_rep::checkNetworkAvailable () {
   QNetworkRequest        request (testUrl);
   QNetworkReply*         reply= manager->head (request);
 
-  QObject::connect (reply, &QNetworkReply::finished, [this, reply] () {
-    bool success= (reply->error () == QNetworkReply::NoError);
-    reply->deleteLater ();
-    bool isLoggedIn= as_bool (call ("logged-in?"));
-    syncScmGuestNotification (!is_community_stem () && !isLoggedIn && success);
-  });
+  QObject::connect (
+      reply, &QNetworkReply::finished, [this, reply, manager] () {
+        bool success= (reply->error () == QNetworkReply::NoError);
+        reply->deleteLater ();
+        manager->deleteLater ();
+        bool isLoggedIn= as_bool (call ("logged-in?"));
+        syncScmGuestNotification (!is_community_stem () && !isLoggedIn && success);
+      });
 }
 
 // 检查版本更新，根据条件显示提示条


### PR DESCRIPTION
## Summary
- 修复 `qt_tm_widget_rep::checkNetworkAvailable` 中 `new QNetworkAccessManager` 在回调中未 `deleteLater` 的内存泄漏
- 每次调用都会创建一个新的 `QNetworkAccessManager`，但 lambda 回调只释放了 `reply`，没有释放 `manager`

## Test plan
- [ ] 启动应用后观察网络可用性检查是否正常工作
- [ ] 反复触发网络检查（如切换窗口），观察内存是否稳定

🤖 Generated with [Claude Code](https://claude.com/claude-code)