### PR TITLE
[0628] 修复 frame 和  framed 结构 LaTeX 导出的递归转译问题

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm
@@ -17,324 +17,898 @@
 ;; Any LaTeX tag
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-rules
-  ((latex-tag% 'x) (latex-arity% 'x 'y))
-  ((latex-supports-option% 'x #t) (latex-optional-arg% 'x)))
+(logic-rules ((latex-tag% 'x) (latex-arity% 'x 'y))
+ ((latex-supports-option% 'x #t) (latex-optional-arg% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; LaTeX commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-command-0%
-  ,(string->symbol " ") ,(string->symbol ";") 
-  ,(string->symbol ",") ,(string->symbol ":") 
-  - / [ ] ! * ,(string->symbol "|") i j ss SS oe OE ae AE
-  AA DH L NG O S TH aa dh dj l ng o P th pounds colon and lq rq
-  quad qquad enspace thinspace par smallskip medskip bigskip
-  noindent newline linebreak nobreak nolinebreak strut
-  pagebreak nopagebreak newpage newdoublepage clearpage cleardoublepage
-  newblock bgroup egroup protect cr hfil hfill hfilll appendix limits nolimits
-  dots maketitle tableofcontents TeX LaTeX onecolumn twocolumn
-  begingroup endgroup printindex today bmod toprule midrule bottomrule
+  ,(string->symbol " ")
+  ,(string->symbol ";")
+  ,(string->symbol ",")
+  ,(string->symbol ":")
+  -
+  /
+  [
+  ]
+  !
+  *
+  ,(string->symbol "|")
+  i
+  j
+  ss
+  SS
+  oe
+  OE
+  ae
+  AE
+  AA
+  DH
+  L
+  NG
+  O
+  S
+  TH
+  aa
+  dh
+  dj
+  l
+  ng
+  o
+  P
+  th
+  pounds
+  colon
+  and
+  lq
+  rq
+  quad
+  qquad
+  enspace
+  thinspace
+  par
+  smallskip
+  medskip
+  bigskip
+  noindent
+  newline
+  linebreak
+  nobreak
+  nolinebreak
+  strut
+  pagebreak
+  nopagebreak
+  newpage
+  newdoublepage
+  clearpage
+  cleardoublepage
+  newblock
+  bgroup
+  egroup
+  protect
+  cr
+  hfil
+  hfill
+  hfilll
+  appendix
+  limits
+  nolimits
+  dots
+  maketitle
+  tableofcontents
+  TeX
+  LaTeX
+  onecolumn
+  twocolumn
+  begingroup
+  endgroup
+  printindex
+  today
+  bmod
+  toprule
+  midrule
+  bottomrule
 
   ;; AMS commands
-  dotsc dotsb dotsm dotsi dotso qed
+  dotsc
+  dotsb
+  dotsm
+  dotsi
+  dotso
+  qed
   ;; mathtools
   coloneqq
   ;; temporarily
-  hline hrulefill
+  hline
+  hrulefill
   ;; rewritten
-  notin vert Vert addots
-  implies iff gets
+  notin
+  vert
+  Vert
+  addots
+  implies
+  iff
+  gets
   ;; wikipedia
-  infin rang
+  infin
+  rang
   ;; bibtex
   bysame
   ;; for (e.g.) includegraphics
-  width height
+  width
+  height
   ;; miscellaneous
-  null unskip
+  null
+  unskip
 
   ;; Algorithms
-  AND BlankLine Ensure ENSURE FALSE GLOBALS NOT OR PRINT Require REQUIRE
-  Repeat RETURN State STATE TO KwTo TRUE XOR Else ENDBODY EndFor ENDFOR
-  EndFunction EndIf ENDIF ENDINPUTS EndLoop ENDLOOP ENDOUTPUTS
-  EndProcedure ENDWHILE EndWhile Loop)
+  AND
+  BlankLine
+  Ensure
+  ENSURE
+  FALSE
+  GLOBALS
+  NOT
+  OR
+  PRINT
+  Require
+  REQUIRE
+  Repeat
+  RETURN
+  State
+  STATE
+  TO
+  KwTo
+  TRUE
+  XOR
+  Else
+  ENDBODY
+  EndFor
+  ENDFOR
+  EndFunction
+  EndIf
+  ENDIF
+  ENDINPUTS
+  EndLoop
+  ENDLOOP
+  ENDOUTPUTS
+  EndProcedure
+  ENDWHILE
+  EndWhile
+  Loop
+) ;logic-group
 
 (logic-group latex-command-1%
-  part* chapter* section* subsection* subsubsection* paragraph* subparagraph*
-  nextbib geometry
-  footnote overline underline <sub> <sup> not left middle right
-  big Big bigg Bigg bigl Bigl biggl Biggl
-  bigm Bigm biggm Biggm bigr Bigr biggr Biggr
-  bar Bar hat Hat tilde Tilde widehat widetilde vec Vec bm ring
-  overrightarrow overleftarrow overleftrightarrow
-  underrightarrow underleftarrow underleftrightarrow
-  grave Grave acute Acute check Check breve Breve invbreve abovering mathring
-  dot Dot ddot Ddot dddot ddddot mod pod pmod
-  label ref pageref index hspace hspace* vspace vspace* mspace
-  mbox hbox textnormal text not substack
-  ,(string->symbol "'") ,(string->symbol "`") ,(string->symbol "\"")
-  ^ over atop choose ~ = u v H t c d b k r textsuperscript textsubscript
-  thispagestyle ensuremath
-  mathord mathbin mathopen mathpunct mathop mathrel mathclose mathalpha
+  part*
+  chapter*
+  section*
+  subsection*
+  subsubsection*
+  paragraph*
+  subparagraph*
+  nextbib
+  geometry
+  footnote
+  overline
+  underline
+  <sub>
+  <sup>
+  not
+  left
+  middle
+  right
+  big
+  Big
+  bigg
+  Bigg
+  bigl
+  Bigl
+  biggl
+  Biggl
+  bigm
+  Bigm
+  biggm
+  Biggm
+  bigr
+  Bigr
+  biggr
+  Biggr
+  bar
+  Bar
+  hat
+  Hat
+  tilde
+  Tilde
+  widehat
+  widetilde
+  vec
+  Vec
+  bm
+  ring
+  overrightarrow
+  overleftarrow
+  overleftrightarrow
+  underrightarrow
+  underleftarrow
+  underleftrightarrow
+  grave
+  Grave
+  acute
+  Acute
+  check
+  Check
+  breve
+  Breve
+  invbreve
+  abovering
+  mathring
+  dot
+  Dot
+  ddot
+  Ddot
+  dddot
+  ddddot
+  mod
+  pod
+  pmod
+  label
+  ref
+  pageref
+  index
+  hspace
+  hspace*
+  vspace
+  vspace*
+  mspace
+  mbox
+  hbox
+  textnormal
+  text
+  not
+  substack
+  ,(string->symbol "'")
+  ,(string->symbol "`")
+  ,(string->symbol "\"")
+  ^
+  over
+  atop
+  choose
+  ~
+  =
+  u
+  v
+  H
+  t
+  c
+  d
+  b
+  k
+  r
+  textsuperscript
+  textsubscript
+  thispagestyle
+  ensuremath
+  mathord
+  mathbin
+  mathopen
+  mathpunct
+  mathop
+  mathrel
+  mathclose
+  mathalpha
   mathinner
-  arabic alph Alph roman Roman fnsymbol displaylines cases underbrace overbrace
-  phantom hphantom vphantom smash date terms
-  newcounter stepcounter refstepcounter value
-  citealt citealt* citealp*
-  citetext citeauthor citeauthor* citeyear onlinecite citeN
-  epsfig url penalty centerline fbox framebox cline cmidrule
+  arabic
+  alph
+  Alph
+  roman
+  Roman
+  fnsymbol
+  displaylines
+  cases
+  underbrace
+  overbrace
+  phantom
+  hphantom
+  vphantom
+  smash
+  date
+  terms
+  newcounter
+  stepcounter
+  refstepcounter
+  value
+  citealt
+  citealt*
+  citealp*
+  citetext
+  citeauthor
+  citeauthor*
+  citeyear
+  onlinecite
+  citeN
+  epsfig
+  url
+  penalty
+  centerline
+  fbox
+  framebox
+  cline
+  cmidrule
   enlargethispage
-  newlength newdimen newskip
-  Comment COMMENT For ForAll If Input KwData KwResult KwRet lnl nllabel
-  lElse uElse Output Until UNTIL While
-  etalchar MR listpart custombinding cref Cref)
+  newlength
+  newdimen
+  newskip
+  Comment
+  COMMENT
+  For
+  ForAll
+  If
+  Input
+  KwData
+  KwResult
+  KwRet
+  lnl
+  nllabel
+  lElse
+  uElse
+  Output
+  Until
+  UNTIL
+  While
+  etalchar
+  MR
+  listpart
+  custombinding
+  cref
+  Cref
+) ;logic-group
 
-(logic-group latex-command-1% ;; . needs a special treatment
-  ,(string->symbol "."))
+(logic-group latex-command-1%
+  ;; . needs a special treatment
+  ,(string->symbol ".")
+) ;logic-group
 
 (logic-group latex-command-2%
-  binom tbinom dbinom cfrac tfrac equal href
-  sideset stackrel underaccent
-  setcounter addtocounter setlength addtolength
-  colorbox scalebox texorpdfstring raisebox foreignlanguage
-  Call Function Procedure SetKw SetKwData SetKwFunction SetKwInOut
-  ifthispageodd adjustbox)
+  binom
+  tbinom
+  dbinom
+  cfrac
+  tfrac
+  equal
+  href
+  sideset
+  stackrel
+  underaccent
+  setcounter
+  addtocounter
+  setlength
+  addtolength
+  colorbox
+  scalebox
+  texorpdfstring
+  raisebox
+  foreignlanguage
+  Call
+  Function
+  Procedure
+  SetKw
+  SetKwData
+  SetKwFunction
+  SetKwInOut
+  ifthispageodd
+  adjustbox
+) ;logic-group
 
 (logic-group latex-command-3%
-  ifthenelse resizebox fcolorbox @setfontsize eIf multicolumn)
+  ifthenelse
+  resizebox
+  fcolorbox
+  @setfontsize
+  eIf
+  multicolumn
+) ;logic-group
 
-(logic-group latex-command-4%
-  mathchoice)
+(logic-group latex-command-4% mathchoice)
 
-(logic-group latex-command-6%
-  genfrac @startsection)
+(logic-group latex-command-6% genfrac @startsection)
 
-(logic-rules
-  ((latex-command% 'x) (latex-command-0% 'x))
-  ((latex-arity% 'x 0) (latex-command-0% 'x))
-  ((latex-command% 'x) (latex-command-1% 'x))
-  ((latex-arity% 'x 1) (latex-command-1% 'x))
-  ((latex-command% 'x) (latex-command-2% 'x))
-  ((latex-arity% 'x 2) (latex-command-2% 'x))
-  ((latex-command% 'x) (latex-command-3% 'x))
-  ((latex-arity% 'x 3) (latex-command-3% 'x))
-  ((latex-command% 'x) (latex-command-4% 'x))
-  ((latex-arity% 'x 4) (latex-command-4% 'x))
-  ((latex-command% 'x) (latex-command-6% 'x))
-  ((latex-arity% 'x 6) (latex-command-6% 'x)))
+(logic-rules ((latex-command% 'x) (latex-command-0% 'x))
+ ((latex-arity% 'x 0) (latex-command-0% 'x))
+ ((latex-command% 'x) (latex-command-1% 'x))
+ ((latex-arity% 'x 1) (latex-command-1% 'x))
+ ((latex-command% 'x) (latex-command-2% 'x))
+ ((latex-arity% 'x 2) (latex-command-2% 'x))
+ ((latex-command% 'x) (latex-command-3% 'x))
+ ((latex-arity% 'x 3) (latex-command-3% 'x))
+ ((latex-command% 'x) (latex-command-4% 'x))
+ ((latex-arity% 'x 4) (latex-command-4% 'x))
+ ((latex-command% 'x) (latex-command-6% 'x))
+ ((latex-arity% 'x 6) (latex-command-6% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; LaTeX commands with optional arguments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-command-0*%
-  item ,(string->symbol "\\")
-  BODY ELSE INPUTS LOOP OUTPUTS REPEAT
-  hdashline)
+  item
+  ,(string->symbol "\\")
+  BODY
+  ELSE
+  INPUTS
+  LOOP
+  OUTPUTS
+  REPEAT
+  hdashline
+) ;logic-group
 
 (logic-group latex-command-1*%
-  usepackage documentclass documentstyle sqrt bibitem cite caption  
-  title author thanks marginpar
-  part chapter section subsection subsubsection paragraph subparagraph
-  includegraphics includegraphics*
+  usepackage
+  documentclass
+  documentstyle
+  sqrt
+  bibitem
+  cite
+  caption
+  title
+  author
+  thanks
+  marginpar
+  part
+  chapter
+  section
+  subsection
+  subsubsection
+  paragraph
+  subparagraph
+  includegraphics
+  includegraphics*
   makebox
-  subjclass declaretheorem footnotetext
-  xleftarrow xrightarrow xleftrightarrow xminus
-  xLeftarrow xRightarrow xLeftrightarrow xequal
-  xmapsto xmapsfrom citealp citet citep citet* citep*
-  Begin ELSIF FORALL FOR IF WHILE tcp tcp* tcc tcc*
-  hyperref)
+  subjclass
+  declaretheorem
+  footnotetext
+  xleftarrow
+  xrightarrow
+  xleftrightarrow
+  xminus
+  xLeftarrow
+  xRightarrow
+  xLeftrightarrow
+  xequal
+  xmapsto
+  xmapsfrom
+  citealp
+  citet
+  citep
+  citet*
+  citep*
+  Begin
+  ELSIF
+  FORALL
+  FOR
+  IF
+  WHILE
+  tcp
+  tcp*
+  tcc
+  tcc*
+  hyperref
+) ;logic-group
 
 (logic-group latex-command-2*%
-  def newcommand renewcommand providecommand
-  newtheorem newtheorem* frac parbox 
-  ElseIf uElseIf lElseIf ForEach lForEach lForAll lFor)
+  def
+  newcommand
+  renewcommand
+  providecommand
+  newtheorem
+  newtheorem*
+  frac
+  parbox
+  ElseIf
+  uElseIf
+  lElseIf
+  ForEach
+  lForEach
+  lForAll
+  lFor
+) ;logic-group
 
 (logic-group latex-command-3*%
-  category newenvironment renewenvironment multirow)
+  category
+  newenvironment
+  renewenvironment
+  multirow
+) ;logic-group
 
