### PR TITLE
[0232] 补充 ChatSidebar 重命名功能单元测试

### DIFF
--- a/devel/0232.md
+++ b/devel/0232.md
@@ -42,3 +42,21 @@ xmake b stem
 - 编辑完成：`endEditTitle` 中 `emit renameRequested(sid, newTitle)`，newTitle 非空 → 调用 onRenameRequested
 
 这样复用现有信号，避免引入新信号。endEditTitle 通过 `titleEdit->isVisible()` 防止重复调用。
+
+## 6. 2026/05/28 补充单元测试
+
+### 6.1 What
+为 `ChatSidebar` 的重命名功能补充 8 个单元测试：
+1. `test_beginEditTitle_shows_editor` — 调用后 `titleEdit` 显示
+2. `test_beginEditTitle_hides_button` — 调用后 `sidebarButton` 隐藏
+3. `test_endEditTitle_accept_emits_signal` — 修改标题后确认发出 `renameRequested` 信号，参数正确
+4. `test_endEditTitle_empty_title_no_signal` — 空标题不发出信号
+5. `test_endEditTitle_same_title_no_signal` — 相同标题不发出信号
+6. `test_endEditTitle_trims_whitespace` — 自动去除首尾空白
+7. `test_updateItemTitle_updates_titleEdit` — `updateItemTitle` 同时更新 `titleEdit` 文本
+
+### 6.2 Why
+0232 提交仅包含功能实现，缺少对 `beginEditTitle`/`endEditTitle`/`updateItemTitle` 的自动化测试。
+
+### 6.3 How
+在 `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp` 中新增测试槽，通过 `findChild` 定位 `QLineEdit` 和 `QPushButton`，使用 lambda 连接 `renameRequested` 信号捕获 `moebius::string` 参数，避免 `QSignalSpy` 对自定义类型转换的问题。

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -6,7 +6,9 @@
  ******************************************************************************/
 
 #include "Qt/qt_chat_tab_widget.hpp"
+#include "Qt/qt_utilities.hpp"
 #include "base.hpp"
+#include <QLineEdit>
 #include <QPushButton>
 #include <QSignalSpy>
 #include <QtTest/QtTest>
@@ -184,6 +186,132 @@ private slots:
     widget.setCloseSidebarButtonVisible (true);
     QTest::mouseClick (widget.closeSidebarButton (), Qt::LeftButton);
     QCOMPARE (spy.count (), 1);
