### PR TITLE
[0176] 修复 PDFAttachment 析构函数中 delete 与 delete[] 不匹配

### DIFF
--- a/devel/0176.md
+++ b/devel/0176.md
@@ -1,0 +1,26 @@
+# [0176] 修复 PDFAttachment 析构函数中 delete 与 delete[] 不匹配
+
+## 相关文档
+- [0171.md](0171.md) - 上一轮内存泄漏修复
+
+## 任务相关的代码文件
+- `src/Plugins/Pdf/pdf_hummus_make_attachment.cpp`
+
+## 如何测试
+
+### 确定性测试
+```bash
+xmake b stem
+```
+
+## What
+
+1. 修复 `PDFAttachment::~PDFAttachment` 中 `delete file_content` 应为 `delete[] file_content` 的问题。`file_content` 通过 `new Byte[]` 分配，使用 `delete` 释放是未定义行为。
+
+## Why
+
+C++ 标准要求 `new[]` 分配的内存必须用 `delete[]` 释放。使用 `delete` 释放数组是未定义行为，可能导致内存泄漏或堆损坏。
+
+## How
+
+将 `delete file_content` 改为 `delete[] file_content`。

--- a/src/Plugins/Pdf/pdf_hummus_make_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_make_attachment.cpp
@@ -177,7 +177,7 @@ PDFAttachment::PDFAttachment (Byte inByte[], size_t inLenth, string inName) {
 }
 
 PDFAttachment::~PDFAttachment (void) {
-  if (file_content) delete file_content;
+  if (file_content) delete[] file_content;
 }
 
 PDFAttachmentWriter::PDFAttachmentWriter (PDFWriter* inPDFWriter) {


### PR DESCRIPTION
## Summary
- 将 `PDFAttachment::~PDFAttachment` 中的 `delete file_content` 改为 `delete[] file_content`，修复 `new Byte[]` 与 `delete` 不匹配导致的未定义行为

## Test plan
- [x] `xmake b stem` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)