### PR TITLE
[0170] 优化首页与 Chat 页面 update_menus 性能

### DIFF
--- a/devel/0170.md
+++ b/devel/0170.md
@@ -1,0 +1,33 @@
+# [0170] 优化首页与 Chat 页面 update_menus 性能
+
+## 任务相关的代码文件
+- `src/Edit/Interface/edit_interface.cpp` - `edit_interface_rep::update_menus()` 主函数
+- `src/Texmacs/Data/new_view.cpp` / `new_view.hpp` - `is_startup_tab_buffer()` 辅助函数
+- `src/Plugins/Qt/qt_tm_widget.cpp` - `qt_tm_widget_rep::write()` 中菜单 slot 处理
+
+## 如何测试
+
+### 确定性测试
+```bash
+xmake b stem
+```
+
+### 非确定性测试
+启动 Mogan STEM，切换到 Home/Chat 页面，确认 tab 栏正常显示 chat 标签，观察 update_menus 不再执行不必要的 Scheme 求值和 widget 重建。
+
+## What
+
+在首页 (`tmfs://startup-tab`) 和 Chat 页面 (`tmfs://chat-tab`) 上，`update_menus()` 仍会被 idle 循环触发，执行完整的菜单/工具栏/状态栏更新。本任务跳过这些页面不需要的更新。
+
+## Why
+
+`update_menus` 是性能热点。对于 startup/chat 页面，main menu、focus icons、side tools 等更新是纯浪费。
+
+## How
+
+分四步逐层优化：
+
+1. 在 `update_menus` 中，startup tab 保留 `menu_icons` 调用，跳过 `side_tools`/`bottom_tools`/`footer`/`drd_update` 等后续操作。
+2. chat tab 做同样跳过。
+3. Qt 层面：当 `startupTabMode` 或 `chatTabMode` 时，跳过 `SLOT_MAIN_MENU`、`SLOT_MAIN_ICONS` 等不需要的 widget 重建。
+4. C++ 层面：startup/chat tab 跳过不需要的 `SERVER` 调用，避免 Scheme 求值开销。仅保留 `menu_icons(1)` (mode) 和 `menu_icons(4)` (tab pages)。

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -16,6 +16,7 @@
 #include "file.hpp"
 #include "gui.hpp" // for gui_interrupted
 #include "message.hpp"
+#include "new_view.hpp"
 #include "observers.hpp"
 #include "preferences.hpp"
 #include "server.hpp"