-(logic-rules
-  ((latex-command-0% 'x) (latex-command-0*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-0*% 'x))
-  ((latex-command-1% 'x) (latex-command-1*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-1*% 'x))
-  ((latex-command-2% 'x) (latex-command-2*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-2*% 'x))
-  ((latex-command-3% 'x) (latex-command-3*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-3*% 'x)))
+(logic-rules ((latex-command-0% 'x) (latex-command-0*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-0*% 'x))
+ ((latex-command-1% 'x) (latex-command-1*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-1*% 'x))
+ ((latex-command-2% 'x) (latex-command-2*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-2*% 'x))
+ ((latex-command-3% 'x) (latex-command-3*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-3*% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-environment-0%
-  begin-document begin-abstract begin-verbatim begin-proof
-  begin-matrix begin-pmatrix begin-bmatrix begin-vmatrix begin-smallmatrix
+  begin-mdframed
+  begin-document
+  begin-abstract
+  begin-verbatim
+  begin-proof
+  begin-matrix
+  begin-pmatrix
+  begin-bmatrix
+  begin-vmatrix
+  begin-smallmatrix
   begin-cases
-  begin-center begin-flushleft begin-flushright
-  begin-picture)
+  begin-center
+  begin-flushleft
+  begin-flushright
+  begin-picture
+) ;logic-group
 
 (logic-group latex-environment-0*%
-  begin-figure begin-table begin-figure* begin-table*
-  begin-algorithmic begin-algorithm begin-algorithm2e
-  begin-teaserfigure)
+  begin-figure
+  begin-table
+  begin-figure*
+  begin-table*
+  begin-algorithmic
+  begin-algorithm
+  begin-algorithm2e
+  begin-teaserfigure
+) ;logic-group
 
 (logic-group latex-environment-1%
-  begin-otherlanguage begin-otherlanguage*
-  begin-tabbing begin-thebibliography begin-multicols)
+  begin-otherlanguage
+  begin-otherlanguage*
+  begin-tabbing
+  begin-thebibliography
+  begin-multicols
+) ;logic-group
 
-(logic-group latex-environment-1*%
-  begin-array begin-tabular begin-minipage)
+(logic-group latex-environment-1*% begin-array begin-tabular begin-minipage)
 
-(logic-group latex-environment-2*%
-  begin-tabular* begin-tabularx)
+(logic-group latex-environment-2*% begin-tabular* begin-tabularx)
 
-(logic-rules
-  ((latex-environment% 'x) (latex-environment-0% 'x))
-  ((latex-arity% 'x 0) (latex-environment-0% 'x))
-  ((latex-environment% 'x) (latex-environment-1% 'x))
-  ((latex-arity% 'x 1) (latex-environment-1% 'x))
-  ((latex-environment% 'x) (latex-environment-2% 'x))
-  ((latex-arity% 'x 2) (latex-environment-2% 'x))
-  ((latex-environment% 'x) (latex-environment-3% 'x))
-  ((latex-arity% 'x 3) (latex-environment-3% 'x))
-  ((latex-environment-0% 'x) (latex-environment-0*% 'x))
-  ((latex-optional-arg% 'x) (latex-environment-0*% 'x))
-  ((latex-environment-1% 'x) (latex-environment-1*% 'x))
-  ((latex-optional-arg% 'x) (latex-environment-1*% 'x))
-  ((latex-environment-2% 'x) (latex-environment-2*% 'x))
-  ((latex-optional-arg% 'x) (latex-environment-2*% 'x)))
+(logic-rules ((latex-environment% 'x) (latex-environment-0% 'x))
+ ((latex-arity% 'x 0) (latex-environment-0% 'x))
+ ((latex-environment% 'x) (latex-environment-1% 'x))
+ ((latex-arity% 'x 1) (latex-environment-1% 'x))
+ ((latex-environment% 'x) (latex-environment-2% 'x))
+ ((latex-arity% 'x 2) (latex-environment-2% 'x))
+ ((latex-environment% 'x) (latex-environment-3% 'x))
+ ((latex-arity% 'x 3) (latex-environment-3% 'x))
+ ((latex-environment-0% 'x) (latex-environment-0*% 'x))
+ ((latex-optional-arg% 'x) (latex-environment-0*% 'x))
+ ((latex-environment-1% 'x) (latex-environment-1*% 'x))
+ ((latex-optional-arg% 'x) (latex-environment-1*% 'x))
+ ((latex-environment-2% 'x) (latex-environment-2*% 'x))
+ ((latex-optional-arg% 'x) (latex-environment-2*% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Enunciations
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-enunciation%
-  begin-theorem begin-proposition begin-lemma begin-corollary begin-proof
-  begin-axiom begin-definition begin-notation begin-conjecture
-  begin-remark begin-note begin-example begin-warning
-  begin-convention begin-acknowledgments
-  begin-exercise begin-problem
-  begin-solution begin-question begin-answer
-  begin-quote-env begin-quotation begin-verse
+  begin-theorem
+  begin-proposition
+  begin-lemma
+  begin-corollary
+  begin-proof
+  begin-axiom
+  begin-definition
+  begin-notation
+  begin-conjecture
+  begin-remark
+  begin-note
+  begin-example
+  begin-warning
+  begin-convention
+  begin-acknowledgments
+  begin-exercise
+  begin-problem
+  begin-solution
+  begin-question
+  begin-answer
+  begin-quote-env
+  begin-quotation
+  begin-verse
 
-  begin-theorem* begin-proposition* begin-lemma* begin-corollary*
-  begin-axiom* begin-definition* begin-notation* begin-conjecture*
-  begin-remark* begin-note* begin-example* begin-warning*
-  begin-convention* begin-acknowledgments*
-  begin-exercise* begin-problem*
-  begin-solution* begin-question* begin-answer*
+  begin-theorem*
+  begin-proposition*
+  begin-lemma*
+  begin-corollary*
+  begin-axiom*
+  begin-definition*
+  begin-notation*
+  begin-conjecture*
+  begin-remark*
+  begin-note*
+  begin-example*
+  begin-warning*
+  begin-convention*
+  begin-acknowledgments*
+  begin-exercise*
+  begin-problem*
+  begin-solution*
+  begin-question*
+  begin-answer*
 
   ;; guessed
-  begin-th begin-thm begin-prop begin-lem begin-cor begin-corr
-  begin-pf begin-dem begin-preuve begin-IEEEproof
-  begin-ax begin-def begin-dfn begin-defn
-  begin-not begin-ex begin-exa begin-rem begin-war begin-conv
-  begin-exe begin-exc begin-exo begin-prop begin-sol begin-ans
-  begin-acks)
+  begin-th
+  begin-thm
+  begin-prop
+  begin-lem
+  begin-cor
+  begin-corr
+  begin-pf
+  begin-dem
+  begin-preuve
+  begin-IEEEproof
+  begin-ax
+  begin-def
+  begin-dfn
+  begin-defn
+  begin-not
+  begin-ex
+  begin-exa
+  begin-rem
+  begin-war
+  begin-conv
+  begin-exe
+  begin-exc
+  begin-exo
+  begin-prop
+  begin-sol
+  begin-ans
+  begin-acks
+) ;logic-group
 
-(logic-rules
-  ((latex-environment-0*% 'x) (latex-enunciation% 'x)))
+(logic-rules ((latex-environment-0*% 'x) (latex-enunciation% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modifiers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-modifier-0%
-  normalfont rm tt sf md bf it em sl sc rmfamily ttfamily sffamily
-  mdseries bfseries upshape itshape slshape scshape
-  displaystyle textstyle scriptstyle scriptscriptstyle cal frak Bbb boldmath
-  tiny scriptsize footnotesize small normalsize
-  large Large LARGE huge Huge
-  black white grey red blue yellow green orange magenta brown pink
-  centering raggedleft raggedright flushleft flushright)
+  normalfont
+  rm
+  tt
+  sf
+  md
+  bf
+  it
+  em
+  sl
+  sc
+  rmfamily
+  ttfamily
+  sffamily
+  mdseries
+  bfseries
+  upshape
+  itshape
+  slshape
+  scshape
+  displaystyle
+  textstyle
+  scriptstyle
+  scriptscriptstyle
+  cal
+  frak
+  Bbb
+  boldmath
+  tiny
+  scriptsize
+  footnotesize
+  small
+  normalsize
+  large
+  Large
+  LARGE
+  huge
+  Huge
+  black
+  white
+  grey
+  red
+  blue
+  yellow
+  green
+  orange
+  magenta
+  brown
+  pink
+  centering
+  raggedleft
+  raggedright
+  flushleft
+  flushright
+) ;logic-group
 
 (logic-group latex-modifier-1%
   textnormalfont
-  textrm texttt textsf textmd textbf textup textit textsl textsc emph
-  mathrm mathtt mathsf mathmd mathbf mathup mathit mathsl mathnormal
-  mathcal mathfrak mathbb mathbbm mathscr operatorname boldsymbol
-  lowercase MakeLowercase uppercase MakeUppercase selectlanguage)
+  textrm
+  texttt
+  textsf
+  textmd
+  textbf
+  textup
+  textit
+  textsl
+  textsc
+  emph
+  mathrm
+  mathtt
+  mathsf
+  mathmd
+  mathbf
+  mathup
+  mathit
+  mathsl
+  mathnormal
+  mathcal
+  mathfrak
+  mathbb
+  mathbbm
+  mathscr
+  operatorname
+  boldsymbol
+  lowercase
+  MakeLowercase
+  uppercase
+  MakeUppercase
+  selectlanguage
+) ;logic-group
 
-(logic-group latex-modifier-1*%
-  color)
+(logic-group latex-modifier-1*% color)
 
-(logic-group latex-modifier-2*%
-  textcolor)
+(logic-group latex-modifier-2*% textcolor)
 
-(logic-rules
-  ((latex-modifier% 'x)     (latex-modifier-0% 'x))
-  ((latex-arity% 'x 0)      (latex-modifier-0% 'x))
-  ((latex-modifier% 'x)     (latex-modifier-1% 'x))
-  ((latex-arity% 'x 1)      (latex-modifier-1% 'x))
-  ((latex-optional-arg% 'x) (latex-modifier-1*% 'x))
-  ((latex-modifier% 'x)     (latex-modifier-1*% 'x))
-  ((latex-arity% 'x 1)      (latex-modifier-1*% 'x))
-  ((latex-optional-arg% 'x) (latex-modifier-2*% 'x))
-  ((latex-modifier% 'x)     (latex-modifier-2*% 'x))
-  ((latex-arity% 'x 2)      (latex-modifier-2*% 'x)))
+(logic-rules ((latex-modifier% 'x) (latex-modifier-0% 'x))
+ ((latex-arity% 'x 0) (latex-modifier-0% 'x))
+ ((latex-modifier% 'x) (latex-modifier-1% 'x))
+ ((latex-arity% 'x 1) (latex-modifier-1% 'x))
+ ((latex-optional-arg% 'x) (latex-modifier-1*% 'x))
+ ((latex-modifier% 'x) (latex-modifier-1*% 'x))
+ ((latex-arity% 'x 1) (latex-modifier-1*% 'x))
+ ((latex-optional-arg% 'x) (latex-modifier-2*% 'x))
+ ((latex-modifier% 'x) (latex-modifier-2*% 'x))
+ ((latex-arity% 'x 2) (latex-modifier-2*% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special types of LaTeX primitives
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-control%
-  $ & % ,(string->symbol "#") _ { } <less> <gtr>)
+(logic-group latex-control% $ & % ,(string->symbol "#") _ { } <less> <gtr>)
 
 (logic-group latex-operator%
-  arccos arcsin arctan arg cos cosh cot coth csc deg det dim exp gcd hom
-  inf ker lg lim liminf limsup ln log max min Pr sec sin sinh sup tan tanh)
+  arccos
+  arcsin
+  arctan
+  arg
+  cos
+  cosh
+  cot
+  coth
+  csc
+  deg
+  det
+  dim
+  exp
+  gcd
+  hom
+  inf
+  ker
+  lg
+  lim
+  liminf
+  limsup
+  ln
+  log
+  max
+  min
+  Pr
+  sec
+  sin
+  sinh
+  sup
+  tan
+  tanh
+) ;logic-group
 
 (logic-group latex-list%
-  begin-itemize begin-enumerate begin-description
-  begin-asparaitem begin-inparaitem begin-compactitem
-  begin-asparaenum begin-inparaenum begin-compactenum)
+  begin-itemize
+  begin-enumerate
+  begin-description
+  begin-asparaitem
+  begin-inparaitem
+  begin-compactitem
+  begin-asparaenum
+  begin-inparaenum
+  begin-compactenum
+) ;logic-group
 
 (logic-group latex-math-environment-0%
-  begin-formula begin-equation*
-  begin-math begin-displaymath begin-equation
-  begin-eqnarray begin-eqnarray*
-  begin-flalign begin-flalign*
-  begin-align begin-align*
-  begin-multline begin-multline*
-  begin-gather begin-gather*
-  begin-eqsplit begin-eqsplit*)
+  begin-formula
+  begin-equation*
+  begin-math
+  begin-displaymath
+  begin-equation
+  begin-eqnarray
+  begin-eqnarray*
+  begin-flalign
+  begin-flalign*
+  begin-align
+  begin-align*
+  begin-multline
+  begin-multline*
+  begin-gather
+  begin-gather*
+  begin-eqsplit
+  begin-eqsplit*
+) ;logic-group
 
