### PR TITLE
[0178] 修复 pdf_hummus_renderer 中 DestinationsWriter 的内存泄漏

### DIFF
--- a/devel/0178.md
+++ b/devel/0178.md
@@ -1,0 +1,26 @@
+# [0178] 修复 pdf_hummus_renderer 中 DestinationsWriter 的内存泄漏
+
+## 相关文档
+- [0171.md](0171.md) - 上一轮内存泄漏修复
+
+## 任务相关的代码文件
+- `src/Plugins/Pdf/pdf_hummus_renderer.cpp`
+
+## 如何测试
+
+### 确定性测试
+```bash
+xmake b stem
+```
+
+## What
+
+1. 修复 `pdf_hummus_renderer_rep` 构造函数中 `DestinationsWriter` 的内存泄漏。构造函数通过 `new DestinationsWriter(this)` 创建对象并传给 `AddDocumentContextExtender`，但 PDFHummus 的 `DocumentContext` 只存储裸指针，不会负责释放。析构函数中也从未释放该对象。
+
+## Why
+
+每次创建 PDF 导出渲染器都会泄漏一个 `DestinationsWriter` 对象。PDFHummus 的 `mExtenders.clear()` 只清除指针列表，不释放对象。
+
+## How
+
+将 `DestinationsWriter*` 存储为 `pdf_hummus_renderer_rep` 的成员变量，在析构函数中 `delete`。

--- a/src/Plugins/Pdf/pdf_hummus_renderer.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_renderer.cpp
@@ -225,6 +225,8 @@ class pdf_hummus_renderer_rep : public renderer_rep {
     }
   };
 
+  DestinationsWriter* destinations_writer;
+
   PDFHummus::EStatusCode
   on_catalog_write (CatalogInformation*         inCatalogInformation,
                     DictionaryContext*          inCatalogDictionaryContext,
@@ -310,7 +312,7 @@ pdf_hummus_renderer_rep::pdf_hummus_renderer_rep (
       paper_w (paper_w2), paper_h (paper_h2), page_num (0), inText (false),
       fg (-1), bg (-1), lw (-1), pen (black), bgb (white), fgb (black),
       cfn (""), cfid (NULL), native_fonts (NULL), t3font_registry_id (-1),
-      destId (0), label_count (0), outlineId (0) {
+      destId (0), label_count (0), outlineId (0), destinations_writer (NULL) {
   width = default_dpi * paper_w / 2.54;
   height= default_dpi * paper_h / 2.54;
 
@@ -334,9 +336,10 @@ pdf_hummus_renderer_rep::pdf_hummus_renderer_rep (
     started= false;
   }
   else {
-    started= true;
+    started            = true;
+    destinations_writer= new DestinationsWriter (this);
     pdfWriter.GetDocumentContext ().AddDocumentContextExtender (
-        new DestinationsWriter (this));
+        destinations_writer);
 
     // create a graphic state with default values
     initial_GState_id= pdfWriter.GetObjectsContext ()
@@ -419,6 +422,8 @@ pdf_hummus_renderer_rep::~pdf_hummus_renderer_rep () {
   if (status != PDFHummus::eSuccess) {
     convert_error << "Failed in end PDF\n";
   }
+
+  delete destinations_writer;
 
   // remove temporary pictures
   for (int i= 0; i < N (temp_images); i++)


### PR DESCRIPTION
## Summary
- 将 `DestinationsWriter*` 存储为成员变量并在析构函数中 `delete`，修复每次 PDF 导出都泄漏一个 `DestinationsWriter` 对象的问题

## Test plan
- [x] `xmake b stem` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)