@@ -820,6 +821,11 @@ edit_interface_rep::update_menus () {
   SERVER (menu_icons (3, "(horizontal (link texmacs-extra-icons))"));
   SERVER (menu_icons (4, "(horizontal (link texmacs-tab-pages))"));
   SERVER (notification_bar ("(horizontal (link texmacs-notification-bar))"));
+  if (is_startup_tab_buffer (buf->buf->name)) {
+    last_update= last_change;
+    bench_end ("update_menus");
+    return;
+  }
   array<url> a= buffer_to_windows (buf->buf->name);
   if (N (a) > 0) {
     string win = "(string->url \"" * as_string (a[0]) * "\")";

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -813,16 +813,23 @@ edit_interface_rep::change_time () {
 
 void
 edit_interface_rep::update_menus () {
+  bool is_startup= is_startup_tab_buffer (buf->buf->name);
+  bool is_chat   = is_chat_tab_buffer (buf->buf->name);
   bench_start ("update_menus");
-  SERVER (menu_main ("(horizontal (link texmacs-menu))"));
-  SERVER (menu_icons (0, "(horizontal (link texmacs-main-icons))"));
-  SERVER (menu_icons (1, "(horizontal (link texmacs-mode-icons))"));
-  SERVER (menu_icons (2, "(horizontal (link texmacs-focus-icons))"));
-  SERVER (menu_icons (3, "(horizontal (link texmacs-extra-icons))"));
+  if (!is_startup && !is_chat)
+    SERVER (menu_main ("(horizontal (link texmacs-menu))"));
+  if (!is_startup && !is_chat)
+    SERVER (menu_icons (0, "(horizontal (link texmacs-main-icons))"));
+  if (!is_startup)
+    SERVER (menu_icons (1, "(horizontal (link texmacs-mode-icons))"));
+  if (!is_startup && !is_chat)
+    SERVER (menu_icons (2, "(horizontal (link texmacs-focus-icons))"));
+  if (!is_startup && !is_chat)
+    SERVER (menu_icons (3, "(horizontal (link texmacs-extra-icons))"));
   SERVER (menu_icons (4, "(horizontal (link texmacs-tab-pages))"));
-  SERVER (notification_bar ("(horizontal (link texmacs-notification-bar))"));
-  if (is_startup_tab_buffer (buf->buf->name) ||
-      is_chat_tab_buffer (buf->buf->name)) {
+  if (!is_startup && !is_chat)
+    SERVER (notification_bar ("(horizontal (link texmacs-notification-bar))"));
+  if (is_startup || is_chat) {
     last_update= last_change;
     bench_end ("update_menus");
     return;

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -821,7 +821,8 @@ edit_interface_rep::update_menus () {
   SERVER (menu_icons (3, "(horizontal (link texmacs-extra-icons))"));
   SERVER (menu_icons (4, "(horizontal (link texmacs-tab-pages))"));
   SERVER (notification_bar ("(horizontal (link texmacs-notification-bar))"));
-  if (is_startup_tab_buffer (buf->buf->name)) {
+  if (is_startup_tab_buffer (buf->buf->name) ||
+      is_chat_tab_buffer (buf->buf->name)) {
     last_update= last_change;
     bench_end ("update_menus");
     return;

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1810,6 +1810,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_MAIN_MENU:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       waiting_main_menu_widget= concrete (w);
       if (menu_count <= 0) install_main_menu ();
@@ -1821,6 +1822,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_MAIN_ICONS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       main_icons_widget    = concrete (w);
       QList<QAction*>* list= main_icons_widget->get_qactionlist ();
@@ -1849,6 +1851,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_NOTIFICATION_BAR:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       notification_bar_widget     = concrete (w);
       QList<QAction*>* action_list= notification_bar_widget->get_qactionlist ();
@@ -1910,6 +1913,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_FOCUS_ICONS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       bool can_update= true;
 #if (QT_VERSION >= 0x050000)
@@ -1939,6 +1943,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_USER_ICONS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       user_icons_widget    = concrete (w);
       QList<QAction*>* list= user_icons_widget->get_qactionlist ();
@@ -1951,6 +1956,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_SIDE_TOOLS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       side_tools_widget   = concrete (w);
       QWidget* new_qwidget= side_tools_widget->as_qwidget ();
@@ -1971,6 +1977,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_LEFT_TOOLS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       left_tools_widget   = concrete (w);
       QWidget* new_qwidget= left_tools_widget->as_qwidget ();
@@ -1991,6 +1998,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_BOTTOM_TOOLS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       bottom_tools_widget = concrete (w);
       QWidget* new_qwidget= bottom_tools_widget->as_qwidget ();
@@ -2011,6 +2019,7 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
 
   case SLOT_EXTRA_TOOLS:
     check_type_void (index, s);
+    if (startupTabMode || chatTabMode) break;
     {
       extra_tools_widget  = concrete (w);
       QWidget* new_qwidget= extra_tools_widget->as_qwidget ();

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -87,6 +87,11 @@ is_chat_tab_buffer (url name) {
   return starts (as_string (name), "tmfs://chat-tab");
 }
 
+bool
+is_startup_tab_buffer (url name) {
+  return name == url ("tmfs://startup-tab");
+}
+
 url
 abstract_view (tm_view vw) {
   if (vw == NULL) return url_none ();

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -52,6 +52,7 @@ void       make_cursor_visible (url u);
 url        get_most_recent_view ();
 void       invalidate_most_recent_view ();
 bool       is_chat_tab_buffer (url name);
+bool       is_startup_tab_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);
 


### PR DESCRIPTION
## Summary
- 在 `update_menus` 中跳过 startup tab 和 chat tab 不需要的 side_tools/bottom_tools/footer/drd_update 等操作
- Qt 层面跳过 startup/chat tab 不需要的 widget 重建（SLOT_MAIN_MENU、SLOT_MAIN_ICONS 等）
- C++ 层面跳过 startup/chat tab 不需要的 SERVER 调用，避免 Scheme 求值开销
- 仅保留 `menu_icons(1)` (mode) 和 `menu_icons(4)` (tab pages)

## Test plan
- [x] 启动 Mogan STEM，首页正常显示
- [x] 切换到 Chat 标签页，tab 栏正常显示 chat 标签
- [x] 逐步验证每个优化点不影响 chat 标签页显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)