-(logic-group latex-math-environment-1%
-  begin-alignat begin-alignat*)
+(logic-group latex-math-environment-1% begin-alignat begin-alignat*)
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-control% 'x))
-  ((latex-arity% 'x 0) (latex-operator% 'x))
-  ((latex-environment-0*% 'x) (latex-list% 'x))
-  ((latex-math-environment% 'x) (latex-math-environment-0% 'x))
-  ((latex-math-environment% 'x) (latex-math-environment-1% 'x))
-  ((latex-environment-1% 'x) (latex-math-environment-1% 'x))
-  ((latex-environment-0% 'x) (latex-math-environment-0% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-control% 'x))
+ ((latex-arity% 'x 0) (latex-operator% 'x))
+ ((latex-environment-0*% 'x) (latex-list% 'x))
+ ((latex-math-environment% 'x) (latex-math-environment-0% 'x))
+ ((latex-math-environment% 'x) (latex-math-environment-1% 'x))
+ ((latex-environment-1% 'x) (latex-math-environment-1% 'x))
+ ((latex-environment-0% 'x) (latex-math-environment-0% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Counters
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-counter%
-  badness enumi enumii enumiii enumiv equation figure inputlineno
-  mpfootnote page setlanguage table)
+  badness
+  enumi
+  enumii
+  enumiii
+  enumiv
+  equation
+  figure
+  inputlineno
+  mpfootnote
+  page
+  setlanguage
+  table
+) ;logic-group
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-counter% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-counter% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Names
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-name%
-  abstractname appendixname contentname figurename indexname
-  litfigurename littablename partname refname tablename)
+  abstractname
+  appendixname
+  contentname
+  figurename
+  indexname
+  litfigurename
+  littablename
+  partname
+  refname
+  tablename
+) ;logic-group
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-name% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-name% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lengths
@@ -343,78 +917,174 @@
 (logic-group latex-length%
   ;; From latex.ltx
   ;; -- lengths
-  @textfloatsheight arraycolsep arrayrulewidth columnsep columnseprule
-  columnwidth doublerulesep emergencystretch evensidemargin fboxrule
-  fboxsep footnotesep footskip headheight headsep itemindent labelsep
-  labelwidth leftmargin leftmargini leftmarginii leftmarginiii
-  leftmarginiv leftmarginv leftmarginvi linewidth listparindent
-  marginparpush marginparsep marginparwidth oddsidemargin p@ paperheight
-  paperwidth rightmargin tabbingsep tabcolsep textheight textwidth
-  topmargin unitlength z@ @bls @vpt @vipt @viipt @viiipt @ixpt @xpt @xipt
-  @xiipt @xivpt @xviipt @xxpt @xxvpt 
+  @textfloatsheight
+  arraycolsep
+  arrayrulewidth
+  columnsep
+  columnseprule
+  columnwidth
+  doublerulesep
+  emergencystretch
+  evensidemargin
+  fboxrule
+  fboxsep
+  footnotesep
+  footskip
+  headheight
+  headsep
+  itemindent
+  labelsep
+  labelwidth
+  leftmargin
+  leftmargini
+  leftmarginii
+  leftmarginiii
+  leftmarginiv
+  leftmarginv
+  leftmarginvi
+  linewidth
+  listparindent
+  marginparpush
+  marginparsep
+  marginparwidth
+  oddsidemargin
+  p@
+  paperheight
+  paperwidth
+  rightmargin
+  tabbingsep
+  tabcolsep
+  textheight
+  textwidth
+  topmargin
+  unitlength
+  z@
+  @bls
+  @vpt
+  @vipt
+  @viipt
+  @viiipt
+  @ixpt
+  @xpt
+  @xipt
+  @xiipt
+  @xivpt
+  @xviipt
+  @xxpt
+  @xxvpt
   ;; -- skips
-  topsep partopsep itemsep parsep floatsep textfloatsep intextsep
-  dblfloatsep dbltextfloatsep 
+  topsep
+  partopsep
+  itemsep
+  parsep
+  floatsep
+  textfloatsep
+  intextsep
+  dblfloatsep
+  dbltextfloatsep
   ;; From latex classes
-  abovecaptionskip belowcaptionskip bibindent
+  abovecaptionskip
+  belowcaptionskip
+  bibindent
   ;; From fleqn
   mathindent
   ;; Plain TeX
-  maxdimen hfuzz vfuzz overfullrule hsize vsize maxdepth lineskiplimit
-  delimitershortfall nulldelimiterspace scriptspace mathsurround
-  predisplaysize displaywidth displayindent parindent hangindent hoffset
-  voffset baselineskip lineskip parskip abovedisplayskip
-  abovedisplayshortskip belowdisplayskip belowdisplayshortskip leftskip
-  rightskip topskip splittopskip tabskip spaceskip xspaceskip parfillskip
-  thinmuskip medmuskip thickmuskip hideskip smallskipamount medskipamount
-  bigskipamount normalbaselineskip normallineskip normallineskiplimit jot 
-  )
+  maxdimen
+  hfuzz
+  vfuzz
+  overfullrule
+  hsize
+  vsize
+  maxdepth
+  lineskiplimit
+  delimitershortfall
+  nulldelimiterspace
+  scriptspace
+  mathsurround
+  predisplaysize
+  displaywidth
+  displayindent
+  parindent
+  hangindent
+  hoffset
+  voffset
+  baselineskip
+  lineskip
+  parskip
+  abovedisplayskip
+  abovedisplayshortskip
+  belowdisplayskip
+  belowdisplayshortskip
+  leftskip
+  rightskip
+  topskip
+  splittopskip
+  tabskip
+  spaceskip
+  xspaceskip
+  parfillskip
+  thinmuskip
+  medmuskip
+  thickmuskip
+  hideskip
+  smallskipamount
+  medskipamount
+  bigskipamount
+  normalbaselineskip
+  normallineskip
+  normallineskiplimit
+  jot
+) ;logic-group
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-length% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-length% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; To be imported as pictures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-as-pic-0%
-  begin-pspicture begin-pspicture* begin-tikzpicture)
+(logic-group latex-as-pic-0% begin-pspicture begin-pspicture* begin-tikzpicture)
 
-(logic-group latex-as-pic-1%
-  xymatrix)
+(logic-group latex-as-pic-1% xymatrix)
 
-(logic-rules
-  ((latex-as-pic% 'x)       (latex-as-pic-0% 'x))
-  ((latex-as-pic% 'x)       (latex-as-pic-1% 'x))
-  ((latex-arity%  'x 0)     (latex-as-pic-0% 'x))
-  ((latex-arity%  'x 1)     (latex-as-pic-1% 'x)))
+(logic-rules ((latex-as-pic% 'x) (latex-as-pic-0% 'x))
+ ((latex-as-pic% 'x) (latex-as-pic-1% 'x))
+ ((latex-arity% 'x 0) (latex-as-pic-0% 'x))
+ ((latex-arity% 'x 1) (latex-as-pic-1% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; To be ignored
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-ignore-0%
-  allowbreak notag xspace break sloppy makeatother makeatletter relax
+  allowbreak
+  notag
+  xspace
+  break
+  sloppy
+  makeatother
+  makeatletter
+  relax
   qedhere
-  ignorespacesafterend ignorespaces balancecolumns
-  tightlist)
+  ignorespacesafterend
+  ignorespaces
+  balancecolumns
+  tightlist
+) ;logic-group
 
-(logic-group latex-ignore-0*%
-  displaybreak allowdisplaybreaks)
+(logic-group latex-ignore-0*% displaybreak allowdisplaybreaks)
 
-(logic-group latex-ignore-1%
-  tag hyphenation)
+(logic-group latex-ignore-1% tag hyphenation)
 
-(logic-group latex-ignore-2%
-  newdir)
+(logic-group latex-ignore-2% newdir)
 
-(logic-rules
-  ((latex-ignore% 'x)       (latex-ignore-0% 'x))
-  ((latex-ignore% 'x)       (latex-ignore-0*% 'x))
-  ((latex-ignore% 'x)       (latex-ignore-1% 'x))
-  ((latex-ignore% 'x)       (latex-ignore-2% 'x))
-  ((latex-arity% 'x 0)      (latex-ignore-0% 'x))
-  ((latex-arity% 'x 0)      (latex-ignore-0*% 'x))
-  ((latex-arity% 'x 1)      (latex-ignore-1% 'x))
-  ((latex-arity% 'x 2)      (latex-ignore-2% 'x))
-  ((latex-optional-arg% 'x) (latex-ignore-1*% 'x)))
+(logic-rules ((latex-ignore% 'x) (latex-ignore-0% 'x))
+ ((latex-ignore% 'x) (latex-ignore-0*% 'x))
+ ((latex-ignore% 'x) (latex-ignore-1% 'x))
+ ((latex-ignore% 'x) (latex-ignore-2% 'x))
+ ((latex-arity% 'x 0) (latex-ignore-0% 'x))
+ ((latex-arity% 'x 0) (latex-ignore-0*% 'x))
+ ((latex-arity% 'x 1) (latex-ignore-1% 'x))
+ ((latex-arity% 'x 2) (latex-ignore-2% 'x))
+ ((latex-optional-arg% 'x) (latex-ignore-1*% 'x))
+) ;logic-rules

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
@@ -12,40 +12,41 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert latex latex-drd)
-  (:use (convert latex latex-overload)))
+(texmacs-module (convert latex latex-drd) (:use (convert latex latex-overload)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Order in which packages should be included
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-package-priority%
-  ("geometry" 10)
-  ("amsmath" 20)
-  ("amssymb" 30)
-  ("graphicx" 40)
-  ("wasysym" 50)
-  ("stmaryrd" 60)
-  ("textcomp" 60)
-  ("enumerate" 70)
-  ("epsfig" 80)
-  ("mathrsfs" 90)
-  ("bbm" 100)
-  ("dsfont" 110)
-  ("euscript" 120)
-  ("multicol" 130)
-  ("hyperref" 140)
-  ("mathtools" 150)
-  ("cleveref" 160))
+ ("geometry" 10)
+ ("amsmath" 20)
+ ("amssymb" 30)
+ ("graphicx" 40)
+ ("wasysym" 50)
+ ("stmaryrd" 60)
+ ("textcomp" 60)
+ ("enumerate" 70)
+ ("epsfig" 80)
+ ("mathrsfs" 90)
+ ("bbm" 100)
+ ("dsfont" 110)
+ ("euscript" 120)
+ ("multicol" 130)
+ ("hyperref" 140)
+ ("mathtools" 150)
+ ("cleveref" 160)
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies between style files and packages
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-depends%
-  ("amsart" "amstex")
-  ("amstex" "amsmath")
-  ("amstex" "amsthm"))
+ ("amsart" "amstex")
+ ("amstex" "amsmath")
+ ("amstex" "amsthm")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies of commands on packages
@@ -111,18 +112,19 @@
 
   (underaccent "accents")
   (ring "accents")
-  
+
   (ifthenelse "ifthen")
   (captionof "capt-of")
   (widthof "calc")
-  
-  (color     "xcolor")
+
+  (color "xcolor")
   (fcolorbox "xcolor")
   (textcolor "xcolor")
 
   (euro "eurosym")
 
   (mdfsetup ("tikz" "mdframed"))
+  (begin-mdframed "mdframed")
   (tikz "tikz")
 
   (omicron "pslatex")
@@ -138,7 +140,7 @@
 
   (cref "cleveref")
   (Cref "cleveref")
-  
+
   (citet "natbib")
   (citep "natbib")
   (citet* "natbib")
@@ -162,82 +164,91 @@
   (ifthispageodd "scrextend")
 
   (begin-linenumbers "lineno")
