### PR TITLE
[0177] 修复 extract_attachments_from_pdf 中 streamReader 的内存泄漏

### DIFF
--- a/devel/0177.md
+++ b/devel/0177.md
@@ -1,0 +1,26 @@
+# [0177] 修复 extract_attachments_from_pdf 中 streamReader 的内存泄漏
+
+## 相关文档
+- [0171.md](0171.md) - 上一轮内存泄漏修复
+
+## 任务相关的代码文件
+- `src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp`
+
+## 如何测试
+
+### 确定性测试
+```bash
+xmake b stem
+```
+
+## What
+
+1. 修复 `extract_attachments_from_pdf` 函数中 `IByteReader* streamReader` 的内存泄漏。`streamReader` 仅在 for 循环的成功迭代结束时被 `delete`，当循环中任何错误路径触发 `break` 时，`streamReader` 不会被释放。
+
+## Why
+
+`streamReader` 在循环内部通过 `parser.CreateInputStreamReader()` 分配。循环中有多个 `break` 点（文件打开失败、流拷贝失败、关闭失败等），这些路径跳过了 `delete streamReader`。
+
+## How
+
+将 `streamReader` 声明提升到 for 循环之前并初始化为 `nullptr`。成功路径在 `delete` 后置 `nullptr`。在 for 循环结束后添加 `delete streamReader`（`delete nullptr` 安全），确保 `break` 路径也能释放。

--- a/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
@@ -98,6 +98,7 @@ extract_attachments_from_pdf (url pdf_path, list<url>& names) {
       status= PDFHummus::eFailure;
       break;
     }
+    IByteReader* streamReader= nullptr;
     for (unsigned long i= 0; i < n; i+= 2) {
       PDFObjectCastPtr<PDFLiteralString> name (arr->QueryObject (i));
       if (!name) {
@@ -129,8 +130,7 @@ extract_attachments_from_pdf (url pdf_path, list<url>& names) {
       }
       PDFDictionary* dir= stream->QueryStreamDictionary ();
 
-      IByteReader* streamReader=
-          parser.CreateInputStreamReader (stream.GetPtr ());
+      streamReader= parser.CreateInputStreamReader (stream.GetPtr ());
       if (!streamReader) {
         if (DEBUG_CONVERT) debug_convert << "Can't find streamReader" << LF;
         status= PDFHummus::eFailure;
@@ -165,7 +165,9 @@ extract_attachments_from_pdf (url pdf_path, list<url>& names) {
 
       names= names * attachment_path;
       delete streamReader;
+      streamReader= nullptr;
     }
+    delete streamReader;
   } while (false);
   if (status == PDFHummus::eFailure) return false;
   else return true;


### PR DESCRIPTION
## Summary
- 将 `streamReader` 声明提升到 for 循环之前并在循环后添加 `delete`，修复多个 `break` 路径跳过释放 `IByteReader*` 的内存泄漏

## Test plan
- [x] `xmake b stem` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)