### PR TITLE
[0629] 修复 coloneqq 相关的 mathtools 宏包依赖导出缺失问题

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
@@ -12,40 +12,41 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert latex latex-drd)
-  (:use (convert latex latex-overload)))
+(texmacs-module (convert latex latex-drd) (:use (convert latex latex-overload)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Order in which packages should be included
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-package-priority%
-  ("geometry" 10)
-  ("amsmath" 20)
-  ("amssymb" 30)
-  ("graphicx" 40)
-  ("wasysym" 50)
-  ("stmaryrd" 60)
-  ("textcomp" 60)
-  ("enumerate" 70)
-  ("epsfig" 80)
-  ("mathrsfs" 90)
-  ("bbm" 100)
-  ("dsfont" 110)
-  ("euscript" 120)
-  ("multicol" 130)
-  ("hyperref" 140)
-  ("mathtools" 150)
-  ("cleveref" 160))
+ ("geometry" 10)
+ ("amsmath" 20)
+ ("amssymb" 30)
+ ("graphicx" 40)
+ ("wasysym" 50)
+ ("stmaryrd" 60)
+ ("textcomp" 60)
+ ("enumerate" 70)
+ ("epsfig" 80)
+ ("mathrsfs" 90)
+ ("bbm" 100)
+ ("dsfont" 110)
+ ("euscript" 120)
+ ("multicol" 130)
+ ("hyperref" 140)
+ ("mathtools" 150)
+ ("cleveref" 160)
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies between style files and packages
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-depends%
-  ("amsart" "amstex")
-  ("amstex" "amsmath")
-  ("amstex" "amsthm"))
+ ("amsart" "amstex")
+ ("amstex" "amsmath")
+ ("amstex" "amsthm")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies of commands on packages
@@ -76,6 +77,7 @@
   (mathbb "amssymb")
   (theorembodyfont "theorem")
   (substack "mathtools")
+  (coloneqq "mathtools")
 
   (begin-align "amsmath")
   (begin-align* "amsmath")
@@ -111,12 +113,12 @@
 
   (underaccent "accents")
   (ring "accents")
-  
+
   (ifthenelse "ifthen")
   (captionof "capt-of")
   (widthof "calc")
-  
-  (color     "xcolor")
+
+  (color "xcolor")
   (fcolorbox "xcolor")
   (textcolor "xcolor")
 
@@ -138,7 +140,7 @@
 
   (cref "cleveref")
   (Cref "cleveref")
-  
+
   (citet "natbib")
   (citep "natbib")
   (citet* "natbib")
@@ -162,82 +164,91 @@
   (ifthispageodd "scrextend")
 
   (begin-linenumbers "lineno")
-  (resetlinenumber "lineno"))
+  (resetlinenumber "lineno")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Page size settings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-paper-opts%
-  ("page-top"         "top")
-  ("page-bot"         "bottom")
-  ("page-odd"         "left")
-  ("page-even"        "left")
-  ("page-right"       "right")
-  ("page-height"      "paperheight")
-  ("page-width"       "paperwidth")
-  ("page-type"        "page-type")
-  ("page-orientation" "page-orientation"))
+ ("page-top" "top")
+ ("page-bot" "bottom")
+ ("page-odd" "left")
+ ("page-even" "left")
+ ("page-right" "right")
+ ("page-height" "paperheight")
+ ("page-width" "paperwidth")
+ ("page-type" "page-type")
+ ("page-orientation" "page-orientation")
+) ;logic-table
 
 (logic-table latex-paper-type%
-  ("a0" "a0paper")
-  ("a1" "a1paper")
-  ("a2" "a2paper")
-  ("a3" "a3paper")
-  ("a4" "a4paper")
-  ("a5" "a5paper")
-  ("a6" "a6paper")
-  ("a7" "papersize={74mm,105mm}")
-  ("a8" "papersize={52mm,74mm")
-  ("a9" "papersize={37mm,52mm}")
-  ("b0" "b0paper")
-  ("b1" "b1paper")
-  ("b2" "b2paper")
-  ("b3" "b3paper")
-  ("b4" "b4paper")
-  ("b5" "b5paper")
-  ("b6" "b6paper")
-  ("b7" "papersize={88mm,125mm}")
-  ("b8" "papersize={62mm,88mm}")
-  ("b9" "papersize={44mm,62mm}")
-  ("legal" "legalpaper")
-  ("letter" "letterpaper")
-  ("executive" "executivepaper")
-  ("archA" "papersize={9in,12in}")
-  ("archB" "papersize={12in,18in}")
-  ("archC" "papersize={18in,24in}")
-  ("archD" "papersize={24in,36in}")
-  ("archE" "papersize={36in,48in}")
-  ("10x14" "papersize={10in,14in}")
-  ("11x17" "papersize={11in,17in}")
-  ("C5" "papersize={162mm,229mm}")
-  ("Comm10" "papersize={297pt,684pt}")
-  ("DL" "papersize={110mm,220mm}")
-  ("halfletter" "papersize={140mm,216mm}")
-  ("halfexecutive" "papersize={133mm,184mm}")
-  ("ledger" "papersize={432mm,279mm}")
-  ("Monarch" "papersize={98mm,190mm}")
-  ("csheet" "papersize={432mm,559mm}")
-  ("dsheet" "papersize={559mm,864mm}")
-  ("esheet" "papersize={864mm,1118mm}")
-  ("flsa" "papersize={216mm,330mm}")
-  ("flse" "papersize={216mm,330mm}")
-  ("folio" "papersize={216mm,330mm}")
-  ("lecture note" "papersize={15.5cm,23.5cm}")
-  ("note" "papersize={216mm,279mm}")
-  ("quarto" "papersize={215mm,275mm}")
-  ("statement" "papersize={140mm,216mm}")
-  ("tabloid" "papersize={279mm,432mm}"))
+ ("a0" "a0paper")
+ ("a1" "a1paper")
+ ("a2" "a2paper")
+ ("a3" "a3paper")
+ ("a4" "a4paper")
+ ("a5" "a5paper")
+ ("a6" "a6paper")
+ ("a7" "papersize={74mm,105mm}")
+ ("a8" "papersize={52mm,74mm")
+ ("a9" "papersize={37mm,52mm}")
+ ("b0" "b0paper")
+ ("b1" "b1paper")
+ ("b2" "b2paper")
+ ("b3" "b3paper")
+ ("b4" "b4paper")
+ ("b5" "b5paper")
+ ("b6" "b6paper")
+ ("b7" "papersize={88mm,125mm}")
+ ("b8" "papersize={62mm,88mm}")
+ ("b9" "papersize={44mm,62mm}")
+ ("legal" "legalpaper")
+ ("letter" "letterpaper")
+ ("executive" "executivepaper")
+ ("archA" "papersize={9in,12in}")
+ ("archB" "papersize={12in,18in}")
+ ("archC" "papersize={18in,24in}")
+ ("archD" "papersize={24in,36in}")
+ ("archE" "papersize={36in,48in}")
+ ("10x14" "papersize={10in,14in}")
+ ("11x17" "papersize={11in,17in}")
+ ("C5" "papersize={162mm,229mm}")
+ ("Comm10" "papersize={297pt,684pt}")
+ ("DL" "papersize={110mm,220mm}")
+ ("halfletter" "papersize={140mm,216mm}")
+ ("halfexecutive" "papersize={133mm,184mm}")
+ ("ledger" "papersize={432mm,279mm}")
+ ("Monarch" "papersize={98mm,190mm}")
+ ("csheet" "papersize={432mm,559mm}")
+ ("dsheet" "papersize={559mm,864mm}")
+ ("esheet" "papersize={864mm,1118mm}")
+ ("flsa" "papersize={216mm,330mm}")
+ ("flse" "papersize={216mm,330mm}")
+ ("folio" "papersize={216mm,330mm}")
+ ("lecture note" "papersize={15.5cm,23.5cm}")
+ ("note" "papersize={216mm,279mm}")
+ ("quarto" "papersize={215mm,275mm}")
+ ("statement" "papersize={140mm,216mm}")
+ ("tabloid" "papersize={279mm,432mm}")
+) ;logic-table
 
 ;; cpp interface with reversed access
 
 (tm-define (latex-paper-opts s)
-  (with r (query `(latex-paper-opts% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-opts% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 (tm-define (latex-paper-type s)
-  (with r (query `(latex-paper-type% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-type% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for consulting the database (might become deprecated)
@@ -245,28 +256,35 @@
 
 (define (latex-resolve s)
   (define (safe-string2symbol s)
-    (if (== s "") (string->symbol " ") (string->symbol s)))
+    (if (== s "") (string->symbol " ") (string->symbol s))
+  ) ;define
 
-  (if (string-starts? s "\\")
-      (set! s (substring s 1 (string-length s))))
+  (if (string-starts? s "\\") (set! s (substring s 1 (string-length s))))
 
-  (with arity (logic-ref latex-arity% (safe-string2symbol s))
+  (with arity
+    (logic-ref latex-arity% (safe-string2symbol s))
     (if (logic-in? (safe-string2symbol s) latex-optional-arg%)
-        (set! arity (- -1 arity)))
+      (set! arity (- -1 arity))
+    ) ;if
     (if (string-starts? s "end-")
-        (begin
-          (set! s (string-append "begin-" (substring s 4 (string-length s))))
-          (set! arity 0)))
-    (values (safe-string2symbol s) arity)))
+      (begin
+        (set! s (string-append "begin-" (substring s 4 (string-length s))))
+        (set! arity 0)
+      ) ;begin
+    ) ;if
+    (values (safe-string2symbol s) arity)
+  ) ;with
+) ;define
 
 (tm-define (latex-arity tag)
   "Get the arity of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
-    (or arity 0)))
+  (receive (s arity) (latex-resolve tag) (or arity 0))
+) ;tm-define
 
 (tm-define (latex-type tag)
   "Get the type of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
+  (receive (s arity)
+    (latex-resolve tag)
     (cond ((not arity) "undefined")
           ((logic-in? s latex-command%) "command")
           ((logic-in? s latex-length%) "length")
@@ -284,4 +302,7 @@
           ((logic-in? s latex-texmacs%) "texmacs")
           ((logic-in? s latex-symbol%) "symbol")
           ((logic-in? s latex-big-symbol%) "big-symbol")
-          (else "undefined"))))
+          (else "undefined")
+    ) ;cond
+  ) ;receive
+) ;tm-define

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-symbol-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-symbol-drd.scm
@@ -12,191 +12,800 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (convert latex latex-symbol-drd)
-  (:use (convert latex latex-command-drd)))
+  (:use (convert latex latex-command-drd))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic symbols and big symbols
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-symbol%
+  coloneqq
   ;; Greek letters