-  (resetlinenumber "lineno"))
+  (resetlinenumber "lineno")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Page size settings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-paper-opts%
-  ("page-top"         "top")
-  ("page-bot"         "bottom")
-  ("page-odd"         "left")
-  ("page-even"        "left")
-  ("page-right"       "right")
-  ("page-height"      "paperheight")
-  ("page-width"       "paperwidth")
-  ("page-type"        "page-type")
-  ("page-orientation" "page-orientation"))
+ ("page-top" "top")
+ ("page-bot" "bottom")
+ ("page-odd" "left")
+ ("page-even" "left")
+ ("page-right" "right")
+ ("page-height" "paperheight")
+ ("page-width" "paperwidth")
+ ("page-type" "page-type")
+ ("page-orientation" "page-orientation")
+) ;logic-table
 
 (logic-table latex-paper-type%
-  ("a0" "a0paper")
-  ("a1" "a1paper")
-  ("a2" "a2paper")
-  ("a3" "a3paper")
-  ("a4" "a4paper")
-  ("a5" "a5paper")
-  ("a6" "a6paper")
-  ("a7" "papersize={74mm,105mm}")
-  ("a8" "papersize={52mm,74mm")
-  ("a9" "papersize={37mm,52mm}")
-  ("b0" "b0paper")
-  ("b1" "b1paper")
-  ("b2" "b2paper")
-  ("b3" "b3paper")
-  ("b4" "b4paper")
-  ("b5" "b5paper")
-  ("b6" "b6paper")
-  ("b7" "papersize={88mm,125mm}")
-  ("b8" "papersize={62mm,88mm}")
-  ("b9" "papersize={44mm,62mm}")
-  ("legal" "legalpaper")
-  ("letter" "letterpaper")
-  ("executive" "executivepaper")
-  ("archA" "papersize={9in,12in}")
-  ("archB" "papersize={12in,18in}")
-  ("archC" "papersize={18in,24in}")
-  ("archD" "papersize={24in,36in}")
-  ("archE" "papersize={36in,48in}")
-  ("10x14" "papersize={10in,14in}")
-  ("11x17" "papersize={11in,17in}")
-  ("C5" "papersize={162mm,229mm}")
-  ("Comm10" "papersize={297pt,684pt}")
-  ("DL" "papersize={110mm,220mm}")
-  ("halfletter" "papersize={140mm,216mm}")
-  ("halfexecutive" "papersize={133mm,184mm}")
-  ("ledger" "papersize={432mm,279mm}")
-  ("Monarch" "papersize={98mm,190mm}")
-  ("csheet" "papersize={432mm,559mm}")
-  ("dsheet" "papersize={559mm,864mm}")
-  ("esheet" "papersize={864mm,1118mm}")
-  ("flsa" "papersize={216mm,330mm}")
-  ("flse" "papersize={216mm,330mm}")
-  ("folio" "papersize={216mm,330mm}")
-  ("lecture note" "papersize={15.5cm,23.5cm}")
-  ("note" "papersize={216mm,279mm}")
-  ("quarto" "papersize={215mm,275mm}")
-  ("statement" "papersize={140mm,216mm}")
-  ("tabloid" "papersize={279mm,432mm}"))
+ ("a0" "a0paper")
+ ("a1" "a1paper")
+ ("a2" "a2paper")
+ ("a3" "a3paper")
+ ("a4" "a4paper")
+ ("a5" "a5paper")
+ ("a6" "a6paper")
+ ("a7" "papersize={74mm,105mm}")
+ ("a8" "papersize={52mm,74mm")
+ ("a9" "papersize={37mm,52mm}")
+ ("b0" "b0paper")
+ ("b1" "b1paper")
+ ("b2" "b2paper")
+ ("b3" "b3paper")
+ ("b4" "b4paper")
+ ("b5" "b5paper")
+ ("b6" "b6paper")
+ ("b7" "papersize={88mm,125mm}")
+ ("b8" "papersize={62mm,88mm}")
+ ("b9" "papersize={44mm,62mm}")
+ ("legal" "legalpaper")
+ ("letter" "letterpaper")
+ ("executive" "executivepaper")
+ ("archA" "papersize={9in,12in}")
+ ("archB" "papersize={12in,18in}")
+ ("archC" "papersize={18in,24in}")
+ ("archD" "papersize={24in,36in}")
+ ("archE" "papersize={36in,48in}")
+ ("10x14" "papersize={10in,14in}")
+ ("11x17" "papersize={11in,17in}")
+ ("C5" "papersize={162mm,229mm}")
+ ("Comm10" "papersize={297pt,684pt}")
+ ("DL" "papersize={110mm,220mm}")
+ ("halfletter" "papersize={140mm,216mm}")
+ ("halfexecutive" "papersize={133mm,184mm}")
+ ("ledger" "papersize={432mm,279mm}")
+ ("Monarch" "papersize={98mm,190mm}")
+ ("csheet" "papersize={432mm,559mm}")
+ ("dsheet" "papersize={559mm,864mm}")
+ ("esheet" "papersize={864mm,1118mm}")
+ ("flsa" "papersize={216mm,330mm}")
+ ("flse" "papersize={216mm,330mm}")
+ ("folio" "papersize={216mm,330mm}")
+ ("lecture note" "papersize={15.5cm,23.5cm}")
+ ("note" "papersize={216mm,279mm}")
+ ("quarto" "papersize={215mm,275mm}")
+ ("statement" "papersize={140mm,216mm}")
+ ("tabloid" "papersize={279mm,432mm}")
+) ;logic-table
 
 ;; cpp interface with reversed access
 
 (tm-define (latex-paper-opts s)
-  (with r (query `(latex-paper-opts% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-opts% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 (tm-define (latex-paper-type s)
-  (with r (query `(latex-paper-type% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-type% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for consulting the database (might become deprecated)
@@ -245,28 +256,35 @@
 
 (define (latex-resolve s)
   (define (safe-string2symbol s)
-    (if (== s "") (string->symbol " ") (string->symbol s)))
+    (if (== s "") (string->symbol " ") (string->symbol s))
+  ) ;define
 
-  (if (string-starts? s "\\")
-      (set! s (substring s 1 (string-length s))))
+  (if (string-starts? s "\\") (set! s (substring s 1 (string-length s))))
 
-  (with arity (logic-ref latex-arity% (safe-string2symbol s))
+  (with arity
+    (logic-ref latex-arity% (safe-string2symbol s))
     (if (logic-in? (safe-string2symbol s) latex-optional-arg%)
-        (set! arity (- -1 arity)))
+      (set! arity (- -1 arity))
+    ) ;if
     (if (string-starts? s "end-")
-        (begin
-          (set! s (string-append "begin-" (substring s 4 (string-length s))))
-          (set! arity 0)))
-    (values (safe-string2symbol s) arity)))
+      (begin
+        (set! s (string-append "begin-" (substring s 4 (string-length s))))
+        (set! arity 0)
+      ) ;begin
+    ) ;if
+    (values (safe-string2symbol s) arity)
+  ) ;with
+) ;define
 
 (tm-define (latex-arity tag)
   "Get the arity of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
-    (or arity 0)))
+  (receive (s arity) (latex-resolve tag) (or arity 0))
+) ;tm-define
 
 (tm-define (latex-type tag)
   "Get the type of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
+  (receive (s arity)
+    (latex-resolve tag)
     (cond ((not arity) "undefined")
           ((logic-in? s latex-command%) "command")
           ((logic-in? s latex-length%) "length")
@@ -284,4 +302,7 @@
           ((logic-in? s latex-texmacs%) "texmacs")
           ((logic-in? s latex-symbol%) "symbol")
           ((logic-in? s latex-big-symbol%) "big-symbol")
-          (else "undefined"))))
+          (else "undefined")
+    ) ;cond
+  ) ;receive
+) ;tm-define

