### PR TITLE
[0801] 集成 Julia 交互式会话插件

### DIFF
--- a/TeXmacs/plugins/julia/julia/MoganJulia.jl
+++ b/TeXmacs/plugins/julia/julia/MoganJulia.jl
@@ -1,0 +1,365 @@
+# 
+#  MoganJulia.jl
+#  A Mogan plugin for the Julia language
+#  (c) 2021  Massimiliano Gubinelli <mgubi@mac.com>
+#      2026  Tianyou Liu <tianyou@liii.pro>
+# 
+#  This software falls under the GNU general public license version 3 or later.
+#  It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+#  in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+#
+
+#==============================================================================
+Useful links:
+
+* https://github.com/JuliaDocs/ANSIColoredPrinters.jl
+* https://github.com/JuliaDocs/Documenter.jl/pull/1441
+* https://docs.julialang.org/en/v1/stdlib/REPL/
+* https://github.com/JuliaLang/julia/blob/28e63dc65a3ca3850ac2b530bd8a7a89cda551dc/base/version.jl
+* https://juliagraphics.github.io/Luxor.jl/stable/moreexamples/
+* https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/docs/src/index.md
+
+* https://github.com/JuliaLang/julia/issues/3744
+
+* https://github.com/JuliaLang/IJulia.jl
+* https://julia-doc.readthedocs.io/en/latest/
+
+==============================================================================#
+
+module MoganJulia
+
+import Base.Libc: flush_cstdio
+import REPL: helpmode
+import REPL.REPLCompletions: completions, completion_text
+using REPL
+import UUIDs
+import Markdown
+import Base: AbstractDisplay, display, redisplay, catch_stack, show
+
+const current_module = Ref{Module}(Main)
+const orig_stdout = Ref{IO}(stdout)
+const orig_stderr = Ref{IO}(stderr)
+	
+#=============================================================================#
+## Mogan protocol
+
+const DATA_BEGIN = Char(2)
+const DATA_END = Char(5)
+const DATA_ESCAPE = Char(27)
+const DATA_COMMAND = Char(16)
+const VERBATIM = "verbatim:"
+const SCHEME = "scheme:"
+const COMMAND = "command:"
+const PROMPT = "prompt#"
+
+mogan_escape(data) = replace(replace(replace(data,
+        DATA_ESCAPE => DATA_ESCAPE * DATA_ESCAPE),
+        DATA_BEGIN => DATA_ESCAPE * DATA_BEGIN), 
+        DATA_END => DATA_ESCAPE * DATA_END)
+  
+# Mogan expects all output to be bracketed in a DATA_BEGIN and DATA_END
+# so that it can determines when the plugin ended the interaction        
+tm_begin() = write(orig_stdout[], DATA_BEGIN, VERBATIM)
+tm_end() = begin
+    write(orig_stdout[],DATA_END)
+    flush(orig_stdout[]) 
+end
+
+tm_out(data) = begin
+    write(orig_stdout[], mogan_escape(data))
+    flush(orig_stdout[]) 
+end
+
+tm_out(header, data) = begin
+    write(orig_stdout[], 
+        DATA_BEGIN, header, mogan_escape(data), DATA_END)
+    flush(orig_stdout[]) 
+end
+
+tm_err(header, data) = begin
+    write(orig_stderr[], 
+        DATA_BEGIN, header, mogan_escape(data), DATA_END)
+    flush(orig_stderr[]) 
+end
+
+#=============================================================================#
+### Flush all redirected streams to Mogan
+
+function flush_all()
+    flush_cstdio() # flush writes to stdout/stderr by external C code
+    flush(stdout)
+    flush(stderr)
+end
+
+#=============================================================================#
+### Stream redirection (from IJulia)
+
+# create a wrapper type around redirected stdio streams,
+# both for overloading things like `flush` and so that we
+# can set properties like `color`.
+struct TMJuliaStdio{IO_t <: IO} <: Base.AbstractPipe
+    io::IOContext{IO_t}
+    read_stream::Base.PipeEndpoint
+end
+
+TMJuliaStdio(io::IO, read_stream::Base.PipeEndpoint, stream::AbstractString="unknown") =
+    TMJuliaStdio{typeof(io)}(IOContext(io, :color=>false,
+                            :mogan_stream=>stream,
+                            :displaysize=>displaysize()), read_stream)
+Base.pipe_reader(io::TMJuliaStdio) = io.io.io
+Base.pipe_writer(io::TMJuliaStdio) = io.io.io
+Base.lock(io::TMJuliaStdio) = lock(io.io.io)
+Base.unlock(io::TMJuliaStdio) = unlock(io.io.io)
+Base.in(key_value::Pair, io::TMJuliaStdio) = in(key_value, io.io)
+Base.haskey(io::TMJuliaStdio, key) = haskey(io.io, key)
+Base.getindex(io::TMJuliaStdio, key) = getindex(io.io, key)
+Base.get(io::TMJuliaStdio, key, default) = get(io.io, key, default)
+Base.displaysize(io::TMJuliaStdio) = displaysize(io.io)
+Base.unwrapcontext(io::TMJuliaStdio) = Base.unwrapcontext(io.io)
+Base.setup_stdio(io::TMJuliaStdio, readable::Bool) = Base.setup_stdio(io.io.io, readable)
+
+Base.flush(io::TMJuliaStdio) = begin
+    #write(orig_stdout[],"FLUSHING $(get(io.io, :mogan_stream, "error"))\n")
+    Base.flush(io.io.io)
+    # add one more char so that we do not block on readavailable later
+    write(io.io.io,"!")
+    local buf = chop(String(readavailable(io.read_stream)));
+    buf == "" && return
+    if get(io.io, :mogan_stream, "error") == "stdout"
+        tm_out(buf * "\n")
+    elseif get(io.io, :mogan_stream, "error") == "stderr"
+        tm_err(VERBATIM, buf)
+    end
+end
+
+if VERSION < v"1.7.0-DEV.254"
+    for s in ("stdout", "stderr", "stdin")
+        f = Symbol("redirect_", s)
+        sq = QuoteNode(Symbol(s))
+        @eval function Base.$f(io::TMJuliaStdio)
+            io[:mogan_stream] != $s && throw(ArgumentError(string("expecting ", $s, " stream")))
+            Core.eval(Base, Expr(:(=), $sq, io))
+            return io
+        end
+    end
+end
+
+#=============================================================================#
+### display redirection
+
+# need special handling for showing a string as a textmime
+# type, since in that case the string is assumed to be
+# raw data unless it is text/plain
+israwtext(::MIME, x::AbstractString) = true
+israwtext(::MIME"text/plain", x::AbstractString) = false
+israwtext(::MIME, x) = false
+
+# convert x to a string of type mime, making sure to use an
+# IOContext that tells the underlying show function to limit output
+function limitstringmime(mime::MIME, x)
+    buf = IOBuffer()
+    if israwtext(mime, x)
+        return String(x)
+    else
+        show(IOContext(buf, :limit=>true, :color=>false), mime, x)
+    end
+    return String(take!(buf))
+end
+
+struct InlineDisplay <: AbstractDisplay end
+
+showtofile(file::AbstractString, m::MIME, x) = begin
+    open("$(ENV["TEXMACS_HOME_PATH"])/system/tmp/$(file)", "w") do io
+        show(io, m, x)
+    end
+    tm_out("file:", file)
+end
+
+sendimage(ext::AbstractString, m::MIME, x) = begin
+    buf = IOBuffer()
+    show(buf, m, x)
+    tm_out("mogan:","<image|<tuple|<#$(bytes2hex(take!(buf)))>|julia-output-$(UUIDs.uuid1()).$(ext)>|0.618par|||>")
+end
+
+display(d::InlineDisplay, m::MIME"image/png", x) = 
+    sendimage("png", m, x)
+
+display(d::InlineDisplay, m::MIME"image/jpeg", x) = 
+    sendimage("jpg", m, x)
+
+display(d::InlineDisplay, m::MIME"application/pdf", x) = 
+    sendimage("pdf", m, x)
+
+display(d::InlineDisplay, m::MIME"text/html", x) = 
+    tm_out("html:", limitstringmime(m, x))
+
+display(d::InlineDisplay, m::MIME"text/latex", x) = 
+    tm_out("latex:", limitstringmime(m, x))
+
+display(d::InlineDisplay, m::MIME"text/markdown", x) = 
+    display(d, MIME("text/html"), Markdown.html(x))
+
+display(d::InlineDisplay, m::MIME"text/plain", s::AbstractString) = 
+    tm_out(s)
+
+# fallback
+display(d::InlineDisplay, m::MIME, x) =
+    tm_out(limitstringmime(m, x))
+
+# generic display overloading
+display(d::InlineDisplay, x::Markdown.MD) = display(d, MIME("text/markdown"), x) 
+
+# we try to display data according to these mime types
+# in order
+const tm_mimetypes = [
+    MIME("image/svg"),
+    MIME("application/pdf"),
+    MIME("image/png"),
+    MIME("image/jpg"),
+    MIME("text/html"), 
+    MIME("text/markdown"), 
+    MIME("text/latex")]
+
+function display(d::InlineDisplay, x)
+    for m in tm_mimetypes
+        if showable(m, x)
+            display(d, m, x)
+            return
+        end
+    end
+    # default behaviour is showing text
+    display(d, MIME("text/plain"), x)
+#    tm_out("TODO: display an object of type [$(typeof(x))]")   
+end
+
+#=============================================================================#
+### Some utilities
+
+function banner()
+    io = IOBuffer()
+    # the Julia banner is in REPL in Julia >1.11, and in Base before that
+    # so we need to do a little chasing
+    if isdefined(REPL,:banner)
+        REPL.banner(io)
+    elseif isdefined(Base,:banner)
+        Base.banner(io)
+    else
+        write(io, "Cannot find the startup banner, sorry!\n");
+    end    
+    write(io, "Julia plugin for Mogan STEM.\n");
+    tm_out(String(take!(io)))
+end
+
+function pdf_out(x) 
+    if showable(MIME("application/pdf"), x)
+        display(MIME("application/pdf"), x)
+    else
+        tm_out("[Cannot display PDF for $(typeof(x))]")
+    end
+end
+
+function do_tab_complete(cmd::AbstractString)
+    # syntax [DATA_COMMAND](complete [STRING] [CURSOR])
+    try
+        pos = 12
+        arg1,pos = Meta.parse(cmd,pos; greedy=false) # [STRING]
+        arg2,pos = Meta.parse(cmd,pos; greedy=false) # [CURSOR]
+        if isa(arg1,AbstractString) && isa(arg2,Integer)
+            ret,range,shouldcomplete = completions(arg1,arg2)
+            compls = join(unique!(map(x -> "\"$(completion_text(x)[range.stop+2-range.start:end])\"",ret))," ")
+            tm_out("scheme:", "(tuple \"$(arg1[range])\" $(compls))")
+        end
+    catch e 
+        # ignore errors 
+    end
+end
+
+#=============================================================================#
+### Main loop
+
+# we do not want to exit on SIGINT
+# we can then catch InterruptException
+Base.exit_on_sigint(false)
+
+local read_stdout, read_stderr
+# redirect output/error
+read_stdout, = redirect_stdout()
+redirect_stdout(TMJuliaStdio(stdout,read_stdout,"stdout"))
+read_stderr, = redirect_stderr()
+redirect_stderr(TMJuliaStdio(stderr,read_stderr,"stderr"))
+#redirect_stdin(TMJuliaStdio(stdin,"stdin"))
+
+# redirect display
+pushdisplay(InlineDisplay())
+
+# print banner
+tm_begin()
+banner()
+tm_out(PROMPT,">>> ")
+tm_end()
+
+# go
+n = 0 # execution counter
+ans = nothing # record last successful answer in ans
+
+while true
+    line = readline(stdin)
+    length(line) == 0 && continue
+    if line[1] == DATA_COMMAND
+        # is tab completion the only possible command?
+        do_tab_complete(line)
+        continue
+    end
+    lines = []
+    while line != "<EOF>"
+        push!(lines, line)
+        line = readline(stdin)
+    end
+    local code = join(lines,"\n")
+    local result = nothing
+    local err = nothing
+    global ans = nothing
+    tm_begin()
+    try
+        global n += 1
+        # "; ..." cells are interpreted as shell commands for run
+        code = replace(code, r"^\s*;.*$" =>
+            m -> string(replace(m, r"^\s*;" => "Base.repl_cmd(`"),
+                        "`, stdout)"))
+        # a cell beginning with "? ..." is interpreted as a help request
+        hcode = replace(code, r"^\s*\?" => "")
+        # Let's try to run the input
+        if hcode != code # help request
+            buf = IOBuffer()
+            help = Core.eval(Main, helpmode(buf, hcode))
+            #flush_output()
+            tm_out("HELP: $(String(take!(buf)))\n")
+            display(help)
+        else
+            # finally run the code! 
+            result = include_string(current_module[], code, "In[$n]")
+            REPL.ends_with_semicolon(code) ? result = nothing : ans = result
+        end
+    catch e
+        err = e
+        result = catch_stack()
+    end    
+
+    # output
+    try 
+        if err != nothing 
+            Base.invokelatest(Base.display_error, stderr, result)
+        elseif result != nothing 
+            Base.invokelatest(display, result)
+            #show(stdout, result) # display the result as string
+        end
+    catch e 
+        write(stdout, "Error showing values $(e)");
+        Base.invokelatest(Base.display_error, stderr, catch_stack())
+    end
+    flush_all() # send all to mogan
+#    flush_output() # send all to mogan
+    tm_end()
+end # while true
+
+end # module MoganJulia

