### PR TITLE
[0175] 修复 tm_server_rep 析构函数中 QTMOAuth 的内存泄漏

### DIFF
--- a/devel/0175.md
+++ b/devel/0175.md
@@ -1,0 +1,29 @@
+# [0175] 修复 tm_server_rep 析构函数中 QTMOAuth 的内存泄漏
+
+## 相关文档
+- [0174.md](0174.md) - 本轮另一个内存泄漏修复
+
+## 任务相关的代码文件
+- `src/Texmacs/Server/tm_server.cpp`
+
+## 如何测试
+
+### 确定性测试
+```bash
+xmake b stem
+```
+
+### 非确定性测试
+使用 Valgrind 或 AddressSanitizer 验证 `QTMOAuth` 在 `tm_server_rep` 析构时被正确释放。
+
+## What
+
+1. 修复 `tm_server_rep` 析构函数中 `QTMOAuth` 的内存泄漏。构造函数中通过 `new QTMOAuth()` 创建的 `m_account` 对象从未在析构函数中释放。
+
+## Why
+
+`tm_server_rep::~tm_server_rep()` 是空实现，但构造函数分配了 `m_account`。由于 `tm_server_rep` 的生命周期贯穿整个应用，该泄漏在退出时发生。
+
+## How
+
+在 `~tm_server_rep()` 中添加 `delete m_account;`，由于 `m_account` 在头文件中默认初始化为 `nullptr`，对未构造的情况也是安全的。

--- a/src/Texmacs/Server/tm_server.cpp
+++ b/src/Texmacs/Server/tm_server.cpp
@@ -170,7 +170,7 @@ tm_server_rep::tm_server_rep (app_type app) : def_zoomf (1.0) {
 #endif
 }
 
-tm_server_rep::~tm_server_rep () {}
+tm_server_rep::~tm_server_rep () { delete m_account; }
 server::server (app_type app) : rep (tm_new<tm_server_rep> (app)) {}
 server_rep*
 tm_server_rep::get_server () {


### PR DESCRIPTION
## Summary
- 在 `~tm_server_rep()` 析构函数中添加 `delete m_account`，修复构造函数中 `new QTMOAuth()` 分配的对象从未被释放的内存泄漏

## Test plan
- [x] `xmake b stem` 编译通过
- [ ] 使用 Valgrind 或 AddressSanitizer 验证退出时无泄漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)