--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
@@ -3577,12 +3577,18 @@
 ) ;define
 
 (define (tmtex-ornamented s l)
-  (let* ((env (string-append "tm" s))
-         (option (get-ornament-env))
-         (option* (if (!= option "") `((!option ,option)) '()))
-        ) ;
-    `((!begin ,env ,@option*) ,(tmtex (car l)))
-  ) ;let*
+  (if (== s "framed")
+    (if (not (and (pair? (car l)) (in? (caar l) '(document para))))
+      `(fbox ,(tmtex (car l)))
+      `((!begin "mdframed") ,(tmtex (car l)))
+    ) ;if
+    (let* ((env (string-append "tm" s))
+           (option (get-ornament-env))
+           (option* (if (!= option "") `((!option ,option)) '()))
+          ) ;
+      `((!begin ,env ,@option*) ,(tmtex (car l)))
+    ) ;let*
+  ) ;if
 ) ;define
 
 (logic-table tex-ornament-opts%

--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
@@ -3174,7 +3174,7 @@
 ) ;define
 
 (define (tmtex-frame s l)
-  `(fbox ,(car l))
+  `(fbox ,(tmtex (car l)))
 ) ;define
 
 (define (tmtex-colored-frame s l)

--- a/TeXmacs/progs/convert/latex/latex-command-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-command-drd.scm
@@ -17,324 +17,898 @@
 ;; Any LaTeX tag
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-rules
-  ((latex-tag% 'x) (latex-arity% 'x 'y))
-  ((latex-supports-option% 'x #t) (latex-optional-arg% 'x)))
+(logic-rules ((latex-tag% 'x) (latex-arity% 'x 'y))
+ ((latex-supports-option% 'x #t) (latex-optional-arg% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; LaTeX commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-command-0%
-  ,(string->symbol " ") ,(string->symbol ";") 
-  ,(string->symbol ",") ,(string->symbol ":") 
-  - / [ ] ! * ,(string->symbol "|") i j ss SS oe OE ae AE
-  AA DH L NG O S TH aa dh dj l ng o P th pounds colon and lq rq
-  quad qquad enspace thinspace par smallskip medskip bigskip
-  noindent newline linebreak nobreak nolinebreak strut
-  pagebreak nopagebreak newpage newdoublepage clearpage cleardoublepage
-  newblock bgroup egroup protect cr hfil hfill hfilll appendix limits nolimits
-  dots maketitle tableofcontents TeX LaTeX onecolumn twocolumn
-  begingroup endgroup printindex today bmod toprule midrule bottomrule
+  ,(string->symbol " ")
+  ,(string->symbol ";")
+  ,(string->symbol ",")
+  ,(string->symbol ":")
+  -
+  /
+  [
+  ]
+  !
+  *
+  ,(string->symbol "|")
+  i
+  j
+  ss
+  SS
+  oe
+  OE
+  ae
+  AE
+  AA
+  DH
+  L
+  NG
+  O
+  S
+  TH
+  aa
+  dh
+  dj
+  l
+  ng
+  o
+  P
+  th
+  pounds
+  colon
+  and
+  lq
+  rq
+  quad
+  qquad
+  enspace
+  thinspace
+  par
+  smallskip
+  medskip
+  bigskip
+  noindent
+  newline
+  linebreak
+  nobreak
+  nolinebreak
+  strut
+  pagebreak
+  nopagebreak
+  newpage
+  newdoublepage
+  clearpage
+  cleardoublepage
+  newblock
+  bgroup
+  egroup
+  protect
+  cr
+  hfil
+  hfill
+  hfilll
+  appendix
+  limits
+  nolimits
+  dots
+  maketitle
+  tableofcontents
+  TeX
+  LaTeX
+  onecolumn
+  twocolumn
+  begingroup
+  endgroup
+  printindex
+  today
+  bmod
+  toprule
+  midrule
+  bottomrule
 
   ;; AMS commands
-  dotsc dotsb dotsm dotsi dotso qed
+  dotsc
+  dotsb
+  dotsm
+  dotsi
+  dotso
+  qed
   ;; mathtools
   coloneqq
   ;; temporarily
-  hline hrulefill
+  hline
+  hrulefill
   ;; rewritten
-  notin vert Vert addots
-  implies iff gets
+  notin
+  vert
+  Vert
+  addots
+  implies
+  iff
+  gets
   ;; wikipedia
-  infin rang
+  infin
+  rang
   ;; bibtex
   bysame
   ;; for (e.g.) includegraphics
-  width height
+  width
+  height
   ;; miscellaneous
-  null unskip
+  null
+  unskip
 
   ;; Algorithms
-  AND BlankLine Ensure ENSURE FALSE GLOBALS NOT OR PRINT Require REQUIRE
-  Repeat RETURN State STATE TO KwTo TRUE XOR Else ENDBODY EndFor ENDFOR
-  EndFunction EndIf ENDIF ENDINPUTS EndLoop ENDLOOP ENDOUTPUTS
-  EndProcedure ENDWHILE EndWhile Loop)
+  AND
+  BlankLine
+  Ensure
+  ENSURE
+  FALSE
+  GLOBALS
+  NOT
+  OR
+  PRINT
+  Require
+  REQUIRE
+  Repeat
+  RETURN
+  State
+  STATE
+  TO
+  KwTo
+  TRUE
+  XOR
+  Else
+  ENDBODY
+  EndFor
+  ENDFOR
+  EndFunction
+  EndIf
+  ENDIF
+  ENDINPUTS
+  EndLoop
+  ENDLOOP
+  ENDOUTPUTS
+  EndProcedure
+  ENDWHILE
+  EndWhile
+  Loop
+) ;logic-group
 
 (logic-group latex-command-1%
-  part* chapter* section* subsection* subsubsection* paragraph* subparagraph*
-  nextbib geometry
-  footnote overline underline <sub> <sup> not left middle right
-  big Big bigg Bigg bigl Bigl biggl Biggl
-  bigm Bigm biggm Biggm bigr Bigr biggr Biggr
-  bar Bar hat Hat tilde Tilde widehat widetilde vec Vec bm ring
-  overrightarrow overleftarrow overleftrightarrow
-  underrightarrow underleftarrow underleftrightarrow
-  grave Grave acute Acute check Check breve Breve invbreve abovering mathring
-  dot Dot ddot Ddot dddot ddddot mod pod pmod
-  label ref pageref index hspace hspace* vspace vspace* mspace
-  mbox hbox textnormal text not substack
-  ,(string->symbol "'") ,(string->symbol "`") ,(string->symbol "\"")
-  ^ over atop choose ~ = u v H t c d b k r textsuperscript textsubscript
-  thispagestyle ensuremath
-  mathord mathbin mathopen mathpunct mathop mathrel mathclose mathalpha
+  part*
+  chapter*
+  section*
+  subsection*
+  subsubsection*
+  paragraph*
+  subparagraph*
+  nextbib
+  geometry
+  footnote
+  overline
+  underline
+  <sub>
+  <sup>
+  not
+  left
+  middle
+  right
+  big
+  Big
+  bigg
+  Bigg
+  bigl
+  Bigl
+  biggl
+  Biggl
+  bigm
+  Bigm
+  biggm
+  Biggm
+  bigr
+  Bigr
+  biggr
+  Biggr
+  bar
+  Bar
+  hat
+  Hat
+  tilde
+  Tilde
+  widehat
+  widetilde
+  vec
+  Vec
+  bm
+  ring
+  overrightarrow
+  overleftarrow
+  overleftrightarrow
+  underrightarrow
+  underleftarrow
+  underleftrightarrow
+  grave
+  Grave
+  acute
+  Acute
+  check
+  Check
+  breve
+  Breve
+  invbreve
+  abovering
+  mathring
+  dot
+  Dot
+  ddot
+  Ddot
+  dddot
+  ddddot
+  mod
+  pod
+  pmod
+  label
+  ref
+  pageref
+  index
+  hspace
+  hspace*
+  vspace
+  vspace*
+  mspace
+  mbox
+  hbox
+  textnormal
+  text
+  not
+  substack
+  ,(string->symbol "'")
+  ,(string->symbol "`")
+  ,(string->symbol "\"")
+  ^
+  over
+  atop
+  choose
+  ~
+  =
+  u
+  v
+  H
+  t
+  c
+  d
+  b
+  k
+  r
+  textsuperscript
+  textsubscript
+  thispagestyle
+  ensuremath
+  mathord
+  mathbin
+  mathopen
+  mathpunct
+  mathop
+  mathrel
+  mathclose
+  mathalpha
   mathinner
-  arabic alph Alph roman Roman fnsymbol displaylines cases underbrace overbrace
-  phantom hphantom vphantom smash date terms
-  newcounter stepcounter refstepcounter value
-  citealt citealt* citealp*
-  citetext citeauthor citeauthor* citeyear onlinecite citeN
-  epsfig url penalty centerline fbox framebox cline cmidrule
+  arabic
+  alph
+  Alph
+  roman
+  Roman
+  fnsymbol
+  displaylines
+  cases
+  underbrace
+  overbrace
+  phantom
+  hphantom
+  vphantom
+  smash
+  date
+  terms
+  newcounter
+  stepcounter
+  refstepcounter
+  value
+  citealt
+  citealt*
+  citealp*
+  citetext
+  citeauthor
+  citeauthor*
+  citeyear
+  onlinecite
+  citeN
+  epsfig
+  url
+  penalty
+  centerline
+  fbox
+  framebox
+  cline
+  cmidrule
   enlargethispage
-  newlength newdimen newskip
-  Comment COMMENT For ForAll If Input KwData KwResult KwRet lnl nllabel
-  lElse uElse Output Until UNTIL While
-  etalchar MR listpart custombinding cref Cref)
+  newlength
+  newdimen
+  newskip
+  Comment
+  COMMENT
+  For
+  ForAll
+  If
+  Input
+  KwData
+  KwResult
+  KwRet
+  lnl
+  nllabel
+  lElse
+  uElse
+  Output
+  Until
+  UNTIL
+  While
+  etalchar
+  MR
+  listpart
+  custombinding
+  cref
+  Cref
+) ;logic-group
 
-(logic-group latex-command-1% ;; . needs a special treatment
-  ,(string->symbol "."))
+(logic-group latex-command-1%
+  ;; . needs a special treatment
+  ,(string->symbol ".")
+) ;logic-group
 
 (logic-group latex-command-2%
-  binom tbinom dbinom cfrac tfrac equal href
-  sideset stackrel underaccent
-  setcounter addtocounter setlength addtolength
-  colorbox scalebox texorpdfstring raisebox foreignlanguage
-  Call Function Procedure SetKw SetKwData SetKwFunction SetKwInOut
-  ifthispageodd adjustbox)
+  binom
+  tbinom
+  dbinom
+  cfrac
+  tfrac
+  equal
+  href
+  sideset
+  stackrel
+  underaccent
+  setcounter
+  addtocounter
+  setlength
+  addtolength
+  colorbox
+  scalebox
+  texorpdfstring
+  raisebox
+  foreignlanguage
+  Call
+  Function
+  Procedure
+  SetKw
+  SetKwData
+  SetKwFunction
+  SetKwInOut
+  ifthispageodd
+  adjustbox
+) ;logic-group
 
 (logic-group latex-command-3%
-  ifthenelse resizebox fcolorbox @setfontsize eIf multicolumn)
+  ifthenelse
+  resizebox
+  fcolorbox
+  @setfontsize
+  eIf
+  multicolumn
+) ;logic-group
 
-(logic-group latex-command-4%
-  mathchoice)
+(logic-group latex-command-4% mathchoice)
 
-(logic-group latex-command-6%
-  genfrac @startsection)
+(logic-group latex-command-6% genfrac @startsection)
 
-(logic-rules
-  ((latex-command% 'x) (latex-command-0% 'x))
-  ((latex-arity% 'x 0) (latex-command-0% 'x))
-  ((latex-command% 'x) (latex-command-1% 'x))
-  ((latex-arity% 'x 1) (latex-command-1% 'x))
-  ((latex-command% 'x) (latex-command-2% 'x))
-  ((latex-arity% 'x 2) (latex-command-2% 'x))
-  ((latex-command% 'x) (latex-command-3% 'x))
-  ((latex-arity% 'x 3) (latex-command-3% 'x))
-  ((latex-command% 'x) (latex-command-4% 'x))
-  ((latex-arity% 'x 4) (latex-command-4% 'x))
-  ((latex-command% 'x) (latex-command-6% 'x))
-  ((latex-arity% 'x 6) (latex-command-6% 'x)))
+(logic-rules ((latex-command% 'x) (latex-command-0% 'x))
+ ((latex-arity% 'x 0) (latex-command-0% 'x))
+ ((latex-command% 'x) (latex-command-1% 'x))
+ ((latex-arity% 'x 1) (latex-command-1% 'x))
+ ((latex-command% 'x) (latex-command-2% 'x))
+ ((latex-arity% 'x 2) (latex-command-2% 'x))
+ ((latex-command% 'x) (latex-command-3% 'x))
+ ((latex-arity% 'x 3) (latex-command-3% 'x))
+ ((latex-command% 'x) (latex-command-4% 'x))
+ ((latex-arity% 'x 4) (latex-command-4% 'x))
+ ((latex-command% 'x) (latex-command-6% 'x))
+ ((latex-arity% 'x 6) (latex-command-6% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; LaTeX commands with optional arguments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-command-0*%
-  item ,(string->symbol "\\")
-  BODY ELSE INPUTS LOOP OUTPUTS REPEAT
-  hdashline)
+  item
+  ,(string->symbol "\\")
+  BODY
+  ELSE
+  INPUTS
+  LOOP
+  OUTPUTS
+  REPEAT
+  hdashline
+) ;logic-group
 
 (logic-group latex-command-1*%
-  usepackage documentclass documentstyle sqrt bibitem cite caption  
-  title author thanks marginpar
-  part chapter section subsection subsubsection paragraph subparagraph
-  includegraphics includegraphics*
+  usepackage
+  documentclass
+  documentstyle
+  sqrt
+  bibitem
+  cite
+  caption
+  title
+  author
+  thanks
+  marginpar
+  part
+  chapter
+  section
+  subsection
+  subsubsection
+  paragraph
+  subparagraph
+  includegraphics
+  includegraphics*
   makebox
-  subjclass declaretheorem footnotetext
-  xleftarrow xrightarrow xleftrightarrow xminus
-  xLeftarrow xRightarrow xLeftrightarrow xequal
-  xmapsto xmapsfrom citealp citet citep citet* citep*
-  Begin ELSIF FORALL FOR IF WHILE tcp tcp* tcc tcc*
-  hyperref)
+  subjclass
+  declaretheorem
+  footnotetext
+  xleftarrow
+  xrightarrow
+  xleftrightarrow
+  xminus
+  xLeftarrow
+  xRightarrow
+  xLeftrightarrow
+  xequal
+  xmapsto
+  xmapsfrom
+  citealp
+  citet
+  citep
+  citet*
+  citep*
+  Begin
+  ELSIF
+  FORALL
+  FOR
+  IF
+  WHILE
+  tcp
+  tcp*
+  tcc
+  tcc*
+  hyperref
+) ;logic-group
 
 (logic-group latex-command-2*%
-  def newcommand renewcommand providecommand
-  newtheorem newtheorem* frac parbox 
-  ElseIf uElseIf lElseIf ForEach lForEach lForAll lFor)
+  def
+  newcommand
+  renewcommand
+  providecommand
+  newtheorem
+  newtheorem*
+  frac
+  parbox
+  ElseIf
+  uElseIf
+  lElseIf
+  ForEach
+  lForEach
+  lForAll
+  lFor
+) ;logic-group
 
 (logic-group latex-command-3*%
-  category newenvironment renewenvironment multirow)
+  category
+  newenvironment
+  renewenvironment
+  multirow
+) ;logic-group
 
-(logic-rules
-  ((latex-command-0% 'x) (latex-command-0*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-0*% 'x))
-  ((latex-command-1% 'x) (latex-command-1*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-1*% 'x))
-  ((latex-command-2% 'x) (latex-command-2*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-2*% 'x))
-  ((latex-command-3% 'x) (latex-command-3*% 'x))
-  ((latex-optional-arg% 'x) (latex-command-3*% 'x)))
+(logic-rules ((latex-command-0% 'x) (latex-command-0*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-0*% 'x))
+ ((latex-command-1% 'x) (latex-command-1*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-1*% 'x))
+ ((latex-command-2% 'x) (latex-command-2*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-2*% 'x))
+ ((latex-command-3% 'x) (latex-command-3*% 'x))
+ ((latex-optional-arg% 'x) (latex-command-3*% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-environment-0%
-  begin-document begin-abstract begin-verbatim begin-proof
-  begin-matrix begin-pmatrix begin-bmatrix begin-vmatrix begin-smallmatrix
+  begin-mdframed
+  begin-document
+  begin-abstract
+  begin-verbatim
+  begin-proof
+  begin-matrix
+  begin-pmatrix
+  begin-bmatrix
+  begin-vmatrix
+  begin-smallmatrix
   begin-cases
-  begin-center begin-flushleft begin-flushright
-  begin-picture)
+  begin-center
+  begin-flushleft
+  begin-flushright
+  begin-picture
+) ;logic-group
 
 (logic-group latex-environment-0*%
-  begin-figure begin-table begin-figure* begin-table*
-  begin-algorithmic begin-algorithm begin-algorithm2e
-  begin-teaserfigure)
+  begin-figure
+  begin-table
+  begin-figure*
+  begin-table*
+  begin-algorithmic
+  begin-algorithm
+  begin-algorithm2e
+  begin-teaserfigure
+) ;logic-group
 
 (logic-group latex-environment-1%
-  begin-otherlanguage begin-otherlanguage*
-  begin-tabbing begin-thebibliography begin-multicols)
+  begin-otherlanguage
+  begin-otherlanguage*
+  begin-tabbing
+  begin-thebibliography
+  begin-multicols
+) ;logic-group
 
-(logic-group latex-environment-1*%
-  begin-array begin-tabular begin-minipage)
+(logic-group latex-environment-1*% begin-array begin-tabular begin-minipage)
 
-(logic-group latex-environment-2*%
-  begin-tabular* begin-tabularx)
+(logic-group latex-environment-2*% begin-tabular* begin-tabularx)
 
-(logic-rules
-  ((latex-environment% 'x) (latex-environment-0% 'x))
-  ((latex-arity% 'x 0) (latex-environment-0% 'x))
-  ((latex-environment% 'x) (latex-environment-1% 'x))
-  ((latex-arity% 'x 1) (latex-environment-1% 'x))
-  ((latex-environment% 'x) (latex-environment-2% 'x))
-  ((latex-arity% 'x 2) (latex-environment-2% 'x))
-  ((latex-environment% 'x) (latex-environment-3% 'x))
-  ((latex-arity% 'x 3) (latex-environment-3% 'x))
-  ((latex-environment-0% 'x) (latex-environment-0*% 'x))
-  ((latex-optional-arg% 'x) (latex-environment-0*% 'x))
-  ((latex-environment-1% 'x) (latex-environment-1*% 'x))
-  ((latex-optional-arg% 'x) (latex-environment-1*% 'x))
-  ((latex-environment-2% 'x) (latex-environment-2*% 'x))
-  ((latex-optional-arg% 'x) (latex-environment-2*% 'x)))
+(logic-rules ((latex-environment% 'x) (latex-environment-0% 'x))
+ ((latex-arity% 'x 0) (latex-environment-0% 'x))
+ ((latex-environment% 'x) (latex-environment-1% 'x))
+ ((latex-arity% 'x 1) (latex-environment-1% 'x))
+ ((latex-environment% 'x) (latex-environment-2% 'x))
+ ((latex-arity% 'x 2) (latex-environment-2% 'x))
+ ((latex-environment% 'x) (latex-environment-3% 'x))
+ ((latex-arity% 'x 3) (latex-environment-3% 'x))
+ ((latex-environment-0% 'x) (latex-environment-0*% 'x))
+ ((latex-optional-arg% 'x) (latex-environment-0*% 'x))
+ ((latex-environment-1% 'x) (latex-environment-1*% 'x))
+ ((latex-optional-arg% 'x) (latex-environment-1*% 'x))
+ ((latex-environment-2% 'x) (latex-environment-2*% 'x))
+ ((latex-optional-arg% 'x) (latex-environment-2*% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Enunciations
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-enunciation%
-  begin-theorem begin-proposition begin-lemma begin-corollary begin-proof
-  begin-axiom begin-definition begin-notation begin-conjecture
-  begin-remark begin-note begin-example begin-warning
-  begin-convention begin-acknowledgments
-  begin-exercise begin-problem
-  begin-solution begin-question begin-answer
-  begin-quote-env begin-quotation begin-verse
+  begin-theorem
+  begin-proposition
+  begin-lemma
+  begin-corollary
+  begin-proof
+  begin-axiom
+  begin-definition
+  begin-notation
+  begin-conjecture
+  begin-remark
+  begin-note
+  begin-example
+  begin-warning
+  begin-convention
+  begin-acknowledgments
+  begin-exercise
+  begin-problem
+  begin-solution
+  begin-question
+  begin-answer
+  begin-quote-env
+  begin-quotation
+  begin-verse
 
-  begin-theorem* begin-proposition* begin-lemma* begin-corollary*
-  begin-axiom* begin-definition* begin-notation* begin-conjecture*
-  begin-remark* begin-note* begin-example* begin-warning*
-  begin-convention* begin-acknowledgments*
-  begin-exercise* begin-problem*
-  begin-solution* begin-question* begin-answer*
+  begin-theorem*
+  begin-proposition*
+  begin-lemma*
+  begin-corollary*
+  begin-axiom*
+  begin-definition*
+  begin-notation*
+  begin-conjecture*
+  begin-remark*
+  begin-note*
+  begin-example*
+  begin-warning*
+  begin-convention*
+  begin-acknowledgments*
+  begin-exercise*
+  begin-problem*
+  begin-solution*
+  begin-question*
+  begin-answer*
 
   ;; guessed
-  begin-th begin-thm begin-prop begin-lem begin-cor begin-corr
-  begin-pf begin-dem begin-preuve begin-IEEEproof
-  begin-ax begin-def begin-dfn begin-defn
-  begin-not begin-ex begin-exa begin-rem begin-war begin-conv
-  begin-exe begin-exc begin-exo begin-prop begin-sol begin-ans
-  begin-acks)
+  begin-th
+  begin-thm
+  begin-prop
+  begin-lem
+  begin-cor
+  begin-corr
+  begin-pf
+  begin-dem
+  begin-preuve
+  begin-IEEEproof
+  begin-ax
+  begin-def
+  begin-dfn
+  begin-defn
+  begin-not
+  begin-ex
+  begin-exa
+  begin-rem
+  begin-war
+  begin-conv
+  begin-exe
+  begin-exc
+  begin-exo
+  begin-prop
+  begin-sol
+  begin-ans
+  begin-acks
+) ;logic-group
 
-(logic-rules
-  ((latex-environment-0*% 'x) (latex-enunciation% 'x)))
+(logic-rules ((latex-environment-0*% 'x) (latex-enunciation% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modifiers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-modifier-0%
-  normalfont rm tt sf md bf it em sl sc rmfamily ttfamily sffamily
-  mdseries bfseries upshape itshape slshape scshape
-  displaystyle textstyle scriptstyle scriptscriptstyle cal frak Bbb boldmath
-  tiny scriptsize footnotesize small normalsize
-  large Large LARGE huge Huge
-  black white grey red blue yellow green orange magenta brown pink
-  centering raggedleft raggedright flushleft flushright)
+  normalfont
+  rm
+  tt
+  sf
+  md
+  bf
+  it
+  em
+  sl
+  sc
+  rmfamily
+  ttfamily
+  sffamily
+  mdseries
+  bfseries
+  upshape
+  itshape
+  slshape
+  scshape
+  displaystyle
+  textstyle
+  scriptstyle
+  scriptscriptstyle
+  cal
+  frak
+  Bbb
+  boldmath
+  tiny
+  scriptsize
+  footnotesize
+  small
+  normalsize
+  large
+  Large
+  LARGE
+  huge
+  Huge
+  black
+  white
+  grey
+  red
+  blue
+  yellow
+  green
+  orange
+  magenta
+  brown
+  pink
+  centering
+  raggedleft
+  raggedright
+  flushleft
+  flushright
+) ;logic-group
 
 (logic-group latex-modifier-1%
   textnormalfont
-  textrm texttt textsf textmd textbf textup textit textsl textsc emph
-  mathrm mathtt mathsf mathmd mathbf mathup mathit mathsl mathnormal
-  mathcal mathfrak mathbb mathbbm mathscr operatorname boldsymbol
-  lowercase MakeLowercase uppercase MakeUppercase selectlanguage)
+  textrm
+  texttt
+  textsf
+  textmd
+  textbf
+  textup
+  textit
+  textsl
+  textsc
+  emph
+  mathrm
+  mathtt
+  mathsf
+  mathmd
+  mathbf
+  mathup
+  mathit
+  mathsl
+  mathnormal
+  mathcal
+  mathfrak
+  mathbb
+  mathbbm
+  mathscr
+  operatorname
+  boldsymbol
+  lowercase
+  MakeLowercase
+  uppercase
+  MakeUppercase
+  selectlanguage
+) ;logic-group
 
-(logic-group latex-modifier-1*%
-  color)
+(logic-group latex-modifier-1*% color)
 
-(logic-group latex-modifier-2*%
-  textcolor)
+(logic-group latex-modifier-2*% textcolor)
 
-(logic-rules
-  ((latex-modifier% 'x)     (latex-modifier-0% 'x))
-  ((latex-arity% 'x 0)      (latex-modifier-0% 'x))
-  ((latex-modifier% 'x)     (latex-modifier-1% 'x))
-  ((latex-arity% 'x 1)      (latex-modifier-1% 'x))
-  ((latex-optional-arg% 'x) (latex-modifier-1*% 'x))
-  ((latex-modifier% 'x)     (latex-modifier-1*% 'x))
-  ((latex-arity% 'x 1)      (latex-modifier-1*% 'x))
-  ((latex-optional-arg% 'x) (latex-modifier-2*% 'x))
-  ((latex-modifier% 'x)     (latex-modifier-2*% 'x))
-  ((latex-arity% 'x 2)      (latex-modifier-2*% 'x)))
+(logic-rules ((latex-modifier% 'x) (latex-modifier-0% 'x))
+ ((latex-arity% 'x 0) (latex-modifier-0% 'x))
+ ((latex-modifier% 'x) (latex-modifier-1% 'x))
+ ((latex-arity% 'x 1) (latex-modifier-1% 'x))
+ ((latex-optional-arg% 'x) (latex-modifier-1*% 'x))
+ ((latex-modifier% 'x) (latex-modifier-1*% 'x))
+ ((latex-arity% 'x 1) (latex-modifier-1*% 'x))
+ ((latex-optional-arg% 'x) (latex-modifier-2*% 'x))
+ ((latex-modifier% 'x) (latex-modifier-2*% 'x))
+ ((latex-arity% 'x 2) (latex-modifier-2*% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special types of LaTeX primitives
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-control%
-  $ & % ,(string->symbol "#") _ { } <less> <gtr>)
+(logic-group latex-control% $ & % ,(string->symbol "#") _ { } <less> <gtr>)
 
 (logic-group latex-operator%
-  arccos arcsin arctan arg cos cosh cot coth csc deg det dim exp gcd hom
-  inf ker lg lim liminf limsup ln log max min Pr sec sin sinh sup tan tanh)
+  arccos
+  arcsin
+  arctan
+  arg
+  cos
+  cosh
+  cot
+  coth
+  csc
+  deg
+  det
+  dim
+  exp
+  gcd
+  hom
+  inf
+  ker
+  lg
+  lim
+  liminf
+  limsup
+  ln
+  log
+  max
+  min
+  Pr
+  sec
+  sin
+  sinh
+  sup
+  tan
+  tanh
+) ;logic-group
 
 (logic-group latex-list%
-  begin-itemize begin-enumerate begin-description
-  begin-asparaitem begin-inparaitem begin-compactitem
-  begin-asparaenum begin-inparaenum begin-compactenum)
+  begin-itemize
+  begin-enumerate
+  begin-description
+  begin-asparaitem
+  begin-inparaitem
+  begin-compactitem
+  begin-asparaenum
+  begin-inparaenum
+  begin-compactenum
+) ;logic-group
 
 (logic-group latex-math-environment-0%
-  begin-formula begin-equation*
-  begin-math begin-displaymath begin-equation
-  begin-eqnarray begin-eqnarray*
-  begin-flalign begin-flalign*
-  begin-align begin-align*
-  begin-multline begin-multline*
-  begin-gather begin-gather*
-  begin-eqsplit begin-eqsplit*)
+  begin-formula
+  begin-equation*
+  begin-math
+  begin-displaymath
+  begin-equation
+  begin-eqnarray
+  begin-eqnarray*
+  begin-flalign
+  begin-flalign*
+  begin-align
+  begin-align*
+  begin-multline
+  begin-multline*
+  begin-gather
+  begin-gather*
+  begin-eqsplit
+  begin-eqsplit*
+) ;logic-group
 
-(logic-group latex-math-environment-1%
-  begin-alignat begin-alignat*)
+(logic-group latex-math-environment-1% begin-alignat begin-alignat*)
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-control% 'x))
-  ((latex-arity% 'x 0) (latex-operator% 'x))
-  ((latex-environment-0*% 'x) (latex-list% 'x))
-  ((latex-math-environment% 'x) (latex-math-environment-0% 'x))
-  ((latex-math-environment% 'x) (latex-math-environment-1% 'x))
-  ((latex-environment-1% 'x) (latex-math-environment-1% 'x))
-  ((latex-environment-0% 'x) (latex-math-environment-0% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-control% 'x))
+ ((latex-arity% 'x 0) (latex-operator% 'x))
+ ((latex-environment-0*% 'x) (latex-list% 'x))
+ ((latex-math-environment% 'x) (latex-math-environment-0% 'x))
+ ((latex-math-environment% 'x) (latex-math-environment-1% 'x))
+ ((latex-environment-1% 'x) (latex-math-environment-1% 'x))
+ ((latex-environment-0% 'x) (latex-math-environment-0% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Counters
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-counter%
-  badness enumi enumii enumiii enumiv equation figure inputlineno
-  mpfootnote page setlanguage table)
+  badness
+  enumi
+  enumii
+  enumiii
+  enumiv
+  equation
+  figure
+  inputlineno
+  mpfootnote
+  page
+  setlanguage
+  table
+) ;logic-group
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-counter% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-counter% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Names
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-name%
-  abstractname appendixname contentname figurename indexname
-  litfigurename littablename partname refname tablename)
+  abstractname
+  appendixname
+  contentname
+  figurename
+  indexname
+  litfigurename
+  littablename
+  partname
+  refname
+  tablename
+) ;logic-group
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-name% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-name% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lengths
@@ -343,78 +917,174 @@
 (logic-group latex-length%
   ;; From latex.ltx
   ;; -- lengths
-  @textfloatsheight arraycolsep arrayrulewidth columnsep columnseprule
-  columnwidth doublerulesep emergencystretch evensidemargin fboxrule
-  fboxsep footnotesep footskip headheight headsep itemindent labelsep
-  labelwidth leftmargin leftmargini leftmarginii leftmarginiii
-  leftmarginiv leftmarginv leftmarginvi linewidth listparindent
-  marginparpush marginparsep marginparwidth oddsidemargin p@ paperheight
-  paperwidth rightmargin tabbingsep tabcolsep textheight textwidth
-  topmargin unitlength z@ @bls @vpt @vipt @viipt @viiipt @ixpt @xpt @xipt
-  @xiipt @xivpt @xviipt @xxpt @xxvpt 
+  @textfloatsheight
+  arraycolsep
+  arrayrulewidth
+  columnsep
+  columnseprule
+  columnwidth
+  doublerulesep
+  emergencystretch
+  evensidemargin
+  fboxrule
+  fboxsep
+  footnotesep
+  footskip
+  headheight
+  headsep
+  itemindent
+  labelsep
+  labelwidth
+  leftmargin
+  leftmargini
+  leftmarginii
+  leftmarginiii
+  leftmarginiv
+  leftmarginv
+  leftmarginvi
+  linewidth
+  listparindent
+  marginparpush
+  marginparsep
+  marginparwidth
+  oddsidemargin
+  p@
+  paperheight
+  paperwidth
+  rightmargin
+  tabbingsep
+  tabcolsep
+  textheight
+  textwidth
+  topmargin
+  unitlength
+  z@
+  @bls
+  @vpt
+  @vipt
+  @viipt
+  @viiipt
+  @ixpt
+  @xpt
+  @xipt
+  @xiipt
+  @xivpt
+  @xviipt
+  @xxpt
+  @xxvpt
   ;; -- skips
-  topsep partopsep itemsep parsep floatsep textfloatsep intextsep
-  dblfloatsep dbltextfloatsep 
+  topsep
+  partopsep
+  itemsep
+  parsep
+  floatsep
+  textfloatsep
+  intextsep
+  dblfloatsep
+  dbltextfloatsep
   ;; From latex classes
-  abovecaptionskip belowcaptionskip bibindent
+  abovecaptionskip
+  belowcaptionskip
+  bibindent
   ;; From fleqn
   mathindent
   ;; Plain TeX
-  maxdimen hfuzz vfuzz overfullrule hsize vsize maxdepth lineskiplimit
-  delimitershortfall nulldelimiterspace scriptspace mathsurround
-  predisplaysize displaywidth displayindent parindent hangindent hoffset
-  voffset baselineskip lineskip parskip abovedisplayskip
-  abovedisplayshortskip belowdisplayskip belowdisplayshortskip leftskip
-  rightskip topskip splittopskip tabskip spaceskip xspaceskip parfillskip
-  thinmuskip medmuskip thickmuskip hideskip smallskipamount medskipamount
-  bigskipamount normalbaselineskip normallineskip normallineskiplimit jot 
-  )
+  maxdimen
+  hfuzz
+  vfuzz
+  overfullrule
+  hsize
+  vsize
+  maxdepth
+  lineskiplimit
+  delimitershortfall
+  nulldelimiterspace
+  scriptspace
+  mathsurround
+  predisplaysize
+  displaywidth
+  displayindent
+  parindent
+  hangindent
+  hoffset
+  voffset
+  baselineskip
+  lineskip
+  parskip
+  abovedisplayskip
+  abovedisplayshortskip
+  belowdisplayskip
+  belowdisplayshortskip
+  leftskip
+  rightskip
+  topskip
+  splittopskip
+  tabskip
+  spaceskip
+  xspaceskip
+  parfillskip
+  thinmuskip
+  medmuskip
+  thickmuskip
+  hideskip
+  smallskipamount
+  medskipamount
+  bigskipamount
+  normalbaselineskip
+  normallineskip
+  normallineskiplimit
+  jot
+) ;logic-group
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-length% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-length% 'x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; To be imported as pictures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-as-pic-0%
-  begin-pspicture begin-pspicture* begin-tikzpicture)
+(logic-group latex-as-pic-0% begin-pspicture begin-pspicture* begin-tikzpicture)
 
-(logic-group latex-as-pic-1%
-  xymatrix)
+(logic-group latex-as-pic-1% xymatrix)
 
-(logic-rules
-  ((latex-as-pic% 'x)       (latex-as-pic-0% 'x))
-  ((latex-as-pic% 'x)       (latex-as-pic-1% 'x))
-  ((latex-arity%  'x 0)     (latex-as-pic-0% 'x))
-  ((latex-arity%  'x 1)     (latex-as-pic-1% 'x)))
+(logic-rules ((latex-as-pic% 'x) (latex-as-pic-0% 'x))
+ ((latex-as-pic% 'x) (latex-as-pic-1% 'x))
+ ((latex-arity% 'x 0) (latex-as-pic-0% 'x))
+ ((latex-arity% 'x 1) (latex-as-pic-1% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; To be ignored
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-ignore-0%
-  allowbreak notag xspace break sloppy makeatother makeatletter relax
+  allowbreak
+  notag
+  xspace
+  break
+  sloppy
+  makeatother
+  makeatletter
+  relax
   qedhere
-  ignorespacesafterend ignorespaces balancecolumns
-  tightlist)
+  ignorespacesafterend
+  ignorespaces
+  balancecolumns
+  tightlist
+) ;logic-group
 
-(logic-group latex-ignore-0*%
-  displaybreak allowdisplaybreaks)
+(logic-group latex-ignore-0*% displaybreak allowdisplaybreaks)
 
-(logic-group latex-ignore-1%
-  tag hyphenation)
+(logic-group latex-ignore-1% tag hyphenation)
 
-(logic-group latex-ignore-2%
-  newdir)
+(logic-group latex-ignore-2% newdir)
 
-(logic-rules
-  ((latex-ignore% 'x)       (latex-ignore-0% 'x))
-  ((latex-ignore% 'x)       (latex-ignore-0*% 'x))
-  ((latex-ignore% 'x)       (latex-ignore-1% 'x))
-  ((latex-ignore% 'x)       (latex-ignore-2% 'x))
-  ((latex-arity% 'x 0)      (latex-ignore-0% 'x))
-  ((latex-arity% 'x 0)      (latex-ignore-0*% 'x))
-  ((latex-arity% 'x 1)      (latex-ignore-1% 'x))
-  ((latex-arity% 'x 2)      (latex-ignore-2% 'x))
-  ((latex-optional-arg% 'x) (latex-ignore-1*% 'x)))
+(logic-rules ((latex-ignore% 'x) (latex-ignore-0% 'x))
+ ((latex-ignore% 'x) (latex-ignore-0*% 'x))
+ ((latex-ignore% 'x) (latex-ignore-1% 'x))
+ ((latex-ignore% 'x) (latex-ignore-2% 'x))
+ ((latex-arity% 'x 0) (latex-ignore-0% 'x))
+ ((latex-arity% 'x 0) (latex-ignore-0*% 'x))
+ ((latex-arity% 'x 1) (latex-ignore-1% 'x))
+ ((latex-arity% 'x 2) (latex-ignore-2% 'x))
+ ((latex-optional-arg% 'x) (latex-ignore-1*% 'x))
+) ;logic-rules

--- a/TeXmacs/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-drd.scm
@@ -12,40 +12,41 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert latex latex-drd)
-  (:use (convert latex latex-overload)))
+(texmacs-module (convert latex latex-drd) (:use (convert latex latex-overload)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Order in which packages should be included
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-package-priority%
-  ("geometry" 10)
-  ("amsmath" 20)
-  ("amssymb" 30)
-  ("graphicx" 40)
-  ("wasysym" 50)
-  ("stmaryrd" 60)
-  ("textcomp" 60)
-  ("enumerate" 70)
-  ("epsfig" 80)
-  ("mathrsfs" 90)
-  ("bbm" 100)
-  ("dsfont" 110)
-  ("euscript" 120)
-  ("multicol" 130)
-  ("hyperref" 140)
-  ("mathtools" 150)
-  ("cleveref" 160))
+ ("geometry" 10)
+ ("amsmath" 20)
+ ("amssymb" 30)
+ ("graphicx" 40)
+ ("wasysym" 50)
+ ("stmaryrd" 60)
+ ("textcomp" 60)
+ ("enumerate" 70)
+ ("epsfig" 80)
+ ("mathrsfs" 90)
+ ("bbm" 100)
+ ("dsfont" 110)
+ ("euscript" 120)
+ ("multicol" 130)
+ ("hyperref" 140)
+ ("mathtools" 150)
+ ("cleveref" 160)
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies between style files and packages
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-depends%
-  ("amsart" "amstex")
-  ("amstex" "amsmath")
-  ("amstex" "amsthm"))
+ ("amsart" "amstex")
+ ("amstex" "amsmath")
+ ("amstex" "amsthm")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies of commands on packages
@@ -111,18 +112,19 @@
 
   (underaccent "accents")
   (ring "accents")
-  
+
   (ifthenelse "ifthen")
   (captionof "capt-of")
   (widthof "calc")
-  
-  (color     "xcolor")
+
+  (color "xcolor")
   (fcolorbox "xcolor")
   (textcolor "xcolor")
 
   (euro "eurosym")
 
   (mdfsetup ("tikz" "mdframed"))
+  (begin-mdframed "mdframed")
   (tikz "tikz")
 
   (omicron "pslatex")
@@ -138,7 +140,7 @@
 
   (cref "cleveref")
   (Cref "cleveref")
-  
+
   (citet "natbib")
   (citep "natbib")
   (citet* "natbib")
@@ -162,82 +164,91 @@
   (ifthispageodd "scrextend")
 
   (begin-linenumbers "lineno")
-  (resetlinenumber "lineno"))
+  (resetlinenumber "lineno")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Page size settings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-paper-opts%
-  ("page-top"         "top")
-  ("page-bot"         "bottom")
-  ("page-odd"         "left")
-  ("page-even"        "left")
-  ("page-right"       "right")
-  ("page-height"      "paperheight")
-  ("page-width"       "paperwidth")
-  ("page-type"        "page-type")
-  ("page-orientation" "page-orientation"))
+ ("page-top" "top")
+ ("page-bot" "bottom")
+ ("page-odd" "left")
+ ("page-even" "left")
+ ("page-right" "right")
+ ("page-height" "paperheight")
+ ("page-width" "paperwidth")
+ ("page-type" "page-type")
+ ("page-orientation" "page-orientation")
+) ;logic-table
 
 (logic-table latex-paper-type%
-  ("a0" "a0paper")
-  ("a1" "a1paper")
-  ("a2" "a2paper")
-  ("a3" "a3paper")
-  ("a4" "a4paper")
-  ("a5" "a5paper")
-  ("a6" "a6paper")
-  ("a7" "papersize={74mm,105mm}")
-  ("a8" "papersize={52mm,74mm")
-  ("a9" "papersize={37mm,52mm}")
-  ("b0" "b0paper")
-  ("b1" "b1paper")
-  ("b2" "b2paper")
-  ("b3" "b3paper")
-  ("b4" "b4paper")
-  ("b5" "b5paper")
-  ("b6" "b6paper")
-  ("b7" "papersize={88mm,125mm}")
-  ("b8" "papersize={62mm,88mm}")
-  ("b9" "papersize={44mm,62mm}")
-  ("legal" "legalpaper")
-  ("letter" "letterpaper")
-  ("executive" "executivepaper")
-  ("archA" "papersize={9in,12in}")
-  ("archB" "papersize={12in,18in}")
-  ("archC" "papersize={18in,24in}")
-  ("archD" "papersize={24in,36in}")
-  ("archE" "papersize={36in,48in}")
-  ("10x14" "papersize={10in,14in}")
-  ("11x17" "papersize={11in,17in}")
-  ("C5" "papersize={162mm,229mm}")
-  ("Comm10" "papersize={297pt,684pt}")
-  ("DL" "papersize={110mm,220mm}")
-  ("halfletter" "papersize={140mm,216mm}")
-  ("halfexecutive" "papersize={133mm,184mm}")
-  ("ledger" "papersize={432mm,279mm}")
-  ("Monarch" "papersize={98mm,190mm}")
-  ("csheet" "papersize={432mm,559mm}")
-  ("dsheet" "papersize={559mm,864mm}")
-  ("esheet" "papersize={864mm,1118mm}")
-  ("flsa" "papersize={216mm,330mm}")
-  ("flse" "papersize={216mm,330mm}")
-  ("folio" "papersize={216mm,330mm}")
-  ("lecture note" "papersize={15.5cm,23.5cm}")
-  ("note" "papersize={216mm,279mm}")
-  ("quarto" "papersize={215mm,275mm}")
-  ("statement" "papersize={140mm,216mm}")
-  ("tabloid" "papersize={279mm,432mm}"))
+ ("a0" "a0paper")
+ ("a1" "a1paper")
+ ("a2" "a2paper")
+ ("a3" "a3paper")
+ ("a4" "a4paper")
+ ("a5" "a5paper")
+ ("a6" "a6paper")
+ ("a7" "papersize={74mm,105mm}")
+ ("a8" "papersize={52mm,74mm")
+ ("a9" "papersize={37mm,52mm}")
+ ("b0" "b0paper")
+ ("b1" "b1paper")
+ ("b2" "b2paper")
+ ("b3" "b3paper")
+ ("b4" "b4paper")
+ ("b5" "b5paper")
+ ("b6" "b6paper")
+ ("b7" "papersize={88mm,125mm}")
+ ("b8" "papersize={62mm,88mm}")
+ ("b9" "papersize={44mm,62mm}")
+ ("legal" "legalpaper")
+ ("letter" "letterpaper")
+ ("executive" "executivepaper")
+ ("archA" "papersize={9in,12in}")
+ ("archB" "papersize={12in,18in}")
+ ("archC" "papersize={18in,24in}")
+ ("archD" "papersize={24in,36in}")
+ ("archE" "papersize={36in,48in}")
+ ("10x14" "papersize={10in,14in}")
+ ("11x17" "papersize={11in,17in}")
+ ("C5" "papersize={162mm,229mm}")
+ ("Comm10" "papersize={297pt,684pt}")
+ ("DL" "papersize={110mm,220mm}")
+ ("halfletter" "papersize={140mm,216mm}")
+ ("halfexecutive" "papersize={133mm,184mm}")
+ ("ledger" "papersize={432mm,279mm}")
+ ("Monarch" "papersize={98mm,190mm}")
+ ("csheet" "papersize={432mm,559mm}")
+ ("dsheet" "papersize={559mm,864mm}")
+ ("esheet" "papersize={864mm,1118mm}")
+ ("flsa" "papersize={216mm,330mm}")
+ ("flse" "papersize={216mm,330mm}")
+ ("folio" "papersize={216mm,330mm}")
+ ("lecture note" "papersize={15.5cm,23.5cm}")
+ ("note" "papersize={216mm,279mm}")
+ ("quarto" "papersize={215mm,275mm}")
+ ("statement" "papersize={140mm,216mm}")
+ ("tabloid" "papersize={279mm,432mm}")
+) ;logic-table
 
 ;; cpp interface with reversed access
 
 (tm-define (latex-paper-opts s)
-  (with r (query `(latex-paper-opts% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-opts% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 (tm-define (latex-paper-type s)
-  (with r (query `(latex-paper-type% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-type% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for consulting the database (might become deprecated)
@@ -245,28 +256,35 @@
 
 (define (latex-resolve s)
   (define (safe-string2symbol s)
-    (if (== s "") (string->symbol " ") (string->symbol s)))
+    (if (== s "") (string->symbol " ") (string->symbol s))
+  ) ;define
 
-  (if (string-starts? s "\\")
-      (set! s (substring s 1 (string-length s))))
+  (if (string-starts? s "\\") (set! s (substring s 1 (string-length s))))
 
-  (with arity (logic-ref latex-arity% (safe-string2symbol s))
+  (with arity
+    (logic-ref latex-arity% (safe-string2symbol s))
     (if (logic-in? (safe-string2symbol s) latex-optional-arg%)
-        (set! arity (- -1 arity)))
+      (set! arity (- -1 arity))
+    ) ;if
     (if (string-starts? s "end-")
-        (begin
-          (set! s (string-append "begin-" (substring s 4 (string-length s))))
-          (set! arity 0)))
-    (values (safe-string2symbol s) arity)))
+      (begin
+        (set! s (string-append "begin-" (substring s 4 (string-length s))))
+        (set! arity 0)
+      ) ;begin
+    ) ;if
+    (values (safe-string2symbol s) arity)
+  ) ;with
+) ;define
 
 (tm-define (latex-arity tag)
   "Get the arity of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
-    (or arity 0)))
+  (receive (s arity) (latex-resolve tag) (or arity 0))
+) ;tm-define
 
 (tm-define (latex-type tag)
   "Get the type of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
+  (receive (s arity)
+    (latex-resolve tag)
     (cond ((not arity) "undefined")
           ((logic-in? s latex-command%) "command")
           ((logic-in? s latex-length%) "length")
@@ -284,4 +302,7 @@
           ((logic-in? s latex-texmacs%) "texmacs")
           ((logic-in? s latex-symbol%) "symbol")
           ((logic-in? s latex-big-symbol%) "big-symbol")
-          (else "undefined"))))
+          (else "undefined")
+    ) ;cond
+  ) ;receive
+) ;tm-define