--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -1,0 +1,43 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-julia.scm
+;; DESCRIPTION : Initialize the julia plugin
+;; COPYRIGHT   : (C) 2021 Massimiliano Gubinelli
+;;                   2026 Tianyou Liu
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (dynamic session-edit))
+
+(define (julia-serialize lan t)
+  (let* ((u (pre-serialize lan t))
+         (s (texmacs->code (stree->tree u) "SourceCode")))
+    (string-append s "\n<EOF>\n")))
+
+(define (julia-entry)
+  (system-url->string
+    (if (url-exists? "$TEXMACS_HOME_PATH/plugins/julia/julia/MoganJulia.jl")
+        "$TEXMACS_HOME_PATH/plugins/julia/julia/MoganJulia.jl"
+        "$TEXMACS_PATH/plugins/julia/julia/MoganJulia.jl")))
+
+(define (julia-launcher)
+  (let* ((boot (string-quote (julia-entry))))
+    (string-append "julia " boot)))
+
+(plugin-configure julia
+  (:winpath "Julia" "bin")
+  (:macpath "Julia*" "Contents/Resources/julia/bin")
+  (:require (url-exists-in-path? "julia"))
+  (:serializer ,julia-serialize)
+  (:launch ,(julia-launcher))
+  (:tab-completion #t)
+  (:session "Julia"))
+
+(lazy-format (data julia) julia)
+
+(when (supports-julia?)
+  (plugin-input-converters julia))

--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -19,17 +19,17 @@
     (string-append s "\n<EOF>\n")))
 
 (define (julia-entry)
-  (system-url->string
+  (url->system (string->url
     (if (url-exists? "$TEXMACS_HOME_PATH/plugins/julia/julia/MoganJulia.jl")
         "$TEXMACS_HOME_PATH/plugins/julia/julia/MoganJulia.jl"
-        "$TEXMACS_PATH/plugins/julia/julia/MoganJulia.jl")))
+        "$TEXMACS_PATH/plugins/julia/julia/MoganJulia.jl"))))
 
 (define (julia-launcher)
   (let* ((boot (string-quote (julia-entry))))
     (string-append "julia " boot)))
 
 (plugin-configure julia
-  (:winpath "Julia" "bin")
+  (:winpath "Julia*" "bin")
   (:macpath "Julia*" "Contents/Resources/julia/bin")
   (:require (url-exists-in-path? "julia"))
   (:serializer ,julia-serialize)

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -605,7 +605,7 @@
          (connection-insert-handler name (second cmd) (symbol->string (third cmd)))
         ) ;
         ((func? cmd :winpath 2)
-         (when (os-mingw?)
+         (when (or (os-win32?) (os-mingw?))
            (add-windows-program-path (url-append (second cmd) (third cmd)) #t)
          ) ;when
         ) ;

--- a/TeXmacs/tests/tmu/0801.tmu
+++ b/TeXmacs/tests/tmu/0801.tmu
@@ -1,0 +1,117 @@
+<TMU|<tuple|1.1.0|2026.2.5>>
+
+<style|<tuple|generic|number-europe|preview-ref|framed-session|julia>>
+
+<\body>
+  <\session|julia|default>
+    <\output>
+      \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ _
+
+      \ \ \ _ \ \ \ \ \ \ _ _(_)_ \ \ \ \ \| \ Documentation: https://docs.julialang.org
+
+      \ \ (_) \ \ \ \ \| (_) (_) \ \ \ \|
+
+      \ \ \ _ _ \ \ _\| \|_ \ __ _ \ \ \| \ Type "?" for help, "]?" for Pkg help.
+
+      \ \ \| \| \| \| \| \| \|/ _‘ \| \ \|
+
+      \ \ \| \| \|_\| \| \| \| (_\| \| \ \| \ Version 1.12.6 (2026-04-09)
+
+      \ _/ \|\\__'_\|_\|_\|\\__'_\| \ \| \ Official https://julialang.org release
+
+      \|__/ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \|
+
+      \;
+
+      Julia plugin for Mogan STEM.
+    </output>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      1 + 2
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      ?sin
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      sin(fill(1.0, (2,2)))
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      sqrt(-1)
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      non_existent_variable
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      ; ls -la
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      prin
+    <|unfolded-io>
+      \;
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      using Markdown
+
+      Markdown.parse("# Title\\nthis is **bold** font.\\n\\nthis is a list:\\n- A\\n - B")
+    <|unfolded-io>
+      <\html-text>
+        \;
+      </html-text>
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|input>
+      \;
+    </input>
+  </session>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|B5E48B3A-CB10-4210-8018-C6BF17CD3640>
+  </collection>
+</initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|?|?>>
+  </collection>
+</references>

--- a/devel/0801.md
+++ b/devel/0801.md
@@ -1,0 +1,25 @@
+# [0801] 集成 Julia 交互式会话插件
+
+## 如何测试
+1. 打开 `TeXmacs\tests\tmu\0801.tmu`；同时安装 Julia 软件并配置环境变量；
+2. 第一行回车，应该显示 `3`；
+3. 第二行回车，应该显示 `HELP:` 开头的文档；
+4. 第三行回车，应该显示：
+```
+2×2 Matrix{Float64}:
+0.454649  0.454649
+0.454649  0.454649
+```
+5. 第四行回车，应该显示 `ERROR: LoadError: DomainError with -1.0:` 开头的报错，且在红框环境内；
+6. 第五行回车，应该显示 `ERROR: LoadError: UndefVarError: ‘non_existent_variable‘ not defined in ‘Main‘` 开头的报错，且在红框环境内；
+7. 第六行回车，应该显示当前目录的 `ls -la` 命令执行结果；
+8. 第七行按 `tab` 键，应该显示自动补全候选结果；
+9. 第八行回车，应该显示能被成功渲染的 Markdown 格式的文本；
+
+## 2026/5/28
+### What
+集成 Julia 交互式会话插件，提供 Julia 的富文本终端计算环境。
+
+### How
+1. 新增 `TeXmacs/plugins/julia/julia/TeXmacsJulia.jl`：在 Julia 端实现标准流（stdout/stderr）重定向、富媒体渲染重定向（支持 Markdown/HTML/LaTeX 和各类图像）、异常捕获以及 Tab 自动补全协议。
+2. 新增 `TeXmacs/plugins/julia/progs/init-julia.scm`：使用 Goldfish Scheme 语法在顶层配置并注册 `Julia` 会话，关联后端包装器并设置输入转换器。

--- a/devel/0801.md
+++ b/devel/0801.md
@@ -1,7 +1,7 @@
 # [0801] 集成 Julia 交互式会话插件
 
 ## 如何测试
-1. 打开 `TeXmacs\tests\tmu\0801.tmu`；同时安装 Julia 软件并配置环境变量；
+1. 打开 `TeXmacs\tests\tmu\0801.tmu`，同时安装 Julia 软件（Linux环境需要添加环境变量，Windows环境不需要配path）；
 2. 第一行回车，应该显示 `3`；
 3. 第二行回车，应该显示 `HELP:` 开头的文档；
 4. 第三行回车，应该显示：
@@ -12,7 +12,7 @@
 ```
 5. 第四行回车，应该显示 `ERROR: LoadError: DomainError with -1.0:` 开头的报错，且在红框环境内；
 6. 第五行回车，应该显示 `ERROR: LoadError: UndefVarError: ‘non_existent_variable‘ not defined in ‘Main‘` 开头的报错，且在红框环境内；
-7. 第六行回车，应该显示当前目录的 `ls -la` 命令执行结果；
+7. 第六行回车，应该显示当前目录的 `ls -la` 命令执行结果（如果是Windows，输入改成 `; cmd /c dir` 或 `readdir()`）；
 8. 第七行按 `tab` 键，应该显示自动补全候选结果；
 9. 第八行回车，应该显示能被成功渲染的 Markdown 格式的文本；
 

--- a/devel/0801.md
+++ b/devel/0801.md
@@ -1,20 +1,22 @@
 # [0801] 集成 Julia 交互式会话插件
 
 ## 如何测试
-1. 打开 `TeXmacs\tests\tmu\0801.tmu`，同时安装 Julia 软件（Linux环境需要添加环境变量，Windows环境不需要配path）；
-2. 第一行回车，应该显示 `3`；
-3. 第二行回车，应该显示 `HELP:` 开头的文档；
-4. 第三行回车，应该显示：
+1. 安装 Julia 软件（Linux环境需要添加环境变量，Windows环境不需要配path）
+2. 在 `插入交互会话` 按钮中，可以看到出现了 `Julia` 会话选项，点击后会打开一个新的 `Julia` 会话窗口；
+3. 打开 `TeXmacs\tests\tmu\0801.tmu`；
+4. 第一行回车，应该显示 `3`；
+5. 第二行回车，应该显示 `HELP:` 开头的文档；
+6. 第三行回车，应该显示：
 ```
 2×2 Matrix{Float64}:
 0.454649  0.454649
 0.454649  0.454649
 ```
-5. 第四行回车，应该显示 `ERROR: LoadError: DomainError with -1.0:` 开头的报错，且在红框环境内；
-6. 第五行回车，应该显示 `ERROR: LoadError: UndefVarError: ‘non_existent_variable‘ not defined in ‘Main‘` 开头的报错，且在红框环境内；
-7. 第六行回车，应该显示当前目录的 `ls -la` 命令执行结果（如果是Windows，输入改成 `; cmd /c dir` 或 `readdir()`）；
-8. 第七行按 `tab` 键，应该显示自动补全候选结果；
-9. 第八行回车，应该显示能被成功渲染的 Markdown 格式的文本；
+7. 第四行回车，应该显示 `ERROR: LoadError: DomainError with -1.0:` 开头的报错，且在红框环境内；
+8. 第五行回车，应该显示 `ERROR: LoadError: UndefVarError:` 开头的报错，且在红框环境内；
+9. 第六行回车，应该显示当前目录的 `ls -la` 命令执行结果（如果是Windows，输入改成 `; cmd /c dir` 或 `readdir()`）；
+10.  第七行按 `tab` 键，应该显示自动补全候选结果；
+11.  第八行回车，应该显示能被成功渲染的 Markdown 格式的文本；
 
 ## 2026/5/28
 ### What


### PR DESCRIPTION
# [0801] 集成 Julia 交互式会话插件

## 如何测试
1. 打开 `TeXmacs\tests\tmu\0801.tmu`，同时安装 Julia 软件（Linux环境需要添加环境变量，Windows环境不需要配path）；
2. 第一行回车，应该显示 `3`；
3. 第二行回车，应该显示 `HELP:` 开头的文档；
4. 第三行回车，应该显示：
```
2×2 Matrix{Float64}:
0.454649  0.454649
0.454649  0.454649
```
5. 第四行回车，应该显示 `ERROR: LoadError: DomainError with -1.0:` 开头的报错，且在红框环境内；
6. 第五行回车，应该显示 `ERROR: LoadError: UndefVarError: ‘non_existent_variable‘ not defined in ‘Main‘` 开头的报错，且在红框环境内；
7. 第六行回车，应该显示当前目录的 `ls -la` 命令执行结果（如果是Windows，输入改成 `; cmd /c dir` 或 `readdir()`）；
8. 第七行按 `tab` 键，应该显示自动补全候选结果；
9. 第八行回车，应该显示能被成功渲染的 Markdown 格式的文本；

## 2026/5/28
### What
集成 Julia 交互式会话插件，提供 Julia 的富文本终端计算环境。

### How
1. 新增 `TeXmacs/plugins/julia/julia/TeXmacsJulia.jl`：在 Julia 端实现标准流（stdout/stderr）重定向、富媒体渲染重定向（支持 Markdown/HTML/LaTeX 和各类图像）、异常捕获以及 Tab 自动补全协议。
2. 新增 `TeXmacs/plugins/julia/progs/init-julia.scm`：使用 Goldfish Scheme 语法在顶层配置并注册 `Julia` 会话，关联后端包装器并设置输入转换器。