-  Gamma Delta Theta Lambda Xi Pi Sigma Upsilon Phi Psi Omega varOmega
-  alpha beta gamma delta epsilon
-  varepsilon zeta eta theta vartheta
-  iota kappa lambda mu nu omicron
-  xi pi varpi rho
-  varrho sigma varsigma tau upsilon
-  phi varphi chi psi omega
+  Gamma
+  Delta
+  Theta
+  Lambda
+  Xi
+  Pi
+  Sigma
+  Upsilon
+  Phi
+  Psi
+  Omega
+  varOmega
+  alpha
+  beta
+  gamma
+  delta
+  epsilon
+  varepsilon
+  zeta
+  eta
+  theta
+  vartheta
+  iota
+  kappa
+  lambda
+  mu
+  nu
+  omicron
+  xi
+  pi
+  varpi
+  rho
+  varrho
+  sigma
+  varsigma
+  tau
+  upsilon
+  phi
+  varphi
+  chi
+  psi
+  omega
 
   ;; Binary operations
-  pm mp times div ast star circ bullet cdot
-  cap cup uplus sqcap sqcup vee wedge setminus wr
-  diamond triangleleft triangleright land lor lnot
-  oplus ominus otimes oslash odot bigcirc amalg notin
+  pm
+  mp
+  times
+  div
+  ast
+  star
+  circ
+  bullet
+  cdot
+  cap
+  cup
+  uplus
+  sqcap
+  sqcup
+  vee
+  wedge
+  setminus
+  wr
+  diamond
+  triangleleft
+  triangleright
+  land
+  lor
+  lnot
+  oplus
+  ominus
+  otimes
+  oslash
+  odot
+  bigcirc
+  amalg
+  notin
 
   ;; Relations
-  leq le geq ge equiv models prec
-  succ sim perp preceq succeq
-  simeq mid ll gg asymp
-  parallel subset supset approx bowtie
-  subseteq supseteq cong
-  ne neq smile sqsubseteq sqsupseteq
-  doteq frown in ni propto
-  vdash dashv
-  
+  leq
+  le
+  geq
+  ge
+  equiv
+  models
+  prec
+  succ
+  sim
+  perp
+  preceq
+  succeq
+  simeq
+  mid
+  ll
+  gg
+  asymp
+  parallel
+  subset
+  supset
+  approx
+  bowtie
+  subseteq
+  supseteq
+  cong
+  ne
+  neq
+  smile
+  sqsubseteq
+  sqsupseteq
+  doteq
+  frown
+  in
+  ni
+  propto
+  vdash
+  dashv
+
   ;; Arrows
-  leftarrow rightarrow uparrow downarrow
-  Leftarrow Rightarrow Uparrow Downarrow
-  nearrow searrow swarrow nwarrow
-  leftrightarrow updownarrow Updownarrow Leftrightarrow 
-  leftharpoonup leftharpoondown rightharpoonup rightharpoondown
-  hookleftarrow hookrightarrow
-  to mapsto longmapsto
-  longrightarrow longleftarrow longleftrightarrow
-  Longrightarrow Longleftarrow Longleftrightarrow 
-  
+  leftarrow
+  rightarrow
+  uparrow
+  downarrow
+  Leftarrow
+  Rightarrow
+  Uparrow
+  Downarrow
+  nearrow
+  searrow
+  swarrow
+  nwarrow
+  leftrightarrow
+  updownarrow
+  Updownarrow
+  Leftrightarrow
+  leftharpoonup
+  leftharpoondown
+  rightharpoonup
+  rightharpoondown
+  hookleftarrow
+  hookrightarrow
+  to
+  mapsto
+  longmapsto
+  longrightarrow
+  longleftarrow
+  longleftrightarrow
+  Longrightarrow
+  Longleftarrow
+  Longleftrightarrow
+
   ;; Miscellaneous symbols
-  ldots cdots vdots ddots hdots aleph
-  prime forall infty hbar emptyset
-  exists nabla surd triangle
-  imath jmath ell neg
-  top flat natural sharp wp
-  bot clubsuit diamondsuit heartsuit spadesuit
-  Re Im angle partial textbackslash
-  dag ddag dagger ddagger guillemotleft guillemotright
+  ldots
+  cdots
+  vdots
+  ddots
+  hdots
+  aleph
+  prime
+  forall
+  infty
+  hbar
+  emptyset
+  exists
+  nabla
+  surd
+  triangle
+  imath
+  jmath
+  ell
+  neg
+  top
+  flat
+  natural
+  sharp
+  wp
+  bot
+  clubsuit
+  diamondsuit
+  heartsuit
+  spadesuit
+  Re
+  Im
+  angle
+  partial
+  textbackslash
+  dag
+  ddag
+  dagger
+  ddagger
+  guillemotleft
+  guillemotright
 
   ;; Delimiters
-  uparrow Uparrow downarrow Downarrow
-  updownarrow Updownarrow
-  lfloor rfloor lceil rceil
-  langle rangle backslash
+  uparrow
+  Uparrow
+  downarrow
+  Downarrow
+  updownarrow
+  Updownarrow
+  lfloor
+  rfloor
+  lceil
+  rceil
+  langle
+  rangle
+  backslash
 
   ;; Big delimiters
-  rmoustache lmoustache rgroup lgroup
-  lbrack rbrack lbrace rbrace
-  arrowvert Arrowvert bracevert)
+  rmoustache
+  lmoustache
+  rgroup
+  lgroup
+  lbrack
+  rbrack
+  lbrace
+  rbrace
+  arrowvert
+  Arrowvert
+  bracevert
+) ;logic-group
 
 (logic-group latex-big-symbol%
-  sum prod coprod
-  bignone bigtimes bigoplus bigotimes bigodot
-  bigvee bigwedge bigsqcup bigcup bigcap bigpluscup
-  bigtriangledown bigtriangleup
-  int iint iiint iiiint idotsint bigint bigiint bigiiint bigiiiint bigidotsint
-  upint upiint upiiint upiiiint upidotsint bigupint bigupiint bigupiiint bigupiiiint bigupidotsint
-  oint oiint oiiint bigoint bigoiint bigoiiint
-  upoint upoiint upoiiint bigupoint bigupoiint bigupoiiint
-  intwl iintwl iiintwl iiiintwl idotsintwl bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
-  upintwl upiintwl upiiintwl upiiiintwl upidotsintwl bigupintwl bigupiintwl bigupiiintwl bigupiiiintwl bigupidotsintwl
-  ointwl oiintwl oiiintwl bigointwl bigoiintwl bigoiiintwl
-  upointwl upoiintwl upoiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
+  sum
+  prod
+  coprod
+  bignone
+  bigtimes
+  bigoplus
+  bigotimes
+  bigodot
+  bigvee
+  bigwedge
+  bigsqcup
+  bigcup
+  bigcap
+  bigpluscup
+  bigtriangledown
+  bigtriangleup
+  int
+  iint
+  iiint
+  iiiint
+  idotsint
+  bigint
+  bigiint
+  bigiiint
+  bigiiiint
+  bigidotsint
+  upint
+  upiint
+  upiiint
+  upiiiint
+  upidotsint
+  bigupint
+  bigupiint
+  bigupiiint
+  bigupiiiint
+  bigupidotsint
+  oint
+  oiint
+  oiiint
+  bigoint
+  bigoiint
+  bigoiiint
+  upoint
+  upoiint
+  upoiiint
+  bigupoint
+  bigupoiint
+  bigupoiiint
+  intwl
+  iintwl
+  iiintwl
+  iiiintwl
+  idotsintwl
+  bigintwl
+  bigiintwl
+  bigiiintwl
+  bigiiiintwl
+  bigidotsintwl
+  upintwl
+  upiintwl
+  upiiintwl
+  upiiiintwl
+  upidotsintwl
+  bigupintwl
+  bigupiintwl
+  bigupiiintwl
+  bigupiiiintwl
+  bigupidotsintwl
+  ointwl
+  oiintwl
+  oiiintwl
+  bigointwl
+  bigoiintwl
+  bigoiiintwl
+  upointwl
+  upoiintwl
+  upoiiintwl
+  bigupointwl
+  bigupoiintwl
+  bigupoiiintwl
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from latexsym package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-latexsym-symbol%
-  mho Join Box Diamond leadsto
-  sqsubset sqsupset lhd rhd unlhd unrhd)
+  mho
+  Join
+  Box
+  Diamond
+  leadsto
+  sqsubset
+  sqsupset
+  lhd
+  rhd
+  unlhd
+  unrhd
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from amssymb package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-ams-symbol%
-  ;;`
+  ;; `
   ;; Box sqsubset sqsupset lhd unlhd rhd unrhd