--- a/TeXmacs/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/progs/convert/latex/tmtex.scm
@@ -3175,7 +3175,7 @@
 ) ;define
 
 (define (tmtex-frame s l)
-  `(fbox ,(car l))
+  `(fbox ,(tmtex (car l)))
 ) ;define
 
 (define (tmtex-colored-frame s l)

--- a/TeXmacs/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/progs/convert/latex/tmtex.scm
@@ -3578,12 +3578,18 @@
 ) ;define
 
 (define (tmtex-ornamented s l)
-  (let* ((env (string-append "tm" s))
-         (option (get-ornament-env))
-         (option* (if (!= option "") `((!option ,option)) '()))
-        ) ;
-    `((!begin ,env ,@option*) ,(tmtex (car l)))
-  ) ;let*
+  (if (== s "framed")
+    (if (not (and (pair? (car l)) (in? (caar l) '(document para))))
+      `(fbox ,(tmtex (car l)))
+      `((!begin "mdframed") ,(tmtex (car l)))
+    ) ;if
+    (let* ((env (string-append "tm" s))
+           (option (get-ornament-env))
+           (option* (if (!= option "") `((!option ,option)) '()))
+          ) ;
+      `((!begin ,env ,@option*) ,(tmtex (car l)))
+    ) ;let*
+  ) ;if
 ) ;define
 
 (logic-table tex-ornament-opts%

--- a/TeXmacs/tests/0628.scm
+++ b/TeXmacs/tests/0628.scm
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0628.scm
+;; DESCRIPTION : Tests for bold calligraph* (mathscr) latex export
+;; COPYRIGHT   : (C) 2026  Jack Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(define (export-as-latex-and-load path)
+  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (string-load tmpfile))))
+  
+(define (load-latex path)
+  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path)  "\r\n" "\n")))
+
+
+(define (test_0628)
+  (check (export-as-latex-and-load "0628.tmu") => (load-latex "0628_frame_export.tex"))
+  (check-report))

--- a/TeXmacs/tests/0628.scm
+++ b/TeXmacs/tests/0628.scm
@@ -15,17 +15,29 @@
 (load "./TeXmacs/plugins/latex/progs/init-latex.scm")
 
 (define (export-as-latex-and-load path)
-  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
-    (with tmpfile (url-temp)
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile
+      (url-temp)
       (load-buffer path)
       (buffer-export path tmpfile "latex")
-      (string-load tmpfile))))
-  
+      (string-load tmpfile)
+    ) ;with
+  ) ;with
+) ;define
+
 (define (load-latex path)
-  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
-    (string-replace (string-load path)  "\r\n" "\n")))
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path) "\r\n" "\n")
+  ) ;with
+) ;define
 
 
 (define (test_0628)
-  (check (export-as-latex-and-load "0628.tmu") => (load-latex "0628_frame_export.tex"))
-  (check-report))
+  (check (export-as-latex-and-load "0628.tmu")
+    =>
+    (load-latex "0628_frame_export.tex")
+  ) ;check
+  (check-report)
+) ;define