+  }
+
+  // === ChatSidebar title rename ===
+  void test_beginEditTitle_shows_editor () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+    sidebar.beginEditTitle ("s1");
+
+    auto item= sidebar.findChild<QLineEdit*> ("chat-tab-title-edit");
+    QVERIFY (item != nullptr);
+    QVERIFY (item->isVisible ());
+  }
+
+  void test_beginEditTitle_hides_button () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+    auto button= sidebar.findChild<QPushButton*> ("chat-tab-conversation-btn");
+    QVERIFY (button != nullptr);
+    QVERIFY (button->isVisible ());
+
+    sidebar.beginEditTitle ("s1");
+    QVERIFY (!button->isVisible ());
+  }
+
+  void test_endEditTitle_accept_emits_signal () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+
+    QString capturedSessionId;
+    QString capturedNewTitle;
+    connect (&sidebar, &ChatSidebar::renameRequested,
+             [&capturedSessionId, &capturedNewTitle] (const string& sessionId,
+                                                   const string& newTitle) {
+               capturedSessionId= to_qstring (sessionId);
+               capturedNewTitle = to_qstring (newTitle);
+             });
+
+    sidebar.beginEditTitle ("s1");
+    auto edit= sidebar.findChild<QLineEdit*> ("chat-tab-title-edit");
+    QVERIFY (edit != nullptr);
+    edit->setText ("world");
+    emit edit->returnPressed ();
+
+    QCOMPARE (capturedSessionId, QString ("s1"));
+    QCOMPARE (capturedNewTitle, QString ("world"));
+  }
+
+  void test_endEditTitle_empty_title_no_signal () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+
+    bool signalEmitted= false;
+    connect (&sidebar, &ChatSidebar::renameRequested,
+             [&signalEmitted] (const string&, const string&) {
+               signalEmitted= true;
+             });
+
+    sidebar.beginEditTitle ("s1");
+    auto edit= sidebar.findChild<QLineEdit*> ("chat-tab-title-edit");
+    QVERIFY (edit != nullptr);
+    edit->setText ("");
+    emit edit->returnPressed ();
+
+    QVERIFY (!signalEmitted);
+  }
+
+  void test_endEditTitle_same_title_no_signal () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+
+    bool signalEmitted= false;
+    connect (&sidebar, &ChatSidebar::renameRequested,
+             [&signalEmitted] (const string&, const string&) {
+               signalEmitted= true;
+             });
+
+    sidebar.beginEditTitle ("s1");
+    auto edit= sidebar.findChild<QLineEdit*> ("chat-tab-title-edit");
+    QVERIFY (edit != nullptr);
+    edit->setText ("hello");
+    emit edit->returnPressed ();
+
+    QVERIFY (!signalEmitted);
+  }
+
+  void test_endEditTitle_trims_whitespace () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+
+    QString capturedNewTitle;
+    connect (&sidebar, &ChatSidebar::renameRequested,
+             [&capturedNewTitle] (const string&, const string& newTitle) {
+               capturedNewTitle= to_qstring (newTitle);
+             });
+
+    sidebar.beginEditTitle ("s1");
+    auto edit= sidebar.findChild<QLineEdit*> ("chat-tab-title-edit");
+    QVERIFY (edit != nullptr);
+    edit->setText ("  world  ");
+    emit edit->returnPressed ();
+
+    QCOMPARE (capturedNewTitle, QString ("world"));
+  }
+
+  void test_updateItemTitle_updates_titleEdit () {
+    QList<SessionDisplayInfo> sessions;
+    sessions << SessionDisplayInfo{"s1", "hello", "", false};
+    ChatSidebar sidebar (sessions, "s1", nullptr);
+    sidebar.show ();
+
+    sidebar.updateItemTitle ("s1", "world");
+    auto edit= sidebar.findChild<QLineEdit*> ("chat-tab-title-edit");
+    QVERIFY (edit != nullptr);
+    QCOMPARE (edit->text (), QString ("world"));
   }
 };
 

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -224,7 +224,7 @@ private slots:
     QString capturedNewTitle;
     connect (&sidebar, &ChatSidebar::renameRequested,
              [&capturedSessionId, &capturedNewTitle] (const string& sessionId,
-                                                   const string& newTitle) {
+                                                      const string& newTitle) {
                capturedSessionId= to_qstring (sessionId);
                capturedNewTitle = to_qstring (newTitle);
              });


### PR DESCRIPTION
## Summary

为 0232（侧边栏内联重命名 Session Title）补充单元测试，覆盖 `ChatSidebar::beginEditTitle`、`endEditTitle` 和 `updateItemTitle` 的核心逻辑。

## 新增测试

- `test_beginEditTitle_shows_editor` — 调用后 `titleEdit` 显示
- `test_beginEditTitle_hides_button` — 调用后 `sidebarButton` 隐藏
- `test_endEditTitle_accept_emits_signal` — 修改标题后确认发出 `renameRequested` 信号，参数正确
- `test_endEditTitle_empty_title_no_signal` — 空标题不发出信号
- `test_endEditTitle_same_title_no_signal` — 相同标题不发出信号
- `test_endEditTitle_trims_whitespace` — 自动去除首尾空白
- `test_updateItemTitle_updates_titleEdit` — `updateItemTitle` 同时更新 `titleEdit` 文本

## Test plan

- [x] `xmake b qt_chat_tab_widget_test` 编译通过
- [x] `xmake r qt_chat_tab_widget_test` 全部 30 个测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)