-  Bbbk Bumpeq Cap Cup Finv Game Lleftarrow Lsh
-  Rrightarrow Rsh Subset Supset Vdash Vvdash
-  angle approxeq backepsilon backprime backsim backsimeq barwedge
-  because beth between bigstar blacklozenge blacksquare blacktriangle
-  blacktriangledown blacktriangleleft blacktriangleright box boxdot
-  boxminus boxplus boxtimes bumpeq centerdot checkmark circeq
-  circlearrowleft circlearrowright circledR circledS circledast
-  circledcirc circleddash complement curlyeqprec curlyeqsucc curlyvee
-  curlywedge curvearrowleft curvearrowright daleth diagdown diagup
-  digamma divideontimes doteqdot dotplus doublebarwedge downdownarrows
-  downharpoonleft downharpoonright eqcirc eqsim eqslantgtr eqslantless
-  eth fallingdotseq frown geqq geqslant ggg gimel gnapprox gneq gneqq
-  gnsim gtrapprox gtrdot gtreqless gtreqqless gtrless gtrsim gvertneqq
-  hslash intercal leftarrowtail leftleftarrows leftrightarrows
-  leftrightharpoons leftrightsquigarrow leftthreetimes leqq leqslant
-  lessapprox lessdot lesseqgtr lesseqqgtr lessgtr lesssim
-  llcorner lll lnapprox lneq lneqq lnsim looparrowleft looparrowright
-  lozenge lrcorner ltimes lvert lVert lvertneqq maltese measuredangle models
-  multimap nLeftarrow nLeftrightarrow nRightarrow nVDash nVdash
-  ncong nexists ngeq ngeqq ngeqslant ngtr nleftarrow nleftrightarrow
-  nleq nleqq nleqslant nless nmid nparallel nprec npreceq nrightarrow
-  nshortmid nshortparallel nsim nsubseteq nsubseteqq nsucc nsucceq
-  nsupseteq nsupseteqq ntriangleleft ntrianglelefteq ntriangleright
-  ntrianglerighteq nvDash nvdash pitchfork precapprox preccurlyeq
-  precnapprox precneqq precnsim precsim propto rhd rightarrowtail
-  rightleftarrows rightleftharpoons rightrightarrows rightsquigarrow
-  rightthreetimes risingdotseq rtimes rvert rVert shortleftarrow shortmid
-  shortparallel shortrightarrow smalldash smallfrown smallsetminus
-  smallsmile smile sphericalangle subseteqq
-  subsetneq subsetneqq succapprox succcurlyeq succnapprox succneqq
-  succnsim succsim supseteqq supsetneq supsetneqq therefore
-  thickapprox thicksim triangle triangledown trianglelefteq
-  triangleq trianglerighteq twoheadleftarrow twoheadrightarrow
-  ulcorner upharpoonleft upharpoonright upuparrows
-  urcorner vDash varkappa varnothing varpropto varsubsetneq
-  varsubsetneqq varsupsetneq varsupsetneqq vartriangle
-  vartriangleleft vartriangleright veebar yen)
+  Bbbk
+  Bumpeq
+  Cap
+  Cup
+  Finv
+  Game
+  Lleftarrow
+  Lsh
+  Rrightarrow
+  Rsh
+  Subset
+  Supset
+  Vdash
+  Vvdash
+  angle
+  approxeq
+  backepsilon
+  backprime
+  backsim
+  backsimeq
+  barwedge
+  because
+  beth
+  between
+  bigstar
+  blacklozenge
+  blacksquare
+  blacktriangle
+  blacktriangledown
+  blacktriangleleft
+  blacktriangleright
+  box
+  boxdot
+  boxminus
+  boxplus
+  boxtimes
+  bumpeq
+  centerdot
+  checkmark
+  circeq
+  circlearrowleft
+  circlearrowright
+  circledR
+  circledS
+  circledast
+  circledcirc
+  circleddash
+  complement
+  curlyeqprec
+  curlyeqsucc
+  curlyvee
+  curlywedge
+  curvearrowleft
+  curvearrowright
+  daleth
+  diagdown
+  diagup
+  digamma
+  divideontimes
+  doteqdot
+  dotplus
+  doublebarwedge
+  downdownarrows
+  downharpoonleft
+  downharpoonright
+  eqcirc
+  eqsim
+  eqslantgtr
+  eqslantless
+  eth
+  fallingdotseq
+  frown
+  geqq
+  geqslant
+  ggg
+  gimel
+  gnapprox
+  gneq
+  gneqq
+  gnsim
+  gtrapprox
+  gtrdot
+  gtreqless
+  gtreqqless
+  gtrless
+  gtrsim
+  gvertneqq
+  hslash
+  intercal
+  leftarrowtail
+  leftleftarrows
+  leftrightarrows
+  leftrightharpoons
+  leftrightsquigarrow
+  leftthreetimes
+  leqq
+  leqslant
+  lessapprox
+  lessdot
+  lesseqgtr
+  lesseqqgtr
+  lessgtr
+  lesssim
+  llcorner
+  lll
+  lnapprox
+  lneq
+  lneqq
+  lnsim
+  looparrowleft
+  looparrowright
+  lozenge
+  lrcorner
+  ltimes
+  lvert
+  lVert
+  lvertneqq
+  maltese
+  measuredangle
+  models
+  multimap
+  nLeftarrow
+  nLeftrightarrow
+  nRightarrow
+  nVDash
+  nVdash
+  ncong
+  nexists
+  ngeq
+  ngeqq
+  ngeqslant
+  ngtr
+  nleftarrow
+  nleftrightarrow
+  nleq
+  nleqq
+  nleqslant
+  nless
+  nmid
+  nparallel
+  nprec
+  npreceq
+  nrightarrow
+  nshortmid
+  nshortparallel
+  nsim
+  nsubseteq
+  nsubseteqq
+  nsucc
+  nsucceq
+  nsupseteq
+  nsupseteqq
+  ntriangleleft
+  ntrianglelefteq
+  ntriangleright
+  ntrianglerighteq
+  nvDash
+  nvdash
+  pitchfork
+  precapprox
+  preccurlyeq
+  precnapprox
+  precneqq
+  precnsim
+  precsim
+  propto
+  rhd
+  rightarrowtail
+  rightleftarrows
+  rightleftharpoons
+  rightrightarrows
+  rightsquigarrow
+  rightthreetimes
+  risingdotseq
+  rtimes
+  rvert
+  rVert
+  shortleftarrow
+  shortmid
+  shortparallel
+  shortrightarrow
+  smalldash
+  smallfrown
+  smallsetminus
+  smallsmile
+  smile
+  sphericalangle
+  subseteqq
+  subsetneq
+  subsetneqq
+  succapprox
+  succcurlyeq
+  succnapprox
+  succneqq
+  succnsim
+  succsim
+  supseteqq
+  supsetneq
+  supsetneqq
+  therefore
+  thickapprox
+  thicksim
+  triangle
+  triangledown
+  trianglelefteq
+  triangleq
+  trianglerighteq
+  twoheadleftarrow
+  twoheadrightarrow
+  ulcorner
+  upharpoonleft
+  upharpoonright
+  upuparrows
+  urcorner
+  vDash
+  varkappa
+  varnothing
+  varpropto
+  varsubsetneq
+  varsubsetneqq
+  varsupsetneq
+  varsupsetneqq
+  vartriangle
+  vartriangleleft
+  vartriangleright
+  veebar
+  yen
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from wasysym package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-wasy-symbol%
-  agemO APLbox APLcomment APLdownarrowbox APLdown APLinput
-  APLleftarrowbox APLrightarrowbox APLstar APLuparrowbox APLup apprge
-  apprle aquarius ascnode ataribox bell blacksmiley
-  Bowtie brokenvert cancer capricornus cent checked
-  CIRCLE Circle clock conjunction currency davidsstar
-  descnode dh diameter DOWNarrow eighthnote female
-  frownie fullnote gemini halfnote hexagon hexstar
-  invdiameter inve invneg jupiter kreuz LEFTarrow
-  LEFTCIRCLE Leftcircle leftmoon leftturn libra logof
-  male mercury neptune octagon openo opposition
-  pentagon permil phone pisces pluto pointer
-  quarternote recorder RIGHTarrow RIGHTCIRCLE Rightcircle
-  rightmoon rightturn sagittarius saturn
-  scorpio smiley square sun taurus Thorn
-  thorn twonotes UParrow uranus varangle varhexagon
-  varhexstar varlightning vernal VHF virgo
-  ;;wasy-38 wasy-58 wasy-80 wasy-81 wasy-82
-  wasyBox wasyDiamond wasyleadsto wasylhd wasylozenge
-  wasypropto wasyrhd wasysqsubset wasysqsupset wasytherefore
-  wasyunlhd wasyunrhd XBox)
+  agemO
+  APLbox
+  APLcomment
+  APLdownarrowbox
+  APLdown
+  APLinput
+  APLleftarrowbox
+  APLrightarrowbox
+  APLstar
+  APLuparrowbox
+  APLup
+  apprge
+  apprle
+  aquarius
+  ascnode
+  ataribox
+  bell
+  blacksmiley
+  Bowtie
+  brokenvert
+  cancer
+  capricornus
+  cent
+  checked
+  CIRCLE
+  Circle
+  clock
+  conjunction
+  currency
+  davidsstar
+  descnode
+  dh
+  diameter
+  DOWNarrow
+  eighthnote
+  female
+  frownie
+  fullnote
+  gemini
+  halfnote
+  hexagon
+  hexstar
+  invdiameter
+  inve
+  invneg
+  jupiter
+  kreuz
+  LEFTarrow
+  LEFTCIRCLE
+  Leftcircle
+  leftmoon
+  leftturn
+  libra
+  logof
+  male
+  mercury
+  neptune
+  octagon
+  openo
+  opposition
+  pentagon
+  permil
+  phone
+  pisces
+  pluto
+  pointer
+  quarternote
+  recorder
+  RIGHTarrow
+  RIGHTCIRCLE
+  Rightcircle
+  rightmoon
+  rightturn
+  sagittarius
+  saturn
+  scorpio
+  smiley
+  square
+  sun
+  taurus
+  Thorn
+  thorn
+  twonotes
+  UParrow
+  uranus
+  varangle
+  varhexagon
+  varhexstar
+  varlightning
+  vernal
+  VHF
+  virgo
+  ;; wasy-38 wasy-58 wasy-80 wasy-81 wasy-82
+  wasyBox
+  wasyDiamond
+  wasyleadsto
+  wasylhd
+  wasylozenge
+  wasypropto
+  wasyrhd
+  wasysqsubset
+  wasysqsupset
+  wasytherefore
+  wasyunlhd
+  wasyunrhd
+  XBox
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from stmaryrd package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-stmary-symbol%
-  Arrownot arrownot baro bbslash binampersand bindnasrepma
-  boxast boxbar boxbox boxbslash boxcircle
-  ;;boxdot
-  boxempty boxslash curlyveedownarrow curlyveeuparrow
-  curlywedgedownarrow curlywedgeuparrow fatbslash fatsemi fatslash
-  inplus interleave large-llbracket large-rrbracket Lbag lbag
-  leftarrowtriangle leftrightarroweq leftrightarrowtriangle
-  leftslice lightning llbracket llceil llfloor llparenthesis
-  Mapsfromchar mapsfromchar Mapstochar merge minuso moo
-  niplus nnearrow nnwarrow nplus ntrianglelefteqslant
-  ntrianglerighteqslant obar oblong obslash ogreaterthan
-  olessthan ovee owedge Rbag rbag rightarrowtriangle rightslice
-  rrbracket rrceil rrfloor rrparenthesis shortdownarrow
-  shortleftarrow shortrightarrow shortuparrow ssearrow sslash
-  sswarrow subsetpluseq subsetplus supsetpluseq supsetplus talloblong
-  trianglelefteqslant trianglerighteqslant varbigcirc varcurlyvee
-  varcurlywedge varoast varobar varobslash varocircle
-  varodot varogreaterthan varolessthan varominus varoplus varoslash
-  varotimes varovee varowedge vartimes Ydown Yleft Yright Yup)
+  Arrownot
+  arrownot
+  baro
+  bbslash
+  binampersand
+  bindnasrepma
+  boxast
+  boxbar
+  boxbox
+  boxbslash
+  boxcircle
+  ;; boxdot
+  boxempty
+  boxslash
+  curlyveedownarrow
+  curlyveeuparrow
+  curlywedgedownarrow
+  curlywedgeuparrow
+  fatbslash
+  fatsemi
+  fatslash
+  inplus
+  interleave
+  large-llbracket
+  large-rrbracket
+  Lbag
+  lbag
+  leftarrowtriangle
+  leftrightarroweq
+  leftrightarrowtriangle
+  leftslice
+  lightning
+  llbracket
+  llceil
+  llfloor
+  llparenthesis
+  Mapsfromchar
+  mapsfromchar
+  Mapstochar
+  merge
+  minuso
+  moo
+  niplus
+  nnearrow
+  nnwarrow
+  nplus
+  ntrianglelefteqslant
+  ntrianglerighteqslant
+  obar
+  oblong
+  obslash
+  ogreaterthan
+  olessthan
+  ovee
+  owedge
+  Rbag
+  rbag
+  rightarrowtriangle
+  rightslice
+  rrbracket
+  rrceil
+  rrfloor
+  rrparenthesis
+  shortdownarrow
+  shortleftarrow
+  shortrightarrow
+  shortuparrow
+  ssearrow
+  sslash
+  sswarrow
+  subsetpluseq
+  subsetplus
+  supsetpluseq
+  supsetplus
+  talloblong
+  trianglelefteqslant
+  trianglerighteqslant
+  varbigcirc
+  varcurlyvee
+  varcurlywedge
+  varoast
+  varobar
+  varobslash
+  varocircle
+  varodot
+  varogreaterthan
+  varolessthan
+  varominus
+  varoplus
+  varoslash
+  varotimes
+  varovee
+  varowedge
+  vartimes
+  Ydown
+  Yleft
+  Yright
+  Yup
+) ;logic-group
 
 (logic-group latex-stmary-big-symbol%
-  bigbox bigcurlyvee bigcurlywedge biginterleave
-  bignplus bigparallel bigsqcap)
+  bigbox
+  bigcurlyvee
+  bigcurlywedge
+  biginterleave
+  bignplus
+  bigparallel
+  bigsqcap
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from mathabx package
@@ -204,7 +813,7 @@
 ;; to be badly installed and incompatible with certain styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;(logic-group latex-mathabx-symbol%
+;; (logic-group latex-mathabx-symbol%
 ;;  divides ndivides npreccurlyeq asterisk
 ;;  dottimes nequiv precdot)
 
@@ -213,48 +822,110 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-textcomp-symbol%
-  textcent textcurrency textyen textbrokenbar textasciidieresis textlnot
-  textasciimacron textdegree degree textpm texttwosuperior textthreesuperior
-  textasciiacute textmu textonesuperior textonequarter textonehalf
-  textthreequarters texttimes textdiv)
+  textcent
+  textcurrency
+  textyen
+  textbrokenbar
+  textasciidieresis
+  textlnot
+  textasciimacron
+  textdegree
+  degree
+  textpm
+  texttwosuperior
+  textthreesuperior
+  textasciiacute
+  textmu
+  textonesuperior
+  textonequarter
+  textonehalf
+  textthreequarters
+  texttimes
+  textdiv
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from upgreek package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-upgreek-symbol%
-  upalpha upbeta upgamma updelta upepsilon
-  upvarepsilon upzeta upeta uptheta upvartheta
-  upiota upkappa uplambda upmu upnu upomicron
-  upxi uppi upvarpi uprho
-  upvarrho upsigma upvarsigma uptau upupsilon
-  upphi upvarphi upchi uppsi upomega
+  upalpha
+  upbeta
+  upgamma
+  updelta
+  upepsilon
+  upvarepsilon
+  upzeta
+  upeta
+  uptheta
+  upvartheta
+  upiota
+  upkappa
+  uplambda
+  upmu
+  upnu
+  upomicron
+  upxi
+  uppi
+  upvarpi
+  uprho
+  upvarrho
+  upsigma
+  upvarsigma
+  uptau
+  upupsilon
+  upphi
+  upvarphi
+  upchi
+  uppsi
+  upomega
 