--- a/TeXmacs/tests/tex/0628_frame_export.tex
+++ b/TeXmacs/tests/tex/0628_frame_export.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+\usepackage[english]{babel}
+
+\begin{document}
+
+This is a \fbox{text with $x 2$} frame test.
+
+\end{document}

--- a/TeXmacs/tests/tex/0628_frame_export.tex
+++ b/TeXmacs/tests/tex/0628_frame_export.tex
@@ -1,8 +1,17 @@
 \documentclass{article}
 \usepackage[english]{babel}
+\usepackage{mdframed}
 
 \begin{document}
 
-This is a \fbox{text with $x 2$} frame test.
+This is a \fbox{text with $x^2$} frame test.
+
+This is an \fbox{inline framed text with $z^4$} test.
+
+\begin{mdframed}
+  This is a $y^3$ framed block test.
+  
+  This is the second paragraph of the framed block.
+\end{mdframed}
 
 \end{document}

--- a/TeXmacs/tests/tmu/0628.tmu
+++ b/TeXmacs/tests/tmu/0628.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.1.0|2026.5.28>>
+
+<style|<tuple|generic|number-europe|preview-ref>>
+
+<\body>
+  This is a <frame|text with <math|x^2>> frame test.
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tmu/0628.tmu
+++ b/TeXmacs/tests/tmu/0628.tmu
@@ -4,6 +4,14 @@
 
 <\body>
   This is a <frame|text with <math|x<rsup|2>>> frame test.
