### PR TITLE
[0174] 修复 hummus_pdf_image_size 中 PDFParser 的内存泄漏

### DIFF
--- a/devel/0174.md
+++ b/devel/0174.md
@@ -1,0 +1,29 @@
+# [0174] 修复 hummus_pdf_image_size 中 PDFParser 的内存泄漏
+
+## 相关文档
+- [0171.md](0171.md) - 上一轮内存泄漏修复
+
+## 任务相关的代码文件
+- `src/Plugins/Pdf/pdf_image.cpp`
+
+## 如何测试
+
+### 确定性测试
+```bash
+xmake b stem
+```
+
+### 非确定性测试
+使用损坏的 PDF 文件触发 `hummus_pdf_image_size` 的失败路径，验证 `PDFParser` 被正确释放。
+
+## What
+
+1. 修复 `hummus_pdf_image_size` 函数中 `PDFParser` 的内存泄漏。当 `StartPDFParsing` 返回 `eFailure` 时，`parser` 未被 `delete`，导致每次对损坏的 PDF 文件调用此函数都会泄漏一个 `PDFParser` 对象。
+
+## Why
+
+`hummus_pdf_image_size` 使用 `new PDFParser()` 分配解析器对象。成功路径有 `delete parser`，但失败路径（`else` 分支）缺少 `delete`。
+
+## How
+
+将 `delete parser` 从成功分支内移到 `if-else` 块之后，使成功和失败路径都能释放 `PDFParser`。

--- a/src/Plugins/Pdf/pdf_image.cpp
+++ b/src/Plugins/Pdf/pdf_image.cpp
@@ -404,13 +404,13 @@ hummus_pdf_image_size (url image, int& w, int& h) {
     double       tMat[6]= {1, 0, 0, 1, 0, 0};
     PDFRectangle cropBox (0, 0, 0, 0);
     pdf_image_info (image, w, h, cropBox, tMat, pageInput);
-    delete (parser);
   }
   else {
     convert_error << "pdf_hummus, failed to get image size for: "
                   << resolved_image << LF << "resolved from " << image << LF;
     w= h= 0;
   }
+  delete parser;
 }
 
 void


### PR DESCRIPTION
## Summary
- 将 `delete parser` 从 `if` 成功分支内移到 `if-else` 块之后，修复 `hummus_pdf_image_size` 在 `StartPDFParsing` 失败时未释放 `PDFParser` 的内存泄漏

## Test plan
- [x] `xmake b stem` 编译通过
- [ ] 使用损坏的 PDF 文件触发失败路径验证无泄漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)