-  Upalpha Upbeta Upgamma Updelta Upepsilon
-  Upzeta Upeta Uptheta Upiota Upkappa Uplambda
-  Upmu Upnu Upomicron Upxi Uppi Uprho Upsigma
-  Uptau Upupsilon Upphi Upchi Uppsi Upomega)
+  Upalpha
+  Upbeta
+  Upgamma
+  Updelta
+  Upepsilon
+  Upzeta
+  Upeta
+  Uptheta
+  Upiota
+  Upkappa
+  Uplambda
+  Upmu
+  Upnu
+  Upomicron
+  Upxi
+  Uppi
+  Uprho
+  Upsigma
+  Uptau
+  Upupsilon
+  Upphi
+  Upchi
+  Uppsi
+  Upomega
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Rules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-symbol% 'x))
-  ((latex-arity% 'x 0) (latex-big-symbol% 'x))
-  ((latex-symbol% 'x) (latex-latexsym-symbol% 'x))
-  ((latex-needs% 'x "latexsym") (latex-latexsym-symbol% 'x))
-  ((latex-symbol% 'x) (latex-ams-symbol% 'x))
-  ((latex-needs% 'x "amssymb") (latex-ams-symbol% 'x))
-  ((latex-symbol% 'x) (latex-wasy-symbol% 'x))
-  ((latex-needs% 'x "wasysym") (latex-wasy-symbol% 'x))
-  ((latex-symbol% 'x) (latex-stmary-symbol% 'x))
-  ((latex-needs% 'x "stmaryrd") (latex-stmary-symbol% 'x))
-  ((latex-big-symbol% 'x) (latex-stmary-big-symbol% 'x))
-  ((latex-needs% 'x "stmaryrd") (latex-stmary-big-symbol% 'x))
-  ;;((latex-symbol% 'x) (latex-mathabx-symbol% 'x))
-  ;;((latex-needs% 'x "mathabx") (latex-mathabx-symbol% 'x))
-  ((latex-symbol% 'x) (latex-textcomp-symbol% 'x))
-  ((latex-needs% 'x "textcomp") (latex-textcomp-symbol% 'x))
-  ((latex-symbol% 'x) (latex-upgreek-symbol% 'x))
-  ((latex-needs% 'x "upgreek") (latex-upgreek-symbol% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-symbol% 'x))
+ ((latex-arity% 'x 0) (latex-big-symbol% 'x))
+ ((latex-symbol% 'x) (latex-latexsym-symbol% 'x))
+ ((latex-needs% 'x "latexsym") (latex-latexsym-symbol% 'x))
+ ((latex-symbol% 'x) (latex-ams-symbol% 'x))
+ ((latex-needs% 'x "amssymb") (latex-ams-symbol% 'x))
+ ((latex-symbol% 'x) (latex-wasy-symbol% 'x))
+ ((latex-needs% 'x "wasysym") (latex-wasy-symbol% 'x))
+ ((latex-symbol% 'x) (latex-stmary-symbol% 'x))
+ ((latex-needs% 'x "stmaryrd") (latex-stmary-symbol% 'x))
+ ((latex-big-symbol% 'x) (latex-stmary-big-symbol% 'x))
+ ((latex-needs% 'x "stmaryrd") (latex-stmary-big-symbol% 'x))
+ ;; ((latex-symbol% 'x) (latex-mathabx-symbol% 'x))
+ ;; ((latex-needs% 'x "mathabx") (latex-mathabx-symbol% 'x))
+ ((latex-symbol% 'x) (latex-textcomp-symbol% 'x))
+ ((latex-needs% 'x "textcomp") (latex-textcomp-symbol% 'x))
+ ((latex-symbol% 'x) (latex-upgreek-symbol% 'x))
+ ((latex-needs% 'x "upgreek") (latex-upgreek-symbol% 'x))
+) ;logic-rules

--- a/TeXmacs/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-drd.scm
@@ -12,40 +12,41 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert latex latex-drd)
-  (:use (convert latex latex-overload)))
+(texmacs-module (convert latex latex-drd) (:use (convert latex latex-overload)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Order in which packages should be included
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-package-priority%
-  ("geometry" 10)
-  ("amsmath" 20)
-  ("amssymb" 30)
-  ("graphicx" 40)
-  ("wasysym" 50)
-  ("stmaryrd" 60)
-  ("textcomp" 60)
-  ("enumerate" 70)
-  ("epsfig" 80)
-  ("mathrsfs" 90)
-  ("bbm" 100)
-  ("dsfont" 110)
-  ("euscript" 120)
-  ("multicol" 130)
-  ("hyperref" 140)
-  ("mathtools" 150)
-  ("cleveref" 160))
+ ("geometry" 10)
+ ("amsmath" 20)
+ ("amssymb" 30)
+ ("graphicx" 40)
+ ("wasysym" 50)
+ ("stmaryrd" 60)
+ ("textcomp" 60)
+ ("enumerate" 70)
+ ("epsfig" 80)
+ ("mathrsfs" 90)
+ ("bbm" 100)
+ ("dsfont" 110)
+ ("euscript" 120)
+ ("multicol" 130)
+ ("hyperref" 140)
+ ("mathtools" 150)
+ ("cleveref" 160)
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies between style files and packages
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-depends%
-  ("amsart" "amstex")
-  ("amstex" "amsmath")
-  ("amstex" "amsthm"))
+ ("amsart" "amstex")
+ ("amstex" "amsmath")
+ ("amstex" "amsthm")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dependencies of commands on packages
@@ -76,6 +77,7 @@
   (mathbb "amssymb")
   (theorembodyfont "theorem")
   (substack "mathtools")
+  (coloneqq "mathtools")
 
   (begin-align "amsmath")
   (begin-align* "amsmath")
@@ -111,12 +113,12 @@
 
   (underaccent "accents")
   (ring "accents")
-  
+
   (ifthenelse "ifthen")
   (captionof "capt-of")
   (widthof "calc")
-  
-  (color     "xcolor")
+
+  (color "xcolor")
   (fcolorbox "xcolor")
   (textcolor "xcolor")
 
@@ -138,7 +140,7 @@
 
   (cref "cleveref")
   (Cref "cleveref")
-  
+
   (citet "natbib")
   (citep "natbib")
   (citet* "natbib")
@@ -162,82 +164,91 @@
   (ifthispageodd "scrextend")
 
   (begin-linenumbers "lineno")