+
+  This is an <framed|inline framed text with <math|z<rsup|4>>> test.
+
+  <\framed>
+    This is a <math|y<rsup|3>> framed block test.
+
+    This is the second paragraph of the framed block.
+  </framed>
 </body>
 
 <\initial>

--- a/TeXmacs/tests/tmu/0628.tmu
+++ b/TeXmacs/tests/tmu/0628.tmu
@@ -1,9 +1,9 @@
-<TMU|<tuple|1.1.0|2026.5.28>>
+<TMU|<tuple|1.1.0|2026.2.5>>
 
 <style|<tuple|generic|number-europe|preview-ref>>
 
 <\body>
-  This is a <frame|text with <math|x^2>> frame test.
+  This is a <frame|text with <math|x<rsup|2>>> frame test.
 </body>
 
 <\initial>

--- a/devel/0628.md
+++ b/devel/0628.md
@@ -1,0 +1,55 @@
+# [0628] 修复 frame 结构的 LaTeX 导出递归转换问题
+
+## 相关文档
+- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
+
+## 任务相关的代码文件
+- `TeXmacs/progs/convert/latex/tmtex.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`
+- `TeXmacs/tests/0628.scm`
+- `TeXmacs/tests/tex/0628_frame_export.tex`
+- `TeXmacs/tests/tmu/0628.tmu`
+
+## 如何测试
+
+### 确定性测试（单元与集成测试）
+```bash
+xmake run 0628
+```
+
+### 非确定性测试（文档验证）
+1. 打开 Mogan STEM，导入 `TeXmacs/tests/tmu/0628.tmu`。
+2. 导出为 LaTeX，确认 `frame` 标签内的数学公式和文字被正确导出。
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+一个 PR 至少分为两个 commit：
+1. 第一个 commit 更新 `devel/0628.md` 任务文档
+2. 第二个 commit 为代码改动（包含测试与实现）
+
+```bash
+xmake run 0628
+```
+
+## What
+修复 `frame` 结构在导出 LaTeX 时其内部子节点（如 `math`）没有被递归转译，从而导致原样输出为 TeXmacs tree 格式的问题。
+
+## Why
+在 TeXmacs 中，`frame` 用于在文本中给某个词或公式画边框。然而在 `tmtex.scm` 中：
+```scheme
+(define (tmtex-frame s l)
+  `(fbox ,(car l))
+)
+```
+这里直接把 `(car l)`（即子节点列表）作为 `fbox` 的内容输出，而没有调用 `(tmtex (car l))` 进行递归转译。当 frame 内包含数学模式或特殊字符时，子节点的内容就会直接被输出为原始 tree 形式，导致生成的 LaTeX 代码报错且无法正常编译。
+
+## How
+修改 `tmtex.scm` 中的 `tmtex-frame`：
+```scheme
+(define (tmtex-frame s l)
+  `(fbox ,(tmtex (car l)))
+)
+```
+确保子节点的内容在装入 `\fbox` 之前通过 `tmtex` 进行正确的 Scheme -> LaTeX 转译处理。

--- a/devel/0628.md
+++ b/devel/0628.md
@@ -1,4 +1,4 @@
-# [0628] 修复 frame 结构的 LaTeX 导出递归转换问题
+# [0628] 修复 frame 递归转译问题，并重构 framed 块级与行内 LaTeX 导出
 
 ## 相关文档
 - [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
@@ -6,6 +6,10 @@
 ## 任务相关的代码文件
 - `TeXmacs/progs/convert/latex/tmtex.scm`
 - `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`
+- `TeXmacs/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/progs/convert/latex/latex-command-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm`
 - `TeXmacs/tests/0628.scm`
 - `TeXmacs/tests/tex/0628_frame_export.tex`
 - `TeXmacs/tests/tmu/0628.tmu`
@@ -19,7 +23,7 @@ xmake run 0628
 
 ### 非确定性测试（文档验证）
 1. 打开 Mogan STEM，导入 `TeXmacs/tests/tmu/0628.tmu`。
-2. 导出为 LaTeX，确认 `frame` 标签内的数学公式和文字被正确导出。
+2. 导出为 LaTeX，确认 `frame` 与 `framed`（包含块级和行内装饰）均能完美、安全地导出。
 
 ## 如何提交
 
@@ -34,22 +38,31 @@ xmake run 0628
 ```
 
 ## What
-修复 `frame` 结构在导出 LaTeX 时其内部子节点（如 `math`）没有被递归转译，从而导致原样输出为 TeXmacs tree 格式的问题。
+1. 修复 `frame` 结构在导出 LaTeX 时其内部子节点没有被递归转译的问题。
+2. 重构 `framed` 的 LaTeX 导出，在行内时自动输出为标准的 `\fbox`，在块级（段落）时直接输出为标准的 `mdframed` 环境（`\begin{mdframed} ... \end{mdframed}`）。
+3. 彻底避免在导出的 LaTeX 导言区中生成非标准的自定义宏（如 `tmframed` 及其 `\newmdenv` 定义）。
 
 ## Why
-在 TeXmacs 中，`frame` 用于在文本中给某个词或公式画边框。然而在 `tmtex.scm` 中：
-```scheme
-(define (tmtex-frame s l)
-  `(fbox ,(car l))
-)
-```
-这里直接把 `(car l)`（即子节点列表）作为 `fbox` 的内容输出，而没有调用 `(tmtex (car l))` 进行递归转译。当 frame 内包含数学模式或特殊字符时，子节点的内容就会直接被输出为原始 tree 形式，导致生成的 LaTeX 代码报错且无法正常编译。
+- 对于 `frame`：原本的实现直接把 `(car l)` 作为 `fbox` 的内容输出，而没有调用 `(tmtex (car l))` 进行递归转译。当 frame 内包含数学公式等标签时，子节点的内容会被直接输出为原始 s-expression tree，导致生成的 LaTeX 代码报错崩溃。
+- 对于 `framed`：以往的实现会为 `framed` 创建自定义的 `tmframed` 宏并通过 `\newmdenv` 定义在 LaTeX 导言区。然而，这对于 LaTeX 用户来说极其不友好（污染了导言区且代码冗余）。同时，如果将 `framed` 作为行内标签使用，生成块级环境 `\begin{tmframed}` 会导致段落换行破坏排版。
 
 ## How
-修改 `tmtex.scm` 中的 `tmtex-frame`：
-```scheme
-(define (tmtex-frame s l)
-  `(fbox ,(tmtex (car l)))
-)
-```
-确保子节点的内容在装入 `\fbox` 之前通过 `tmtex` 进行正确的 Scheme -> LaTeX 转译处理。
+1. 修改 `tmtex-frame`，使其对子节点使用 `(tmtex (car l))` 进行正确的递归转译：
+   ```scheme
+   (define (tmtex-frame s l)
+     `(fbox ,(tmtex (car l)))
+   )
+   ```
+2. 重构 `tmtex-ornamented`。当匹配到 `"framed"` 时，如果其子节点不以 `document` 或 `para` 等块级标记开头，则识别为行内并转译为标准的行内 `fbox`；如果是块级，则直接翻译为标准的 `mdframed` 环境，剔除自定义 `tmframed` 的生成：
+   ```scheme
+   (define (tmtex-ornamented s l)
+     (if (== s "framed")
+         (if (not (and (pair? (car l)) (in? (caar l) '(document para))))
+             `(fbox ,(tmtex (car l)))
+             `((!begin "mdframed") ,(tmtex (car l)))
+         )
+         ...
+     )
+   )
+   ```
+3. 在 `latex-command-drd.scm` 中注册 `begin-mdframed` 作为合法环境，并在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册其与 `"mdframed"` 宏包的关联，使得导出时能够完美、自动地在导言区引入 `\usepackage{mdframed}`。


### PR DESCRIPTION
# [0628] 修复 frame 递归转译问题，并重构 framed 块级与行内 LaTeX 导出

## 相关文档
- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档

## 任务相关的代码文件
- `TeXmacs/progs/convert/latex/tmtex.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`
- `TeXmacs/progs/convert/latex/latex-drd.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
- `TeXmacs/progs/convert/latex/latex-command-drd.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm`
- `TeXmacs/tests/0628.scm`
- `TeXmacs/tests/tex/0628_frame_export.tex`
- `TeXmacs/tests/tmu/0628.tmu`

## 如何测试

### 确定性测试（单元与集成测试）
```bash
xmake run 0628
```

### 非确定性测试（文档验证）
1. 打开 Mogan STEM，导入 `TeXmacs/tests/tmu/0628.tmu`。
2. 导出为 LaTeX，确认 `frame` 与 `framed`（包含块级和行内装饰）均能完美、安全地导出。

## 如何提交

提交前执行以下最少步骤：

一个 PR 至少分为两个 commit：
1. 第一个 commit 更新 `devel/0628.md` 任务文档
2. 第二个 commit 为代码改动（包含测试与实现）

```bash
xmake run 0628
```

## What
1. 修复 `frame` 结构在导出 LaTeX 时其内部子节点没有被递归转译的问题。
2. 重构 `framed` 的 LaTeX 导出，在行内时自动输出为标准的 `\fbox`，在块级（段落）时直接输出为标准的 `mdframed` 环境（`\begin{mdframed} ... \end{mdframed}`）。
3. 彻底避免在导出的 LaTeX 导言区中生成非标准的自定义宏（如 `tmframed` 及其 `\newmdenv` 定义）。

## Why
- 对于 `frame`：原本的实现直接把 `(car l)` 作为 `fbox` 的内容输出，而没有调用 `(tmtex (car l))` 进行递归转译。当 frame 内包含数学公式等标签时，子节点的内容会被直接输出为原始 s-expression tree，导致生成的 LaTeX 代码报错崩溃。
- 对于 `framed`：以往的实现会为 `framed` 创建自定义的 `tmframed` 宏并通过 `\newmdenv` 定义在 LaTeX 导言区。然而，这对于 LaTeX 用户来说极其不友好（污染了导言区且代码冗余）。同时，如果将 `framed` 作为行内标签使用，生成块级环境 `\begin{tmframed}` 会导致段落换行破坏排版。

## How
1. 修改 `tmtex-frame`，使其对子节点使用 `(tmtex (car l))` 进行正确的递归转译：
   ```scheme
   (define (tmtex-frame s l)
     `(fbox ,(tmtex (car l)))
   )
   ```
2. 重构 `tmtex-ornamented`。当匹配到 `"framed"` 时，如果其子节点不以 `document` 或 `para` 等块级标记开头，则识别为行内并转译为标准的行内 `fbox`；如果是块级，则直接翻译为标准的 `mdframed` 环境，剔除自定义 `tmframed` 的生成：
   ```scheme
   (define (tmtex-ornamented s l)
     (if (== s "framed")
         (if (not (and (pair? (car l)) (in? (caar l) '(document para))))
             `(fbox ,(tmtex (car l)))
             `((!begin "mdframed") ,(tmtex (car l)))
         )
         ...
     )
   )
   ```
3. 在 `latex-command-drd.scm` 中注册 `begin-mdframed` 作为合法环境，并在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册其与 `"mdframed"` 宏包的关联，使得导出时能够完美、自动地在导言区引入 `\usepackage{mdframed}`。