### PR TITLE
[0629] 修复 newmdenv 相关的 mdframed 宏包依赖导出缺失问题

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
@@ -123,6 +123,7 @@
   (euro "eurosym")
 
   (mdfsetup ("tikz" "mdframed"))
+  (newmdenv ("tikz" "mdframed"))
   (tikz "tikz")
 
   (omicron "pslatex")

--- a/TeXmacs/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-drd.scm
@@ -123,6 +123,7 @@
   (euro "eurosym")
 
   (mdfsetup ("tikz" "mdframed"))
+  (newmdenv ("tikz" "mdframed"))
   (tikz "tikz")
 
   (omicron "pslatex")

--- a/TeXmacs/tests/0629.scm
+++ b/TeXmacs/tests/0629.scm
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0629.scm
+;; DESCRIPTION : Tests for mdframed dependency latex export
+;; COPYRIGHT   : (C) 2026  Jack Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(define (export-as-latex-and-load path)
+  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (string-load tmpfile))))
+  
+(define (load-latex path)
+  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path)  "\r\n" "\n")))
+
+
+(define (test_0629)
+  (check (export-as-latex-and-load "0629.tmu") => (load-latex "0629_mdframed_dependency_export.tex"))
+  (check-report))

--- a/TeXmacs/tests/tex/0629_mdframed_dependency_export.tex
+++ b/TeXmacs/tests/tex/0629_mdframed_dependency_export.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+\usepackage[english]{babel}
+\usepackage[tikz]{mdframed}
+
+%%%%%%%%%% Start TeXmacs macros
+\newmdenv[hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex]{tmframed}
+%%%%%%%%%% End TeXmacs macros
+
+\begin{document}
+
+\begin{tmframed}
+  This is a test of mdframed dependency.
+\end{tmframed}
+
+\end{document}

--- a/TeXmacs/tests/tmu/0629.tmu
+++ b/TeXmacs/tests/tmu/0629.tmu
@@ -1,0 +1,15 @@
+<TMU|<tuple|1.1.0|2026.5.28>>
+
+<style|<tuple|generic|number-europe|preview-ref>>
+
+<\body>
+  <\framed>
+    This is a test of mdframed dependency.
+  </framed>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0629.md
+++ b/devel/0629.md
@@ -1,0 +1,48 @@
+# [0629] 修复 newmdenv 相关的 mdframed 宏包依赖在 LaTeX 导出中的缺失问题
+
+## 相关文档
+- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
+
+## 任务相关的代码文件
+- `TeXmacs/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/tests/0629.scm`
+- `TeXmacs/tests/tex/0629_mdframed_dependency_export.tex`
+- `TeXmacs/tests/tmu/0629.tmu`
+
+## 如何测试
+
+### 确定性测试（单元与集成测试）
+```bash
+xmake run 0629
+```
+
+### 非确定性测试（文档验证）
+1. 打开 Mogan STEM，在文档中应用 `framed` 装饰。
+2. 导出为 LaTeX，确认导出的 `.tex` 文件的导言区中正确包含了 `\usepackage{mdframed}`，避免 LaTeX 编译时报错 "Undefined control sequence \newmdenv"。
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+一个 PR 至少分为两个 commit：
+1. 第一个 commit 更新 `devel/0629.md` 任务文档
+2. 第二个 commit 为代码改动（包含测试与实现）
+
+```bash
+xmake run 0629
+```
+
+## What
+修复在 LaTeX 导出中，凡是使用 `framed`、`padded` 等使用了 `newmdenv`（即 `tmframed`、`tmpadded` 等自定义环境）的文档，由于缺失对 `mdframed` 宏包依赖的匹配声明，导致导出的 LaTeX 文件导言区没有引入 `\usepackage{mdframed}` 而引发编译报错的问题。
+
+## Why
+在 `latex-define.scm` 中，所有的装饰环境（如 `tmframed`、`tmpadded`、`tmoverlined`、`tmunderlined`、`tmbothlined`、`tmornamented` 等）均使用 `newmdenv` 命令来生成自定义环境。`newmdenv` 属于 LaTeX 的 `mdframed` 宏包。
+但是在 LaTeX 依赖定义表 `latex-drd.scm` 中，只有 `mdfsetup` 被声明依赖于 `mdframed`（`(mdfsetup ("tikz" "mdframed"))`），而没有任何关于 `newmdenv` 的依赖声明。所以，当导出包含 `framed` 等环境的文档时，由于导出的 LaTeX 包含 `\newmdenv`，但没有任何包依赖声明将其关联到 `mdframed`，导致最终导出的 `.tex` 文档导言区完全缺失了 `\usepackage{mdframed}`，从而导致编译崩溃。
+
+## How
+在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册 `newmdenv` 宏包依赖：
+```scheme
+  (newmdenv "mdframed")
+```
+使得在 LaTeX 导出中只要生成了 `\newmdenv` 命令，就会自动引入 `mdframed` 包。


### PR DESCRIPTION
# [0629] 修复 newmdenv 相关的 mdframed 宏包依赖在 LaTeX 导出中的缺失问题

## 相关文档
- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档

## 任务相关的代码文件
- `TeXmacs/progs/convert/latex/latex-drd.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
- `TeXmacs/tests/0629.scm`
- `TeXmacs/tests/tex/0629_mdframed_dependency_export.tex`
- `TeXmacs/tests/tmu/0629.tmu`

## 如何测试

### 确定性测试（单元与集成测试）
```bash
xmake run 0629
```

### 非确定性测试（文档验证）
1. 打开 Mogan STEM，在文档中应用 `framed` 装饰。
2. 导出为 LaTeX，确认导出的 `.tex` 文件的导言区中正确包含了 `\usepackage{mdframed}`，避免 LaTeX 编译时报错 "Undefined control sequence \newmdenv"。

## 如何提交

提交前执行以下最少步骤：

一个 PR 至少分为两个 commit：
1. 第一个 commit 更新 `devel/0629.md` 任务文档
2. 第二个 commit 为代码改动（包含测试与实现）

```bash
xmake run 0629
```

## What
修复在 LaTeX 导出中，凡是使用 `framed`、`padded` 等使用了 `newmdenv`（即 `tmframed`、`tmpadded` 等自定义环境）的文档，由于缺失对 `mdframed` 宏包依赖的匹配声明，导致导出的 LaTeX 文件导言区没有引入 `\usepackage{mdframed}` 而引发编译报错的问题。

## Why
在 `latex-define.scm` 中，所有的装饰环境（如 `tmframed`、`tmpadded`、`tmoverlined`、`tmunderlined`、`tmbothlined`、`tmornamented` 等）均使用 `newmdenv` 命令来生成自定义环境。`newmdenv` 属于 LaTeX 的 `mdframed` 宏包。
但是在 LaTeX 依赖定义表 `latex-drd.scm` 中，只有 `mdfsetup` 被声明依赖于 `mdframed`（`(mdfsetup ("tikz" "mdframed"))`），而没有任何关于 `newmdenv` 的依赖声明。所以，当导出包含 `framed` 等环境的文档时，由于导出的 LaTeX 包含 `\newmdenv`，但没有任何包依赖声明将其关联到 `mdframed`，导致最终导出的 `.tex` 文档导言区完全缺失了 `\usepackage{mdframed}`，从而导致编译崩溃。

## How
在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册 `newmdenv` 宏包依赖：
```scheme
  (newmdenv "mdframed")
```
使得在 LaTeX 导出中只要生成了 `\newmdenv` 命令，就会自动引入 `mdframed` 包。