-  (resetlinenumber "lineno"))
+  (resetlinenumber "lineno")
+) ;logic-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Page size settings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-paper-opts%
-  ("page-top"         "top")
-  ("page-bot"         "bottom")
-  ("page-odd"         "left")
-  ("page-even"        "left")
-  ("page-right"       "right")
-  ("page-height"      "paperheight")
-  ("page-width"       "paperwidth")
-  ("page-type"        "page-type")
-  ("page-orientation" "page-orientation"))
+ ("page-top" "top")
+ ("page-bot" "bottom")
+ ("page-odd" "left")
+ ("page-even" "left")
+ ("page-right" "right")
+ ("page-height" "paperheight")
+ ("page-width" "paperwidth")
+ ("page-type" "page-type")
+ ("page-orientation" "page-orientation")
+) ;logic-table
 
 (logic-table latex-paper-type%
-  ("a0" "a0paper")
-  ("a1" "a1paper")
-  ("a2" "a2paper")
-  ("a3" "a3paper")
-  ("a4" "a4paper")
-  ("a5" "a5paper")
-  ("a6" "a6paper")
-  ("a7" "papersize={74mm,105mm}")
-  ("a8" "papersize={52mm,74mm")
-  ("a9" "papersize={37mm,52mm}")
-  ("b0" "b0paper")
-  ("b1" "b1paper")
-  ("b2" "b2paper")
-  ("b3" "b3paper")
-  ("b4" "b4paper")
-  ("b5" "b5paper")
-  ("b6" "b6paper")
-  ("b7" "papersize={88mm,125mm}")
-  ("b8" "papersize={62mm,88mm}")
-  ("b9" "papersize={44mm,62mm}")
-  ("legal" "legalpaper")
-  ("letter" "letterpaper")
-  ("executive" "executivepaper")
-  ("archA" "papersize={9in,12in}")
-  ("archB" "papersize={12in,18in}")
-  ("archC" "papersize={18in,24in}")
-  ("archD" "papersize={24in,36in}")
-  ("archE" "papersize={36in,48in}")
-  ("10x14" "papersize={10in,14in}")
-  ("11x17" "papersize={11in,17in}")
-  ("C5" "papersize={162mm,229mm}")
-  ("Comm10" "papersize={297pt,684pt}")
-  ("DL" "papersize={110mm,220mm}")
-  ("halfletter" "papersize={140mm,216mm}")
-  ("halfexecutive" "papersize={133mm,184mm}")
-  ("ledger" "papersize={432mm,279mm}")
-  ("Monarch" "papersize={98mm,190mm}")
-  ("csheet" "papersize={432mm,559mm}")
-  ("dsheet" "papersize={559mm,864mm}")
-  ("esheet" "papersize={864mm,1118mm}")
-  ("flsa" "papersize={216mm,330mm}")
-  ("flse" "papersize={216mm,330mm}")
-  ("folio" "papersize={216mm,330mm}")
-  ("lecture note" "papersize={15.5cm,23.5cm}")
-  ("note" "papersize={216mm,279mm}")
-  ("quarto" "papersize={215mm,275mm}")
-  ("statement" "papersize={140mm,216mm}")
-  ("tabloid" "papersize={279mm,432mm}"))
+ ("a0" "a0paper")
+ ("a1" "a1paper")
+ ("a2" "a2paper")
+ ("a3" "a3paper")
+ ("a4" "a4paper")
+ ("a5" "a5paper")
+ ("a6" "a6paper")
+ ("a7" "papersize={74mm,105mm}")
+ ("a8" "papersize={52mm,74mm")
+ ("a9" "papersize={37mm,52mm}")
+ ("b0" "b0paper")
+ ("b1" "b1paper")
+ ("b2" "b2paper")
+ ("b3" "b3paper")
+ ("b4" "b4paper")
+ ("b5" "b5paper")
+ ("b6" "b6paper")
+ ("b7" "papersize={88mm,125mm}")
+ ("b8" "papersize={62mm,88mm}")
+ ("b9" "papersize={44mm,62mm}")
+ ("legal" "legalpaper")
+ ("letter" "letterpaper")
+ ("executive" "executivepaper")
+ ("archA" "papersize={9in,12in}")
+ ("archB" "papersize={12in,18in}")
+ ("archC" "papersize={18in,24in}")
+ ("archD" "papersize={24in,36in}")
+ ("archE" "papersize={36in,48in}")
+ ("10x14" "papersize={10in,14in}")
+ ("11x17" "papersize={11in,17in}")
+ ("C5" "papersize={162mm,229mm}")
+ ("Comm10" "papersize={297pt,684pt}")
+ ("DL" "papersize={110mm,220mm}")
+ ("halfletter" "papersize={140mm,216mm}")
+ ("halfexecutive" "papersize={133mm,184mm}")
+ ("ledger" "papersize={432mm,279mm}")
+ ("Monarch" "papersize={98mm,190mm}")
+ ("csheet" "papersize={432mm,559mm}")
+ ("dsheet" "papersize={559mm,864mm}")
+ ("esheet" "papersize={864mm,1118mm}")
+ ("flsa" "papersize={216mm,330mm}")
+ ("flse" "papersize={216mm,330mm}")
+ ("folio" "papersize={216mm,330mm}")
+ ("lecture note" "papersize={15.5cm,23.5cm}")
+ ("note" "papersize={216mm,279mm}")
+ ("quarto" "papersize={215mm,275mm}")
+ ("statement" "papersize={140mm,216mm}")
+ ("tabloid" "papersize={279mm,432mm}")
+) ;logic-table
 
 ;; cpp interface with reversed access
 
 (tm-define (latex-paper-opts s)
-  (with r (query `(latex-paper-opts% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-opts% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 (tm-define (latex-paper-type s)
-  (with r (query `(latex-paper-type% 'x ,s))
-    (if (nnull? r) (cdaar r) "undefined")))
+  (with r
+    (query `(latex-paper-type% 'x ,s))
+    (if (nnull? r) (cdaar r) "undefined")
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routines for consulting the database (might become deprecated)
@@ -245,28 +256,35 @@
 
 (define (latex-resolve s)
   (define (safe-string2symbol s)
-    (if (== s "") (string->symbol " ") (string->symbol s)))
+    (if (== s "") (string->symbol " ") (string->symbol s))
+  ) ;define
 
-  (if (string-starts? s "\\")
-      (set! s (substring s 1 (string-length s))))
+  (if (string-starts? s "\\") (set! s (substring s 1 (string-length s))))
 
-  (with arity (logic-ref latex-arity% (safe-string2symbol s))
+  (with arity
+    (logic-ref latex-arity% (safe-string2symbol s))
     (if (logic-in? (safe-string2symbol s) latex-optional-arg%)
-        (set! arity (- -1 arity)))
+      (set! arity (- -1 arity))
+    ) ;if
     (if (string-starts? s "end-")
-        (begin
-          (set! s (string-append "begin-" (substring s 4 (string-length s))))
-          (set! arity 0)))
-    (values (safe-string2symbol s) arity)))
+      (begin
+        (set! s (string-append "begin-" (substring s 4 (string-length s))))
+        (set! arity 0)
+      ) ;begin
+    ) ;if
+    (values (safe-string2symbol s) arity)
+  ) ;with
+) ;define
 
 (tm-define (latex-arity tag)
   "Get the arity of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
-    (or arity 0)))
+  (receive (s arity) (latex-resolve tag) (or arity 0))
+) ;tm-define
 
 (tm-define (latex-type tag)
   "Get the type of a LaTeX @tag"
-  (receive (s arity) (latex-resolve tag)
+  (receive (s arity)
+    (latex-resolve tag)
     (cond ((not arity) "undefined")
           ((logic-in? s latex-command%) "command")
           ((logic-in? s latex-length%) "length")
@@ -284,4 +302,7 @@
           ((logic-in? s latex-texmacs%) "texmacs")
           ((logic-in? s latex-symbol%) "symbol")
           ((logic-in? s latex-big-symbol%) "big-symbol")
-          (else "undefined"))))
+          (else "undefined")
+    ) ;cond
+  ) ;receive
+) ;tm-define

--- a/TeXmacs/progs/convert/latex/latex-symbol-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-symbol-drd.scm
@@ -12,191 +12,801 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (convert latex latex-symbol-drd)
-  (:use (convert latex latex-command-drd)))
+  (:use (convert latex latex-command-drd))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic symbols and big symbols
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-symbol%
+  coloneqq
   ;; Greek letters
-  Gamma Delta Theta Lambda Xi Pi Sigma Upsilon Phi Psi Omega varOmega
-  alpha beta gamma delta epsilon
-  varepsilon zeta eta theta vartheta
-  iota kappa lambda mu nu omicron
-  xi pi varpi rho
-  varrho sigma varsigma tau upsilon
-  phi varphi chi psi omega
+  Gamma
+  Delta
+  Theta
+  Lambda
+  Xi
+  Pi
+  Sigma
+  Upsilon
+  Phi
+  Psi
+  Omega
+  varOmega
+  alpha
+  beta
+  gamma
+  delta
+  epsilon
+  varepsilon
+  zeta
+  eta
+  theta
+  vartheta
+  iota
+  kappa
+  lambda
+  mu
+  nu
+  omicron
+  xi
+  pi
+  varpi
+  rho
+  varrho
+  sigma
+  varsigma
+  tau
+  upsilon
+  phi
+  varphi
+  chi
+  psi
+  omega
 
   ;; Binary operations
-  pm mp times div ast star circ bullet cdot
-  cap cup uplus sqcap sqcup vee wedge setminus wr
-  diamond triangleleft triangleright land lor lnot
-  oplus ominus otimes oslash odot bigcirc amalg notin
+  pm
+  mp
+  times
+  div
+  ast
+  star
+  circ
+  bullet
+  cdot
+  cap
+  cup
+  uplus
+  sqcap
+  sqcup
+  vee
+  wedge
+  setminus
+  wr
+  diamond
+  triangleleft
+  triangleright
+  land
+  lor
+  lnot
+  oplus
+  ominus
+  otimes
+  oslash
+  odot
+  bigcirc
+  amalg
+  notin
 
   ;; Relations
-  leq le geq ge equiv models prec
-  succ sim perp preceq succeq
-  simeq mid ll gg asymp
-  parallel subset supset approx bowtie
-  subseteq supseteq cong
-  ne neq smile sqsubseteq sqsupseteq
-  doteq frown in ni propto
-  vdash dashv
-  
+  leq
+  le
+  geq
+  ge
+  equiv
+  models
+  prec
+  succ
+  sim
+  perp
+  preceq
+  succeq
+  simeq
+  mid
+  ll
+  gg
+  asymp
+  parallel
+  subset
+  supset
+  approx
+  bowtie
+  subseteq
+  supseteq
+  cong
+  ne
+  neq
+  smile
+  sqsubseteq
+  sqsupseteq
+  doteq
+  frown
+  in
+  ni
+  propto
+  vdash
+  dashv
+
   ;; Arrows
-  leftarrow rightarrow uparrow downarrow
-  Leftarrow Rightarrow Uparrow Downarrow
-  nearrow searrow swarrow nwarrow
-  leftrightarrow updownarrow Updownarrow Leftrightarrow 
-  leftharpoonup leftharpoondown rightharpoonup rightharpoondown
-  hookleftarrow hookrightarrow
-  to mapsto longmapsto
-  longrightarrow longleftarrow longleftrightarrow
-  Longrightarrow Longleftarrow Longleftrightarrow 
-  
+  leftarrow
+  rightarrow
+  uparrow
+  downarrow
+  Leftarrow
+  Rightarrow
+  Uparrow
+  Downarrow
+  nearrow
+  searrow
+  swarrow
+  nwarrow
+  leftrightarrow
+  updownarrow
+  Updownarrow
+  Leftrightarrow
+  leftharpoonup
+  leftharpoondown
+  rightharpoonup
+  rightharpoondown
+  hookleftarrow
+  hookrightarrow
+  to
+  mapsto
+  longmapsto
+  longrightarrow
+  longleftarrow
+  longleftrightarrow
+  Longrightarrow
+  Longleftarrow
+  Longleftrightarrow
+
   ;; Miscellaneous symbols
-  ldots cdots vdots ddots hdots aleph
-  prime forall infty hbar emptyset
-  exists nabla surd triangle
-  imath jmath ell neg
-  top flat natural sharp wp
-  bot clubsuit diamondsuit heartsuit spadesuit
-  Re Im angle partial textbackslash
-  dag ddag dagger ddagger guillemotleft guillemotright
+  ldots
+  cdots
+  vdots
+  ddots
+  hdots
+  aleph
+  prime
+  forall
+  infty
+  hbar
+  emptyset
+  exists
+  nabla
+  surd
+  triangle
+  imath
+  jmath
+  ell
+  neg
+  top
+  flat
+  natural
+  sharp
+  wp
+  bot
+  clubsuit
+  diamondsuit
+  heartsuit
+  spadesuit
+  Re
+  Im
+  angle
+  partial
+  textbackslash
+  dag
+  ddag
+  dagger
+  ddagger
+  guillemotleft
+  guillemotright
 
   ;; Delimiters
-  uparrow Uparrow downarrow Downarrow
-  updownarrow Updownarrow
-  lfloor rfloor lceil rceil
-  langle rangle backslash
+  uparrow
+  Uparrow
+  downarrow
+  Downarrow
+  updownarrow
+  Updownarrow
+  lfloor
+  rfloor
+  lceil
+  rceil
+  langle
+  rangle
+  backslash
 
   ;; Big delimiters
-  rmoustache lmoustache rgroup lgroup
-  lbrack rbrack lbrace rbrace
-  arrowvert Arrowvert bracevert)
+  rmoustache
+  lmoustache
+  rgroup
+  lgroup
+  lbrack
+  rbrack
+  lbrace
+  rbrace
+  arrowvert
+  Arrowvert
+  bracevert
+) ;logic-group
 
 (logic-group latex-big-symbol%
-  sum prod coprod
-  bignone bigtimes bigoplus bigotimes bigodot
-  bigvee bigwedge bigsqcup bigcup bigcap bigpluscup
-  bigtriangledown bigtriangleup
-  int iint iiint iiiint idotsint bigint bigiint bigiiint bigiiiint bigidotsint
-  upint upiint upiiint upiiiint upidotsint bigupint bigupiint bigupiiint bigupiiiint bigupidotsint
-  oint oiint oiiint bigoint bigoiint bigoiiint
-  upoint upoiint upoiiint bigupoint bigupoiint bigupoiiint
-  intwl iintwl iiintwl iiiintwl idotsintwl bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
-  upintwl upiintwl upiiintwl upiiiintwl upidotsintwl bigupintwl bigupiintwl bigupiiintwl bigupiiiintwl bigupidotsintwl
-  ointwl oiintwl oiiintwl bigointwl bigoiintwl bigoiiintwl
-  upointwl upoiintwl upoiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
+  sum
+  prod
+  coprod
+  bignone
+  bigtimes
+  bigoplus
+  bigotimes
+  bigodot
+  bigvee
+  bigwedge
+  bigsqcup
+  bigcup
+  bigcap
+  bigpluscup
+  bigtriangledown
+  bigtriangleup
+  int
+  iint
+  iiint
+  iiiint
+  idotsint
+  bigint
+  bigiint
+  bigiiint
+  bigiiiint
+  bigidotsint
+  upint
+  upiint
+  upiiint
+  upiiiint
+  upidotsint
+  bigupint
+  bigupiint
+  bigupiiint
+  bigupiiiint
+  bigupidotsint
+  oint
+  oiint
+  oiiint
+  bigoint
+  bigoiint
+  bigoiiint
+  upoint
+  upoiint
+  upoiiint
+  bigupoint
+  bigupoiint
+  bigupoiiint
+  intwl
+  iintwl
+  iiintwl
+  iiiintwl
+  idotsintwl
+  bigintwl
+  bigiintwl
+  bigiiintwl
+  bigiiiintwl
+  bigidotsintwl
+  upintwl
+  upiintwl
+  upiiintwl
+  upiiiintwl
+  upidotsintwl
+  bigupintwl
+  bigupiintwl
+  bigupiiintwl
+  bigupiiiintwl
+  bigupidotsintwl
+  ointwl
+  oiintwl
+  oiiintwl
+  bigointwl
+  bigoiintwl
+  bigoiiintwl
+  upointwl
+  upoiintwl
+  upoiiintwl
+  bigupointwl
+  bigupoiintwl
+  bigupoiiintwl
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from latexsym package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-latexsym-symbol%
-  mho Join Box Diamond leadsto
-  sqsubset sqsupset lhd rhd unlhd unrhd)
+  mho
+  Join
+  Box
+  Diamond
+  leadsto
+  sqsubset
+  sqsupset
+  lhd
+  rhd
+  unlhd
+  unrhd
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from amssymb package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-ams-symbol%
-  ;;`
+  ;; `
   ;; Box sqsubset sqsupset lhd unlhd rhd unrhd
-  Bbbk Bumpeq Cap Cup Finv Game Lleftarrow Lsh
-  Rrightarrow Rsh Subset Supset Vdash Vvdash
-  angle approxeq backepsilon backprime backsim backsimeq barwedge
-  because beth between bigstar blacklozenge blacksquare blacktriangle
-  blacktriangledown blacktriangleleft blacktriangleright box boxdot
-  boxminus boxplus boxtimes bumpeq centerdot checkmark circeq
-  circlearrowleft circlearrowright circledR circledS circledast
-  circledcirc circleddash complement curlyeqprec curlyeqsucc curlyvee
-  curlywedge curvearrowleft curvearrowright daleth diagdown diagup
-  digamma divideontimes doteqdot dotplus doublebarwedge downdownarrows
-  downharpoonleft downharpoonright eqcirc eqsim eqslantgtr eqslantless
-  eth fallingdotseq frown geqq geqslant ggg gimel gnapprox gneq gneqq
-  gnsim gtrapprox gtrdot gtreqless gtreqqless gtrless gtrsim gvertneqq
-  hslash intercal leftarrowtail leftleftarrows leftrightarrows
-  leftrightharpoons leftrightsquigarrow leftthreetimes leqq leqslant
-  lessapprox lessdot lesseqgtr lesseqqgtr lessgtr lesssim
-  llcorner lll lnapprox lneq lneqq lnsim looparrowleft looparrowright
-  lozenge lrcorner ltimes lvert lVert lvertneqq maltese measuredangle models
-  multimap nLeftarrow nLeftrightarrow nRightarrow nVDash nVdash
-  ncong nexists ngeq ngeqq ngeqslant ngtr nleftarrow nleftrightarrow
-  nleq nleqq nleqslant nless nmid nparallel nprec npreceq nrightarrow
-  nshortmid nshortparallel nsim nsubseteq nsubseteqq nsucc nsucceq
-  nsupseteq nsupseteqq ntriangleleft ntrianglelefteq ntriangleright
-  ntrianglerighteq nvDash nvdash pitchfork precapprox preccurlyeq
-  precnapprox precneqq precnsim precsim propto rhd rightarrowtail
-  rightleftarrows rightleftharpoons rightrightarrows rightsquigarrow
-  rightthreetimes risingdotseq rtimes rvert rVert shortleftarrow shortmid
-  shortparallel varparallel shortrightarrow smalldash smallfrown smallsetminus
-  smallsmile smile sphericalangle subseteqq
-  subsetneq subsetneqq succapprox succcurlyeq succnapprox succneqq
-  succnsim succsim supseteqq supsetneq supsetneqq therefore
-  thickapprox thicksim triangle triangledown trianglelefteq
-  triangleq trianglerighteq twoheadleftarrow twoheadrightarrow
-  ulcorner upharpoonleft upharpoonright upuparrows
-  urcorner vDash varkappa varnothing varpropto varsubsetneq
-  varsubsetneqq varsupsetneq varsupsetneqq vartriangle
-  vartriangleleft vartriangleright veebar yen)
+  Bbbk
+  Bumpeq
+  Cap
+  Cup
+  Finv
+  Game
+  Lleftarrow
+  Lsh
+  Rrightarrow
+  Rsh
+  Subset
+  Supset
+  Vdash
+  Vvdash
+  angle
+  approxeq
+  backepsilon
+  backprime
+  backsim
+  backsimeq
+  barwedge
+  because
+  beth
+  between
+  bigstar
+  blacklozenge
+  blacksquare
+  blacktriangle
+  blacktriangledown
+  blacktriangleleft
+  blacktriangleright
+  box
+  boxdot
+  boxminus
+  boxplus
+  boxtimes
+  bumpeq
+  centerdot
+  checkmark
+  circeq
+  circlearrowleft
+  circlearrowright
+  circledR
+  circledS
+  circledast
+  circledcirc
+  circleddash
+  complement
+  curlyeqprec
+  curlyeqsucc
+  curlyvee
+  curlywedge
+  curvearrowleft
+  curvearrowright
+  daleth
+  diagdown
+  diagup
+  digamma
+  divideontimes
+  doteqdot
+  dotplus
+  doublebarwedge
+  downdownarrows
+  downharpoonleft
+  downharpoonright
+  eqcirc
+  eqsim
+  eqslantgtr
+  eqslantless
+  eth
+  fallingdotseq
+  frown
+  geqq
+  geqslant
+  ggg
+  gimel
+  gnapprox
+  gneq
+  gneqq
+  gnsim
+  gtrapprox
+  gtrdot
+  gtreqless
+  gtreqqless
+  gtrless
+  gtrsim
+  gvertneqq
+  hslash
+  intercal
+  leftarrowtail
+  leftleftarrows
+  leftrightarrows
+  leftrightharpoons
+  leftrightsquigarrow
+  leftthreetimes
+  leqq
+  leqslant
+  lessapprox
+  lessdot
+  lesseqgtr
+  lesseqqgtr
+  lessgtr
+  lesssim
+  llcorner
+  lll
+  lnapprox
+  lneq
+  lneqq
+  lnsim
+  looparrowleft
+  looparrowright
+  lozenge
+  lrcorner
+  ltimes
+  lvert
+  lVert
+  lvertneqq
+  maltese
+  measuredangle
+  models
+  multimap
+  nLeftarrow
+  nLeftrightarrow
+  nRightarrow
+  nVDash
+  nVdash
+  ncong
+  nexists
+  ngeq
+  ngeqq
+  ngeqslant
+  ngtr
+  nleftarrow
+  nleftrightarrow
+  nleq
+  nleqq
+  nleqslant
+  nless
+  nmid
+  nparallel
+  nprec
+  npreceq
+  nrightarrow
+  nshortmid
+  nshortparallel
+  nsim
+  nsubseteq
+  nsubseteqq
+  nsucc
+  nsucceq
+  nsupseteq
+  nsupseteqq
+  ntriangleleft
+  ntrianglelefteq
+  ntriangleright
+  ntrianglerighteq
+  nvDash
+  nvdash
+  pitchfork
+  precapprox
+  preccurlyeq
+  precnapprox
+  precneqq
+  precnsim
+  precsim
+  propto
+  rhd
+  rightarrowtail
+  rightleftarrows
+  rightleftharpoons
+  rightrightarrows
+  rightsquigarrow
+  rightthreetimes
+  risingdotseq
+  rtimes
+  rvert
+  rVert
+  shortleftarrow
+  shortmid
+  shortparallel
+  varparallel
+  shortrightarrow
+  smalldash
+  smallfrown
+  smallsetminus
+  smallsmile
+  smile
+  sphericalangle
+  subseteqq
+  subsetneq
+  subsetneqq
+  succapprox
+  succcurlyeq
+  succnapprox
+  succneqq
+  succnsim
+  succsim
+  supseteqq
+  supsetneq
+  supsetneqq
+  therefore
+  thickapprox
+  thicksim
+  triangle
+  triangledown
+  trianglelefteq
+  triangleq
+  trianglerighteq
+  twoheadleftarrow
+  twoheadrightarrow
+  ulcorner
+  upharpoonleft
+  upharpoonright
+  upuparrows
+  urcorner
+  vDash
+  varkappa
+  varnothing
+  varpropto
+  varsubsetneq
+  varsubsetneqq
+  varsupsetneq
+  varsupsetneqq
+  vartriangle
+  vartriangleleft
+  vartriangleright
+  veebar
+  yen
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from wasysym package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-wasy-symbol%
-  agemO APLbox APLcomment APLdownarrowbox APLdown APLinput
-  APLleftarrowbox APLrightarrowbox APLstar APLuparrowbox APLup apprge
-  apprle aquarius ascnode ataribox bell blacksmiley
-  Bowtie brokenvert cancer capricornus cent checked
-  CIRCLE Circle clock conjunction currency davidsstar
-  descnode dh diameter DOWNarrow eighthnote female
-  frownie fullnote gemini halfnote hexagon hexstar
-  invdiameter inve invneg jupiter kreuz LEFTarrow
-  LEFTCIRCLE Leftcircle leftmoon leftturn libra logof
-  male mercury neptune octagon openo opposition
-  pentagon permil phone pisces pluto pointer
-  quarternote recorder RIGHTarrow RIGHTCIRCLE Rightcircle
-  rightmoon rightturn sagittarius saturn
-  scorpio smiley square sun taurus Thorn
-  thorn twonotes UParrow uranus varangle varhexagon
-  varhexstar varlightning vernal VHF virgo
-  ;;wasy-38 wasy-58 wasy-80 wasy-81 wasy-82
-  wasyBox wasyDiamond wasyleadsto wasylhd wasylozenge
-  wasypropto wasyrhd wasysqsubset wasysqsupset wasytherefore
-  wasyunlhd wasyunrhd XBox)
+  agemO
+  APLbox
+  APLcomment
+  APLdownarrowbox
+  APLdown
+  APLinput
+  APLleftarrowbox
+  APLrightarrowbox
+  APLstar
+  APLuparrowbox
+  APLup
+  apprge
+  apprle
+  aquarius
+  ascnode
+  ataribox
+  bell
+  blacksmiley
+  Bowtie
+  brokenvert
+  cancer
+  capricornus
+  cent
+  checked
+  CIRCLE
+  Circle
+  clock
+  conjunction
+  currency
+  davidsstar
+  descnode
+  dh
+  diameter
+  DOWNarrow
+  eighthnote
+  female
+  frownie
+  fullnote
+  gemini
+  halfnote
+  hexagon
+  hexstar
+  invdiameter
+  inve
+  invneg
+  jupiter
+  kreuz
+  LEFTarrow
+  LEFTCIRCLE
+  Leftcircle
+  leftmoon
+  leftturn
+  libra
+  logof
+  male
+  mercury
+  neptune
+  octagon
+  openo
+  opposition
+  pentagon
+  permil
+  phone
+  pisces
+  pluto
+  pointer
+  quarternote
+  recorder
+  RIGHTarrow
+  RIGHTCIRCLE
+  Rightcircle
+  rightmoon
+  rightturn
+  sagittarius
+  saturn
+  scorpio
+  smiley
+  square
+  sun
+  taurus
+  Thorn
+  thorn
+  twonotes
+  UParrow
+  uranus
+  varangle
+  varhexagon
+  varhexstar
+  varlightning
+  vernal
+  VHF
+  virgo
+  ;; wasy-38 wasy-58 wasy-80 wasy-81 wasy-82
+  wasyBox
+  wasyDiamond
+  wasyleadsto
+  wasylhd
+  wasylozenge
+  wasypropto
+  wasyrhd
+  wasysqsubset
+  wasysqsupset
+  wasytherefore
+  wasyunlhd
+  wasyunrhd
+  XBox
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from stmaryrd package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-stmary-symbol%
-  Arrownot arrownot baro bbslash binampersand bindnasrepma
-  boxast boxbar boxbox boxbslash boxcircle
-  ;;boxdot
-  boxempty boxslash curlyveedownarrow curlyveeuparrow
-  curlywedgedownarrow curlywedgeuparrow fatbslash fatsemi fatslash
-  inplus interleave large-llbracket large-rrbracket Lbag lbag
-  leftarrowtriangle leftrightarroweq leftrightarrowtriangle
-  leftslice lightning llbracket llceil llfloor llparenthesis
-  Mapsfromchar mapsfromchar Mapstochar merge minuso moo
-  niplus nnearrow nnwarrow nplus ntrianglelefteqslant
-  ntrianglerighteqslant obar oblong obslash ogreaterthan
-  olessthan ovee owedge Rbag rbag rightarrowtriangle rightslice
-  rrbracket rrceil rrfloor rrparenthesis shortdownarrow
-  shortleftarrow shortrightarrow shortuparrow ssearrow sslash
-  sswarrow subsetpluseq subsetplus supsetpluseq supsetplus talloblong
-  trianglelefteqslant trianglerighteqslant varbigcirc varcurlyvee
-  varcurlywedge varoast varobar varobslash varocircle
-  varodot varogreaterthan varolessthan varominus varoplus varoslash
-  varotimes varovee varowedge vartimes Ydown Yleft Yright Yup)
+  Arrownot
+  arrownot
+  baro
+  bbslash
+  binampersand
+  bindnasrepma
+  boxast
+  boxbar
+  boxbox
+  boxbslash
+  boxcircle
+  ;; boxdot
+  boxempty
+  boxslash
+  curlyveedownarrow
+  curlyveeuparrow
+  curlywedgedownarrow
+  curlywedgeuparrow
+  fatbslash
+  fatsemi
+  fatslash
+  inplus
+  interleave
+  large-llbracket
+  large-rrbracket
+  Lbag
+  lbag
+  leftarrowtriangle
+  leftrightarroweq
+  leftrightarrowtriangle
+  leftslice
+  lightning
+  llbracket
+  llceil
+  llfloor
+  llparenthesis
+  Mapsfromchar
+  mapsfromchar
+  Mapstochar
+  merge
+  minuso
+  moo
+  niplus
+  nnearrow
+  nnwarrow
+  nplus
+  ntrianglelefteqslant
+  ntrianglerighteqslant
+  obar
+  oblong
+  obslash
+  ogreaterthan
+  olessthan
+  ovee
+  owedge
+  Rbag
+  rbag
+  rightarrowtriangle
+  rightslice
+  rrbracket
+  rrceil
+  rrfloor
+  rrparenthesis
+  shortdownarrow
+  shortleftarrow
+  shortrightarrow
+  shortuparrow
+  ssearrow
+  sslash
+  sswarrow
+  subsetpluseq
+  subsetplus
+  supsetpluseq
+  supsetplus
+  talloblong
+  trianglelefteqslant
+  trianglerighteqslant
+  varbigcirc
+  varcurlyvee
+  varcurlywedge
+  varoast
+  varobar
+  varobslash
+  varocircle
+  varodot
+  varogreaterthan
+  varolessthan
+  varominus
+  varoplus
+  varoslash
+  varotimes
+  varovee
+  varowedge
+  vartimes
+  Ydown
+  Yleft
+  Yright
+  Yup
+) ;logic-group
 
 (logic-group latex-stmary-big-symbol%
-  bigbox bigcurlyvee bigcurlywedge biginterleave
-  bignplus bigparallel bigsqcap)
+  bigbox
+  bigcurlyvee
+  bigcurlywedge
+  biginterleave
+  bignplus
+  bigparallel
+  bigsqcap
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from mathabx package
@@ -204,7 +814,7 @@
 ;; to be badly installed and incompatible with certain styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;(logic-group latex-mathabx-symbol%
+;; (logic-group latex-mathabx-symbol%
 ;;  divides ndivides npreccurlyeq asterisk
 ;;  dottimes nequiv precdot)
 
@@ -213,48 +823,110 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-textcomp-symbol%
-  textcent textcurrency textyen textbrokenbar textasciidieresis textlnot
-  textasciimacron textdegree degree textpm texttwosuperior textthreesuperior
-  textasciiacute textmu textonesuperior textonequarter textonehalf
-  textthreequarters texttimes textdiv)
+  textcent
+  textcurrency
+  textyen
+  textbrokenbar
+  textasciidieresis
+  textlnot
+  textasciimacron
+  textdegree
+  degree
+  textpm
+  texttwosuperior
+  textthreesuperior
+  textasciiacute
+  textmu
+  textonesuperior
+  textonequarter
+  textonehalf
+  textthreequarters
+  texttimes
+  textdiv
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from upgreek package
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-upgreek-symbol%
-  upalpha upbeta upgamma updelta upepsilon
-  upvarepsilon upzeta upeta uptheta upvartheta
-  upiota upkappa uplambda upmu upnu upomicron
-  upxi uppi upvarpi uprho
-  upvarrho upsigma upvarsigma uptau upupsilon
-  upphi upvarphi upchi uppsi upomega
+  upalpha
+  upbeta
+  upgamma
+  updelta
+  upepsilon
+  upvarepsilon
+  upzeta
+  upeta
+  uptheta
+  upvartheta
+  upiota
+  upkappa
+  uplambda
+  upmu
+  upnu
+  upomicron
+  upxi
+  uppi
+  upvarpi
+  uprho
+  upvarrho
+  upsigma
+  upvarsigma
+  uptau
+  upupsilon
+  upphi
+  upvarphi
+  upchi
+  uppsi
+  upomega
 
-  Upalpha Upbeta Upgamma Updelta Upepsilon
-  Upzeta Upeta Uptheta Upiota Upkappa Uplambda
-  Upmu Upnu Upomicron Upxi Uppi Uprho Upsigma
-  Uptau Upupsilon Upphi Upchi Uppsi Upomega)
+  Upalpha
+  Upbeta
+  Upgamma
+  Updelta
+  Upepsilon
+  Upzeta
+  Upeta
+  Uptheta
+  Upiota
+  Upkappa
+  Uplambda
+  Upmu
+  Upnu
+  Upomicron
+  Upxi
+  Uppi
+  Uprho
+  Upsigma
+  Uptau
+  Upupsilon
+  Upphi
+  Upchi
+  Uppsi
+  Upomega
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Rules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-rules
-  ((latex-arity% 'x 0) (latex-symbol% 'x))
-  ((latex-arity% 'x 0) (latex-big-symbol% 'x))
-  ((latex-symbol% 'x) (latex-latexsym-symbol% 'x))
-  ((latex-needs% 'x "latexsym") (latex-latexsym-symbol% 'x))
-  ((latex-symbol% 'x) (latex-ams-symbol% 'x))
-  ((latex-needs% 'x "amssymb") (latex-ams-symbol% 'x))
-  ((latex-symbol% 'x) (latex-wasy-symbol% 'x))
-  ((latex-needs% 'x "wasysym") (latex-wasy-symbol% 'x))
-  ((latex-symbol% 'x) (latex-stmary-symbol% 'x))
-  ((latex-needs% 'x "stmaryrd") (latex-stmary-symbol% 'x))
-  ((latex-big-symbol% 'x) (latex-stmary-big-symbol% 'x))
-  ((latex-needs% 'x "stmaryrd") (latex-stmary-big-symbol% 'x))
-  ;;((latex-symbol% 'x) (latex-mathabx-symbol% 'x))
-  ;;((latex-needs% 'x "mathabx") (latex-mathabx-symbol% 'x))
-  ((latex-symbol% 'x) (latex-textcomp-symbol% 'x))
-  ((latex-needs% 'x "textcomp") (latex-textcomp-symbol% 'x))
-  ((latex-symbol% 'x) (latex-upgreek-symbol% 'x))
-  ((latex-needs% 'x "upgreek") (latex-upgreek-symbol% 'x)))
+(logic-rules ((latex-arity% 'x 0) (latex-symbol% 'x))
+ ((latex-arity% 'x 0) (latex-big-symbol% 'x))
+ ((latex-symbol% 'x) (latex-latexsym-symbol% 'x))
+ ((latex-needs% 'x "latexsym") (latex-latexsym-symbol% 'x))
+ ((latex-symbol% 'x) (latex-ams-symbol% 'x))
+ ((latex-needs% 'x "amssymb") (latex-ams-symbol% 'x))
+ ((latex-symbol% 'x) (latex-wasy-symbol% 'x))
+ ((latex-needs% 'x "wasysym") (latex-wasy-symbol% 'x))
+ ((latex-symbol% 'x) (latex-stmary-symbol% 'x))
+ ((latex-needs% 'x "stmaryrd") (latex-stmary-symbol% 'x))
+ ((latex-big-symbol% 'x) (latex-stmary-big-symbol% 'x))
+ ((latex-needs% 'x "stmaryrd") (latex-stmary-big-symbol% 'x))
+ ;; ((latex-symbol% 'x) (latex-mathabx-symbol% 'x))
+ ;; ((latex-needs% 'x "mathabx") (latex-mathabx-symbol% 'x))
+ ((latex-symbol% 'x) (latex-textcomp-symbol% 'x))
+ ((latex-needs% 'x "textcomp") (latex-textcomp-symbol% 'x))
+ ((latex-symbol% 'x) (latex-upgreek-symbol% 'x))
+ ((latex-needs% 'x "upgreek") (latex-upgreek-symbol% 'x))
+) ;logic-rules

--- a/TeXmacs/tests/0629.scm
+++ b/TeXmacs/tests/0629.scm
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0629.scm
+;; DESCRIPTION : Tests for coloneqq dependency latex export
+;; COPYRIGHT   : (C) 2026  Jack Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(define (export-as-latex-and-load path)
+  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (string-load tmpfile))))
+  
+(define (load-latex path)
+  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path)  "\r\n" "\n")))
+
+
+(define (test_0629)
+  (check (export-as-latex-and-load "0629.tmu") => (load-latex "0629_coloneqq_dependency_export.tex"))
+  (check-report))

--- a/TeXmacs/tests/tex/0629_coloneqq_dependency_export.tex
+++ b/TeXmacs/tests/tex/0629_coloneqq_dependency_export.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage[english]{babel}
+\usepackage{mathtools}
+
+\begin{document}
+
+$x \coloneqq y$
+
+\end{document}

--- a/TeXmacs/tests/tmu/0629.tmu
+++ b/TeXmacs/tests/tmu/0629.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.1.0|2026.5.28>>
+
+<style|<tuple|generic|number-europe|preview-ref>>
+
+<\body>
+  <math|x\<coloneqq\>y>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0629.md
+++ b/devel/0629.md
@@ -1,0 +1,48 @@
+# [0629] 修复 coloneqq 相关的 mathtools 宏包依赖在 LaTeX 导出中的缺失问题
+
+## 相关文档
+- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
+
+## 任务相关的代码文件
+- `TeXmacs/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/tests/0629.scm`
+- `TeXmacs/tests/tex/0629_coloneqq_dependency_export.tex`
+- `TeXmacs/tests/tmu/0629.tmu`
+
+## 如何测试
+
+### 确定性测试（单元与集成测试）
+```bash
+xmake run 0629
+```
+
+### 非确定性测试（文档验证）
+1. 打开 Mogan STEM，在数学公式中输入定义运算符 `:=`（LaTeX 中的 `\coloneqq`）。
+2. 导出为 LaTeX，确认导出的 `.tex` 文件的导言区中正确包含了 `\usepackage{mathtools}`，避免 LaTeX 编译时报错 "Undefined control sequence \coloneqq"。
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+一个 PR 至少分为两个 commit：
+1. 第一个 commit 更新 `devel/0629.md` 任务文档
+2. 第二个 commit 为代码改动（包含测试与实现）
+
+```bash
+xmake run 0629
+```
+
+## What
+修复在 LaTeX 导出中，凡是使用了定义符号 `:=`（对应 LaTeX 中的 `\coloneqq` 命令）的数学公式文档，由于缺失对 `mathtools` 宏包依赖的匹配声明，导致导出的 LaTeX 文件导言区没有引入 `\usepackage{mathtools}` 而引发编译报错的问题。
+
+## Why
+定义运算符 `:=`（在 LaTeX 中由 `\coloneqq` 表示）在数学和物理论文中极为常用。该符号并不是标准 LaTeX 或 `amsmath` 的内置命令，而是由 `mathtools` 宏包提供。
+但是在 LaTeX 依赖定义表 `latex-drd.scm` 中，虽然注册了 `coloneqq` 作为一个合法命令，却完全缺失了对 `mathtools` 包依赖的声明映射。导致当用户在 TeXmacs 里使用 `:=` 导出为 LaTeX 时，导出的 `.tex` 文档导言区没有包含 `\usepackage{mathtools}`，使得 LaTeX 编译崩溃。
+
+## How
+在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册 `coloneqq` 宏包依赖：
+```scheme
+  (coloneqq "mathtools")
+```
+这样一旦导出的 LaTeX 文档中包含 `\coloneqq`，就会自动在导言区正确引入 `mathtools` 宏包。


### PR DESCRIPTION
# [0629] 修复 coloneqq 相关的 mathtools 宏包依赖在 LaTeX 导出中的缺失问题

## 相关文档
- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档

## 任务相关的代码文件
- `TeXmacs/progs/convert/latex/latex-drd.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
- `TeXmacs/tests/0629.scm`
- `TeXmacs/tests/tex/0629_coloneqq_dependency_export.tex`
- `TeXmacs/tests/tmu/0629.tmu`

## 如何测试

### 确定性测试（单元与集成测试）
```bash
xmake run 0629
```

### 非确定性测试（文档验证）
1. 打开 Mogan STEM，在数学公式中输入定义运算符 `:=`（LaTeX 中的 `\coloneqq`）。
2. 导出为 LaTeX，确认导出的 `.tex` 文件的导言区中正确包含了 `\usepackage{mathtools}`，避免 LaTeX 编译时报错 "Undefined control sequence \coloneqq"。

## 如何提交

提交前执行以下最少步骤：

一个 PR 至少分为两个 commit：
1. 第一个 commit 更新 `devel/0629.md` 任务文档
2. 第二个 commit 为代码改动（包含测试与实现）

```bash
xmake run 0629
```

## What
修复在 LaTeX 导出中，凡是使用了定义符号 `:=`（对应 LaTeX 中的 `\coloneqq` 命令）的数学公式文档，由于缺失对 `mathtools` 宏包依赖的匹配声明，导致导出的 LaTeX 文件导言区没有引入 `\usepackage{mathtools}` 而引发编译报错的问题。

## Why
定义运算符 `:=`（在 LaTeX 中由 `\coloneqq` 表示）在数学和物理论文中极为常用。该符号并不是标准 LaTeX 或 `amsmath` 的内置命令，而是由 `mathtools` 宏包提供。
但是在 LaTeX 依赖定义表 `latex-drd.scm` 中，虽然注册了 `coloneqq` 作为一个合法命令，却完全缺失了对 `mathtools` 包依赖的声明映射。导致当用户在 TeXmacs 里使用 `:=` 导出为 LaTeX 时，导出的 `.tex` 文档导言区没有包含 `\usepackage{mathtools}`，使得 LaTeX 编译崩溃。

## How
在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册 `coloneqq` 宏包依赖：
```scheme
  (coloneqq "mathtools")
```
这样一旦导出的 LaTeX 文档中包含 `\coloneqq`，就会自动在导言区正确引入 `mathtools` 宏包。