### PR TITLE
[0173] 修复 MuPDF 字符渲染中 glyph samples 的内存泄漏

### DIFF
--- a/devel/0173.md
+++ b/devel/0173.md
@@ -1,0 +1,16 @@
+# [0173] 修复 MuPDF 字符渲染中的内存泄漏
+
+## 任务相关的代码文件
+- `src/Plugins/MuPDF/mupdf_renderer.cpp`
+
+## What
+
+修复 `mupdf_renderer_rep::draw` 函数中 glyph samples 的内存泄漏。在非原生字体的字符渲染路径中，通过 `fz_malloc` 分配 glyph 的 pixel samples，传给 `fz_new_pixmap_with_data` 创建 pixmap。但该函数不设置 `FZ_PIXMAP_FLAG_FREE_SAMPLES` 标志，导致 pixmap 被 drop 时 samples 不会被释放。每个新渲染的字符 glyph 都会泄漏 `width * height * 4` 字节。
+
+## Why
+
+MuPDF 的 `fz_new_pixmap_with_data` 接受外部提供的 samples 缓冲区，但默认不接管其所有权（不设置 `FZ_PIXMAP_FLAG_FREE_SAMPLES`）。当 pixmap 随 image 被 drop 时，`fz_free(samples)` 不会被调用。
+
+## How
+
+在 `fz_new_pixmap_with_data` 调用之后添加 `pix->flags |= FZ_PIXMAP_FLAG_FREE_SAMPLES`，使 pixmap 被 drop 时自动释放 samples。

--- a/src/Plugins/MuPDF/mupdf_renderer.cpp
+++ b/src/Plugins/MuPDF/mupdf_renderer.cpp
@@ -1166,6 +1166,7 @@ mupdf_renderer_rep::draw (int glyph_index, font_glyphs fng, SI x, SI y,
     fz_pixmap* pix= fz_new_pixmap_with_data (mupdf_context (),
                                              fz_device_rgb (mupdf_context ()),
                                              w, h, NULL, 1, w * 4, samples);
+    pix->flags|= FZ_PIXMAP_FLAG_FREE_SAMPLES;
     fz_image*  im = fz_new_image_from_pixmap (mupdf_context (), pix, NULL);
     mi            = mupdf_image (im);
     mi->xo        = xo;

--- a/src/Plugins/MuPDF/mupdf_renderer.cpp
+++ b/src/Plugins/MuPDF/mupdf_renderer.cpp
@@ -1167,10 +1167,10 @@ mupdf_renderer_rep::draw (int glyph_index, font_glyphs fng, SI x, SI y,
                                              fz_device_rgb (mupdf_context ()),
                                              w, h, NULL, 1, w * 4, samples);
     pix->flags|= FZ_PIXMAP_FLAG_FREE_SAMPLES;
-    fz_image*  im = fz_new_image_from_pixmap (mupdf_context (), pix, NULL);
-    mi            = mupdf_image (im);
-    mi->xo        = xo;
-    mi->yo        = yo;
+    fz_image* im= fz_new_image_from_pixmap (mupdf_context (), pix, NULL);
+    mi          = mupdf_image (im);
+    mi->xo      = xo;
+    mi->yo      = yo;
     character_image (xc)= mi;
     fz_drop_pixmap (mupdf_context (), pix);
     fz_drop_image (mupdf_context (), im);


### PR DESCRIPTION
## Summary
- 修复 `mupdf_renderer_rep::draw` 中 `fz_malloc` 分配的 glyph samples 未被释放的内存泄漏
- `fz_new_pixmap_with_data` 不设置 `FZ_PIXMAP_FLAG_FREE_SAMPLES` 标志，导致 pixmap 被 drop 时 samples 不被释放
- 每个新渲染的字符 glyph（非原生字体路径）都会泄漏 `w*h*4` 字节

## Test plan
- [ ] 正常编辑文档，输入各种字符，确认渲染正常
- [ ] 长时间编辑后观察内存占用是否趋于稳定（不再持续增长）

🤖 Generated with [Claude Code](https://claude.com/claude-code)