### PR TITLE
[0640] 移除 thanksemail 自定义宏并在 LaTeX 导出中改用标准原生 inline 宏

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
@@ -14,7 +14,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (convert latex latex-define)
-  (:use (convert latex latex-texmacs-drd)))
+  (:use (convert latex latex-texmacs-drd))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs symbols
@@ -44,68 +45,68 @@
   (cdotslim "\\mathop{\\cdots}\\limits")
 
   ;; rotated arrows and other symbols
-  (mapsfrom (!group (mbox (rotatebox (!option "origin=c") "180"
-                                     (!math (mapsto))))))
-  (longmapsfrom (!group (mbox (rotatebox (!option "origin=c") "180"
-                                         (!math (longmapsto))))))
-  (mapmulti (!group (mbox (rotatebox (!option "origin=c") "180"
-                                     (!math "\\multimap")))))
-  (leftsquigarrow (!group (mbox (rotatebox (!option "origin=c") "180"
-                                           (!math (rightsquigarrow))))))
-  (upequal (!group (mbox (rotatebox (!option "origin=c") "90"
-                                    (!math "=")))))
-  (downequal (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                      (!math "=")))))
-  (longupequal (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (longequal))))))
-  (longdownequal (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (longequal))))))
-  (longupminus (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (longminus))))))
-  (longdownminus (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (longminus))))))
-  (longuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (longrightarrow))))))
-  (longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (longrightarrow))))))
-  (longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                            (!math (longleftrightarrow))))))
-  (Longuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (Longrightarrow))))))
-  (Longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (Longrightarrow))))))
-  (Longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                            (!math (Longleftrightarrow))))))
-  (mapsup (!group (mbox (rotatebox (!option "origin=c") "90"
-                                   (!math (mapsto))))))
-  (mapsdown (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                     (!math (mapsto))))))
-  (longmapsup (!group (mbox (rotatebox (!option "origin=c") "90"
-                                       (!math (longmapsto))))))
-  (longmapsdown (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                         (!math (longmapsto))))))
-  (upsquigarrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                         (!math (rightsquigarrow))))))
-  (downsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                           (!math (rightsquigarrow))))))
-  (updownsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                             (!math (leftrightsquigarrow))))))
-  (hookuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (hookrightarrow))))))
-  (hookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (hookrightarrow))))))
-  (longhookuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                            (!math (longhookrightarrow))))))
-  (longhookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                              (!math (longhookrightarrow))))))
-  (Backepsilon (!group (mbox (rotatebox (!option "origin=c") "180"
-                                        "E"))))
+  (mapsfrom (!group (mbox (rotatebox (!option "origin=c") "180" (!math (mapsto)))))
+  ) ;mapsfrom
+  (longmapsfrom (!group (mbox (rotatebox (!option "origin=c") "180" (!math (longmapsto)))))
+  ) ;longmapsfrom
+  (mapmulti (!group (mbox (rotatebox (!option "origin=c") "180" (!math "\\multimap"))))
+  ) ;mapmulti
+  (leftsquigarrow (!group (mbox (rotatebox (!option "origin=c") "180" (!math (rightsquigarrow)))))
+  ) ;leftsquigarrow
+  (upequal (!group (mbox (rotatebox (!option "origin=c") "90" (!math "=")))))
+  (downequal (!group (mbox (rotatebox (!option "origin=c") "-90" (!math "=")))))
+  (longupequal (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longequal)))))
+  ) ;longupequal
+  (longdownequal (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longequal)))))
+  ) ;longdownequal
+  (longupminus (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longminus)))))
+  ) ;longupminus
+  (longdownminus (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longminus)))))
+  ) ;longdownminus
+  (longuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longrightarrow)))))
+  ) ;longuparrow
+  (longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longrightarrow)))))
+  ) ;longdownarrow
+  (longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longleftrightarrow))))
+                   ) ;!group
+  ) ;longupdownarrow
+  (Longuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (Longrightarrow)))))
+  ) ;Longuparrow
+  (Longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (Longrightarrow)))))
+  ) ;Longdownarrow
+  (Longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (Longleftrightarrow))))
+                   ) ;!group
+  ) ;Longupdownarrow
+  (mapsup (!group (mbox (rotatebox (!option "origin=c") "90" (!math (mapsto))))))
+  (mapsdown (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (mapsto)))))
+  ) ;mapsdown
+  (longmapsup (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longmapsto)))))
+  ) ;longmapsup
+  (longmapsdown (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longmapsto)))))
+  ) ;longmapsdown
+  (upsquigarrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (rightsquigarrow)))))
+  ) ;upsquigarrow
+  (downsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (rightsquigarrow)))))
+  ) ;downsquigarrow
+  (updownsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (leftrightsquigarrow))))
+                    ) ;!group
+  ) ;updownsquigarrow
+  (hookuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (hookrightarrow)))))
+  ) ;hookuparrow
+  (hookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (hookrightarrow)))))
+  ) ;hookdownarrow
+  (longhookuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longhookrightarrow))))
+                   ) ;!group
+  ) ;longhookuparrow
+  (longhookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longhookrightarrow))))
+                     ) ;!group
+  ) ;longhookdownarrow
+  (Backepsilon (!group (mbox (rotatebox (!option "origin=c") "180" "E"))))
   (Backsigma (!group (mbox (reflectbox (!math "\\Sigma")))))
-  (Mho (!group (mbox (rotatebox (!option "origin=c") "180"
-                                (!math "\\Omega")))))
-  (btimes (!group (mbox (rotatebox (!option "origin=c") "90"
-                                   (!math "\\ltimes")))))
-  
+  (Mho (!group (mbox (rotatebox (!option "origin=c") "180" (!math "\\Omega")))))
+  (btimes (!group (mbox (rotatebox (!option "origin=c") "90" (!math "\\ltimes"))))
+  ) ;btimes
+
   ;; asymptotic relations by Joris
   (nasymp "\\not\\asymp")
   (asympasymp "{\\asymp\\!\\!\\!\\!\\!\\!-}")
@@ -246,76 +247,109 @@
   (gebar (mathrel (Yright)))
   (leangle (mathrel (angle)))
   (geangle (mathrel (!group (mbox (reflectbox (!math (angle)))))))
-  (anglege (mathrel (!group (mbox (rotatebox (!option "origin=c") "180"
-                                             (!math (angle)))))))
-  (anglele (mathrel (!group (mbox (rotatebox (!option "origin=c") "180"
-                                             (!math (!recurse (geangle))))))))
-  ;;(leqangle (mathrel (substack (!append (angle) "\\\\" (smash "-")))))
-  (leqangle (mathrel (!append (angle) " \\llap "
-                              (!group (raisebox "-1ex" (!math "-"))))))
+  (anglege (mathrel (!group (mbox (rotatebox (!option "origin=c") "180" (!math (angle))))))
+  ) ;anglege
+  (anglele (mathrel (!group (mbox (rotatebox (!option "origin=c") "180" (!math (!recurse (geangle)))))
+                    ) ;!group
+           ) ;mathrel
+  ) ;anglele
+  ;; (leqangle (mathrel (substack (!append (angle) "\\\\" (smash "-")))))
+  (leqangle (mathrel (!append (angle) " \\llap " (!group (raisebox "-1ex" (!math "-")))))
+  ) ;leqangle
   (geqangle (mathrel (!group (mbox (reflectbox (!math (!recurse (leqangle))))))))
   (legeangle (mathrel (substack (!append (leangle) "\\\\" (!recurse (anglege))))))
   (geleangle (mathrel (substack (!append (geangle) "\\\\" (!recurse (anglele))))))
-  (udots "{\\mathinner{\\mskip1mu\\raise1pt\\vbox{\\kern7pt\\hbox{.}}\\mskip2mu\\raise4pt\\hbox{.}\\mskip2mu\\raise7pt\\hbox{.}\\mskip1mu}}")
+  (udots "{\\mathinner{\\mskip1mu\\raise1pt\\vbox{\\kern7pt\\hbox{.}}\\mskip2mu\\raise4pt\\hbox{.}\\mskip2mu\\raise7pt\\hbox{.}\\mskip1mu}}"
+  ) ;udots
   (subsetsim (underset (sim) (subset)))
   (supsetsim (underset (sim) (supset)))
   (rightmap (!group (!append (shortmid) "\\!\\!\\!-")))
   (leftmap (!group (!append "-\\!\\!\\!" (shortmid))))
-  (leftrightmap (!group (!append (shortmid) "\\!\\!\\!-\\!\\!\\!"
-                                 (shortmid))))
+  (leftrightmap (!group (!append (shortmid) "\\!\\!\\!-\\!\\!\\!" (shortmid))))
   (LRleftrightarrow (!group (!append (Lleftarrow) "\\!\\!\\!" (Rrightarrow))))
   (Llongleftarrow (!group (!append (Lleftarrow) "\\!" (equiv))))
   (Llongrightarrow (!group (!append (equiv) "\\!" (Rrightarrow))))
-  (Llongleftrightarrow (!group (!append (Lleftarrow) "\\!" (equiv)
-                                        "\\!" (Rrightarrow))))
-  (threeleftarrows
-   (mathrel (substack (!append (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow)))))
-  (fourleftarrows
-   (mathrel (substack (!append (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow)))))
-  (threerightarrows
-   (mathrel (substack (!append (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow)))))
-  (fourrightarrows
-   (mathrel (substack (!append (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow)))))
-  (longleftrightarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longrightarrow)))))
-  (longleftleftarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longthreeleftarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longfourleftarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longrightleftarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longrightrightarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow)))))
-  (longthreerightarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow)))))
-  (longfourrightarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow))))))
+  (Llongleftrightarrow (!group (!append (Lleftarrow) "\\!" (equiv) "\\!" (Rrightarrow)))
+  ) ;Llongleftrightarrow
+  (threeleftarrows (mathrel (substack (!append (leftarrow) "\\\\[-0.6ex]" (leftarrow) "\\\\[-0.6ex]" (leftarrow))
+                            ) ;substack
+                   ) ;mathrel
+  ) ;threeleftarrows
+  (fourleftarrows (mathrel (substack (!append (leftarrow)
+                                       "\\\\[-0.6ex]"
+                                       (leftarrow)
+                                       "\\\\[-0.6ex]"
+                                       (leftarrow)
+                                       "\\\\[-0.6ex]"
+                                       (leftarrow)
+                                     ) ;!append
+                           ) ;substack
+                  ) ;mathrel
+  ) ;fourleftarrows
+  (threerightarrows (mathrel (substack (!append (rightarrow) "\\\\[-0.6ex]" (rightarrow) "\\\\[-0.6ex]" (rightarrow))
+                             ) ;substack
+                    ) ;mathrel
+  ) ;threerightarrows
+  (fourrightarrows (mathrel (substack (!append (rightarrow)
+                                        "\\\\[-0.6ex]"
+                                        (rightarrow)
+                                        "\\\\[-0.6ex]"
+                                        (rightarrow)
+                                        "\\\\[-0.6ex]"
+                                        (rightarrow)
+                                      ) ;!append
+                            ) ;substack
+                   ) ;mathrel
+  ) ;fourrightarrows
+  (longleftrightarrows (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]" (longrightarrow))))
+  ) ;longleftrightarrows
+  (longleftleftarrows (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]" (longleftarrow))))
+  ) ;longleftleftarrows
+  (longthreeleftarrows (mathrel (substack (!append (longleftarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longleftarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longleftarrow)
+                                          ) ;!append
+                                ) ;substack
+                       ) ;mathrel
+  ) ;longthreeleftarrows
+  (longfourleftarrows (mathrel (substack (!append (longleftarrow)
+                                           "\\\\[-0.6ex]"
+                                           (longleftarrow)
+                                           "\\\\[-0.6ex]"
+                                           (longleftarrow)
+                                           "\\\\[-0.6ex]"
+                                           (longleftarrow)
+                                         ) ;!append
+                               ) ;substack
+                      ) ;mathrel
+  ) ;longfourleftarrows
+  (longrightleftarrows (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]" (longleftarrow))))
+  ) ;longrightleftarrows
+  (longrightrightarrows (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]" (longrightarrow))))
+  ) ;longrightrightarrows
+  (longthreerightarrows (mathrel (substack (!append (longrightarrow)
+                                             "\\\\[-0.6ex]"
+                                             (longrightarrow)
+                                             "\\\\[-0.6ex]"
+                                             (longrightarrow)
+                                           ) ;!append
+                                 ) ;substack
+                        ) ;mathrel
+  ) ;longthreerightarrows
+  (longfourrightarrows (mathrel (substack (!append (longrightarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longrightarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longrightarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longrightarrow)
+                                          ) ;!append
+                                ) ;substack
+                       ) ;mathrel
+  ) ;longfourrightarrows
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs macros
@@ -328,21 +362,35 @@
   (tmat "\\symbol{\"40}")
   (tmbsl "\\ensuremath{\\backslash}")
   (tmdummy "$\\mbox{}$")
-  (TeXmacs "T\\kern-.1667em\\lower.5ex\\hbox{E}\\kern-.125emX\\kern-.1em\\lower.5ex\\hbox{\\textsc{m\\kern-.05ema\\kern-.125emc\\kern-.05ems}}")
+  (TeXmacs "T\\kern-.1667em\\lower.5ex\\hbox{E}\\kern-.125emX\\kern-.1em\\lower.5ex\\hbox{\\textsc{m\\kern-.05ema\\kern-.125emc\\kern-.05ems}}"
+  ) ;TeXmacs
   (madebyTeXmacs (footnote (!recurse (withTeXmacstext))))
-  (withTeXmacstext
-    (!append (!translate "This document has been produced using the GNU") " "
-             (!group (!recurse (TeXmacs))) " " (!translate "text editor") " ("
-             (!translate "see") " "
-             (url "https://www.texmacs.org") ")"))
-  (citewebsite
-    (!append (!translate "This document has been written using") " GNU "
-             (!group (!recurse (TeXmacs))) "; " (!translate "see") " "
-             (url "https://www.texmacs.org") "."))
+  (withTeXmacstext (!append (!translate "This document has been produced using the GNU")
+                     " "
+                     (!group (!recurse (TeXmacs)))
+                     " "
+                     (!translate "text editor")
+                     " ("
+                     (!translate "see")
+                     " "
+                     (url "https://www.texmacs.org")
+                     ")"
+                   ) ;!append
+  ) ;withTeXmacstext
+  (citewebsite (!append (!translate "This document has been written using")
+                 " GNU "
+                 (!group (!recurse (TeXmacs)))
+                 "; "
+                 (!translate "see")
+                 " "
+                 (url "https://www.texmacs.org")
+                 "."
+               ) ;!append
+  ) ;citewebsite
   (tmmade (!recurse (tikzframe (Backsigma))))
   (scheme "{\\sc Scheme}")
-  (tmsep  ", ")
-  (tmSep  "; ")
+  (tmsep ", ")
+  (tmSep "; ")
   (pari "{\\sc Pari}")
   (textdots "...")
   (filldots "{\\dotfill\\hfill\\hbox{}}")
@@ -400,13 +448,21 @@
   (tmieeeemail (!append (textit (!translate "Email:")) " " 1))
   (tmnote (thanks (!append (textit (!translate "Note:")) " " 1)))
   (tmmisc (thanks (!append (textit (!translate "Misc:")) " " 1)))
-  (citetexmacs
-    (!append (!translate "This document has been written using") " GNU "
-             (!group (!recurse (TeXmacs))) " " (cite 1) "."))
-  (key (!append
-         (fcolorbox "black" "gray!25!white"
-                    (raisebox "0pt" (!option "5pt") (!option "0pt") (texttt 1)))
-         (hspace "0.5pt")))
+  (citetexmacs (!append (!translate "This document has been written using")
+                 " GNU "
+                 (!group (!recurse (TeXmacs)))
+                 " "
+                 (cite 1)
+                 "."
+               ) ;!append
+  ) ;citetexmacs
+  (key (!append (fcolorbox "black"
+                  "gray!25!white"
+                  (raisebox "0pt" (!option "5pt") (!option "0pt") (texttt 1))
+                ) ;fcolorbox
+         (hspace "0.5pt")
+       ) ;!append
+  ) ;key
   (uhat (underaccent (hat) 1))
   (uwidehat (underaccent (widehat (hphantom 1)) 1))
   (utilde (underaccent (tilde) 1))
@@ -423,7 +479,7 @@
   (udddot (underaccent (dddot (hphantom 1)) 1))
   (uddddot (underaccent (ddddot (hphantom 1)) 1))
   (widespacing 1)
-  (gb  (!append (texttt "[\\!\\![") 1 (texttt "]\\!\\!]")))
+  (gb (!append (texttt "[\\!\\![") 1 (texttt "]\\!\\!]")))
   (gbt (!append (texttt "[\\!\\![\\!\\![") 1 (texttt "]\\!\\!]\\!\\!]")))
 
   ;; With options
@@ -431,26 +487,22 @@
 
   ;; Binary macros
   (tmcolor (!group (color 1) (!group 2)))
-  (tmsummarizeddocumentation
-   (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1)))
+  (tmsummarizeddocumentation (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1))
+  ) ;tmsummarizeddocumentation
   (tmsummarizedgrouped (trivlist (!append (item (!option "[")) (mbox "") 1)))
-  (tmsummarizedexplain
-   (trivlist (!append (item (!option "")) (mbox "") "\\bf" 1)))
+  (tmsummarizedexplain (trivlist (!append (item (!option "")) (mbox "") "\\bf" 1))
+  ) ;tmsummarizedexplain
   (tmsummarizedplain (trivlist (!append (item (!option "")) (mbox "") 1)))
   (tmsummarizedtiny (trivlist (!append (item (!option "")) (mbox "") 1)))
   (tmsummarizedraw (trivlist (!append (item (!option "")) (mbox "") 1)))
-  (tmsummarizedenv
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmsummarizedstd
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmsummarized
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
+  (tmsummarizedenv (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
+  (tmsummarizedstd (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
+  (tmsummarized (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
 
-  (tmdetaileddocumentation
-   (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 2)))
+  (tmdetaileddocumentation (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 2))
+  ) ;tmdetaileddocumentation
   (tmdetailedgrouped (trivlist (!append (item (!option "[")) (mbox "") 2)))
-  (tmdetailedexplain
-   (trivlist (!append (item (!option "")) (mbox "") "\\bf" 2)))
+  (tmdetailedexplain (trivlist (!append (item (!option "")) (mbox "") "\\bf" 2)))
   (tmdetailedplain (trivlist (!append (item (!option "")) (mbox "") 2)))
   (tmdetailedtiny (trivlist (!append (item (!option "")) (mbox "") 2)))
   (tmdetailedraw (trivlist (!append (item (!option "")) (mbox "") 2)))
@@ -458,97 +510,159 @@
   (tmdetailedstd (trivlist (!append (item (!option "$\\circ$")) (mbox "") 2)))
   (tmdetailed (trivlist (!append (item (!option "$\\circ$")) (mbox "") 2)))
 
-  (tmfoldeddocumentation
-   (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1)))
-  (tmunfoldeddocumentation
-   (trivlist (!append (item (!option "")) (mbox "")
-                      (!group "\\large\\bf" 1) "\\\\"
-                      (item (!option "")) (mbox "") 2)))
-  (tmfoldedsubsession
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfoldedsubsession
-   (trivlist (!append (item (!option "$\\circ$"))   (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
-  (tmfoldedgrouped
-   (trivlist (!append (item (!option "["))  (mbox "") 1)))
-  (tmunfoldedgrouped
-   (trivlist (!append (item (!option "$\\lceil$"))  (mbox "") 1 "\\\\"
-                      (item (!option "$\\lfloor$")) (mbox "") 2 )))
+  (tmfoldeddocumentation (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1))
+  ) ;tmfoldeddocumentation
+  (tmunfoldeddocumentation (trivlist (!append (item (!option ""))
+                                       (mbox "")
+                                       (!group "\\large\\bf" 1)
+                                       "\\\\"
+                                       (item (!option ""))
+                                       (mbox "")
+                                       2
+                                     ) ;!append
+                           ) ;trivlist
+  ) ;tmunfoldeddocumentation
+  (tmfoldedsubsession (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1))
+  ) ;tmfoldedsubsession
+  (tmunfoldedsubsession (trivlist (!append (item (!option "$\\circ$"))
+                                    (mbox "")
+                                    1
+                                    "\\\\"
+                                    (item (!option ""))
+                                    (mbox "")
+                                    2
+                                  ) ;!append
+                        ) ;trivlist
+  ) ;tmunfoldedsubsession
+  (tmfoldedgrouped (trivlist (!append (item (!option "[")) (mbox "") 1)))
+  (tmunfoldedgrouped (trivlist (!append (item (!option "$\\lceil$"))
+                                 (mbox "")
+                                 1
+                                 "\\\\"
+                                 (item (!option "$\\lfloor$"))
+                                 (mbox "")
+                                 2
+                               ) ;!append
+                     ) ;trivlist
+  ) ;tmunfoldedgrouped
   (tmfoldedexplain (trivlist (!append (item (!option "")) "\\bf" 1)))
-  (tmunfoldedexplain
-   (trivlist (!append (item (!option "")) (mbox "")
-                      (!group "\\bf" 1) "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedexplain (trivlist (!append (item (!option ""))
+                                 (mbox "")
+                                 (!group "\\bf" 1)
+                                 "\\\\"
+                                 (item (!option ""))
+                                 (mbox "")
+                                 2
+                               ) ;!append
+                     ) ;trivlist
+  ) ;tmunfoldedexplain
   (tmfoldedplain (trivlist (!append (item (!option "")) (mbox "") 1)))
-  (tmunfoldedplain
-   (trivlist (!append (item (!option "")) (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedplain (trivlist (!append (item (!option "")) (mbox "") 1 "\\\\" (item (!option "")) (mbox "") 2)
+                   ) ;trivlist
+  ) ;tmunfoldedplain
   (tmfoldedenv (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfoldedenv
-   (trivlist (!append (item (!option "$\\circ$")) (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedenv (trivlist (!append (item (!option "$\\circ$"))
+                             (mbox "")
+                             1
+                             "\\\\"
+                             (item (!option ""))
+                             (mbox "")
+                             2
+                           ) ;!append
+                 ) ;trivlist
+  ) ;tmunfoldedenv
   (tmfoldedstd (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfoldedstd
-   (trivlist (!append (item (!option "$\\circ$")) (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedstd (trivlist (!append (item (!option "$\\circ$"))
+                             (mbox "")
+                             1
+                             "\\\\"
+                             (item (!option ""))
+                             (mbox "")
+                             2
+                           ) ;!append
+                 ) ;trivlist
+  ) ;tmunfoldedstd
   (tmfolded (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfolded (trivlist (!append (item (!option "$\\circ$")) (mbox "") 1 "\\\\"
-                                 (item (!option "")) (mbox "") 2 )))
-  (tminput
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (!group (!append (color "blue!50!black") (mbox "") 2)))))
-  (tminputmath
-   (trivlist (!append (item (!option 1)) (ensuremath 2))))
-  (tmhlink  (!group (!append (color "blue") 1)))
+  (tmunfolded (trivlist (!append (item (!option "$\\circ$"))
+                          (mbox "")
+                          1
+                          "\\\\"
+                          (item (!option ""))
+                          (mbox "")
+                          2
+                        ) ;!append
+              ) ;trivlist
+  ) ;tmunfolded
+  (tminput (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                       (!group (!append (color "blue!50!black") (mbox "") 2))
+                     ) ;!append
+           ) ;trivlist
+  ) ;tminput
+  (tminputmath (trivlist (!append (item (!option 1)) (ensuremath 2))))
+  (tmhlink (!group (!append (color "blue") 1)))
   (tmaction (!group (!append (color "blue") 1)))
   (ontop (genfrac "" "" "0pt" "" 1 2))
   (subindex (index (!append 1 "!" 2)))
   (renderfootnote (footnotetext (!append (tmrsup 1) " " 2)))
   (renderfootnotestar (footnotetext (!append (tmrsup 1) " " 3)))
-  (tmlinenumber (!append (custombinding 1)
-                         (tmlinenote (footnotesize 1) 2 "0cm")))
+  (tmlinenumber (!append (custombinding 1) (tmlinenote (footnotesize 1) 2 "0cm")))
 
   ;; Ternary macros
   (tmsession (!group (!append (tt) 3)))
-  (tmfoldediomath
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (!group (!append (color "blue!50!black") (ensuremath 2))))))
-  (tmunfoldediomath
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (!group (!append (color "blue!50!black") (ensuremath 2)))
-                      (item (!option "")) (mbox "") 3)))
-  (tmfoldedio
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (mbox "") (!group (!append (color "blue!50!black") 2)))))
-  (tmunfoldedio
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (mbox "") (!group (!append (color "blue!50!black") 2))
-                      (item (!option "")) (mbox "") 3)))
-  (tmlinenote
-   (!append (tmdummy)
-            (marginpar (adjustbox
-                        (!append "right=0cm, lap=" 2
-                                 "-\\textwidth-\\marginparsep, raise=" 3)
-                        1))))
+  (tmfoldediomath (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                              (!group (!append (color "blue!50!black") (ensuremath 2)))
+                            ) ;!append
+                  ) ;trivlist
+  ) ;tmfoldediomath
+  (tmunfoldediomath (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                                (!group (!append (color "blue!50!black") (ensuremath 2)))
+                                (item (!option ""))
+                                (mbox "")
+                                3
+                              ) ;!append
+                    ) ;trivlist
+  ) ;tmunfoldediomath
+  (tmfoldedio (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                          (mbox "")
+                          (!group (!append (color "blue!50!black") 2))
+                        ) ;!append
+              ) ;trivlist
+  ) ;tmfoldedio
+  (tmunfoldedio (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                            (mbox "")
+                            (!group (!append (color "blue!50!black") 2))
+                            (item (!option ""))
+                            (mbox "")
+                            3
+                          ) ;!append
+                ) ;trivlist
+  ) ;tmunfoldedio
+  (tmlinenote (!append (tmdummy)
+                (marginpar (adjustbox (!append "right=0cm, lap=" 2 "-\\textwidth-\\marginparsep, raise=" 3)
+                             1
+                           ) ;adjustbox
+                ) ;marginpar
+              ) ;!append
+  ) ;tmlinenote
   (subsubindex (index (!append 1 "!" 2 "!" 3)))
   (tmref 1)
   (glossaryentry (!append (item (!option (!append 1 (hfill)))) 2 (dotfill) 3))
 
   ;; Tetrary macros
-  (tmscriptinput (fbox (!append (fbox (!append (sf) 2)) " "
-                                (!append (tt) 3))))
+  (tmscriptinput (fbox (!append (fbox (!append (sf) 2)) " " (!append (tt) 3))))
   (tmscriptoutput (!append 4))
-  (tmconverterinput (fbox (!append (fbox (!append (sf) 2)) " "
-                                   (!append (tt) 3))))
+  (tmconverterinput (fbox (!append (fbox (!append (sf) 2)) " " (!append (tt) 3))))
   (tmconverteroutput (!append 4))
-  (subsubsubindex (index (!append 1 "!" 2 "!" 3 "!" 4))))
+  (subsubsubindex (index (!append 1 "!" 2 "!" 3 "!" 4)))
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Deprecated extra macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-macro
-  (labeleqnum "\\addtocounter{equation}{-1}\\refstepcounter{equation}\\addtocounter{equation}{1})")
+  (labeleqnum "\\addtocounter{equation}{-1}\\refstepcounter{equation}\\addtocounter{equation}{1})"
+  ) ;labeleqnum
   (eqnumber (!append "\\hfill(\\theequation" (!recurse (labeleqnum)) ")"))
   (leqnumber (!append "(\\theequation" (!recurse (labeleqnum)) ")\\hfill"))
   (reqnumber (!append "\\hfill(\\theequation" (!recurse (labeleqnum)) ")"))
@@ -556,58 +670,64 @@
   (ckey (!recurse (key (!append "ctrl-" 1))))
   (akey (!recurse (key (!append "alt-" 1))))
   (mkey (!recurse (key (!append "meta-" 1))))
-  (hkey (!recurse (key (!append "hyper-" 1)))))
+  (hkey (!recurse (key (!append "hyper-" 1))))
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-environment
-  ("proof"
-   ((!begin "proof") ---))
-  ("proof*"
-   ((!begin "proof" (!option 1)) ---))
-  ("leftaligned"
-   ((!begin "flushleft") ---))
-  ("rightaligned"
-   ((!begin "flushright") ---))
-  ("quoteenv"
-   ((!begin "quote") ---))
-  ("tmcode"
-   ((!option "")
-    ((!begin "alltt") ---)))
-  ("tmparmod"
-   ((!begin "list" "" (!append "\\setlength{\\topsep}{0pt}"
-                               "\\setlength{\\leftmargin}{" 1 "}"
-                               "\\setlength{\\rightmargin}{" 2 "}"
-                               "\\setlength{\\parindent}{" 3 "}"
-                               "\\setlength{\\listparindent}{\\parindent}"
-                               "\\setlength{\\itemindent}{\\parindent}"
-                               "\\setlength{\\parsep}{\\parskip}"))
-    (!append "\\item[]"
-             ---)))
-  ("tmparsep"
-   (!append (begingroup) "\\setlength{\\parskip}{" 1 "}"
-            ---
-            (endgroup)))
-  ("tmcompact"
-   ((!begin "tmparsep" "0em") ---))
-  ("tmcompressed"
-   ((!begin "tmparsep" "0.25em") ---))
-  ("tmamplified"
-   ((!begin "tmparsep" "0.75em") ---))
-  ("tmjumpin"
-   ((!begin "tmparmod" "1.5em" "0pt" "-1.5em") ---))
-  ("tmindent"
-   ((!begin "tmparmod" "1.5em" "0pt" "0pt") ---))
-  ("tmlisting"
-   ((!begin "linenumbers") (!append (resetlinenumber) ---)))
-  ("elsequation" ((!begin "eqnarray") (!append --- "&&")))
-  ("elsequation*" ((!begin "eqnarray*") (!append --- "&&")))
-  ("theglossary"
-   ((!begin "list" "" (!append "\\setlength{\\labelwidth}{6.5em}"
-                               "\\setlength{\\leftmargin}{7em}"
-                               "\\small")) ---)))
+ ("proof" ((!begin "proof") ---))
+ ("proof*" ((!begin "proof" (!option 1)) ---))
+ ("leftaligned" ((!begin "flushleft") ---))
+ ("rightaligned" ((!begin "flushright") ---))
+ ("quoteenv" ((!begin "quote") ---))
+ ("tmcode" ((!option "") ((!begin "alltt") ---)))
+ ("tmparmod"
+  ((!begin "list"
+     ""
+     (!append "\\setlength{\\topsep}{0pt}"
+       "\\setlength{\\leftmargin}{"
+       1
+       "}"
+       "\\setlength{\\rightmargin}{"
+       2
+       "}"
+       "\\setlength{\\parindent}{"
+       3
+       "}"
+       "\\setlength{\\listparindent}{\\parindent}"
+       "\\setlength{\\itemindent}{\\parindent}"
+       "\\setlength{\\parsep}{\\parskip}"
+     ) ;!append
+   ) ;!begin
+   (!append "\\item[]" ---)
+  ) ;
+ ) ;
+ ("tmparsep"
+   (!append (begingroup) "\\setlength{\\parskip}{" 1 "}" --- (endgroup))
+ ) ;
+ ("tmcompact" ((!begin "tmparsep" "0em") ---))
+ ("tmcompressed" ((!begin "tmparsep" "0.25em") ---))
+ ("tmamplified" ((!begin "tmparsep" "0.75em") ---))
+ ("tmjumpin" ((!begin "tmparmod" "1.5em" "0pt" "-1.5em") ---))
+ ("tmindent" ((!begin "tmparmod" "1.5em" "0pt" "0pt") ---))
+ ("tmlisting" ((!begin "linenumbers") (!append (resetlinenumber) ---)))
+ ("elsequation" ((!begin "eqnarray") (!append --- "&&")))
+ ("elsequation*" ((!begin "eqnarray*") (!append --- "&&")))
+ ("theglossary"
+  ((!begin "list"
+     ""
+     (!append "\\setlength{\\labelwidth}{6.5em}"
+       "\\setlength{\\leftmargin}{7em}"
+       "\\small"
+     ) ;!append
+   ) ;!begin
+   ---
+  ) ;
+ ) ;
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TeXmacs list environments
@@ -617,19 +737,29 @@
   `(smart-table latex-texmacs-environment
      (,env
       ((!begin "itemize")
-       (!append "\\renewcommand{\\labelitemi}{" ,lab "}"
-                "\\renewcommand{\\labelitemii}{" ,lab "}"
-                "\\renewcommand{\\labelitemiii}{" ,lab "}"
-                "\\renewcommand{\\labelitemiv}{" ,lab "}"
-                ---)))))
+       (!append ,"\\renewcommand{\\labelitemi}{"
+         ,lab
+         ,"}"
+         ,"\\renewcommand{\\labelitemii}{"
+         ,lab
+         ,"}"
+         ,"\\renewcommand{\\labelitemiii}{"
+         ,lab
+         ,"}"
+         ,"\\renewcommand{\\labelitemiv}{"
+         ,lab
+         ,"}"
+         ---))))
+) ;define-macro
 
 (define-macro (latex-texmacs-enumerate env lab)
   `(smart-table latex-texmacs-environment
-     (,env ((!begin "enumerate" (!option ,lab)) ---))))
+     (,env ((!begin ,"enumerate" (!option ,lab)) ---)))
+) ;define-macro
 
 (define-macro (latex-texmacs-description env)
-  `(smart-table latex-texmacs-environment
-     (,env ((!begin "description") ---))))
+  `(smart-table latex-texmacs-environment (,env ((!begin "description") ---)))
+) ;define-macro
 
 (latex-texmacs-itemize "itemizeminus" "$-$")
 (latex-texmacs-itemize "itemizedot" "$\\bullet$")
@@ -655,112 +785,139 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-preamble
-  (newmdenv
-   (!append (mdfsetup (!append "linecolor=black,linewidth=0.5pt,"
-                               "skipabove=0.5em,skipbelow=0.5em,"
-                               "hidealllines=true,innerleftmargin=0pt,"
-                               "innerrightmargin=0pt,innertopmargin=0pt,"
-                               "innerbottommargin=0pt" )) "\n"))
-  (tikzframe
-   (!append
-    (!ignore (tikz))
-    "\\newcommand{\\tikzframe}[1]{%\n"
-    "  \\tikz[baseline=(X.base)]\n"
-    "  \\node[draw=black,semithick,rectangle,inner sep=2pt,rounded corners=2pt]\n"
-    "  (X) {#1};}\n"))
-  (nonconverted
-   (!append "\\newcommand{\\nonconverted}[1]{\\mbox{}}\n"))
-  (tmkeywords
-   (!append (newcommand (tmkeywords)
-                        (!append (textbf (!translate "Keywords:")) " "))
-            "\n"))
-  (tmacm
-   (!append (newcommand (tmacm)
-                        (!append
-                         (textbf
-                          (!translate "A.C.M. subject classification:")) " "))
-            "\n"))
-  (tmarxiv
-   (!append (newcommand (tmarxiv)
-                        (!append
-                         (textbf
-                          (!translate "arXiv subject classification:")) " "))
-            "\n"))
-  (tmpacs
-   (!append (newcommand (tmpacs)
-                        (!append
-                         (textbf
-                          (!translate "P.A.C.S. subject classification:"))
-                         " "))
-            "\n"))
-  (tmmsc
-   (!append (newcommand (tmmsc)
-                        (!append
-                         (textbf
-                          (!translate "A.M.S. subject classification:")) " "))
-            "\n"))
+  (newmdenv (!append (mdfsetup (!append "linecolor=black,linewidth=0.5pt,"
+                                 "skipabove=0.5em,skipbelow=0.5em,"
+                                 "hidealllines=true,innerleftmargin=0pt,"
+                                 "innerrightmargin=0pt,innertopmargin=0pt,"
+                                 "innerbottommargin=0pt"
+                               ) ;!append
+                     ) ;mdfsetup
+              "\n"
+            ) ;!append
+  ) ;newmdenv
+  (tikzframe (!append (!ignore (tikz))
+               "\\newcommand{\\tikzframe}[1]{%\n"
+               "  \\tikz[baseline=(X.base)]\n"
+               "  \\node[draw=black,semithick,rectangle,inner sep=2pt,rounded corners=2pt]\n"
+               "  (X) {#1};}\n"
+             ) ;!append
+  ) ;tikzframe
+  (nonconverted (!append "\\newcommand{\\nonconverted}[1]{\\mbox{}}\n"))
+  (tmkeywords (!append (newcommand (tmkeywords) (!append (textbf (!translate "Keywords:")) " "))
+                "\n"
+              ) ;!append
+  ) ;tmkeywords
+  (tmacm (!append (newcommand (tmacm)
+                    (!append (textbf (!translate "A.C.M. subject classification:")) " ")
+                  ) ;newcommand
+           "\n"
+         ) ;!append
+  ) ;tmacm
+  (tmarxiv (!append (newcommand (tmarxiv)
+                      (!append (textbf (!translate "arXiv subject classification:")) " ")
+                    ) ;newcommand
+             "\n"
+           ) ;!append
+  ) ;tmarxiv
+  (tmpacs (!append (newcommand (tmpacs)
+                     (!append (textbf (!translate "P.A.C.S. subject classification:")) " ")
+                   ) ;newcommand
+            "\n"
+          ) ;!append
+  ) ;tmpacs
+  (tmmsc (!append (newcommand (tmmsc)
+                    (!append (textbf (!translate "A.M.S. subject classification:")) " ")
+                  ) ;newcommand
+           "\n"
+         ) ;!append
+  ) ;tmmsc
   (fmtext (!append "\\newcommand{\\fmtext}[2][]{\\fntext[#1]{"
-                   (!translate "Misc:") " #2}}\n"))
+            (!translate "Misc:")
+            " #2}}\n"
+          ) ;!append
+  ) ;fmtext
   (tdatetext (!append "\\newcommand{\\tdatetext}[2][]{\\tnotetext[#1]{"
-                      (!translate "Date:") " #2}}\n"))
+               (!translate "Date:")
+               " #2}}\n"
+             ) ;!append
+  ) ;tdatetext
   (tmisctext (!append "\\newcommand{\\tmisctext}[2][]{\\tnotetext[#1]{"
-                      (!translate "Misc:") " #2}}\n"))
+               (!translate "Misc:")
+               " #2}}\n"
+             ) ;!append
+  ) ;tmisctext
   (tsubtitletext (!append "\\newcommand{\\tsubtitletext}[2][]{\\tnotetext[#1]{"
-                          (!translate "Subtitle:") " #2}}\n"))
+                   (!translate "Subtitle:")
+                   " #2}}\n"
+                 ) ;!append
+  ) ;tsubtitletext
   (thankshomepage (!append "\\newcommand{\\thankshomepage}[2][]{\\thanks[#1]{"
-                           (!translate "URL:") " #2}}\n"))
-  (thanksemail (!append "\\newcommand{\\thanksemail}[2][]{\\thanks[#1]{"
-                        (!translate "Email:") " #2}}\n"))
+                    (!translate "URL:")
+                    " #2}}\n"
+                  ) ;!append
+  ) ;thankshomepage
   (thanksdate (!append "\\newcommand{\\thanksdate}[2][]{\\thanks[#1]{"
-                       (!translate "Date:") " #2}}\n"))
+                (!translate "Date:")
+                " #2}}\n"
+              ) ;!append
+  ) ;thanksdate
   (thanksamisc (!append "\\newcommand{\\thanksamisc}[2][]{\\thanks[#1]{"
-                        (!translate "Misc:") " #2}}\n"))
+                 (!translate "Misc:")
+                 " #2}}\n"
+               ) ;!append
+  ) ;thanksamisc
   (thanksmisc (!append "\\newcommand{\\thanksmisc}[2][]{\\thanks[#1]{"
-                       (!translate "Misc:") " #2}}\n"))
+                (!translate "Misc:")
+                " #2}}\n"
+              ) ;!append
+  ) ;thanksmisc
   (thankssubtitle (!append "\\newcommand{\\thankssubtitle}[2][]{\\thanks[#1]{"
-                           (!translate "Subtitle:") " #2}}\n"))
+                    (!translate "Subtitle:")
+                    " #2}}\n"
+                  ) ;!append
+  ) ;thankssubtitle
   (qed (!append (providecommand "\\qed" (ensuremath (Box))) "\n"))
-  (mho
-   (!append
-    "\\renewcommand{\\mho}{\\mbox{\\rotatebox[origin=c]{180}{$\\omega$}}}"))
-  (invbreve
-   (!append
-    "\\usepackage[T3,T1]{fontenc}\n"
-    "\\DeclareSymbolFont{tipa}{T3}{cmr}{m}{n}\n"
-    "\\DeclareMathAccent{\\invbreve}{\\mathalpha}{tipa}{16}\n"))
-  (custombinding
-   (!append
-    "\\newcounter{tmcounter}\n"
-    "\\newcommand{\\custombinding}[1]{%\n"
-    "  \\setcounter{tmcounter}{#1}%\n"
-    "  \\addtocounter{tmcounter}{-1}%\n"
-    "  \\refstepcounter{tmcounter}}\n"))
-  (tmfloat
-   (!append
-    (!ignore (ifthenelse) (captionof) (widthof))
-    "\\newcommand{\\tmfloatcontents}{}\n"
-    "\\newlength{\\tmfloatwidth}\n"
-    "\\newcommand{\\tmfloat}[5]{\n"
-    "  \\renewcommand{\\tmfloatcontents}{#4}\n"
-    "  \\setlength{\\tmfloatwidth}{\\widthof{\\tmfloatcontents}+1in}\n"
-    "  \\ifthenelse{\\equal{#2}{small}}\n"
-    ;; FIXME: the length test frequently produces an error:
-    ;; '! Missing = inserted for \ifdim'.
-    ;; I (Joris) did not manage to understand this LaTeX mess.
-    ;;"    {\\ifthenelse{\\lengthtest{\\tmfloatwidth > \\linewidth}}\n"
-    ;;"      {\\setlength{\\tmfloatwidth}{\\linewidth}}{}}\n"
-    "    {\\setlength{\\tmfloatwidth}{0.45\\linewidth}}\n"
-    "    {\\setlength{\\tmfloatwidth}{\\linewidth}}\n"
-    "  \\begin{minipage}[#1]{\\tmfloatwidth}\n"
-    "    \\begin{center}\n"
-    "      \\tmfloatcontents\n"
-    "      \\captionof{#3}{#5}\n"
-    "    \\end{center}\n"
-    "  \\end{minipage}}\n"))
+  (mho (!append "\\renewcommand{\\mho}{\\mbox{\\rotatebox[origin=c]{180}{$\\omega$}}}")
+  ) ;mho
+  (invbreve (!append "\\usepackage[T3,T1]{fontenc}\n"
+              "\\DeclareSymbolFont{tipa}{T3}{cmr}{m}{n}\n"
+              "\\DeclareMathAccent{\\invbreve}{\\mathalpha}{tipa}{16}\n"
+            ) ;!append
+  ) ;invbreve
+  (custombinding (!append "\\newcounter{tmcounter}\n"
+                   "\\newcommand{\\custombinding}[1]{%\n"
+                   "  \\setcounter{tmcounter}{#1}%\n"
+                   "  \\addtocounter{tmcounter}{-1}%\n"
+                   "  \\refstepcounter{tmcounter}}\n"
+                 ) ;!append
+  ) ;custombinding
+  (tmfloat (!append (!ignore (ifthenelse) (captionof) (widthof))
+             "\\newcommand{\\tmfloatcontents}{}\n"
+             "\\newlength{\\tmfloatwidth}\n"
+             "\\newcommand{\\tmfloat}[5]{\n"
+             "  \\renewcommand{\\tmfloatcontents}{#4}\n"
+             "  \\setlength{\\tmfloatwidth}{\\widthof{\\tmfloatcontents}+1in}\n"
+             "  \\ifthenelse{\\equal{#2}{small}}\n"
+             ;; FIXME: the length test frequently produces an error:
+             ;; '! Missing = inserted for \ifdim'.
+             ;; I (Joris) did not manage to understand this LaTeX mess.
+             ;; "    {\\ifthenelse{\\lengthtest{\\tmfloatwidth > \\linewidth}}\n"
+             ;; "      {\\setlength{\\tmfloatwidth}{\\linewidth}}{}}\n"
+             "    {\\setlength{\\tmfloatwidth}{0.45\\linewidth}}\n"
+             "    {\\setlength{\\tmfloatwidth}{\\linewidth}}\n"
+             "  \\begin{minipage}[#1]{\\tmfloatwidth}\n"
+             "    \\begin{center}\n"
+             "      \\tmfloatcontents\n"
+             "      \\captionof{#3}{#5}\n"
+             "    \\end{center}\n"
+             "  \\end{minipage}}\n"
+           ) ;!append
+  ) ;tmfloat
   (addtocountergroup (!append "\\newcommand{\\addtocountergroup}[2]{}\n"))
-  (groupcommoncounter (!append "\\newcommand{\\groupcommoncounter}[1]{}\n")))
+  (groupcommoncounter (!append "\\newcommand{\\groupcommoncounter}[1]{}\n"))
+) ;smart-table
 
-;;(define-macro (latex-texmacs-long prim x l m r)
+;; (define-macro (latex-texmacs-long prim x l m r)
 ;;  `(smart-table latex-texmacs-preamble
 ;;     (,(string->symbol (substring prim 1 (string-length prim)))
 ;;      (!append
@@ -771,57 +928,107 @@
 (define-macro (latex-texmacs-long prim x l m r)
   `(smart-table latex-texmacs-preamble
      (,(string->symbol (substring prim 1 (string-length prim)))
-      (!append
-       "\\providecommand{" ,prim "}[2][]{"
-       "\\mathop{" ,x "}\\limits_{#1}^{#2}}\n"))))
+      (!append ,"\\providecommand{"
+        ,prim
+        ,"}[2][]{"
+        ,"\\mathop{"
+        ,x
+        ,"}\\limits_{#1}^{#2}}\n")))
+) ;define-macro
 
-(latex-texmacs-long "\\xminus" "-"
-                    "\\DOTSB\\relbar" "\\relbar" "\\DOTSB\\relbar")
-(latex-texmacs-long "\\xleftrightarrow" "\\longleftrightarrow"
-                    "\\leftarrow" "\\relbar" "\\rightarrow")
-(latex-texmacs-long "\\xmapsto" "\\longmapsto"
-                    "\\vdash" "\\relbar" "\\rightarrow")
-(latex-texmacs-long "\\xmapsfrom" "\\leftarrow\\!\\!\\dashv"
-                    "\\leftarrow" "\\relbar" "\\dashv")
-(latex-texmacs-long "\\xequal" "="
-                    "\\DOTSB\\Relbar" "\\Relbar" "\\DOTSB\\Relbar")
-(latex-texmacs-long "\\xLeftarrow" "\\Longleftarrow"
-                    "\\Leftarrow" "\\Relbar" "\\Relbar")
-(latex-texmacs-long "\\xRightarrow" "\\Longrightarrow"
-                    "\\Relbar" "\\Relbar" "\\Rightarrow")
-(latex-texmacs-long "\\xLeftrightarrow" "\\Longleftrightarrow"
-                    "\\Leftarrow" "\\Relbar" "\\Rightarrow")
+(latex-texmacs-long "\\xminus"
+  "-"
+  "\\DOTSB\\relbar"
+  "\\relbar"
+  "\\DOTSB\\relbar"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xleftrightarrow"
+  "\\longleftrightarrow"
+  "\\leftarrow"
+  "\\relbar"
+  "\\rightarrow"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xmapsto"
+  "\\longmapsto"
+  "\\vdash"
+  "\\relbar"
+  "\\rightarrow"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xmapsfrom"
+  "\\leftarrow\\!\\!\\dashv"
+  "\\leftarrow"
+  "\\relbar"
+  "\\dashv"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xequal"
+  "="
+  "\\DOTSB\\Relbar"
+  "\\Relbar"
+  "\\DOTSB\\Relbar"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xLeftarrow"
+  "\\Longleftarrow"
+  "\\Leftarrow"
+  "\\Relbar"
+  "\\Relbar"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xRightarrow"
+  "\\Longrightarrow"
+  "\\Relbar"
+  "\\Relbar"
+  "\\Rightarrow"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xLeftrightarrow"
+  "\\Longleftrightarrow"
+  "\\Leftarrow"
+  "\\Relbar"
+  "\\Rightarrow"
+) ;latex-texmacs-long
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Plain style theorems
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define-macro (latex-texmacs-thmenv prim name before after . opt-mode)
-  (let* ((head (if (null? opt-mode) (list) (list `(:mode ,(car opt-mode)))))
+  (let* ((head (if (null? opt-mode) (list) (list `(,:mode ,(car opt-mode)))))
          (prim* (string-append prim "*"))
          (nonum (string-append "nn" prim))
-         (thenonum (string-append "\\the" nonum)))
+         (thenonum (string-append "\\the" nonum))
+        ) ;
     `(smart-table latex-texmacs-env-preamble
        ,@head
-       (,prim  (!append ,@before
-                        (newtheorem ,prim (!translate ,name))
-                        ,@after "\n"))
-       (,prim* (!append (newcounter ,nonum) "\n"
-                        "\\def" ,thenonum "{\\unskip}\n"
-                        ,@before
-                        (newtheorem ,prim* (!option ,nonum) (!translate ,name))
-                        ,@after "\n")))))
+       (,prim
+        (!append ,@before (newtheorem ,prim (!translate ,name)) ,@after ,"\n"))
+       (,prim*
+        (!append (newcounter ,nonum)
+          ,"\n"
+          ,"\\def"
+          ,thenonum
+          ,"{\\unskip}\n"
+          ,@before
+          (newtheorem ,prim* (!option ,nonum) (!translate ,name))
+          ,@after
+          ,"\n")))
+  ) ;let*
+) ;tm-define-macro
 
 (define-macro (latex-texmacs-theorem prim name)
-  `(latex-texmacs-thmenv ,prim ,name () ()))
+  `(latex-texmacs-thmenv ,prim ,name ,() ,())
+) ;define-macro
 
 (define-macro (latex-texmacs-remark prim name)
-  `(latex-texmacs-thmenv
-    ,prim ,name ("{" (!recurse (theorembodyfont "\\rmfamily"))) ("}")))
+  `(latex-texmacs-thmenv ,prim
+     ,name
+     ("{" (!recurse (theorembodyfont "\\rmfamily")))
+     ("}"))
+) ;define-macro
 
 (define-macro (latex-texmacs-exercise prim name)
-  `(latex-texmacs-thmenv
-    ,prim ,name ("{" (!recurse (theorembodyfont "\\rmfamily\\small"))) ("}")))
+  `(latex-texmacs-thmenv ,prim
+     ,name
+     ("{" (!recurse (theorembodyfont "\\rmfamily\\small")))
+     ("}"))
+) ;define-macro
 
 (latex-texmacs-theorem "theorem" "Theorem")
 (latex-texmacs-theorem "proposition" "Proposition")
@@ -849,19 +1056,39 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-env-preamble
-  ("tmpadded" (!append (newmdenv (!option "") "tmpadded") "\n"))
-  ("tmoverlined"
-   (!append (newmdenv (!option "topline=true,innertopmargin=1ex")
-                      "tmoverlined") "\n"))
-  ("tmunderlined"
-   (!append (newmdenv (!option "bottomline=true,innerbottommargin=1ex")
-                      "tmunderlined") "\n"))
-  ("tmbothlined"
-   (!append (newmdenv (!option "topline=true,bottomline=true,innertopmargin=1ex,innerbottommargin=1ex")
-                      "tmbothlined") "\n"))
-  ("tmframed"
-   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex")
-                      "tmframed") "\n"))
-  ("tmornamented"
-   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex")
-                      "tmornamented") "\n")))
+ ("tmpadded" (!append (newmdenv (!option "") "tmpadded") "\n"))
+ ("tmoverlined"
+   (!append (newmdenv (!option "topline=true,innertopmargin=1ex") "tmoverlined")
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmunderlined"
+   (!append (newmdenv (!option "bottomline=true,innerbottommargin=1ex") "tmunderlined")
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmbothlined"
+   (!append (newmdenv (!option "topline=true,bottomline=true,innertopmargin=1ex,innerbottommargin=1ex"
+                      ) ;!option
+              "tmbothlined"
+            ) ;newmdenv
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmframed"
+   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex"
+                      ) ;!option
+              "tmframed"
+            ) ;newmdenv
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmornamented"
+   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex"
+                      ) ;!option
+              "tmornamented"
+            ) ;newmdenv
+     "\n"
+   ) ;!append
+ ) ;
+) ;smart-table

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm
@@ -14,7 +14,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (convert latex latex-texmacs-drd)
-  (:use (convert latex latex-symbol-drd)))
+  (:use (convert latex latex-symbol-drd))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs symbols
@@ -22,311 +23,689 @@
 
 (logic-group latex-texmacs-symbol%
   ;; arrows and other symbols with limits
-  leftarrowlim rightarrowlim leftrightarrowlim mapstolim
-  longleftarrowlim longrightarrowlim longleftrightarrowlim longmapstolim
-  leftsquigarrowlim rightsquigarrowlim leftrightsquigarrowlim
-  equallim longequallim Leftarrowlim Rightarrowlim
-  Leftrightarrowlim Longleftarrowlim Longrightarrowlim Longleftrightarrowlim
+  leftarrowlim
+  rightarrowlim
+  leftrightarrowlim
+  mapstolim
+  longleftarrowlim
+  longrightarrowlim
+  longleftrightarrowlim
+  longmapstolim
+  leftsquigarrowlim
+  rightsquigarrowlim
+  leftrightsquigarrowlim
+  equallim
+  longequallim
+  Leftarrowlim
+  Rightarrowlim
+  Leftrightarrowlim
+  Longleftarrowlim
+  Longrightarrowlim
+  Longleftrightarrowlim
   cdotslim
 
   ;; further arrows
-  threeleftarrows threerightarrows
-  fourleftarrows fourrightarrows
-  longleftrightarrows longleftleftarrows
-  longthreeleftarrows longthreerightarrows
-  longrightleftarrows longrightrightarrows
-  longfourleftarrows longfourrightarrows
-  LRleftrightarrow Llongleftarrow Llongrightarrow Llongleftrightarrow
+  threeleftarrows
+  threerightarrows
+  fourleftarrows
+  fourrightarrows
+  longleftrightarrows
+  longleftleftarrows
+  longthreeleftarrows
+  longthreerightarrows
+  longrightleftarrows
+  longrightrightarrows
+  longfourleftarrows
+  longfourrightarrows
+  LRleftrightarrow
+  Llongleftarrow
+  Llongrightarrow
+  Llongleftrightarrow
 
   ;; rotated arrows and other symbols
-  mapsfrom longmapsfrom mapmulti leftsquigarrow
-  upequal downequal longupequal longdownequal longupminus longdownminus
-  longuparrow longdownarrow longupdownarrow
-  Longuparrow Longdownarrow Longupdownarrow
-  mapsup mapsdown longmapsup longmapsdown
-  upsquigarrow downsquigarrow updownsquigarrow
-  hookuparrow hookdownarrow longhookuparrow longhookdownarrow
-  Backepsilon Backsigma Mho btimes
+  mapsfrom
+  longmapsfrom
+  mapmulti
+  leftsquigarrow
+  upequal
+  downequal
+  longupequal
+  longdownequal
+  longupminus
+  longdownminus
+  longuparrow
+  longdownarrow
+  longupdownarrow
+  Longuparrow
+  Longdownarrow
+  Longupdownarrow
+  mapsup
+  mapsdown
+  longmapsup
+  longmapsdown
+  upsquigarrow
+  downsquigarrow
+  updownsquigarrow
+  hookuparrow
+  hookdownarrow
+  longhookuparrow
+  longhookdownarrow
+  Backepsilon
+  Backsigma
+  Mho
+  btimes
 
   ;; asymptotic relations by Joris
-  nasymp asympasymp nasympasymp simsim nsimsim
-  precprec precpreceq precprecprec precprecpreceq
-  succsucc succsucceq succsuccsucc succsuccsucceq
-  lleq llleq ggeq gggeq triplesim ntriplesim
+  nasymp
+  asympasymp
+  nasympasymp
+  simsim
+  nsimsim
+  precprec
+  precpreceq
+  precprecprec
+  precprecpreceq
+  succsucc
+  succsucceq
+  succsuccsucc
+  succsuccsucceq
+  lleq
+  llleq
+  ggeq
+  gggeq
+  triplesim
+  ntriplesim
 
   ;; replacements for symbols from mathabx
-  divides ndivides asterisk dottimes precdot
+  divides
+  ndivides
+  asterisk
+  dottimes
+  precdot
 
   ;; extra literal symbols
-  mathcatalan mathd mathD mathe matheuler
-  mathGamma mathlambda mathLaplace mathi mathpi
-  Alpha Beta Epsilon Eta Iota Kappa Mu Nu Omicron Chi Rho Tau Zeta
+  mathcatalan
+  mathd
+  mathD
+  mathe
+  matheuler
+  mathGamma
+  mathlambda
+  mathLaplace
+  mathi
+  mathpi
+  Alpha
+  Beta
+  Epsilon
+  Eta
+  Iota
+  Kappa
+  Mu
+  Nu
+  Omicron
+  Chi
+  Rho
+  Tau
+  Zeta
 
   ;; negations
-  nin nni notni nequiv nleadsto
-  npreccurlyeq npreceqq nprecsim
-  nsimeq nsubset napprox nsqsubset nsqsubseteq nsqsubseteqq
-  nsqsupset nsqsupseteq nsqsupseteqq
-  nsucccurlyeq nsucceqq nsuccsim  
-  
-  ;; other extra symbols
-  oempty exterior Exists bigintwl bigointwl
-  of suchthat barsuchthat asterisk point cdummy comma copyright
-  bignone nobracket nospace nocomma noplus nosymbol
-  dotminus dotpm dotmp dotamalg dottimes dotoplus dototimes dotast
-  into longminus longequal
-  longhookrightarrow longhookleftarrow
-  triangleup tmprecdot preceqdot
-  llangle rrangle join um upl upm ump pplus
-  assign plusassign minusassign timesassign overassign backassign
-  lflux gflux colons transtype
-  lebar gebar leangle geangle leqangle geqangle
-  anglele anglege legeangle geleangle
-  udots subsetsim supsetsim
-  rightmap leftmap leftrightmap
-  tmxspace)
+  nin
+  nni
+  notni
+  nequiv
+  nleadsto
+  npreccurlyeq
+  npreceqq
+  nprecsim
+  nsimeq
+  nsubset
+  napprox
+  nsqsubset
+  nsqsubseteq
+  nsqsubseteqq
+  nsqsupset
+  nsqsupseteq
+  nsqsupseteqq
+  nsucccurlyeq
+  nsucceqq
+  nsuccsim
 
-(logic-rules
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-symbol% 'x))
-  ((latex-symbol% 'x) (latex-texmacs-symbol% 'x)))
+  ;; other extra symbols
+  oempty
+  exterior
+  Exists
+  bigintwl
+  bigointwl
+  of
+  suchthat
+  barsuchthat
+  asterisk
+  point
+  cdummy
+  comma
+  copyright
+  bignone
+  nobracket
+  nospace
+  nocomma
+  noplus
+  nosymbol
+  dotminus
+  dotpm
+  dotmp
+  dotamalg
+  dottimes
+  dotoplus
+  dototimes
+  dotast
+  into
+  longminus
+  longequal
+  longhookrightarrow
+  longhookleftarrow
+  triangleup
+  tmprecdot
+  preceqdot
+  llangle
+  rrangle
+  join
+  um
+  upl
+  upm
+  ump
+  pplus
+  assign
+  plusassign
+  minusassign
+  timesassign
+  overassign
+  backassign
+  lflux
+  gflux
+  colons
+  transtype
+  lebar
+  gebar
+  leangle
+  geangle
+  leqangle
+  geqangle
+  anglele
+  anglege
+  legeangle
+  geleangle
+  udots
+  subsetsim
+  supsetsim
+  rightmap
+  leftmap
+  leftrightmap
+  tmxspace
+) ;logic-group
+
+(logic-rules ((latex-texmacs-arity% 'x 0) (latex-texmacs-symbol% 'x))
+ ((latex-symbol% 'x) (latex-texmacs-symbol% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-texmacs-0%
-  tmunsc emdash tmhrule tmat tmbsl tmdummy
-  TeXmacs madebyTeXmacs withTeXmacstext citewebsite tmmade
-  scheme tmsep tmSep pari qed textdots hrule filldots
-  infixand infixor infixiff)
+  tmunsc
+  emdash
+  tmhrule
+  tmat
+  tmbsl
+  tmdummy
+  TeXmacs
+  madebyTeXmacs
+  withTeXmacstext
+  citewebsite
+  tmmade
+  scheme
+  tmsep
+  tmSep
+  pari
+  qed
+  textdots
+  hrule
+  filldots
+  infixand
+  infixor
+  infixiff
+) ;logic-group
 
 (logic-group latex-texmacs-1%
-  citetexmacs key tmrsub tmrsup keepcase
-  tmtextrm tmtextsf tmtexttt tmtextmd tmtextbf
-  tmtextup tmtextsl tmtextit tmtextsc tmmathbf tmmathmd
-  tmverbatim tmop tmstrong tmem tmtt tmname tmsamp tmabbr
-  tmdfn tmkbd tmvar tmacronym tmperson tmscript tmdef
-  dueto op todo tmdate tmoutput tmerrput tmtiming
-  tmsubtitle tmrunningtitle tmrunningauthor
-  tmaffiliation tmemail tmhomepage
-  tmfnaffiliation tmfnemail tmfnhomepage
-  tmacmhomepage tmacmmisc tmieeeemail tmnote tmmisc
-  uhat uwidehat utilde uwidetilde
-  uvec ubreve uinvbreve ucheck uring uacute ugrave
-  underdot uddot udddot uddddot
-  widespacing nonconverted
+  citetexmacs
+  key
+  tmrsub
+  tmrsup
+  keepcase
+  tmtextrm
+  tmtextsf
+  tmtexttt
+  tmtextmd
+  tmtextbf
+  tmtextup
+  tmtextsl
+  tmtextit
+  tmtextsc
+  tmmathbf
+  tmmathmd
+  tmverbatim
+  tmop
+  tmstrong
+  tmem
+  tmtt
+  tmname
+  tmsamp
+  tmabbr
+  tmdfn
+  tmkbd
+  tmvar
+  tmacronym
+  tmperson
+  tmscript
+  tmdef
+  dueto
+  op
+  todo
+  tmdate
+  tmoutput
+  tmerrput
+  tmtiming
+  tmsubtitle
+  tmrunningtitle
+  tmrunningauthor
+  tmaffiliation
+  tmemail
+  tmhomepage
+  tmfnaffiliation
+  tmfnemail
+  tmfnhomepage
+  tmacmhomepage
+  tmacmmisc
+  tmieeeemail
+  tmnote
+  tmmisc
+  uhat
+  uwidehat
+  utilde
+  uwidetilde
+  uvec
+  ubreve
+  uinvbreve
+  ucheck
+  uring
+  uacute
+  ugrave
+  underdot
+  uddot
+  udddot
+  uddddot
+  widespacing
+  nonconverted
   groupcommoncounter
   ;; NOTE: for personal use from vdh style package
-  gb gbt)
+  gb
+  gbt
+) ;logic-group
 
-(logic-group latex-texmacs-1*%
-  tmcodeinline)
+(logic-group latex-texmacs-1*% tmcodeinline)
 
 (logic-group latex-texmacs-2%
   tmcolor
-  tmsummarizeddocumentation tmsummarizedgrouped tmsummarizedexplain
-  tmsummarizedplain tmsummarizedtiny tmsummarizedraw tmsummarizedenv
-  tmsummarizedstd tmsummarized
-  tmdetaileddocumentation tmdetailedgrouped tmdetailedexplain
-  tmdetailedplain tmdetailedtiny tmdetailedraw tmdetailedenv
-  tmdetailedstd tmdetailed
-  tmfoldeddocumentation tmunfoldeddocumentation
-  tmfoldedsubsession tmunfoldedsubsession
-  tmfoldedgrouped tmunfoldedgrouped tmfoldedexplain tmunfoldedexplain
-  tmfoldedplain tmunfoldedplain tmfoldedenv tmunfoldedenv
-  tmfoldedstd tmunfoldedstd tmfolded tmunfolded
-  tminput tminputmath tmhlink tmaction ontop subindex
-  renderfootnote tmlinenumber
-  addtocountergroup)
+  tmsummarizeddocumentation
+  tmsummarizedgrouped
+  tmsummarizedexplain
+  tmsummarizedplain
+  tmsummarizedtiny
+  tmsummarizedraw
+  tmsummarizedenv
+  tmsummarizedstd
+  tmsummarized
+  tmdetaileddocumentation
+  tmdetailedgrouped
+  tmdetailedexplain
+  tmdetailedplain
+  tmdetailedtiny
+  tmdetailedraw
+  tmdetailedenv
+  tmdetailedstd
+  tmdetailed
+  tmfoldeddocumentation
+  tmunfoldeddocumentation
+  tmfoldedsubsession
+  tmunfoldedsubsession
+  tmfoldedgrouped
+  tmunfoldedgrouped
+  tmfoldedexplain
+  tmunfoldedexplain
+  tmfoldedplain
+  tmunfoldedplain
+  tmfoldedenv
+  tmunfoldedenv
+  tmfoldedstd
+  tmunfoldedstd
+  tmfolded
+  tmunfolded
+  tminput
+  tminputmath
+  tmhlink
+  tmaction
+  ontop
+  subindex
+  renderfootnote
+  tmlinenumber
+  addtocountergroup
+) ;logic-group
 
 (logic-group latex-texmacs-3%
-  tmsession tmfoldedio tmunfoldedio tmfoldediomath tmunfoldediomath
-  tmlinenote subsubindex tmref glossaryentry natbib-triple
-  renderfootnotestar)
+  tmsession
+  tmfoldedio
+  tmunfoldedio
+  tmfoldediomath
+  tmunfoldediomath
+  tmlinenote
+  subsubindex
+  tmref
+  glossaryentry
+  natbib-triple
+  renderfootnotestar
+) ;logic-group
 
 (logic-group latex-texmacs-4%
-  tmscriptinput tmscriptoutput tmconverterinput tmconverteroutput
-  subsubsubindex)
+  tmscriptinput
+  tmscriptoutput
+  tmconverterinput
+  tmconverteroutput
+  subsubsubindex
+) ;logic-group
 
-(logic-rules
-  ((latex-texmacs% 'x) (latex-texmacs-0% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-1% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-1*% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-2% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-3% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-4% 'x))
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-0% 'x))
-  ((latex-texmacs-arity% 'x 1) (latex-texmacs-1% 'x))
-  ((latex-texmacs-arity% 'x 1) (latex-texmacs-1*% 'x))
-  ((latex-texmacs-arity% 'x 2) (latex-texmacs-2% 'x))
-  ((latex-texmacs-arity% 'x 3) (latex-texmacs-3% 'x))
-  ((latex-texmacs-arity% 'x 4) (latex-texmacs-4% 'x))
-  ((latex-texmacs-option% 'x #t) (latex-texmacs-1*% 'x))
-  ((latex-command-0% 'x) (latex-texmacs-0% 'x))
-  ((latex-command-1% 'x) (latex-texmacs-1% 'x))
-  ((latex-command-1*% 'x) (latex-texmacs-1*% 'x))
-  ((latex-command-2% 'x) (latex-texmacs-2% 'x))
-  ((latex-command-3% 'x) (latex-texmacs-3% 'x))
-  ((latex-command-4% 'x) (latex-texmacs-4% 'x)))
+(logic-rules ((latex-texmacs% 'x) (latex-texmacs-0% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-1% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-1*% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-2% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-3% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-4% 'x))
+ ((latex-texmacs-arity% 'x 0) (latex-texmacs-0% 'x))
+ ((latex-texmacs-arity% 'x 1) (latex-texmacs-1% 'x))
+ ((latex-texmacs-arity% 'x 1) (latex-texmacs-1*% 'x))
+ ((latex-texmacs-arity% 'x 2) (latex-texmacs-2% 'x))
+ ((latex-texmacs-arity% 'x 3) (latex-texmacs-3% 'x))
+ ((latex-texmacs-arity% 'x 4) (latex-texmacs-4% 'x))
+ ((latex-texmacs-option% 'x #t) (latex-texmacs-1*% 'x))
+ ((latex-command-0% 'x) (latex-texmacs-0% 'x))
+ ((latex-command-1% 'x) (latex-texmacs-1% 'x))
+ ((latex-command-1*% 'x) (latex-texmacs-1*% 'x))
+ ((latex-command-2% 'x) (latex-texmacs-2% 'x))
+ ((latex-command-3% 'x) (latex-texmacs-3% 'x))
+ ((latex-command-4% 'x) (latex-texmacs-4% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-texmacs-env-arity%
-  ("proof" 0)
-  ("proof*" 1)
-  ("leftaligned" 0)
-  ("rightaligned" 0)
-  ("tmcode" 0)
-  ("tmparmod" 3)
-  ("tmparsep" 1)
-  ("tmcompact" 0)
-  ("tmcompressed" 0)
-  ("tmamplified" 0)
-  ("tmjumpin" 0)
-  ("tmindent" 0)
-  ("tmlisting" 0)
-  ("elsequation" 0)
-  ("elsequation*" 0)
-  ("theglossary" 1))
+ ("proof" 0)
+ ("proof*" 1)
+ ("leftaligned" 0)
+ ("rightaligned" 0)
+ ("tmcode" 0)
+ ("tmparmod" 3)
+ ("tmparsep" 1)
+ ("tmcompact" 0)
+ ("tmcompressed" 0)
+ ("tmamplified" 0)
+ ("tmjumpin" 0)
+ ("tmindent" 0)
+ ("tmlisting" 0)
+ ("elsequation" 0)
+ ("elsequation*" 0)
+ ("theglossary" 1)
+) ;logic-table
 
-(logic-table latex-texmacs-option%
-  ("tmcode" #t))
+(logic-table latex-texmacs-option% ("tmcode" #t))
 
 (logic-group latex-texmacs-environment-0%
-  begin-proof begin-leftaligned begin-rightaligned begin-quoteenv
-  begin-tmcompact begin-tmcompressed begin-tmamplified begin-tmjumpin
-  begin-tmindent begin-tmlisting begin-elsequation begin-elsequation*)
+  begin-proof
+  begin-leftaligned
+  begin-rightaligned
+  begin-quoteenv
+  begin-tmcompact
+  begin-tmcompressed
+  begin-tmamplified
+  begin-tmjumpin
+  begin-tmindent
+  begin-tmlisting
+  begin-elsequation
+  begin-elsequation*
+) ;logic-group
 
-(logic-group latex-texmacs-environment-0*%
-  begin-tmcode)
+(logic-group latex-texmacs-environment-0*% begin-tmcode)
 
 (logic-group latex-texmacs-environment-1%
-  begin-proof* begin-tmparsep begin-theglossary)
+  begin-proof*
+  begin-tmparsep
+  begin-theglossary
+) ;logic-group
 
-(logic-group latex-texmacs-environment-3%
-  begin-tmparmod)
+(logic-group latex-texmacs-environment-3% begin-tmparmod)
 
-(logic-rules
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0% 'x))
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0*% 'x))
-  ((latex-texmacs-arity% 'x 1) (latex-texmacs-environment-1% 'x))
-  ((latex-texmacs-arity% 'x 3) (latex-texmacs-environment-3% 'x))
-  ((latex-texmacs-option% 'x #t) (latex-texmacs-environment-0*% 'x))
-  ((latex-environment-0%  'x) (latex-texmacs-environment-0% 'x))
-  ((latex-environment-0*% 'x) (latex-texmacs-environment-0*% 'x))
-  ((latex-environment-1%  'x) (latex-texmacs-environment-1% 'x))
-  ((latex-environment-3%  'x) (latex-texmacs-environment-3% 'x)))
+(logic-rules ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0% 'x))
+ ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0*% 'x))
+ ((latex-texmacs-arity% 'x 1) (latex-texmacs-environment-1% 'x))
+ ((latex-texmacs-arity% 'x 3) (latex-texmacs-environment-3% 'x))
+ ((latex-texmacs-option% 'x #t) (latex-texmacs-environment-0*% 'x))
+ ((latex-environment-0% 'x) (latex-texmacs-environment-0% 'x))
+ ((latex-environment-0*% 'x) (latex-texmacs-environment-0*% 'x))
+ ((latex-environment-1% 'x) (latex-texmacs-environment-1% 'x))
+ ((latex-environment-3% 'x) (latex-texmacs-environment-3% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TeXmacs list environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-texmacs-env-arity%
-  ("itemizeminus" 0)
-  ("itemizedot" 0)
-  ("itemizearrow" 0)
-  ("enumeratenumeric" 0)
-  ("enumeratenumericbracket" 0)
-  ("enumerateroman" 0)
-  ("enumerateromanbracket" 0)
-  ("enumerateromanparen" 0)
-  ("enumerateromancap" 0)
-  ("enumeratealpha" 0)
-  ("enumeratealphabracket" 0)
-  ("enumeratealphafullparen" 0)
-  ("enumeratealphacap" 0)
-  ("descriptioncompact" 0)
-  ("descriptionaligned" 0)
-  ("descriptiondash" 0)
-  ("descriptionlong" 0)
-  ("descriptionparagraphs" 0))
+ ("itemizeminus" 0)
+ ("itemizedot" 0)
+ ("itemizearrow" 0)
+ ("enumeratenumeric" 0)
+ ("enumeratenumericbracket" 0)
+ ("enumerateroman" 0)
+ ("enumerateromanbracket" 0)
+ ("enumerateromanparen" 0)
+ ("enumerateromancap" 0)
+ ("enumeratealpha" 0)
+ ("enumeratealphabracket" 0)
+ ("enumeratealphafullparen" 0)
+ ("enumeratealphacap" 0)
+ ("descriptioncompact" 0)
+ ("descriptionaligned" 0)
+ ("descriptiondash" 0)
+ ("descriptionlong" 0)
+ ("descriptionparagraphs" 0)
+) ;logic-table
 
 (logic-group latex-texmacs-list%
-  begin-itemizeminus begin-itemizedot begin-itemizearrow
-  begin-enumeratenumeric begin-enumeratenumericbracket
-  begin-enumerateroman begin-enumerateromanbracket
-  begin-enumerateromanparen begin-enumerateromancap
-  begin-enumeratealpha begin-enumeratealphabracket
-  begin-enumeratealphafullparen begin-enumeratealphacap
-  begin-descriptioncompact begin-descriptionaligned
-  begin-descriptiondash begin-descriptionlong begin-descriptionparagraphs)
+  begin-itemizeminus
+  begin-itemizedot
+  begin-itemizearrow
+  begin-enumeratenumeric
+  begin-enumeratenumericbracket
+  begin-enumerateroman
+  begin-enumerateromanbracket
+  begin-enumerateromanparen
+  begin-enumerateromancap
+  begin-enumeratealpha
+  begin-enumeratealphabracket
+  begin-enumeratealphafullparen
+  begin-enumeratealphacap
+  begin-descriptioncompact
+  begin-descriptionaligned
+  begin-descriptiondash
+  begin-descriptionlong
+  begin-descriptionparagraphs
+) ;logic-group
 
-(logic-rules
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-list% 'x))
-  ((latex-list% 'x) (latex-texmacs-list% 'x)))
+(logic-rules ((latex-texmacs-arity% 'x 0) (latex-texmacs-list% 'x))
+ ((latex-list% 'x) (latex-texmacs-list% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Commands requiring special definitions in the preamble
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-texmacs-preamble-command%
-  newmdenv tikzframe
-  tmkeywords tmacm tmarxiv tmpacs tmmsc
-  fmtext tdatetext tmisctext tsubtitletext
-  thankshomepage thanksemail thanksdate thanksamisc thanksmisc thankssubtitle
-  mho tmfloat
+  newmdenv
+  tikzframe
+  tmkeywords
+  tmacm
+  tmarxiv
+  tmpacs
+  tmmsc
+  fmtext
+  tdatetext
+  tmisctext
+  tsubtitletext
+  thankshomepage
+  thanksdate
+  thanksamisc
+  thanksmisc
+  thankssubtitle
+  mho
+  tmfloat
 
-  xminus xleftrightarrow xmapsto xmapsfrom xequal
-  xLeftarrow xRightarrow xLeftrightarrow)
+  xminus
+  xleftrightarrow
+  xmapsto
+  xmapsfrom
+  xequal
+  xLeftarrow
+  xRightarrow
+  xLeftrightarrow
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Environments requiring special definitions in the preamble
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-texmacs-env-preamble-environment%
-  "tmpadded" "tmoverlined" "tmunderlined" "tmbothlined"
-  "tmframed" "tmornamented")
+  "tmpadded"
+  "tmoverlined"
+  "tmunderlined"
+  "tmbothlined"
+  "tmframed"
+  "tmornamented"
+) ;logic-group
 
 (logic-group latex-texmacs-theorem-environment%
-  "theorem" "proposition" "lemma" "corollary"
-  "axiom" "definition" "assumption" "notation" "conjecture"
-  "remark" "note" "example" "convention"
-  "warning" "acknowledgments" "answer" "question"
-  "exercise" "problem" "solution"
+  "theorem"
+  "proposition"
+  "lemma"
+  "corollary"
+  "axiom"
+  "definition"
+  "assumption"
+  "notation"
+  "conjecture"
+  "remark"
+  "note"
+  "example"
+  "convention"
+  "warning"
+  "acknowledgments"
+  "answer"
+  "question"
+  "exercise"
+  "problem"
+  "solution"
 
-  "theorem*" "proposition*" "lemma*" "corollary*"
-  "axiom*" "definition*" "notation*" "conjecture*"
-  "remark*" "note*" "example*" "convention*"
-  "warning*" "acknowledgments*" "answer*" "question*"
-  "exercise*" "problem*" "solution*")
+  "theorem*"
+  "proposition*"
+  "lemma*"
+  "corollary*"
+  "axiom*"
+  "definition*"
+  "notation*"
+  "conjecture*"
+  "remark*"
+  "note*"
+  "example*"
+  "convention*"
+  "warning*"
+  "acknowledgments*"
+  "answer*"
+  "question*"
+  "exercise*"
+  "problem*"
+  "solution*"
+) ;logic-group
 
 (logic-group latex-texmacs-theorem%
-  begin-theorem begin-proposition begin-lemma begin-corollary
-  begin-axiom begin-definition begin-notation begin-conjecture
-  begin-remark begin-note begin-example begin-convention
-  begin-warning begin-acknowledgments begin-answer begin-question
-  begin-exercise begin-problem begin-solution
+  begin-theorem
+  begin-proposition
+  begin-lemma
+  begin-corollary
+  begin-axiom
+  begin-definition
+  begin-notation
+  begin-conjecture
+  begin-remark
+  begin-note
+  begin-example
+  begin-convention
+  begin-warning
+  begin-acknowledgments
+  begin-answer
+  begin-question
+  begin-exercise
+  begin-problem
+  begin-solution
 
-  begin-theorem* begin-proposition* begin-lemma* begin-corollary*
-  begin-axiom* begin-definition* begin-notation* begin-conjecture*
-  begin-remark* begin-note* begin-example* begin-convention*
-  begin-warning* begin-acknowledgments* begin-answer* begin-question*
-  begin-exercise* begin-problem* begin-solution*)
+  begin-theorem*
+  begin-proposition*
+  begin-lemma*
+  begin-corollary*
+  begin-axiom*
+  begin-definition*
+  begin-notation*
+  begin-conjecture*
+  begin-remark*
+  begin-note*
+  begin-example*
+  begin-convention*
+  begin-warning*
+  begin-acknowledgments*
+  begin-answer*
+  begin-question*
+  begin-exercise*
+  begin-problem*
+  begin-solution*
+) ;logic-group
 
-(logic-rules
-  ((latex-texmacs-env-preamble-environment% 'x)
-   (latex-texmacs-theorem-environment% 'x))
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-theorem% 'x))
-  ((latex-environment-0% 'x) (latex-texmacs-theorem% 'x)))
+(logic-rules ((latex-texmacs-env-preamble-environment% 'x)
+              (latex-texmacs-theorem-environment% 'x)
+             ) ;
+ ((latex-texmacs-arity% 'x 0) (latex-texmacs-theorem% 'x))
+ ((latex-environment-0% 'x) (latex-texmacs-theorem% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; These macros are defined by TeXmacs in certain styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-texmacs-0%
-  appendix)
+(logic-group latex-texmacs-0% appendix)
 
-(logic-group latex-texmacs-1%
-  chapter section subsection paragraph subparagraph)
+(logic-group latex-texmacs-1% chapter section subsection paragraph subparagraph)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Deprecated extra macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-texmacs-0%
-  labeleqnum eqnumber leqnumber reqnumber)
+(logic-group latex-texmacs-0% labeleqnum eqnumber leqnumber reqnumber)
 
-(logic-group latex-texmacs-1%
-  skey ckey akey mkey hkey)
+(logic-group latex-texmacs-1% skey ckey akey mkey hkey)

--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex-elsevier.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex-elsevier.scm
@@ -11,47 +11,52 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert latex tmtex-elsevier)
-  (:use (convert latex tmtex)))
+(texmacs-module (convert latex tmtex-elsevier) (:use (convert latex tmtex)))
 
 (tm-define (tmtex-transform-style x)
   (:mode elsevier-style?)
   (cond ((== x "elsart") "elsart")
         ((== x "elsarticle") "elsarticle")
         ((== x "ifac") "ifacconf")
-        ((== x "jsc") `("amsthm" "elsart"))
-        (else x)))
+        ((== x "jsc") '("amsthm" "elsart"))
+        (else x)
+  ) ;cond
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Initialization of elsevier style
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define note-counter 0)
+
 (define author-counter 0)
+
 (define clustered? #f)
 
 (define (init-elsevier body)
   (set! clustered? #f)
   (set! note-counter 0)
-  (set! author-counter 0))
+  (set! author-counter 0)
+) ;define
 
-(tm-define (tmtex-style-init body)
-  (:mode elsevier-style?)
-  (init-elsevier body))
+(tm-define (tmtex-style-init body) (:mode elsevier-style?) (init-elsevier body))
 
 (tm-define (tmtex-style-init body)
   (:mode ifac-style?)
   (init-elsevier body)
   (set! tmtex-packages (cons "cite-author-year" tmtex-packages))
   (latex-set-packages '("natbib"))
-  )
+) ;tm-define
 
 (tm-define (tmtex-style-init body)
   (:mode jsc-style?)
   (init-elsevier body)
-  ;;(set! tmtex-packages (cons "cite-author-year" tmtex-packages))
-  (latex-set-packages '("amsthm" "yjsco" ;;"natbib"
-                        )))
+  ;; (set! tmtex-packages (cons "cite-author-year" tmtex-packages))
+  (latex-set-packages '("amsthm"
+                        "yjsco"
+                        ;; "natbib")
+  ) ;latex-set-packages
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Hack for ifac incompatibility with hyperref package
@@ -60,21 +65,26 @@
 (tm-define (latex-as-use-package l)
   (:require (latex-ifacconf-style?))
   (if (nin? "hyperref" l)
-      (former l)
-      (let* ((l* (list-remove l "hyperref"))
-             (s1 (if (null? l*) "" (former l*)))
-             (s2 (string-append
-                  "\\makeatletter\n"
-                  "\\let\\old@ssect\\@ssect\n"
-                  "\\makeatother\n"
-                  "\\usepackage{hyperref}\n"
-                  "\\makeatletter\n"
-                  "\\def\\@ssect#1#2#3#4#5#6{%\n"
-                  "  \\NR@gettitle{#6}%\n"
-                  "  \\old@ssect{#1}{#2}{#3}{#4}{#5}{#6}%\n"
-                  "}\n"
-                  "\\makeatother\n")))
-        (string-append s1 s2))))
+    (former l)
+    (let* ((l* (list-remove l "hyperref"))
+           (s1 (if (null? l*) "" (former l*)))
+           (s2 (string-append "\\makeatletter\n"
+                 "\\let\\old@ssect\\@ssect\n"
+                 "\\makeatother\n"
+                 "\\usepackage{hyperref}\n"
+                 "\\makeatletter\n"
+                 "\\def\\@ssect#1#2#3#4#5#6{%\n"
+                 "  \\NR@gettitle{#6}%\n"
+                 "  \\old@ssect{#1}{#2}{#3}{#4}{#5}{#6}%\n"
+                 "}\n"
+                 "\\makeatother\n"
+               ) ;string-append
+           ) ;s2
+          ) ;
+      (string-append s1 s2)
+    ) ;let*
+  ) ;if
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Hack for incomplete ifac list environments
@@ -83,7 +93,9 @@
 (tm-define (latex-extra-preamble)
   (:require (latex-ifacconf-style?))
   (string-append "\\newcommand{\\labelitemiii}{\\labelitemi}\n"
-                 "\\newcommand{\\labelitemiv}{\\labelitemii}\n"))
+    "\\newcommand{\\labelitemiv}{\\labelitemii}\n"
+  ) ;string-append
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Preprocessing data
@@ -91,30 +103,45 @@
 
 (tm-define (tmtex-style-preprocess doc)
   (:mode elsevier-style?)
-  (elsevier-create-frontmatter doc))
+  (elsevier-create-frontmatter doc)
+) ;tm-define
 
 (define (elsarticle-frontmatter? t)
-  (or (func? t 'abstract-data) (func? t 'doc-data) (func? t 'abstract)))
+  (or (func? t 'abstract-data) (func? t 'doc-data) (func? t 'abstract))
+) ;define
 
 (define (partition l pred?)
-  (if (npair? l) l
+  (if (npair? l)
+    l
     (letrec ((npred? (lambda (x) (not (pred? x)))))
       (if (pred? (car l))
-        (receive (h t) (list-break l npred?)
-          (cons h (partition t pred?)))
-        (receive (h t) (list-break l pred?)
-          (cons h (partition t pred?)))))))
+        (receive (h t) (list-break l npred?) (cons h (partition t pred?)))
+        (receive (h t) (list-break l pred?) (cons h (partition t pred?)))
+      ) ;if
+    ) ;letrec
+  ) ;if
+) ;define
 
 (define (elsevier-create-frontmatter t)
-  (if (or (npair? t) (npair? (cdr t))) t
-    (with l (map elsarticle-frontmatter? (cdr t))
+  (if (or (npair? t) (npair? (cdr t)))
+    t
+    (with l
+      (map elsarticle-frontmatter? (cdr t))
       (if (in? #t l)
-        (with parts (partition (cdr t) elsarticle-frontmatter?)
-          `(,(car t) ,@(map (lambda (x)
-                              (if (elsarticle-frontmatter? (car x))
-                                `(elsevier-frontmatter (,(car t) ,@x))
-                                `(,(car t) ,@x))) parts)))
-        `(,(car t) ,@(map elsevier-create-frontmatter (cdr t)))))))
+        (with parts
+          (partition (cdr t) elsarticle-frontmatter?)
+          `(,(car t)
+            ,@(map (lambda (x)
+                     (if (elsarticle-frontmatter? (car x))
+                       `(elsevier-frontmatter (,(car t) ,@x))
+                       `(,(car t) ,@x)))
+                parts))
+        ) ;with
+        `(,(car t) ,@(map elsevier-create-frontmatter (cdr t)))
+      ) ;if
+    ) ;with
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier specific customizations
@@ -122,56 +149,74 @@
 
 (tm-define (tmtex-elsevier-frontmatter s l)
   (:mode elsevier-style?)
-  `((!begin "frontmatter") ,(tmtex (car l))))
+  `((!begin "frontmatter") ,(tmtex (car l)))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsarticle specific title macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (tmtex-replace-documents t)
-  (:mode elsevier-style?) t)
+(tm-define (tmtex-replace-documents t) (:mode elsevier-style?) t)
 
 (tm-define (springer-note-ref l r)
   (if (list? r)
     (set! r (tex-concat* (list-intersperse r ",")))
-    (set! r (string-append l r)))
-  `(tnoteref ,r))
+    (set! r (string-append l r))
+  ) ;if
+  `(tnoteref ,r)
+) ;tm-define
 
 (tm-define (tmtex-doc-subtitle-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "sub-" (car l)))
+  (springer-note-ref "sub-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-subtitle-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "sub-" (car l))
-    `(tsubtitletext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "sub-" (car l))
+    `(tsubtitletext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-note-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "note-" (car l)))
+  (springer-note-ref "note-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-note-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "note-" (car l))
-    `(tnotetext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "note-" (car l))
+    `(tnotetext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-date-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "date-" (car l)))
+  (springer-note-ref "date-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-date-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "date-" (car l))
-    `(tdatetext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "date-" (car l))
+    `(tdatetext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-misc-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "misc-" (car l)))
+  (springer-note-ref "misc-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-misc-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "misc-" (car l))
-    `(tmisctext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "misc-" (car l))
+    `(tmisctext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier specific authors macros
@@ -180,67 +225,89 @@
 (tm-define (springer-author-note-ref l r)
   (if (list? r)
     (set! r (tex-concat* (list-intersperse r ",")))
-    (set! r (string-append l r)))
-  `(fnref ,r))
+    (set! r (string-append l r))
+  ) ;if
+  `(fnref ,r)
+) ;tm-define
 
 (tm-define (tmtex-author-note-ref s l)
   (:mode elsevier-style?)
-  (springer-author-note-ref "author-note-" (car l)))
+  (springer-author-note-ref "author-note-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-note-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "author-note-" (car l))
-    `(fntext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-note-" (car l))
+    `(fntext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-misc-ref s l)
   (:mode elsevier-style?)
-  (springer-author-note-ref "author-misc-" (car l)))
+  (springer-author-note-ref "author-misc-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-misc-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "author-misc-" (car l))
-    `(fmtext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-misc-" (car l))
+    `(fmtext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-affiliation t)
   (:mode elsevier-style?)
-  `(address ,(tmtex (cadr t))))
+  `(address ,(tmtex (cadr t)))
+) ;tm-define
 
 (tm-define (tmtex-author-affiliation-ref s l)
   (:mode elsevier-style?)
-  (springer-author-note-ref "affiliation-" (car l)))
+  (springer-author-note-ref "affiliation-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-affiliation-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "affiliation-" (car l))
-    `(address (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "affiliation-" (car l))
+    `(address (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-email t)
   (:mode elsevier-style?)
-  `(ead ,(tmtex (cadr t))))
+  `(ead ,(tmtex (cadr t)))
+) ;tm-define
 
 (tm-define (tmtex-author-email-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "author-email-" (car l)))
+  (springer-note-ref "author-email-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-email-label s l)
   (:mode elsevier-style?)
-  `(ead ,(tmtex (cadr l))))
+  `(ead ,(tmtex (cadr l)))
+) ;tm-define
 
 (tm-define (tmtex-author-homepage t)
   (:mode elsevier-style?)
-  `(ead (!option "url") ,(tmtex (cadr t))))
+  `(ead (!option "url") ,(tmtex (cadr t)))
+) ;tm-define
 
 (tm-define (tmtex-author-homepage-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "author-url-" (car l)))
+  (springer-note-ref "author-url-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-homepage-label s l)
   (:mode elsevier-style?)
-  `(ead (!option "url") ,(tmtex (cadr l))))
+  `(ead (!option "url") ,(tmtex (cadr l)))
+) ;tm-define
 
 (tm-define (tmtex-author-name t)
   (:mode elsevier-style?)
-  `(author ,(tmtex (cadr t))))
+  `(author ,(tmtex (cadr t)))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsart and IFAC specific title macros
@@ -249,41 +316,60 @@
 (tm-define (tmtex-replace-documents t)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (if (npair? t) t
-    (with (r s) (list (car t) (map tmtex-replace-documents (cdr t)))
-      (if (!= r 'document) `(,r ,@s)
-        `(concat ,@(list-intersperse s '(next-line)))))))
+  (if (npair? t)
+    t
+    (with (r s)
+      (list (car t) (map tmtex-replace-documents (cdr t)))
+      (if (!= r 'document) `(,r ,@s) `(concat ,@(list-intersperse s
+                                                  '(next-line))))
+    ) ;with
+  ) ;if
+) ;tm-define
 
 (tm-define (springer-note-ref l r)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
   (if (list? r)
     `(!concat ,@(map (lambda (x) `(thanksref ,x)) r))
-    `(thanksref ,(string-append l r))))
+    `(thanksref ,(string-append l r))
+  ) ;if
+) ;tm-define
 
 (tm-define (tmtex-doc-subtitle-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "sub-" (car l))
-    `(thankssubtitle (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "sub-" (car l))
+    `(thankssubtitle (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-note-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "note-" (car l))
-    `(thanks (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "note-" (car l))
+    `(thanks (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-date-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "date-" (car l))
-    `(thanksdate (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "date-" (car l))
+    `(thanksdate (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-misc-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "misc-" (car l))
-    `(thanksmisc (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "misc-" (car l))
+    `(thanksmisc (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsart specific authors macros
@@ -292,19 +378,26 @@
 (tm-define (springer-author-note-ref l r)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (springer-note-ref l r))
+  (springer-note-ref l r)
+) ;tm-define
 
 (tm-define (tmtex-author-note-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "author-note-" (car l))
-    `(thanks (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-note-" (car l))
+    `(thanks (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-misc-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "author-misc-" (car l))
-    `(thanksamisc (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-misc-" (car l))
+    `(thanksamisc (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; IFAC specific authors macros
@@ -312,13 +405,20 @@
 
 (tm-define (tmtex-author-email-label s l)
   (:mode ifac-style?)
-  (with label (string-append "author-email-" (car l))
-    `(thanksemail (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-email-" (car l))
+    `(thanks (!option ,label)
+       ,(tex-concat (list "Email:" " " (tmtex (cadr l)))))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-homepage-label s l)
   (:mode ifac-style?)
-  (with label (string-append "author-url-" (car l))
-    `(thankshomepage (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-url-" (car l))
+    `(thankshomepage (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier title and author preprocessing
@@ -327,9 +427,10 @@
 (tm-define (tmtex-prepare-doc-data l)
   (:mode elsevier-style?)
   (set! clustered?
-    (or
-      (contains-stree? l '(doc-title-options "cluster-by-affiliation"))
-      (contains-stree? l '(doc-title-options "cluster-all"))))
+    (or (contains-stree? l '(doc-title-options "cluster-by-affiliation"))
+      (contains-stree? l '(doc-title-options "cluster-all"))
+    ) ;or
+  ) ;set!
   (set! l (map tmtex-replace-documents l))
   (set! l (make-references l 'doc-subtitle #f #f))
   (set! l (make-references l 'doc-note #f #f))
@@ -340,48 +441,81 @@
   (if (ifac-style?)
     (begin
       (set! l (make-references l 'author-email #t #f))
-      (set! l (make-references l 'author-homepage #t #f))))
-  (if clustered?
-    (set! l (make-references l 'author-affiliation #t #f)))
-  l)
+      (set! l (make-references l 'author-homepage #t #f))
+    ) ;begin
+  ) ;if
+  (if clustered? (set! l (make-references l 'author-affiliation #t #f)))
+  l
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier title and author presentation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (tmtex-make-doc-data titles subtitles authors dates miscs notes
-                                subtitles-l dates-l miscs-l notes-l tr ar)
+(tm-define (tmtex-make-doc-data titles
+             subtitles
+             authors
+             dates
+             miscs
+             notes
+             subtitles-l
+             dates-l
+             miscs-l
+             notes-l
+             tr
+             ar
+           ) ;tmtex-make-doc-data
   (:mode elsevier-style?)
   (let* ((authors (filter nnull? authors))
-         (authors (if (null? authors) '()
-                    `((!paragraph ,@authors))))
+         (authors (if (null? authors) '() `((!paragraph ,@authors))))
          (titles (tmtex-concat-Sep (map cadr titles)))
-         (notes  `(,@subtitles ,@dates ,@miscs ,@notes))
-         (notes  (if (null? notes) '()
-                   `(,(springer-note-ref "" (map cadr notes)))))
+         (notes `(,@subtitles ,@dates ,@miscs ,@notes))
+         (notes (if (null? notes) '() `(,(springer-note-ref "" (map cadr notes)))))
          (result `(,@titles ,@notes))
          (result (if (null? result) '() `((title (!concat ,@result)))))
-         (result `(,@result ,@subtitles-l ,@notes-l
-                   ,@miscs-l ,@dates-l ,@authors)))
-    (if (null? result) "" `(!document ,@result))))
+         (result `(,@result
+                   ,@subtitles-l
+                   ,@notes-l
+                   ,@miscs-l
+                   ,@dates-l
+                   ,@authors))
+        ) ;
+    (if (null? result) "" `(!document ,@result))
+  ) ;let*
+) ;tm-define
 
-(tm-define (tmtex-make-author names affs emails urls miscs notes
-                              affs* emails* urls* miscs* notes*)
+(tm-define (tmtex-make-author names
+             affs
+             emails
+             urls
+             miscs
+             notes
+             affs*
+             emails*
+             urls*
+             miscs*
+             notes*
+           ) ;tmtex-make-author
   (:mode elsevier-style?)
-  (let* ((names  (tmtex-concat-Sep (map cadr names)))
-         (notes* (if (ifac-style?)
-                   `(,@emails* ,@urls* ,@miscs* ,@notes*)
-                   `(,@miscs* ,@notes*)))
-         (notes* (if (null? notes*) '()
-                   `(,(springer-author-note-ref "" (map cadr notes*)))))
-         (affs*  (if (null? affs*) '()
-                   `((!option
-                       (!concat ,@(list-intersperse (map cadr affs*) ","))))))
+  (let* ((names (tmtex-concat-Sep (map cadr names)))
+         (notes* (if (ifac-style?) `(,@emails* ,@urls* ,@miscs* ,@notes*) `(,@miscs*
+                                                                            ,@notes*))
+         ) ;notes*
+         (notes* (if (null? notes*) '() `(,(springer-author-note-ref ""
+                                             (map cadr notes*))))
+         ) ;notes*
+         (affs* (if (null? affs*)
+                  '()
+                  `((!option (!concat ,@(list-intersperse (map cadr affs*) ","))))
+                ) ;if
+         ) ;affs*
          (result `(,@names ,@notes*))
-         (result (if (null? result) '()
-                   `((author ,@affs* (!concat ,@result)))))
-         (result `(,@result ,@affs ,@emails ,@urls ,@miscs ,@notes)))
-    (if (null? result) '() `(!paragraph ,@result))))
+         (result (if (null? result) '() `((author ,@affs* (!concat ,@result)))))
+         (result `(,@result ,@affs ,@emails ,@urls ,@miscs ,@notes))
+        ) ;
+    (if (null? result) '() `(!paragraph ,@result))
+  ) ;let*
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier abstract macros
@@ -389,26 +523,38 @@
 
 (tm-define (tmtex-abstract-keywords t)
   (:mode elsevier-style?)
-  (with args (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
-    `((!begin "keyword") (!concat ,@args))))
+  (with args
+    (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
+    `((!begin "keyword") (!concat ,@args))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-abstract-msc t)
   (:mode elsevier-style?)
-  (with args (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
-    `(!concat (MSC) " " (!concat ,@args))))
+  (with args
+    (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
+    `(!concat (MSC) ," " (!concat ,@args))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-abstract-pacs t)
   (:mode elsevier-style?)
-  (with args (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
-    `(!concat (PACS) " " (!concat ,@args))))
+  (with args
+    (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
+    `(!concat (PACS) ," " (!concat ,@args))
+  ) ;with
+) ;tm-define
 
-(tm-define  (tmtex-make-abstract-data keywords acm arxiv msc pacs abstract)
+(tm-define (tmtex-make-abstract-data keywords acm arxiv msc pacs abstract)
   (:mode elsevier-style?)
   (if (or (nnull? msc) (nnull? pacs) (nnull? acm) (nnull? arxiv))
     (set! keywords
-      `(((!begin "keyword") (!document ,@(map cadr keywords)
-                                       ,@pacs ,@msc ,@acm ,@arxiv)))))
-  `(!document ,@abstract ,@keywords))
+      `(((!begin "keyword")
+         (!document ,@(map cadr keywords) ,@pacs ,@msc ,@acm ,@arxiv)))
+    ) ;set!
+  ) ;if
+  `(!document ,@abstract ,@keywords)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The Elsevier style is quite ugly.
@@ -421,15 +567,19 @@
   (let ((r (tmtex (car l))))
     (tmtex-env-reset "mode")
     (if (== s "equation")
-        (list (list '!begin "eqnarray") r)  ;; FIXME: why do elsequation
-        (list (list '!begin "eqnarray*") r) ;; and elsequation* not work?
-        )))
+      (list (list '!begin "eqnarray") r)
+      ;; FIXME: why do elsequation
+      (list (list '!begin "eqnarray*") r)
+      ;; and elsequation* not work?
+    ) ;if
+  ) ;let
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The elsarticle class does not insert a 'References' section title
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;(tm-define (tmtex-bib t)
+;; (tm-define (tmtex-bib t)
 ;;  (:mode elsevier-style?)
 ;;  (:require (elsarticle-style?))
 ;;  (tmtex-biblio (car t) (cdr t) #t))
@@ -441,9 +591,11 @@
 (smart-table latex-texmacs-macro
   (:mode elsevier-style?)
   (:require (elsarticle-style?))
-  (comma #f))
+  (comma #f)
+) ;smart-table
 
 (smart-table latex-texmacs-preamble
   (:mode elsevier-style?)
   (:require (elsarticle-style?))
-  (qed (!append (renewcommand "\\qed" "") "\n")))
+  (qed (!append (renewcommand "\\qed" "") "\n"))
+) ;smart-table

--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex-elsevier.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex-elsevier.scm
@@ -52,10 +52,7 @@
   (:mode jsc-style?)
   (init-elsevier body)
   ;; (set! tmtex-packages (cons "cite-author-year" tmtex-packages))
-  (latex-set-packages '("amsthm"
-                        "yjsco"
-                        ;; "natbib")
-  ) ;latex-set-packages
+  (latex-set-packages '("amsthm" "yjsco"))
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/progs/convert/latex/latex-define.scm
@@ -14,7 +14,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (convert latex latex-define)
-  (:use (convert latex latex-texmacs-drd)))
+  (:use (convert latex latex-texmacs-drd))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs symbols
@@ -44,68 +45,68 @@
   (cdotslim "\\mathop{\\cdots}\\limits")
 
   ;; rotated arrows and other symbols
-  (mapsfrom (!group (mbox (rotatebox (!option "origin=c") "180"
-                                     (!math (mapsto))))))
-  (longmapsfrom (!group (mbox (rotatebox (!option "origin=c") "180"
-                                         (!math (longmapsto))))))
-  (mapmulti (!group (mbox (rotatebox (!option "origin=c") "180"
-                                     (!math "\\multimap")))))
-  (leftsquigarrow (!group (mbox (rotatebox (!option "origin=c") "180"
-                                           (!math (rightsquigarrow))))))
-  (upequal (!group (mbox (rotatebox (!option "origin=c") "90"
-                                    (!math "=")))))
-  (downequal (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                      (!math "=")))))
-  (longupequal (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (longequal))))))
-  (longdownequal (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (longequal))))))
-  (longupminus (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (longminus))))))
-  (longdownminus (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (longminus))))))
-  (longuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (longrightarrow))))))
-  (longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (longrightarrow))))))
-  (longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                            (!math (longleftrightarrow))))))
-  (Longuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (Longrightarrow))))))
-  (Longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (Longrightarrow))))))
-  (Longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                            (!math (Longleftrightarrow))))))
-  (mapsup (!group (mbox (rotatebox (!option "origin=c") "90"
-                                   (!math (mapsto))))))
-  (mapsdown (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                     (!math (mapsto))))))
-  (longmapsup (!group (mbox (rotatebox (!option "origin=c") "90"
-                                       (!math (longmapsto))))))
-  (longmapsdown (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                         (!math (longmapsto))))))
-  (upsquigarrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                         (!math (rightsquigarrow))))))
-  (downsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                           (!math (rightsquigarrow))))))
-  (updownsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                             (!math (leftrightsquigarrow))))))
-  (hookuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                        (!math (hookrightarrow))))))
-  (hookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                          (!math (hookrightarrow))))))
-  (longhookuparrow (!group (mbox (rotatebox (!option "origin=c") "90"
-                                            (!math (longhookrightarrow))))))
-  (longhookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90"
-                                              (!math (longhookrightarrow))))))
-  (Backepsilon (!group (mbox (rotatebox (!option "origin=c") "180"
-                                        "E"))))
+  (mapsfrom (!group (mbox (rotatebox (!option "origin=c") "180" (!math (mapsto)))))
+  ) ;mapsfrom
+  (longmapsfrom (!group (mbox (rotatebox (!option "origin=c") "180" (!math (longmapsto)))))
+  ) ;longmapsfrom
+  (mapmulti (!group (mbox (rotatebox (!option "origin=c") "180" (!math "\\multimap"))))
+  ) ;mapmulti
+  (leftsquigarrow (!group (mbox (rotatebox (!option "origin=c") "180" (!math (rightsquigarrow)))))
+  ) ;leftsquigarrow
+  (upequal (!group (mbox (rotatebox (!option "origin=c") "90" (!math "=")))))
+  (downequal (!group (mbox (rotatebox (!option "origin=c") "-90" (!math "=")))))
+  (longupequal (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longequal)))))
+  ) ;longupequal
+  (longdownequal (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longequal)))))
+  ) ;longdownequal
+  (longupminus (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longminus)))))
+  ) ;longupminus
+  (longdownminus (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longminus)))))
+  ) ;longdownminus
+  (longuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longrightarrow)))))
+  ) ;longuparrow
+  (longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longrightarrow)))))
+  ) ;longdownarrow
+  (longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longleftrightarrow))))
+                   ) ;!group
+  ) ;longupdownarrow
+  (Longuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (Longrightarrow)))))
+  ) ;Longuparrow
+  (Longdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (Longrightarrow)))))
+  ) ;Longdownarrow
+  (Longupdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (Longleftrightarrow))))
+                   ) ;!group
+  ) ;Longupdownarrow
+  (mapsup (!group (mbox (rotatebox (!option "origin=c") "90" (!math (mapsto))))))
+  (mapsdown (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (mapsto)))))
+  ) ;mapsdown
+  (longmapsup (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longmapsto)))))
+  ) ;longmapsup
+  (longmapsdown (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longmapsto)))))
+  ) ;longmapsdown
+  (upsquigarrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (rightsquigarrow)))))
+  ) ;upsquigarrow
+  (downsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (rightsquigarrow)))))
+  ) ;downsquigarrow
+  (updownsquigarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (leftrightsquigarrow))))
+                    ) ;!group
+  ) ;updownsquigarrow
+  (hookuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (hookrightarrow)))))
+  ) ;hookuparrow
+  (hookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (hookrightarrow)))))
+  ) ;hookdownarrow
+  (longhookuparrow (!group (mbox (rotatebox (!option "origin=c") "90" (!math (longhookrightarrow))))
+                   ) ;!group
+  ) ;longhookuparrow
+  (longhookdownarrow (!group (mbox (rotatebox (!option "origin=c") "-90" (!math (longhookrightarrow))))
+                     ) ;!group
+  ) ;longhookdownarrow
+  (Backepsilon (!group (mbox (rotatebox (!option "origin=c") "180" "E"))))
   (Backsigma (!group (mbox (reflectbox (!math "\\Sigma")))))
-  (Mho (!group (mbox (rotatebox (!option "origin=c") "180"
-                                (!math "\\Omega")))))
-  (btimes (!group (mbox (rotatebox (!option "origin=c") "90"
-                                   (!math "\\ltimes")))))
-  
+  (Mho (!group (mbox (rotatebox (!option "origin=c") "180" (!math "\\Omega")))))
+  (btimes (!group (mbox (rotatebox (!option "origin=c") "90" (!math "\\ltimes"))))
+  ) ;btimes
+
   ;; asymptotic relations by Joris
   (nasymp "\\not\\asymp")
   (asympasymp "{\\asymp\\!\\!\\!\\!\\!\\!-}")
@@ -246,76 +247,109 @@
   (gebar (mathrel (Yright)))
   (leangle (mathrel (angle)))
   (geangle (mathrel (!group (mbox (reflectbox (!math (angle)))))))
-  (anglege (mathrel (!group (mbox (rotatebox (!option "origin=c") "180"
-                                             (!math (angle)))))))
-  (anglele (mathrel (!group (mbox (rotatebox (!option "origin=c") "180"
-                                             (!math (!recurse (geangle))))))))
-  ;;(leqangle (mathrel (substack (!append (angle) "\\\\" (smash "-")))))
-  (leqangle (mathrel (!append (angle) " \\llap "
-                              (!group (raisebox "-1ex" (!math "-"))))))
+  (anglege (mathrel (!group (mbox (rotatebox (!option "origin=c") "180" (!math (angle))))))
+  ) ;anglege
+  (anglele (mathrel (!group (mbox (rotatebox (!option "origin=c") "180" (!math (!recurse (geangle)))))
+                    ) ;!group
+           ) ;mathrel
+  ) ;anglele
+  ;; (leqangle (mathrel (substack (!append (angle) "\\\\" (smash "-")))))
+  (leqangle (mathrel (!append (angle) " \\llap " (!group (raisebox "-1ex" (!math "-")))))
+  ) ;leqangle
   (geqangle (mathrel (!group (mbox (reflectbox (!math (!recurse (leqangle))))))))
   (legeangle (mathrel (substack (!append (leangle) "\\\\" (!recurse (anglege))))))
   (geleangle (mathrel (substack (!append (geangle) "\\\\" (!recurse (anglele))))))
-  (udots "{\\mathinner{\\mskip1mu\\raise1pt\\vbox{\\kern7pt\\hbox{.}}\\mskip2mu\\raise4pt\\hbox{.}\\mskip2mu\\raise7pt\\hbox{.}\\mskip1mu}}")
+  (udots "{\\mathinner{\\mskip1mu\\raise1pt\\vbox{\\kern7pt\\hbox{.}}\\mskip2mu\\raise4pt\\hbox{.}\\mskip2mu\\raise7pt\\hbox{.}\\mskip1mu}}"
+  ) ;udots
   (subsetsim (underset (sim) (subset)))
   (supsetsim (underset (sim) (supset)))
   (rightmap (!group (!append (shortmid) "\\!\\!\\!-")))
   (leftmap (!group (!append "-\\!\\!\\!" (shortmid))))
-  (leftrightmap (!group (!append (shortmid) "\\!\\!\\!-\\!\\!\\!"
-                                 (shortmid))))
+  (leftrightmap (!group (!append (shortmid) "\\!\\!\\!-\\!\\!\\!" (shortmid))))
   (LRleftrightarrow (!group (!append (Lleftarrow) "\\!\\!\\!" (Rrightarrow))))
   (Llongleftarrow (!group (!append (Lleftarrow) "\\!" (equiv))))
   (Llongrightarrow (!group (!append (equiv) "\\!" (Rrightarrow))))
-  (Llongleftrightarrow (!group (!append (Lleftarrow) "\\!" (equiv)
-                                        "\\!" (Rrightarrow))))
-  (threeleftarrows
-   (mathrel (substack (!append (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow)))))
-  (fourleftarrows
-   (mathrel (substack (!append (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow) "\\\\[-0.6ex]"
-                               (leftarrow)))))
-  (threerightarrows
-   (mathrel (substack (!append (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow)))))
-  (fourrightarrows
-   (mathrel (substack (!append (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow) "\\\\[-0.6ex]"
-                               (rightarrow)))))
-  (longleftrightarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longrightarrow)))))
-  (longleftleftarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longthreeleftarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longfourleftarrows
-   (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longrightleftarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longleftarrow)))))
-  (longrightrightarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow)))))
-  (longthreerightarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow)))))
-  (longfourrightarrows
-   (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow) "\\\\[-0.6ex]"
-                               (longrightarrow))))))
+  (Llongleftrightarrow (!group (!append (Lleftarrow) "\\!" (equiv) "\\!" (Rrightarrow)))
+  ) ;Llongleftrightarrow
+  (threeleftarrows (mathrel (substack (!append (leftarrow) "\\\\[-0.6ex]" (leftarrow) "\\\\[-0.6ex]" (leftarrow))
+                            ) ;substack
+                   ) ;mathrel
+  ) ;threeleftarrows
+  (fourleftarrows (mathrel (substack (!append (leftarrow)
+                                       "\\\\[-0.6ex]"
+                                       (leftarrow)
+                                       "\\\\[-0.6ex]"
+                                       (leftarrow)
+                                       "\\\\[-0.6ex]"
+                                       (leftarrow)
+                                     ) ;!append
+                           ) ;substack
+                  ) ;mathrel
+  ) ;fourleftarrows
+  (threerightarrows (mathrel (substack (!append (rightarrow) "\\\\[-0.6ex]" (rightarrow) "\\\\[-0.6ex]" (rightarrow))
+                             ) ;substack
+                    ) ;mathrel
+  ) ;threerightarrows
+  (fourrightarrows (mathrel (substack (!append (rightarrow)
+                                        "\\\\[-0.6ex]"
+                                        (rightarrow)
+                                        "\\\\[-0.6ex]"
+                                        (rightarrow)
+                                        "\\\\[-0.6ex]"
+                                        (rightarrow)
+                                      ) ;!append
+                            ) ;substack
+                   ) ;mathrel
+  ) ;fourrightarrows
+  (longleftrightarrows (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]" (longrightarrow))))
+  ) ;longleftrightarrows
+  (longleftleftarrows (mathrel (substack (!append (longleftarrow) "\\\\[-0.6ex]" (longleftarrow))))
+  ) ;longleftleftarrows
+  (longthreeleftarrows (mathrel (substack (!append (longleftarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longleftarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longleftarrow)
+                                          ) ;!append
+                                ) ;substack
+                       ) ;mathrel
+  ) ;longthreeleftarrows
+  (longfourleftarrows (mathrel (substack (!append (longleftarrow)
+                                           "\\\\[-0.6ex]"
+                                           (longleftarrow)
+                                           "\\\\[-0.6ex]"
+                                           (longleftarrow)
+                                           "\\\\[-0.6ex]"
+                                           (longleftarrow)
+                                         ) ;!append
+                               ) ;substack
+                      ) ;mathrel
+  ) ;longfourleftarrows
+  (longrightleftarrows (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]" (longleftarrow))))
+  ) ;longrightleftarrows
+  (longrightrightarrows (mathrel (substack (!append (longrightarrow) "\\\\[-0.6ex]" (longrightarrow))))
+  ) ;longrightrightarrows
+  (longthreerightarrows (mathrel (substack (!append (longrightarrow)
+                                             "\\\\[-0.6ex]"
+                                             (longrightarrow)
+                                             "\\\\[-0.6ex]"
+                                             (longrightarrow)
+                                           ) ;!append
+                                 ) ;substack
+                        ) ;mathrel
+  ) ;longthreerightarrows
+  (longfourrightarrows (mathrel (substack (!append (longrightarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longrightarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longrightarrow)
+                                            "\\\\[-0.6ex]"
+                                            (longrightarrow)
+                                          ) ;!append
+                                ) ;substack
+                       ) ;mathrel
+  ) ;longfourrightarrows
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs macros
@@ -328,21 +362,35 @@
   (tmat "\\symbol{\"40}")
   (tmbsl "\\ensuremath{\\backslash}")
   (tmdummy "$\\mbox{}$")
-  (TeXmacs "T\\kern-.1667em\\lower.5ex\\hbox{E}\\kern-.125emX\\kern-.1em\\lower.5ex\\hbox{\\textsc{m\\kern-.05ema\\kern-.125emc\\kern-.05ems}}")
+  (TeXmacs "T\\kern-.1667em\\lower.5ex\\hbox{E}\\kern-.125emX\\kern-.1em\\lower.5ex\\hbox{\\textsc{m\\kern-.05ema\\kern-.125emc\\kern-.05ems}}"
+  ) ;TeXmacs
   (madebyTeXmacs (footnote (!recurse (withTeXmacstext))))
-  (withTeXmacstext
-    (!append (!translate "This document has been produced using the GNU") " "
-             (!group (!recurse (TeXmacs))) " " (!translate "text editor") " ("
-             (!translate "see") " "
-             (url "https://www.texmacs.org") ")"))
-  (citewebsite
-    (!append (!translate "This document has been written using") " GNU "
-             (!group (!recurse (TeXmacs))) "; " (!translate "see") " "
-             (url "https://www.texmacs.org") "."))
+  (withTeXmacstext (!append (!translate "This document has been produced using the GNU")
+                     " "
+                     (!group (!recurse (TeXmacs)))
+                     " "
+                     (!translate "text editor")
+                     " ("
+                     (!translate "see")
+                     " "
+                     (url "https://www.texmacs.org")
+                     ")"
+                   ) ;!append
+  ) ;withTeXmacstext
+  (citewebsite (!append (!translate "This document has been written using")
+                 " GNU "
+                 (!group (!recurse (TeXmacs)))
+                 "; "
+                 (!translate "see")
+                 " "
+                 (url "https://www.texmacs.org")
+                 "."
+               ) ;!append
+  ) ;citewebsite
   (tmmade (!recurse (tikzframe (Backsigma))))
   (scheme "{\\sc Scheme}")
-  (tmsep  ", ")
-  (tmSep  "; ")
+  (tmsep ", ")
+  (tmSep "; ")
   (pari "{\\sc Pari}")
   (textdots "...")
   (filldots "{\\dotfill\\hfill\\hbox{}}")
@@ -400,13 +448,21 @@
   (tmieeeemail (!append (textit (!translate "Email:")) " " 1))
   (tmnote (thanks (!append (textit (!translate "Note:")) " " 1)))
   (tmmisc (thanks (!append (textit (!translate "Misc:")) " " 1)))
-  (citetexmacs
-    (!append (!translate "This document has been written using") " GNU "
-             (!group (!recurse (TeXmacs))) " " (cite 1) "."))
-  (key (!append
-         (fcolorbox "black" "gray!25!white"
-                    (raisebox "0pt" (!option "5pt") (!option "0pt") (texttt 1)))
-         (hspace "0.5pt")))
+  (citetexmacs (!append (!translate "This document has been written using")
+                 " GNU "
+                 (!group (!recurse (TeXmacs)))
+                 " "
+                 (cite 1)
+                 "."
+               ) ;!append
+  ) ;citetexmacs
+  (key (!append (fcolorbox "black"
+                  "gray!25!white"
+                  (raisebox "0pt" (!option "5pt") (!option "0pt") (texttt 1))
+                ) ;fcolorbox
+         (hspace "0.5pt")
+       ) ;!append
+  ) ;key
   (uhat (underaccent (hat) 1))
   (uwidehat (underaccent (widehat (hphantom 1)) 1))
   (utilde (underaccent (tilde) 1))
@@ -423,7 +479,7 @@
   (udddot (underaccent (dddot (hphantom 1)) 1))
   (uddddot (underaccent (ddddot (hphantom 1)) 1))
   (widespacing 1)
-  (gb  (!append (texttt "[\\!\\![") 1 (texttt "]\\!\\!]")))
+  (gb (!append (texttt "[\\!\\![") 1 (texttt "]\\!\\!]")))
   (gbt (!append (texttt "[\\!\\![\\!\\![") 1 (texttt "]\\!\\!]\\!\\!]")))
 
   ;; With options
@@ -431,26 +487,22 @@
 
   ;; Binary macros
   (tmcolor (!group (color 1) (!group 2)))
-  (tmsummarizeddocumentation
-   (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1)))
+  (tmsummarizeddocumentation (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1))
+  ) ;tmsummarizeddocumentation
   (tmsummarizedgrouped (trivlist (!append (item (!option "[")) (mbox "") 1)))
-  (tmsummarizedexplain
-   (trivlist (!append (item (!option "")) (mbox "") "\\bf" 1)))
+  (tmsummarizedexplain (trivlist (!append (item (!option "")) (mbox "") "\\bf" 1))
+  ) ;tmsummarizedexplain
   (tmsummarizedplain (trivlist (!append (item (!option "")) (mbox "") 1)))
   (tmsummarizedtiny (trivlist (!append (item (!option "")) (mbox "") 1)))
   (tmsummarizedraw (trivlist (!append (item (!option "")) (mbox "") 1)))
-  (tmsummarizedenv
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmsummarizedstd
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmsummarized
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
+  (tmsummarizedenv (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
+  (tmsummarizedstd (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
+  (tmsummarized (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
 
-  (tmdetaileddocumentation
-   (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 2)))
+  (tmdetaileddocumentation (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 2))
+  ) ;tmdetaileddocumentation
   (tmdetailedgrouped (trivlist (!append (item (!option "[")) (mbox "") 2)))
-  (tmdetailedexplain
-   (trivlist (!append (item (!option "")) (mbox "") "\\bf" 2)))
+  (tmdetailedexplain (trivlist (!append (item (!option "")) (mbox "") "\\bf" 2)))
   (tmdetailedplain (trivlist (!append (item (!option "")) (mbox "") 2)))
   (tmdetailedtiny (trivlist (!append (item (!option "")) (mbox "") 2)))
   (tmdetailedraw (trivlist (!append (item (!option "")) (mbox "") 2)))
@@ -458,97 +510,159 @@
   (tmdetailedstd (trivlist (!append (item (!option "$\\circ$")) (mbox "") 2)))
   (tmdetailed (trivlist (!append (item (!option "$\\circ$")) (mbox "") 2)))
 
-  (tmfoldeddocumentation
-   (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1)))
-  (tmunfoldeddocumentation
-   (trivlist (!append (item (!option "")) (mbox "")
-                      (!group "\\large\\bf" 1) "\\\\"
-                      (item (!option "")) (mbox "") 2)))
-  (tmfoldedsubsession
-   (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfoldedsubsession
-   (trivlist (!append (item (!option "$\\circ$"))   (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
-  (tmfoldedgrouped
-   (trivlist (!append (item (!option "["))  (mbox "") 1)))
-  (tmunfoldedgrouped
-   (trivlist (!append (item (!option "$\\lceil$"))  (mbox "") 1 "\\\\"
-                      (item (!option "$\\lfloor$")) (mbox "") 2 )))
+  (tmfoldeddocumentation (trivlist (!append (item (!option "")) (mbox "") "\\large\\bf" 1))
+  ) ;tmfoldeddocumentation
+  (tmunfoldeddocumentation (trivlist (!append (item (!option ""))
+                                       (mbox "")
+                                       (!group "\\large\\bf" 1)
+                                       "\\\\"
+                                       (item (!option ""))
+                                       (mbox "")
+                                       2
+                                     ) ;!append
+                           ) ;trivlist
+  ) ;tmunfoldeddocumentation
+  (tmfoldedsubsession (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1))
+  ) ;tmfoldedsubsession
+  (tmunfoldedsubsession (trivlist (!append (item (!option "$\\circ$"))
+                                    (mbox "")
+                                    1
+                                    "\\\\"
+                                    (item (!option ""))
+                                    (mbox "")
+                                    2
+                                  ) ;!append
+                        ) ;trivlist
+  ) ;tmunfoldedsubsession
+  (tmfoldedgrouped (trivlist (!append (item (!option "[")) (mbox "") 1)))
+  (tmunfoldedgrouped (trivlist (!append (item (!option "$\\lceil$"))
+                                 (mbox "")
+                                 1
+                                 "\\\\"
+                                 (item (!option "$\\lfloor$"))
+                                 (mbox "")
+                                 2
+                               ) ;!append
+                     ) ;trivlist
+  ) ;tmunfoldedgrouped
   (tmfoldedexplain (trivlist (!append (item (!option "")) "\\bf" 1)))
-  (tmunfoldedexplain
-   (trivlist (!append (item (!option "")) (mbox "")
-                      (!group "\\bf" 1) "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedexplain (trivlist (!append (item (!option ""))
+                                 (mbox "")
+                                 (!group "\\bf" 1)
+                                 "\\\\"
+                                 (item (!option ""))
+                                 (mbox "")
+                                 2
+                               ) ;!append
+                     ) ;trivlist
+  ) ;tmunfoldedexplain
   (tmfoldedplain (trivlist (!append (item (!option "")) (mbox "") 1)))
-  (tmunfoldedplain
-   (trivlist (!append (item (!option "")) (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedplain (trivlist (!append (item (!option "")) (mbox "") 1 "\\\\" (item (!option "")) (mbox "") 2)
+                   ) ;trivlist
+  ) ;tmunfoldedplain
   (tmfoldedenv (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfoldedenv
-   (trivlist (!append (item (!option "$\\circ$")) (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedenv (trivlist (!append (item (!option "$\\circ$"))
+                             (mbox "")
+                             1
+                             "\\\\"
+                             (item (!option ""))
+                             (mbox "")
+                             2
+                           ) ;!append
+                 ) ;trivlist
+  ) ;tmunfoldedenv
   (tmfoldedstd (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfoldedstd
-   (trivlist (!append (item (!option "$\\circ$")) (mbox "") 1 "\\\\"
-                      (item (!option "")) (mbox "") 2 )))
+  (tmunfoldedstd (trivlist (!append (item (!option "$\\circ$"))
+                             (mbox "")
+                             1
+                             "\\\\"
+                             (item (!option ""))
+                             (mbox "")
+                             2
+                           ) ;!append
+                 ) ;trivlist
+  ) ;tmunfoldedstd
   (tmfolded (trivlist (!append (item (!option "$\\bullet$")) (mbox "") 1)))
-  (tmunfolded (trivlist (!append (item (!option "$\\circ$")) (mbox "") 1 "\\\\"
-                                 (item (!option "")) (mbox "") 2 )))
-  (tminput
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (!group (!append (color "blue!50!black") (mbox "") 2)))))
-  (tminputmath
-   (trivlist (!append (item (!option 1)) (ensuremath 2))))
-  (tmhlink  (!group (!append (color "blue") 1)))
+  (tmunfolded (trivlist (!append (item (!option "$\\circ$"))
+                          (mbox "")
+                          1
+                          "\\\\"
+                          (item (!option ""))
+                          (mbox "")
+                          2
+                        ) ;!append
+              ) ;trivlist
+  ) ;tmunfolded
+  (tminput (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                       (!group (!append (color "blue!50!black") (mbox "") 2))
+                     ) ;!append
+           ) ;trivlist
+  ) ;tminput
+  (tminputmath (trivlist (!append (item (!option 1)) (ensuremath 2))))
+  (tmhlink (!group (!append (color "blue") 1)))
   (tmaction (!group (!append (color "blue") 1)))
   (ontop (genfrac "" "" "0pt" "" 1 2))
   (subindex (index (!append 1 "!" 2)))
   (renderfootnote (footnotetext (!append (tmrsup 1) " " 2)))
   (renderfootnotestar (footnotetext (!append (tmrsup 1) " " 3)))
-  (tmlinenumber (!append (custombinding 1)
-                         (tmlinenote (footnotesize 1) 2 "0cm")))
+  (tmlinenumber (!append (custombinding 1) (tmlinenote (footnotesize 1) 2 "0cm")))
 
   ;; Ternary macros
   (tmsession (!group (!append (tt) 3)))
-  (tmfoldediomath
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (!group (!append (color "blue!50!black") (ensuremath 2))))))
-  (tmunfoldediomath
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (!group (!append (color "blue!50!black") (ensuremath 2)))
-                      (item (!option "")) (mbox "") 3)))
-  (tmfoldedio
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (mbox "") (!group (!append (color "blue!50!black") 2)))))
-  (tmunfoldedio
-   (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
-                      (mbox "") (!group (!append (color "blue!50!black") 2))
-                      (item (!option "")) (mbox "") 3)))
-  (tmlinenote
-   (!append (tmdummy)
-            (marginpar (adjustbox
-                        (!append "right=0cm, lap=" 2
-                                 "-\\textwidth-\\marginparsep, raise=" 3)
-                        1))))
+  (tmfoldediomath (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                              (!group (!append (color "blue!50!black") (ensuremath 2)))
+                            ) ;!append
+                  ) ;trivlist
+  ) ;tmfoldediomath
+  (tmunfoldediomath (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                                (!group (!append (color "blue!50!black") (ensuremath 2)))
+                                (item (!option ""))
+                                (mbox "")
+                                3
+                              ) ;!append
+                    ) ;trivlist
+  ) ;tmunfoldediomath
+  (tmfoldedio (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                          (mbox "")
+                          (!group (!append (color "blue!50!black") 2))
+                        ) ;!append
+              ) ;trivlist
+  ) ;tmfoldedio
+  (tmunfoldedio (trivlist (!append (item (!option (!append (color "rgb:black,10;red,9;green,4;yellow,2") 1)))
+                            (mbox "")
+                            (!group (!append (color "blue!50!black") 2))
+                            (item (!option ""))
+                            (mbox "")
+                            3
+                          ) ;!append
+                ) ;trivlist
+  ) ;tmunfoldedio
+  (tmlinenote (!append (tmdummy)
+                (marginpar (adjustbox (!append "right=0cm, lap=" 2 "-\\textwidth-\\marginparsep, raise=" 3)
+                             1
+                           ) ;adjustbox
+                ) ;marginpar
+              ) ;!append
+  ) ;tmlinenote
   (subsubindex (index (!append 1 "!" 2 "!" 3)))
   (tmref 1)
   (glossaryentry (!append (item (!option (!append 1 (hfill)))) 2 (dotfill) 3))
 
   ;; Tetrary macros
-  (tmscriptinput (fbox (!append (fbox (!append (sf) 2)) " "
-                                (!append (tt) 3))))
+  (tmscriptinput (fbox (!append (fbox (!append (sf) 2)) " " (!append (tt) 3))))
   (tmscriptoutput (!append 4))
-  (tmconverterinput (fbox (!append (fbox (!append (sf) 2)) " "
-                                   (!append (tt) 3))))
+  (tmconverterinput (fbox (!append (fbox (!append (sf) 2)) " " (!append (tt) 3))))
   (tmconverteroutput (!append 4))
-  (subsubsubindex (index (!append 1 "!" 2 "!" 3 "!" 4))))
+  (subsubsubindex (index (!append 1 "!" 2 "!" 3 "!" 4)))
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Deprecated extra macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-macro
-  (labeleqnum "\\addtocounter{equation}{-1}\\refstepcounter{equation}\\addtocounter{equation}{1})")
+  (labeleqnum "\\addtocounter{equation}{-1}\\refstepcounter{equation}\\addtocounter{equation}{1})"
+  ) ;labeleqnum
   (eqnumber (!append "\\hfill(\\theequation" (!recurse (labeleqnum)) ")"))
   (leqnumber (!append "(\\theequation" (!recurse (labeleqnum)) ")\\hfill"))
   (reqnumber (!append "\\hfill(\\theequation" (!recurse (labeleqnum)) ")"))
@@ -556,58 +670,64 @@
   (ckey (!recurse (key (!append "ctrl-" 1))))
   (akey (!recurse (key (!append "alt-" 1))))
   (mkey (!recurse (key (!append "meta-" 1))))
-  (hkey (!recurse (key (!append "hyper-" 1)))))
+  (hkey (!recurse (key (!append "hyper-" 1))))
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-environment
-  ("proof"
-   ((!begin "proof") ---))
-  ("proof*"
-   ((!begin "proof" (!option 1)) ---))
-  ("leftaligned"
-   ((!begin "flushleft") ---))
-  ("rightaligned"
-   ((!begin "flushright") ---))
-  ("quoteenv"
-   ((!begin "quote") ---))
-  ("tmcode"
-   ((!option "")
-    ((!begin "alltt") ---)))
-  ("tmparmod"
-   ((!begin "list" "" (!append "\\setlength{\\topsep}{0pt}"
-                               "\\setlength{\\leftmargin}{" 1 "}"
-                               "\\setlength{\\rightmargin}{" 2 "}"
-                               "\\setlength{\\parindent}{" 3 "}"
-                               "\\setlength{\\listparindent}{\\parindent}"
-                               "\\setlength{\\itemindent}{\\parindent}"
-                               "\\setlength{\\parsep}{\\parskip}"))
-    (!append "\\item[]"
-             ---)))
-  ("tmparsep"
-   (!append (begingroup) "\\setlength{\\parskip}{" 1 "}"
-            ---
-            (endgroup)))
-  ("tmcompact"
-   ((!begin "tmparsep" "0em") ---))
-  ("tmcompressed"
-   ((!begin "tmparsep" "0.25em") ---))
-  ("tmamplified"
-   ((!begin "tmparsep" "0.75em") ---))
-  ("tmjumpin"
-   ((!begin "tmparmod" "1.5em" "0pt" "-1.5em") ---))
-  ("tmindent"
-   ((!begin "tmparmod" "1.5em" "0pt" "0pt") ---))
-  ("tmlisting"
-   ((!begin "linenumbers") (!append (resetlinenumber) ---)))
-  ("elsequation" ((!begin "eqnarray") (!append --- "&&")))
-  ("elsequation*" ((!begin "eqnarray*") (!append --- "&&")))
-  ("theglossary"
-   ((!begin "list" "" (!append "\\setlength{\\labelwidth}{6.5em}"
-                               "\\setlength{\\leftmargin}{7em}"
-                               "\\small")) ---)))
+ ("proof" ((!begin "proof") ---))
+ ("proof*" ((!begin "proof" (!option 1)) ---))
+ ("leftaligned" ((!begin "flushleft") ---))
+ ("rightaligned" ((!begin "flushright") ---))
+ ("quoteenv" ((!begin "quote") ---))
+ ("tmcode" ((!option "") ((!begin "alltt") ---)))
+ ("tmparmod"
+  ((!begin "list"
+     ""
+     (!append "\\setlength{\\topsep}{0pt}"
+       "\\setlength{\\leftmargin}{"
+       1
+       "}"
+       "\\setlength{\\rightmargin}{"
+       2
+       "}"
+       "\\setlength{\\parindent}{"
+       3
+       "}"
+       "\\setlength{\\listparindent}{\\parindent}"
+       "\\setlength{\\itemindent}{\\parindent}"
+       "\\setlength{\\parsep}{\\parskip}"
+     ) ;!append
+   ) ;!begin
+   (!append "\\item[]" ---)
+  ) ;
+ ) ;
+ ("tmparsep"
+   (!append (begingroup) "\\setlength{\\parskip}{" 1 "}" --- (endgroup))
+ ) ;
+ ("tmcompact" ((!begin "tmparsep" "0em") ---))
+ ("tmcompressed" ((!begin "tmparsep" "0.25em") ---))
+ ("tmamplified" ((!begin "tmparsep" "0.75em") ---))
+ ("tmjumpin" ((!begin "tmparmod" "1.5em" "0pt" "-1.5em") ---))
+ ("tmindent" ((!begin "tmparmod" "1.5em" "0pt" "0pt") ---))
+ ("tmlisting" ((!begin "linenumbers") (!append (resetlinenumber) ---)))
+ ("elsequation" ((!begin "eqnarray") (!append --- "&&")))
+ ("elsequation*" ((!begin "eqnarray*") (!append --- "&&")))
+ ("theglossary"
+  ((!begin "list"
+     ""
+     (!append "\\setlength{\\labelwidth}{6.5em}"
+       "\\setlength{\\leftmargin}{7em}"
+       "\\small"
+     ) ;!append
+   ) ;!begin
+   ---
+  ) ;
+ ) ;
+) ;smart-table
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TeXmacs list environments
@@ -617,19 +737,29 @@
   `(smart-table latex-texmacs-environment
      (,env
       ((!begin "itemize")
-       (!append "\\renewcommand{\\labelitemi}{" ,lab "}"
-                "\\renewcommand{\\labelitemii}{" ,lab "}"
-                "\\renewcommand{\\labelitemiii}{" ,lab "}"
-                "\\renewcommand{\\labelitemiv}{" ,lab "}"
-                ---)))))
+       (!append ,"\\renewcommand{\\labelitemi}{"
+         ,lab
+         ,"}"
+         ,"\\renewcommand{\\labelitemii}{"
+         ,lab
+         ,"}"
+         ,"\\renewcommand{\\labelitemiii}{"
+         ,lab
+         ,"}"
+         ,"\\renewcommand{\\labelitemiv}{"
+         ,lab
+         ,"}"
+         ---))))
+) ;define-macro
 
 (define-macro (latex-texmacs-enumerate env lab)
   `(smart-table latex-texmacs-environment
-     (,env ((!begin "enumerate" (!option ,lab)) ---))))
+     (,env ((!begin ,"enumerate" (!option ,lab)) ---)))
+) ;define-macro
 
 (define-macro (latex-texmacs-description env)
-  `(smart-table latex-texmacs-environment
-     (,env ((!begin "description") ---))))
+  `(smart-table latex-texmacs-environment (,env ((!begin "description") ---)))
+) ;define-macro
 
 (latex-texmacs-itemize "itemizeminus" "$-$")
 (latex-texmacs-itemize "itemizedot" "$\\bullet$")
@@ -655,112 +785,139 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-preamble
-  (newmdenv
-   (!append (mdfsetup (!append "linecolor=black,linewidth=0.5pt,"
-                               "skipabove=0.5em,skipbelow=0.5em,"
-                               "hidealllines=true,innerleftmargin=0pt,"
-                               "innerrightmargin=0pt,innertopmargin=0pt,"
-                               "innerbottommargin=0pt" )) "\n"))
-  (tikzframe
-   (!append
-    (!ignore (tikz))
-    "\\newcommand{\\tikzframe}[1]{%\n"
-    "  \\tikz[baseline=(X.base)]\n"
-    "  \\node[draw=black,semithick,rectangle,inner sep=2pt,rounded corners=2pt]\n"
-    "  (X) {#1};}\n"))
-  (nonconverted
-   (!append "\\newcommand{\\nonconverted}[1]{\\mbox{}}\n"))
-  (tmkeywords
-   (!append (newcommand (tmkeywords)
-                        (!append (textbf (!translate "Keywords:")) " "))
-            "\n"))
-  (tmacm
-   (!append (newcommand (tmacm)
-                        (!append
-                         (textbf
-                          (!translate "A.C.M. subject classification:")) " "))
-            "\n"))
-  (tmarxiv
-   (!append (newcommand (tmarxiv)
-                        (!append
-                         (textbf
-                          (!translate "arXiv subject classification:")) " "))
-            "\n"))
-  (tmpacs
-   (!append (newcommand (tmpacs)
-                        (!append
-                         (textbf
-                          (!translate "P.A.C.S. subject classification:"))
-                         " "))
-            "\n"))
-  (tmmsc
-   (!append (newcommand (tmmsc)
-                        (!append
-                         (textbf
-                          (!translate "A.M.S. subject classification:")) " "))
-            "\n"))
+  (newmdenv (!append (mdfsetup (!append "linecolor=black,linewidth=0.5pt,"
+                                 "skipabove=0.5em,skipbelow=0.5em,"
+                                 "hidealllines=true,innerleftmargin=0pt,"
+                                 "innerrightmargin=0pt,innertopmargin=0pt,"
+                                 "innerbottommargin=0pt"
+                               ) ;!append
+                     ) ;mdfsetup
+              "\n"
+            ) ;!append
+  ) ;newmdenv
+  (tikzframe (!append (!ignore (tikz))
+               "\\newcommand{\\tikzframe}[1]{%\n"
+               "  \\tikz[baseline=(X.base)]\n"
+               "  \\node[draw=black,semithick,rectangle,inner sep=2pt,rounded corners=2pt]\n"
+               "  (X) {#1};}\n"
+             ) ;!append
+  ) ;tikzframe
+  (nonconverted (!append "\\newcommand{\\nonconverted}[1]{\\mbox{}}\n"))
+  (tmkeywords (!append (newcommand (tmkeywords) (!append (textbf (!translate "Keywords:")) " "))
+                "\n"
+              ) ;!append
+  ) ;tmkeywords
+  (tmacm (!append (newcommand (tmacm)
+                    (!append (textbf (!translate "A.C.M. subject classification:")) " ")
+                  ) ;newcommand
+           "\n"
+         ) ;!append
+  ) ;tmacm
+  (tmarxiv (!append (newcommand (tmarxiv)
+                      (!append (textbf (!translate "arXiv subject classification:")) " ")
+                    ) ;newcommand
+             "\n"
+           ) ;!append
+  ) ;tmarxiv
+  (tmpacs (!append (newcommand (tmpacs)
+                     (!append (textbf (!translate "P.A.C.S. subject classification:")) " ")
+                   ) ;newcommand
+            "\n"
+          ) ;!append
+  ) ;tmpacs
+  (tmmsc (!append (newcommand (tmmsc)
+                    (!append (textbf (!translate "A.M.S. subject classification:")) " ")
+                  ) ;newcommand
+           "\n"
+         ) ;!append
+  ) ;tmmsc
   (fmtext (!append "\\newcommand{\\fmtext}[2][]{\\fntext[#1]{"
-                   (!translate "Misc:") " #2}}\n"))
+            (!translate "Misc:")
+            " #2}}\n"
+          ) ;!append
+  ) ;fmtext
   (tdatetext (!append "\\newcommand{\\tdatetext}[2][]{\\tnotetext[#1]{"
-                      (!translate "Date:") " #2}}\n"))
+               (!translate "Date:")
+               " #2}}\n"
+             ) ;!append
+  ) ;tdatetext
   (tmisctext (!append "\\newcommand{\\tmisctext}[2][]{\\tnotetext[#1]{"
-                      (!translate "Misc:") " #2}}\n"))
+               (!translate "Misc:")
+               " #2}}\n"
+             ) ;!append
+  ) ;tmisctext
   (tsubtitletext (!append "\\newcommand{\\tsubtitletext}[2][]{\\tnotetext[#1]{"
-                          (!translate "Subtitle:") " #2}}\n"))
+                   (!translate "Subtitle:")
+                   " #2}}\n"
+                 ) ;!append
+  ) ;tsubtitletext
   (thankshomepage (!append "\\newcommand{\\thankshomepage}[2][]{\\thanks[#1]{"
-                           (!translate "URL:") " #2}}\n"))
-  (thanksemail (!append "\\newcommand{\\thanksemail}[2][]{\\thanks[#1]{"
-                        (!translate "Email:") " #2}}\n"))
+                    (!translate "URL:")
+                    " #2}}\n"
+                  ) ;!append
+  ) ;thankshomepage
   (thanksdate (!append "\\newcommand{\\thanksdate}[2][]{\\thanks[#1]{"
-                       (!translate "Date:") " #2}}\n"))
+                (!translate "Date:")
+                " #2}}\n"
+              ) ;!append
+  ) ;thanksdate
   (thanksamisc (!append "\\newcommand{\\thanksamisc}[2][]{\\thanks[#1]{"
-                        (!translate "Misc:") " #2}}\n"))
+                 (!translate "Misc:")
+                 " #2}}\n"
+               ) ;!append
+  ) ;thanksamisc
   (thanksmisc (!append "\\newcommand{\\thanksmisc}[2][]{\\thanks[#1]{"
-                       (!translate "Misc:") " #2}}\n"))
+                (!translate "Misc:")
+                " #2}}\n"
+              ) ;!append
+  ) ;thanksmisc
   (thankssubtitle (!append "\\newcommand{\\thankssubtitle}[2][]{\\thanks[#1]{"
-                           (!translate "Subtitle:") " #2}}\n"))
+                    (!translate "Subtitle:")
+                    " #2}}\n"
+                  ) ;!append
+  ) ;thankssubtitle
   (qed (!append (providecommand "\\qed" (ensuremath (Box))) "\n"))
-  (mho
-   (!append
-    "\\renewcommand{\\mho}{\\mbox{\\rotatebox[origin=c]{180}{$\\omega$}}}"))
-  (invbreve
-   (!append
-    "\\usepackage[T3,T1]{fontenc}\n"
-    "\\DeclareSymbolFont{tipa}{T3}{cmr}{m}{n}\n"
-    "\\DeclareMathAccent{\\invbreve}{\\mathalpha}{tipa}{16}\n"))
-  (custombinding
-   (!append
-    "\\newcounter{tmcounter}\n"
-    "\\newcommand{\\custombinding}[1]{%\n"
-    "  \\setcounter{tmcounter}{#1}%\n"
-    "  \\addtocounter{tmcounter}{-1}%\n"
-    "  \\refstepcounter{tmcounter}}\n"))
-  (tmfloat
-   (!append
-    (!ignore (ifthenelse) (captionof) (widthof))
-    "\\newcommand{\\tmfloatcontents}{}\n"
-    "\\newlength{\\tmfloatwidth}\n"
-    "\\newcommand{\\tmfloat}[5]{\n"
-    "  \\renewcommand{\\tmfloatcontents}{#4}\n"
-    "  \\setlength{\\tmfloatwidth}{\\widthof{\\tmfloatcontents}+1in}\n"
-    "  \\ifthenelse{\\equal{#2}{small}}\n"
-    ;; FIXME: the length test frequently produces an error:
-    ;; '! Missing = inserted for \ifdim'.
-    ;; I (Joris) did not manage to understand this LaTeX mess.
-    ;;"    {\\ifthenelse{\\lengthtest{\\tmfloatwidth > \\linewidth}}\n"
-    ;;"      {\\setlength{\\tmfloatwidth}{\\linewidth}}{}}\n"
-    "    {\\setlength{\\tmfloatwidth}{0.45\\linewidth}}\n"
-    "    {\\setlength{\\tmfloatwidth}{\\linewidth}}\n"
-    "  \\begin{minipage}[#1]{\\tmfloatwidth}\n"
-    "    \\begin{center}\n"
-    "      \\tmfloatcontents\n"
-    "      \\captionof{#3}{#5}\n"
-    "    \\end{center}\n"
-    "  \\end{minipage}}\n"))
+  (mho (!append "\\renewcommand{\\mho}{\\mbox{\\rotatebox[origin=c]{180}{$\\omega$}}}")
+  ) ;mho
+  (invbreve (!append "\\usepackage[T3,T1]{fontenc}\n"
+              "\\DeclareSymbolFont{tipa}{T3}{cmr}{m}{n}\n"
+              "\\DeclareMathAccent{\\invbreve}{\\mathalpha}{tipa}{16}\n"
+            ) ;!append
+  ) ;invbreve
+  (custombinding (!append "\\newcounter{tmcounter}\n"
+                   "\\newcommand{\\custombinding}[1]{%\n"
+                   "  \\setcounter{tmcounter}{#1}%\n"
+                   "  \\addtocounter{tmcounter}{-1}%\n"
+                   "  \\refstepcounter{tmcounter}}\n"
+                 ) ;!append
+  ) ;custombinding
+  (tmfloat (!append (!ignore (ifthenelse) (captionof) (widthof))
+             "\\newcommand{\\tmfloatcontents}{}\n"
+             "\\newlength{\\tmfloatwidth}\n"
+             "\\newcommand{\\tmfloat}[5]{\n"
+             "  \\renewcommand{\\tmfloatcontents}{#4}\n"
+             "  \\setlength{\\tmfloatwidth}{\\widthof{\\tmfloatcontents}+1in}\n"
+             "  \\ifthenelse{\\equal{#2}{small}}\n"
+             ;; FIXME: the length test frequently produces an error:
+             ;; '! Missing = inserted for \ifdim'.
+             ;; I (Joris) did not manage to understand this LaTeX mess.
+             ;; "    {\\ifthenelse{\\lengthtest{\\tmfloatwidth > \\linewidth}}\n"
+             ;; "      {\\setlength{\\tmfloatwidth}{\\linewidth}}{}}\n"
+             "    {\\setlength{\\tmfloatwidth}{0.45\\linewidth}}\n"
+             "    {\\setlength{\\tmfloatwidth}{\\linewidth}}\n"
+             "  \\begin{minipage}[#1]{\\tmfloatwidth}\n"
+             "    \\begin{center}\n"
+             "      \\tmfloatcontents\n"
+             "      \\captionof{#3}{#5}\n"
+             "    \\end{center}\n"
+             "  \\end{minipage}}\n"
+           ) ;!append
+  ) ;tmfloat
   (addtocountergroup (!append "\\newcommand{\\addtocountergroup}[2]{}\n"))
-  (groupcommoncounter (!append "\\newcommand{\\groupcommoncounter}[1]{}\n")))
+  (groupcommoncounter (!append "\\newcommand{\\groupcommoncounter}[1]{}\n"))
+) ;smart-table
 
-;;(define-macro (latex-texmacs-long prim x l m r)
+;; (define-macro (latex-texmacs-long prim x l m r)
 ;;  `(smart-table latex-texmacs-preamble
 ;;     (,(string->symbol (substring prim 1 (string-length prim)))
 ;;      (!append
@@ -771,57 +928,107 @@
 (define-macro (latex-texmacs-long prim x l m r)
   `(smart-table latex-texmacs-preamble
      (,(string->symbol (substring prim 1 (string-length prim)))
-      (!append
-       "\\providecommand{" ,prim "}[2][]{"
-       "\\mathop{" ,x "}\\limits_{#1}^{#2}}\n"))))
+      (!append ,"\\providecommand{"
+        ,prim
+        ,"}[2][]{"
+        ,"\\mathop{"
+        ,x
+        ,"}\\limits_{#1}^{#2}}\n")))
+) ;define-macro
 
-(latex-texmacs-long "\\xminus" "-"
-                    "\\DOTSB\\relbar" "\\relbar" "\\DOTSB\\relbar")
-(latex-texmacs-long "\\xleftrightarrow" "\\longleftrightarrow"
-                    "\\leftarrow" "\\relbar" "\\rightarrow")
-(latex-texmacs-long "\\xmapsto" "\\longmapsto"
-                    "\\vdash" "\\relbar" "\\rightarrow")
-(latex-texmacs-long "\\xmapsfrom" "\\leftarrow\\!\\!\\dashv"
-                    "\\leftarrow" "\\relbar" "\\dashv")
-(latex-texmacs-long "\\xequal" "="
-                    "\\DOTSB\\Relbar" "\\Relbar" "\\DOTSB\\Relbar")
-(latex-texmacs-long "\\xLeftarrow" "\\Longleftarrow"
-                    "\\Leftarrow" "\\Relbar" "\\Relbar")
-(latex-texmacs-long "\\xRightarrow" "\\Longrightarrow"
-                    "\\Relbar" "\\Relbar" "\\Rightarrow")
-(latex-texmacs-long "\\xLeftrightarrow" "\\Longleftrightarrow"
-                    "\\Leftarrow" "\\Relbar" "\\Rightarrow")
+(latex-texmacs-long "\\xminus"
+  "-"
+  "\\DOTSB\\relbar"
+  "\\relbar"
+  "\\DOTSB\\relbar"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xleftrightarrow"
+  "\\longleftrightarrow"
+  "\\leftarrow"
+  "\\relbar"
+  "\\rightarrow"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xmapsto"
+  "\\longmapsto"
+  "\\vdash"
+  "\\relbar"
+  "\\rightarrow"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xmapsfrom"
+  "\\leftarrow\\!\\!\\dashv"
+  "\\leftarrow"
+  "\\relbar"
+  "\\dashv"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xequal"
+  "="
+  "\\DOTSB\\Relbar"
+  "\\Relbar"
+  "\\DOTSB\\Relbar"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xLeftarrow"
+  "\\Longleftarrow"
+  "\\Leftarrow"
+  "\\Relbar"
+  "\\Relbar"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xRightarrow"
+  "\\Longrightarrow"
+  "\\Relbar"
+  "\\Relbar"
+  "\\Rightarrow"
+) ;latex-texmacs-long
+(latex-texmacs-long "\\xLeftrightarrow"
+  "\\Longleftrightarrow"
+  "\\Leftarrow"
+  "\\Relbar"
+  "\\Rightarrow"
+) ;latex-texmacs-long
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Plain style theorems
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define-macro (latex-texmacs-thmenv prim name before after . opt-mode)
-  (let* ((head (if (null? opt-mode) (list) (list `(:mode ,(car opt-mode)))))
+  (let* ((head (if (null? opt-mode) (list) (list `(,:mode ,(car opt-mode)))))
          (prim* (string-append prim "*"))
          (nonum (string-append "nn" prim))
-         (thenonum (string-append "\\the" nonum)))
+         (thenonum (string-append "\\the" nonum))
+        ) ;
     `(smart-table latex-texmacs-env-preamble
        ,@head
-       (,prim  (!append ,@before
-                        (newtheorem ,prim (!translate ,name))
-                        ,@after "\n"))
-       (,prim* (!append (newcounter ,nonum) "\n"
-                        "\\def" ,thenonum "{\\unskip}\n"
-                        ,@before
-                        (newtheorem ,prim* (!option ,nonum) (!translate ,name))
-                        ,@after "\n")))))
+       (,prim
+        (!append ,@before (newtheorem ,prim (!translate ,name)) ,@after ,"\n"))
+       (,prim*
+        (!append (newcounter ,nonum)
+          ,"\n"
+          ,"\\def"
+          ,thenonum
+          ,"{\\unskip}\n"
+          ,@before
+          (newtheorem ,prim* (!option ,nonum) (!translate ,name))
+          ,@after
+          ,"\n")))
+  ) ;let*
+) ;tm-define-macro
 
 (define-macro (latex-texmacs-theorem prim name)
-  `(latex-texmacs-thmenv ,prim ,name () ()))
+  `(latex-texmacs-thmenv ,prim ,name ,() ,())
+) ;define-macro
 
 (define-macro (latex-texmacs-remark prim name)
-  `(latex-texmacs-thmenv
-    ,prim ,name ("{" (!recurse (theorembodyfont "\\rmfamily"))) ("}")))
+  `(latex-texmacs-thmenv ,prim
+     ,name
+     ("{" (!recurse (theorembodyfont "\\rmfamily")))
+     ("}"))
+) ;define-macro
 
 (define-macro (latex-texmacs-exercise prim name)
-  `(latex-texmacs-thmenv
-    ,prim ,name ("{" (!recurse (theorembodyfont "\\rmfamily\\small"))) ("}")))
+  `(latex-texmacs-thmenv ,prim
+     ,name
+     ("{" (!recurse (theorembodyfont "\\rmfamily\\small")))
+     ("}"))
+) ;define-macro
 
 (latex-texmacs-theorem "theorem" "Theorem")
 (latex-texmacs-theorem "proposition" "Proposition")
@@ -849,19 +1056,39 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (smart-table latex-texmacs-env-preamble
-  ("tmpadded" (!append (newmdenv (!option "") "tmpadded") "\n"))
-  ("tmoverlined"
-   (!append (newmdenv (!option "topline=true,innertopmargin=1ex")
-                      "tmoverlined") "\n"))
-  ("tmunderlined"
-   (!append (newmdenv (!option "bottomline=true,innerbottommargin=1ex")
-                      "tmunderlined") "\n"))
-  ("tmbothlined"
-   (!append (newmdenv (!option "topline=true,bottomline=true,innertopmargin=1ex,innerbottommargin=1ex")
-                      "tmbothlined") "\n"))
-  ("tmframed"
-   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex")
-                      "tmframed") "\n"))
-  ("tmornamented"
-   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex")
-                      "tmornamented") "\n")))
+ ("tmpadded" (!append (newmdenv (!option "") "tmpadded") "\n"))
+ ("tmoverlined"
+   (!append (newmdenv (!option "topline=true,innertopmargin=1ex") "tmoverlined")
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmunderlined"
+   (!append (newmdenv (!option "bottomline=true,innerbottommargin=1ex") "tmunderlined")
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmbothlined"
+   (!append (newmdenv (!option "topline=true,bottomline=true,innertopmargin=1ex,innerbottommargin=1ex"
+                      ) ;!option
+              "tmbothlined"
+            ) ;newmdenv
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmframed"
+   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex"
+                      ) ;!option
+              "tmframed"
+            ) ;newmdenv
+     "\n"
+   ) ;!append
+ ) ;
+ ("tmornamented"
+   (!append (newmdenv (!option "hidealllines=false,innertopmargin=1ex,innerbottommargin=1ex,innerleftmargin=1ex,innerrightmargin=1ex"
+                      ) ;!option
+              "tmornamented"
+            ) ;newmdenv
+     "\n"
+   ) ;!append
+ ) ;
+) ;smart-table

--- a/TeXmacs/progs/convert/latex/latex-texmacs-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-texmacs-drd.scm
@@ -14,7 +14,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (convert latex latex-texmacs-drd)
-  (:use (convert latex latex-symbol-drd)))
+  (:use (convert latex latex-symbol-drd))
+) ;texmacs-module
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs symbols
@@ -22,311 +23,689 @@
 
 (logic-group latex-texmacs-symbol%
   ;; arrows and other symbols with limits
-  leftarrowlim rightarrowlim leftrightarrowlim mapstolim
-  longleftarrowlim longrightarrowlim longleftrightarrowlim longmapstolim
-  leftsquigarrowlim rightsquigarrowlim leftrightsquigarrowlim
-  equallim longequallim Leftarrowlim Rightarrowlim
-  Leftrightarrowlim Longleftarrowlim Longrightarrowlim Longleftrightarrowlim
+  leftarrowlim
+  rightarrowlim
+  leftrightarrowlim
+  mapstolim
+  longleftarrowlim
+  longrightarrowlim
+  longleftrightarrowlim
+  longmapstolim
+  leftsquigarrowlim
+  rightsquigarrowlim
+  leftrightsquigarrowlim
+  equallim
+  longequallim
+  Leftarrowlim
+  Rightarrowlim
+  Leftrightarrowlim
+  Longleftarrowlim
+  Longrightarrowlim
+  Longleftrightarrowlim
   cdotslim
 
   ;; further arrows
-  threeleftarrows threerightarrows
-  fourleftarrows fourrightarrows
-  longleftrightarrows longleftleftarrows
-  longthreeleftarrows longthreerightarrows
-  longrightleftarrows longrightrightarrows
-  longfourleftarrows longfourrightarrows
-  LRleftrightarrow Llongleftarrow Llongrightarrow Llongleftrightarrow
+  threeleftarrows
+  threerightarrows
+  fourleftarrows
+  fourrightarrows
+  longleftrightarrows
+  longleftleftarrows
+  longthreeleftarrows
+  longthreerightarrows
+  longrightleftarrows
+  longrightrightarrows
+  longfourleftarrows
+  longfourrightarrows
+  LRleftrightarrow
+  Llongleftarrow
+  Llongrightarrow
+  Llongleftrightarrow
 
   ;; rotated arrows and other symbols
-  mapsfrom longmapsfrom mapmulti leftsquigarrow
-  upequal downequal longupequal longdownequal longupminus longdownminus
-  longuparrow longdownarrow longupdownarrow
-  Longuparrow Longdownarrow Longupdownarrow
-  mapsup mapsdown longmapsup longmapsdown
-  upsquigarrow downsquigarrow updownsquigarrow
-  hookuparrow hookdownarrow longhookuparrow longhookdownarrow
-  Backepsilon Backsigma Mho btimes
+  mapsfrom
+  longmapsfrom
+  mapmulti
+  leftsquigarrow
+  upequal
+  downequal
+  longupequal
+  longdownequal
+  longupminus
+  longdownminus
+  longuparrow
+  longdownarrow
+  longupdownarrow
+  Longuparrow
+  Longdownarrow
+  Longupdownarrow
+  mapsup
+  mapsdown
+  longmapsup
+  longmapsdown
+  upsquigarrow
+  downsquigarrow
+  updownsquigarrow
+  hookuparrow
+  hookdownarrow
+  longhookuparrow
+  longhookdownarrow
+  Backepsilon
+  Backsigma
+  Mho
+  btimes
 
   ;; asymptotic relations by Joris
-  nasymp asympasymp nasympasymp simsim nsimsim
-  precprec precpreceq precprecprec precprecpreceq
-  succsucc succsucceq succsuccsucc succsuccsucceq
-  lleq llleq ggeq gggeq triplesim ntriplesim
+  nasymp
+  asympasymp
+  nasympasymp
+  simsim
+  nsimsim
+  precprec
+  precpreceq
+  precprecprec
+  precprecpreceq
+  succsucc
+  succsucceq
+  succsuccsucc
+  succsuccsucceq
+  lleq
+  llleq
+  ggeq
+  gggeq
+  triplesim
+  ntriplesim
 
   ;; replacements for symbols from mathabx
-  divides ndivides asterisk dottimes precdot
+  divides
+  ndivides
+  asterisk
+  dottimes
+  precdot
 
   ;; extra literal symbols
-  mathcatalan mathd mathD mathe matheuler
-  mathGamma mathlambda mathLaplace mathi mathpi
-  Alpha Beta Epsilon Eta Iota Kappa Mu Nu Omicron Chi Rho Tau Zeta
+  mathcatalan
+  mathd
+  mathD
+  mathe
+  matheuler
+  mathGamma
+  mathlambda
+  mathLaplace
+  mathi
+  mathpi
+  Alpha
+  Beta
+  Epsilon
+  Eta
+  Iota
+  Kappa
+  Mu
+  Nu
+  Omicron
+  Chi
+  Rho
+  Tau
+  Zeta
 
   ;; negations
-  nin nni notni nequiv nleadsto
-  npreccurlyeq npreceqq nprecsim
-  nsimeq nsubset napprox nsqsubset nsqsubseteq nsqsubseteqq
-  nsqsupset nsqsupseteq nsqsupseteqq
-  nsucccurlyeq nsucceqq nsuccsim  
-  
-  ;; other extra symbols
-  oempty exterior Exists bigintwl bigointwl
-  of suchthat barsuchthat asterisk point cdummy comma copyright
-  bignone nobracket nospace nocomma noplus nosymbol
-  dotminus dotpm dotmp dotamalg dottimes dotoplus dototimes dotast
-  into longminus longequal
-  longhookrightarrow longhookleftarrow
-  triangleup tmprecdot preceqdot
-  llangle rrangle join um upl upm ump pplus
-  assign plusassign minusassign timesassign overassign backassign
-  lflux gflux colons transtype
-  lebar gebar leangle geangle leqangle geqangle
-  anglele anglege legeangle geleangle
-  udots subsetsim supsetsim
-  rightmap leftmap leftrightmap
-  tmxspace)
+  nin
+  nni
+  notni
+  nequiv
+  nleadsto
+  npreccurlyeq
+  npreceqq
+  nprecsim
+  nsimeq
+  nsubset
+  napprox
+  nsqsubset
+  nsqsubseteq
+  nsqsubseteqq
+  nsqsupset
+  nsqsupseteq
+  nsqsupseteqq
+  nsucccurlyeq
+  nsucceqq
+  nsuccsim
 
-(logic-rules
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-symbol% 'x))
-  ((latex-symbol% 'x) (latex-texmacs-symbol% 'x)))
+  ;; other extra symbols
+  oempty
+  exterior
+  Exists
+  bigintwl
+  bigointwl
+  of
+  suchthat
+  barsuchthat
+  asterisk
+  point
+  cdummy
+  comma
+  copyright
+  bignone
+  nobracket
+  nospace
+  nocomma
+  noplus
+  nosymbol
+  dotminus
+  dotpm
+  dotmp
+  dotamalg
+  dottimes
+  dotoplus
+  dototimes
+  dotast
+  into
+  longminus
+  longequal
+  longhookrightarrow
+  longhookleftarrow
+  triangleup
+  tmprecdot
+  preceqdot
+  llangle
+  rrangle
+  join
+  um
+  upl
+  upm
+  ump
+  pplus
+  assign
+  plusassign
+  minusassign
+  timesassign
+  overassign
+  backassign
+  lflux
+  gflux
+  colons
+  transtype
+  lebar
+  gebar
+  leangle
+  geangle
+  leqangle
+  geqangle
+  anglele
+  anglege
+  legeangle
+  geleangle
+  udots
+  subsetsim
+  supsetsim
+  rightmap
+  leftmap
+  leftrightmap
+  tmxspace
+) ;logic-group
+
+(logic-rules ((latex-texmacs-arity% 'x 0) (latex-texmacs-symbol% 'x))
+ ((latex-symbol% 'x) (latex-texmacs-symbol% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-texmacs-0%
-  tmunsc emdash tmhrule tmat tmbsl tmdummy
-  TeXmacs madebyTeXmacs withTeXmacstext citewebsite tmmade
-  scheme tmsep tmSep pari qed textdots hrule filldots
-  infixand infixor infixiff)
+  tmunsc
+  emdash
+  tmhrule
+  tmat
+  tmbsl
+  tmdummy
+  TeXmacs
+  madebyTeXmacs
+  withTeXmacstext
+  citewebsite
+  tmmade
+  scheme
+  tmsep
+  tmSep
+  pari
+  qed
+  textdots
+  hrule
+  filldots
+  infixand
+  infixor
+  infixiff
+) ;logic-group
 
 (logic-group latex-texmacs-1%
-  citetexmacs key tmrsub tmrsup keepcase
-  tmtextrm tmtextsf tmtexttt tmtextmd tmtextbf
-  tmtextup tmtextsl tmtextit tmtextsc tmmathbf tmmathmd
-  tmverbatim tmop tmstrong tmem tmtt tmname tmsamp tmabbr
-  tmdfn tmkbd tmvar tmacronym tmperson tmscript tmdef
-  dueto op todo tmdate tmoutput tmerrput tmtiming
-  tmsubtitle tmrunningtitle tmrunningauthor
-  tmaffiliation tmemail tmhomepage
-  tmfnaffiliation tmfnemail tmfnhomepage
-  tmacmhomepage tmacmmisc tmieeeemail tmnote tmmisc
-  uhat uwidehat utilde uwidetilde
-  uvec ubreve uinvbreve ucheck uring uacute ugrave
-  underdot uddot udddot uddddot
-  widespacing nonconverted
+  citetexmacs
+  key
+  tmrsub
+  tmrsup
+  keepcase
+  tmtextrm
+  tmtextsf
+  tmtexttt
+  tmtextmd
+  tmtextbf
+  tmtextup
+  tmtextsl
+  tmtextit
+  tmtextsc
+  tmmathbf
+  tmmathmd
+  tmverbatim
+  tmop
+  tmstrong
+  tmem
+  tmtt
+  tmname
+  tmsamp
+  tmabbr
+  tmdfn
+  tmkbd
+  tmvar
+  tmacronym
+  tmperson
+  tmscript
+  tmdef
+  dueto
+  op
+  todo
+  tmdate
+  tmoutput
+  tmerrput
+  tmtiming
+  tmsubtitle
+  tmrunningtitle
+  tmrunningauthor
+  tmaffiliation
+  tmemail
+  tmhomepage
+  tmfnaffiliation
+  tmfnemail
+  tmfnhomepage
+  tmacmhomepage
+  tmacmmisc
+  tmieeeemail
+  tmnote
+  tmmisc
+  uhat
+  uwidehat
+  utilde
+  uwidetilde
+  uvec
+  ubreve
+  uinvbreve
+  ucheck
+  uring
+  uacute
+  ugrave
+  underdot
+  uddot
+  udddot
+  uddddot
+  widespacing
+  nonconverted
   groupcommoncounter
   ;; NOTE: for personal use from vdh style package
-  gb gbt)
+  gb
+  gbt
+) ;logic-group
 
-(logic-group latex-texmacs-1*%
-  tmcodeinline)
+(logic-group latex-texmacs-1*% tmcodeinline)
 
 (logic-group latex-texmacs-2%
   tmcolor
-  tmsummarizeddocumentation tmsummarizedgrouped tmsummarizedexplain
-  tmsummarizedplain tmsummarizedtiny tmsummarizedraw tmsummarizedenv
-  tmsummarizedstd tmsummarized
-  tmdetaileddocumentation tmdetailedgrouped tmdetailedexplain
-  tmdetailedplain tmdetailedtiny tmdetailedraw tmdetailedenv
-  tmdetailedstd tmdetailed
-  tmfoldeddocumentation tmunfoldeddocumentation
-  tmfoldedsubsession tmunfoldedsubsession
-  tmfoldedgrouped tmunfoldedgrouped tmfoldedexplain tmunfoldedexplain
-  tmfoldedplain tmunfoldedplain tmfoldedenv tmunfoldedenv
-  tmfoldedstd tmunfoldedstd tmfolded tmunfolded
-  tminput tminputmath tmhlink tmaction ontop subindex
-  renderfootnote tmlinenumber
-  addtocountergroup)
+  tmsummarizeddocumentation
+  tmsummarizedgrouped
+  tmsummarizedexplain
+  tmsummarizedplain
+  tmsummarizedtiny
+  tmsummarizedraw
+  tmsummarizedenv
+  tmsummarizedstd
+  tmsummarized
+  tmdetaileddocumentation
+  tmdetailedgrouped
+  tmdetailedexplain
+  tmdetailedplain
+  tmdetailedtiny
+  tmdetailedraw
+  tmdetailedenv
+  tmdetailedstd
+  tmdetailed
+  tmfoldeddocumentation
+  tmunfoldeddocumentation
+  tmfoldedsubsession
+  tmunfoldedsubsession
+  tmfoldedgrouped
+  tmunfoldedgrouped
+  tmfoldedexplain
+  tmunfoldedexplain
+  tmfoldedplain
+  tmunfoldedplain
+  tmfoldedenv
+  tmunfoldedenv
+  tmfoldedstd
+  tmunfoldedstd
+  tmfolded
+  tmunfolded
+  tminput
+  tminputmath
+  tmhlink
+  tmaction
+  ontop
+  subindex
+  renderfootnote
+  tmlinenumber
+  addtocountergroup
+) ;logic-group
 
 (logic-group latex-texmacs-3%
-  tmsession tmfoldedio tmunfoldedio tmfoldediomath tmunfoldediomath
-  tmlinenote subsubindex tmref glossaryentry natbib-triple
-  renderfootnotestar)
+  tmsession
+  tmfoldedio
+  tmunfoldedio
+  tmfoldediomath
+  tmunfoldediomath
+  tmlinenote
+  subsubindex
+  tmref
+  glossaryentry
+  natbib-triple
+  renderfootnotestar
+) ;logic-group
 
 (logic-group latex-texmacs-4%
-  tmscriptinput tmscriptoutput tmconverterinput tmconverteroutput
-  subsubsubindex)
+  tmscriptinput
+  tmscriptoutput
+  tmconverterinput
+  tmconverteroutput
+  subsubsubindex
+) ;logic-group
 
-(logic-rules
-  ((latex-texmacs% 'x) (latex-texmacs-0% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-1% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-1*% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-2% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-3% 'x))
-  ((latex-texmacs% 'x) (latex-texmacs-4% 'x))
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-0% 'x))
-  ((latex-texmacs-arity% 'x 1) (latex-texmacs-1% 'x))
-  ((latex-texmacs-arity% 'x 1) (latex-texmacs-1*% 'x))
-  ((latex-texmacs-arity% 'x 2) (latex-texmacs-2% 'x))
-  ((latex-texmacs-arity% 'x 3) (latex-texmacs-3% 'x))
-  ((latex-texmacs-arity% 'x 4) (latex-texmacs-4% 'x))
-  ((latex-texmacs-option% 'x #t) (latex-texmacs-1*% 'x))
-  ((latex-command-0% 'x) (latex-texmacs-0% 'x))
-  ((latex-command-1% 'x) (latex-texmacs-1% 'x))
-  ((latex-command-1*% 'x) (latex-texmacs-1*% 'x))
-  ((latex-command-2% 'x) (latex-texmacs-2% 'x))
-  ((latex-command-3% 'x) (latex-texmacs-3% 'x))
-  ((latex-command-4% 'x) (latex-texmacs-4% 'x)))
+(logic-rules ((latex-texmacs% 'x) (latex-texmacs-0% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-1% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-1*% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-2% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-3% 'x))
+ ((latex-texmacs% 'x) (latex-texmacs-4% 'x))
+ ((latex-texmacs-arity% 'x 0) (latex-texmacs-0% 'x))
+ ((latex-texmacs-arity% 'x 1) (latex-texmacs-1% 'x))
+ ((latex-texmacs-arity% 'x 1) (latex-texmacs-1*% 'x))
+ ((latex-texmacs-arity% 'x 2) (latex-texmacs-2% 'x))
+ ((latex-texmacs-arity% 'x 3) (latex-texmacs-3% 'x))
+ ((latex-texmacs-arity% 'x 4) (latex-texmacs-4% 'x))
+ ((latex-texmacs-option% 'x #t) (latex-texmacs-1*% 'x))
+ ((latex-command-0% 'x) (latex-texmacs-0% 'x))
+ ((latex-command-1% 'x) (latex-texmacs-1% 'x))
+ ((latex-command-1*% 'x) (latex-texmacs-1*% 'x))
+ ((latex-command-2% 'x) (latex-texmacs-2% 'x))
+ ((latex-command-3% 'x) (latex-texmacs-3% 'x))
+ ((latex-command-4% 'x) (latex-texmacs-4% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extra TeXmacs environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-texmacs-env-arity%
-  ("proof" 0)
-  ("proof*" 1)
-  ("leftaligned" 0)
-  ("rightaligned" 0)
-  ("tmcode" 0)
-  ("tmparmod" 3)
-  ("tmparsep" 1)
-  ("tmcompact" 0)
-  ("tmcompressed" 0)
-  ("tmamplified" 0)
-  ("tmjumpin" 0)
-  ("tmindent" 0)
-  ("tmlisting" 0)
-  ("elsequation" 0)
-  ("elsequation*" 0)
-  ("theglossary" 1))
+ ("proof" 0)
+ ("proof*" 1)
+ ("leftaligned" 0)
+ ("rightaligned" 0)
+ ("tmcode" 0)
+ ("tmparmod" 3)
+ ("tmparsep" 1)
+ ("tmcompact" 0)
+ ("tmcompressed" 0)
+ ("tmamplified" 0)
+ ("tmjumpin" 0)
+ ("tmindent" 0)
+ ("tmlisting" 0)
+ ("elsequation" 0)
+ ("elsequation*" 0)
+ ("theglossary" 1)
+) ;logic-table
 
-(logic-table latex-texmacs-option%
-  ("tmcode" #t))
+(logic-table latex-texmacs-option% ("tmcode" #t))
 
 (logic-group latex-texmacs-environment-0%
-  begin-proof begin-leftaligned begin-rightaligned begin-quoteenv
-  begin-tmcompact begin-tmcompressed begin-tmamplified begin-tmjumpin
-  begin-tmindent begin-tmlisting begin-elsequation begin-elsequation*)
+  begin-proof
+  begin-leftaligned
+  begin-rightaligned
+  begin-quoteenv
+  begin-tmcompact
+  begin-tmcompressed
+  begin-tmamplified
+  begin-tmjumpin
+  begin-tmindent
+  begin-tmlisting
+  begin-elsequation
+  begin-elsequation*
+) ;logic-group
 
-(logic-group latex-texmacs-environment-0*%
-  begin-tmcode)
+(logic-group latex-texmacs-environment-0*% begin-tmcode)
 
 (logic-group latex-texmacs-environment-1%
-  begin-proof* begin-tmparsep begin-theglossary)
+  begin-proof*
+  begin-tmparsep
+  begin-theglossary
+) ;logic-group
 
-(logic-group latex-texmacs-environment-3%
-  begin-tmparmod)
+(logic-group latex-texmacs-environment-3% begin-tmparmod)
 
-(logic-rules
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0% 'x))
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0*% 'x))
-  ((latex-texmacs-arity% 'x 1) (latex-texmacs-environment-1% 'x))
-  ((latex-texmacs-arity% 'x 3) (latex-texmacs-environment-3% 'x))
-  ((latex-texmacs-option% 'x #t) (latex-texmacs-environment-0*% 'x))
-  ((latex-environment-0%  'x) (latex-texmacs-environment-0% 'x))
-  ((latex-environment-0*% 'x) (latex-texmacs-environment-0*% 'x))
-  ((latex-environment-1%  'x) (latex-texmacs-environment-1% 'x))
-  ((latex-environment-3%  'x) (latex-texmacs-environment-3% 'x)))
+(logic-rules ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0% 'x))
+ ((latex-texmacs-arity% 'x 0) (latex-texmacs-environment-0*% 'x))
+ ((latex-texmacs-arity% 'x 1) (latex-texmacs-environment-1% 'x))
+ ((latex-texmacs-arity% 'x 3) (latex-texmacs-environment-3% 'x))
+ ((latex-texmacs-option% 'x #t) (latex-texmacs-environment-0*% 'x))
+ ((latex-environment-0% 'x) (latex-texmacs-environment-0% 'x))
+ ((latex-environment-0*% 'x) (latex-texmacs-environment-0*% 'x))
+ ((latex-environment-1% 'x) (latex-texmacs-environment-1% 'x))
+ ((latex-environment-3% 'x) (latex-texmacs-environment-3% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; TeXmacs list environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-table latex-texmacs-env-arity%
-  ("itemizeminus" 0)
-  ("itemizedot" 0)
-  ("itemizearrow" 0)
-  ("enumeratenumeric" 0)
-  ("enumeratenumericbracket" 0)
-  ("enumerateroman" 0)
-  ("enumerateromanbracket" 0)
-  ("enumerateromanparen" 0)
-  ("enumerateromancap" 0)
-  ("enumeratealpha" 0)
-  ("enumeratealphabracket" 0)
-  ("enumeratealphafullparen" 0)
-  ("enumeratealphacap" 0)
-  ("descriptioncompact" 0)
-  ("descriptionaligned" 0)
-  ("descriptiondash" 0)
-  ("descriptionlong" 0)
-  ("descriptionparagraphs" 0))
+ ("itemizeminus" 0)
+ ("itemizedot" 0)
+ ("itemizearrow" 0)
+ ("enumeratenumeric" 0)
+ ("enumeratenumericbracket" 0)
+ ("enumerateroman" 0)
+ ("enumerateromanbracket" 0)
+ ("enumerateromanparen" 0)
+ ("enumerateromancap" 0)
+ ("enumeratealpha" 0)
+ ("enumeratealphabracket" 0)
+ ("enumeratealphafullparen" 0)
+ ("enumeratealphacap" 0)
+ ("descriptioncompact" 0)
+ ("descriptionaligned" 0)
+ ("descriptiondash" 0)
+ ("descriptionlong" 0)
+ ("descriptionparagraphs" 0)
+) ;logic-table
 
 (logic-group latex-texmacs-list%
-  begin-itemizeminus begin-itemizedot begin-itemizearrow
-  begin-enumeratenumeric begin-enumeratenumericbracket
-  begin-enumerateroman begin-enumerateromanbracket
-  begin-enumerateromanparen begin-enumerateromancap
-  begin-enumeratealpha begin-enumeratealphabracket
-  begin-enumeratealphafullparen begin-enumeratealphacap
-  begin-descriptioncompact begin-descriptionaligned
-  begin-descriptiondash begin-descriptionlong begin-descriptionparagraphs)
+  begin-itemizeminus
+  begin-itemizedot
+  begin-itemizearrow
+  begin-enumeratenumeric
+  begin-enumeratenumericbracket
+  begin-enumerateroman
+  begin-enumerateromanbracket
+  begin-enumerateromanparen
+  begin-enumerateromancap
+  begin-enumeratealpha
+  begin-enumeratealphabracket
+  begin-enumeratealphafullparen
+  begin-enumeratealphacap
+  begin-descriptioncompact
+  begin-descriptionaligned
+  begin-descriptiondash
+  begin-descriptionlong
+  begin-descriptionparagraphs
+) ;logic-group
 
-(logic-rules
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-list% 'x))
-  ((latex-list% 'x) (latex-texmacs-list% 'x)))
+(logic-rules ((latex-texmacs-arity% 'x 0) (latex-texmacs-list% 'x))
+ ((latex-list% 'x) (latex-texmacs-list% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Commands requiring special definitions in the preamble
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-texmacs-preamble-command%
-  newmdenv tikzframe
-  tmkeywords tmacm tmarxiv tmpacs tmmsc
-  fmtext tdatetext tmisctext tsubtitletext
-  thankshomepage thanksemail thanksdate thanksamisc thanksmisc thankssubtitle
-  mho tmfloat
+  newmdenv
+  tikzframe
+  tmkeywords
+  tmacm
+  tmarxiv
+  tmpacs
+  tmmsc
+  fmtext
+  tdatetext
+  tmisctext
+  tsubtitletext
+  thankshomepage
+  thanksdate
+  thanksamisc
+  thanksmisc
+  thankssubtitle
+  mho
+  tmfloat
 
-  xminus xleftrightarrow xmapsto xmapsfrom xequal
-  xLeftarrow xRightarrow xLeftrightarrow)
+  xminus
+  xleftrightarrow
+  xmapsto
+  xmapsfrom
+  xequal
+  xLeftarrow
+  xRightarrow
+  xLeftrightarrow
+) ;logic-group
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Environments requiring special definitions in the preamble
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (logic-group latex-texmacs-env-preamble-environment%
-  "tmpadded" "tmoverlined" "tmunderlined" "tmbothlined"
-  "tmframed" "tmornamented")
+  "tmpadded"
+  "tmoverlined"
+  "tmunderlined"
+  "tmbothlined"
+  "tmframed"
+  "tmornamented"
+) ;logic-group
 
 (logic-group latex-texmacs-theorem-environment%
-  "theorem" "proposition" "lemma" "corollary"
-  "axiom" "definition" "assumption" "notation" "conjecture"
-  "remark" "note" "example" "convention"
-  "warning" "acknowledgments" "answer" "question"
-  "exercise" "problem" "solution"
+  "theorem"
+  "proposition"
+  "lemma"
+  "corollary"
+  "axiom"
+  "definition"
+  "assumption"
+  "notation"
+  "conjecture"
+  "remark"
+  "note"
+  "example"
+  "convention"
+  "warning"
+  "acknowledgments"
+  "answer"
+  "question"
+  "exercise"
+  "problem"
+  "solution"
 
-  "theorem*" "proposition*" "lemma*" "corollary*"
-  "axiom*" "definition*" "notation*" "conjecture*"
-  "remark*" "note*" "example*" "convention*"
-  "warning*" "acknowledgments*" "answer*" "question*"
-  "exercise*" "problem*" "solution*")
+  "theorem*"
+  "proposition*"
+  "lemma*"
+  "corollary*"
+  "axiom*"
+  "definition*"
+  "notation*"
+  "conjecture*"
+  "remark*"
+  "note*"
+  "example*"
+  "convention*"
+  "warning*"
+  "acknowledgments*"
+  "answer*"
+  "question*"
+  "exercise*"
+  "problem*"
+  "solution*"
+) ;logic-group
 
 (logic-group latex-texmacs-theorem%
-  begin-theorem begin-proposition begin-lemma begin-corollary
-  begin-axiom begin-definition begin-notation begin-conjecture
-  begin-remark begin-note begin-example begin-convention
-  begin-warning begin-acknowledgments begin-answer begin-question
-  begin-exercise begin-problem begin-solution
+  begin-theorem
+  begin-proposition
+  begin-lemma
+  begin-corollary
+  begin-axiom
+  begin-definition
+  begin-notation
+  begin-conjecture
+  begin-remark
+  begin-note
+  begin-example
+  begin-convention
+  begin-warning
+  begin-acknowledgments
+  begin-answer
+  begin-question
+  begin-exercise
+  begin-problem
+  begin-solution
 
-  begin-theorem* begin-proposition* begin-lemma* begin-corollary*
-  begin-axiom* begin-definition* begin-notation* begin-conjecture*
-  begin-remark* begin-note* begin-example* begin-convention*
-  begin-warning* begin-acknowledgments* begin-answer* begin-question*
-  begin-exercise* begin-problem* begin-solution*)
+  begin-theorem*
+  begin-proposition*
+  begin-lemma*
+  begin-corollary*
+  begin-axiom*
+  begin-definition*
+  begin-notation*
+  begin-conjecture*
+  begin-remark*
+  begin-note*
+  begin-example*
+  begin-convention*
+  begin-warning*
+  begin-acknowledgments*
+  begin-answer*
+  begin-question*
+  begin-exercise*
+  begin-problem*
+  begin-solution*
+) ;logic-group
 
-(logic-rules
-  ((latex-texmacs-env-preamble-environment% 'x)
-   (latex-texmacs-theorem-environment% 'x))
-  ((latex-texmacs-arity% 'x 0) (latex-texmacs-theorem% 'x))
-  ((latex-environment-0% 'x) (latex-texmacs-theorem% 'x)))
+(logic-rules ((latex-texmacs-env-preamble-environment% 'x)
+              (latex-texmacs-theorem-environment% 'x)
+             ) ;
+ ((latex-texmacs-arity% 'x 0) (latex-texmacs-theorem% 'x))
+ ((latex-environment-0% 'x) (latex-texmacs-theorem% 'x))
+) ;logic-rules
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; These macros are defined by TeXmacs in certain styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-texmacs-0%
-  appendix)
+(logic-group latex-texmacs-0% appendix)
 
-(logic-group latex-texmacs-1%
-  chapter section subsection paragraph subparagraph)
+(logic-group latex-texmacs-1% chapter section subsection paragraph subparagraph)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Deprecated extra macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(logic-group latex-texmacs-0%
-  labeleqnum eqnumber leqnumber reqnumber)
+(logic-group latex-texmacs-0% labeleqnum eqnumber leqnumber reqnumber)
 
-(logic-group latex-texmacs-1%
-  skey ckey akey mkey hkey)
+(logic-group latex-texmacs-1% skey ckey akey mkey hkey)

--- a/TeXmacs/progs/convert/latex/tmtex-elsevier.scm
+++ b/TeXmacs/progs/convert/latex/tmtex-elsevier.scm
@@ -11,47 +11,52 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert latex tmtex-elsevier)
-  (:use (convert latex tmtex)))
+(texmacs-module (convert latex tmtex-elsevier) (:use (convert latex tmtex)))
 
 (tm-define (tmtex-transform-style x)
   (:mode elsevier-style?)
   (cond ((== x "elsart") "elsart")
         ((== x "elsarticle") "elsarticle")
         ((== x "ifac") "ifacconf")
-        ((== x "jsc") `("amsthm" "elsart"))
-        (else x)))
+        ((== x "jsc") '("amsthm" "elsart"))
+        (else x)
+  ) ;cond
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Initialization of elsevier style
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define note-counter 0)
+
 (define author-counter 0)
+
 (define clustered? #f)
 
 (define (init-elsevier body)
   (set! clustered? #f)
   (set! note-counter 0)
-  (set! author-counter 0))
+  (set! author-counter 0)
+) ;define
 
-(tm-define (tmtex-style-init body)
-  (:mode elsevier-style?)
-  (init-elsevier body))
+(tm-define (tmtex-style-init body) (:mode elsevier-style?) (init-elsevier body))
 
 (tm-define (tmtex-style-init body)
   (:mode ifac-style?)
   (init-elsevier body)
   (set! tmtex-packages (cons "cite-author-year" tmtex-packages))
   (latex-set-packages '("natbib"))
-  )
+) ;tm-define
 
 (tm-define (tmtex-style-init body)
   (:mode jsc-style?)
   (init-elsevier body)
-  ;;(set! tmtex-packages (cons "cite-author-year" tmtex-packages))
-  (latex-set-packages '("amsthm" "yjsco" ;;"natbib"
-                        )))
+  ;; (set! tmtex-packages (cons "cite-author-year" tmtex-packages))
+  (latex-set-packages '("amsthm"
+                        "yjsco"
+                        ;; "natbib")
+  ) ;latex-set-packages
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Hack for ifac incompatibility with hyperref package
@@ -60,21 +65,26 @@
 (tm-define (latex-as-use-package l)
   (:require (latex-ifacconf-style?))
   (if (nin? "hyperref" l)
-      (former l)
-      (let* ((l* (list-remove l "hyperref"))
-             (s1 (if (null? l*) "" (former l*)))
-             (s2 (string-append
-                  "\\makeatletter\n"
-                  "\\let\\old@ssect\\@ssect\n"
-                  "\\makeatother\n"
-                  "\\usepackage{hyperref}\n"
-                  "\\makeatletter\n"
-                  "\\def\\@ssect#1#2#3#4#5#6{%\n"
-                  "  \\NR@gettitle{#6}%\n"
-                  "  \\old@ssect{#1}{#2}{#3}{#4}{#5}{#6}%\n"
-                  "}\n"
-                  "\\makeatother\n")))
-        (string-append s1 s2))))
+    (former l)
+    (let* ((l* (list-remove l "hyperref"))
+           (s1 (if (null? l*) "" (former l*)))
+           (s2 (string-append "\\makeatletter\n"
+                 "\\let\\old@ssect\\@ssect\n"
+                 "\\makeatother\n"
+                 "\\usepackage{hyperref}\n"
+                 "\\makeatletter\n"
+                 "\\def\\@ssect#1#2#3#4#5#6{%\n"
+                 "  \\NR@gettitle{#6}%\n"
+                 "  \\old@ssect{#1}{#2}{#3}{#4}{#5}{#6}%\n"
+                 "}\n"
+                 "\\makeatother\n"
+               ) ;string-append
+           ) ;s2
+          ) ;
+      (string-append s1 s2)
+    ) ;let*
+  ) ;if
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Hack for incomplete ifac list environments
@@ -83,7 +93,9 @@
 (tm-define (latex-extra-preamble)
   (:require (latex-ifacconf-style?))
   (string-append "\\newcommand{\\labelitemiii}{\\labelitemi}\n"
-                 "\\newcommand{\\labelitemiv}{\\labelitemii}\n"))
+    "\\newcommand{\\labelitemiv}{\\labelitemii}\n"
+  ) ;string-append
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Preprocessing data
@@ -91,30 +103,45 @@
 
 (tm-define (tmtex-style-preprocess doc)
   (:mode elsevier-style?)
-  (elsevier-create-frontmatter doc))
+  (elsevier-create-frontmatter doc)
+) ;tm-define
 
 (define (elsarticle-frontmatter? t)
-  (or (func? t 'abstract-data) (func? t 'doc-data) (func? t 'abstract)))
+  (or (func? t 'abstract-data) (func? t 'doc-data) (func? t 'abstract))
+) ;define
 
 (define (partition l pred?)
-  (if (npair? l) l
+  (if (npair? l)
+    l
     (letrec ((npred? (lambda (x) (not (pred? x)))))
       (if (pred? (car l))
-        (receive (h t) (list-break l npred?)
-          (cons h (partition t pred?)))
-        (receive (h t) (list-break l pred?)
-          (cons h (partition t pred?)))))))
+        (receive (h t) (list-break l npred?) (cons h (partition t pred?)))
+        (receive (h t) (list-break l pred?) (cons h (partition t pred?)))
+      ) ;if
+    ) ;letrec
+  ) ;if
+) ;define
 
 (define (elsevier-create-frontmatter t)
-  (if (or (npair? t) (npair? (cdr t))) t
-    (with l (map elsarticle-frontmatter? (cdr t))
+  (if (or (npair? t) (npair? (cdr t)))
+    t
+    (with l
+      (map elsarticle-frontmatter? (cdr t))
       (if (in? #t l)
-        (with parts (partition (cdr t) elsarticle-frontmatter?)
-          `(,(car t) ,@(map (lambda (x)
-                              (if (elsarticle-frontmatter? (car x))
-                                `(elsevier-frontmatter (,(car t) ,@x))
-                                `(,(car t) ,@x))) parts)))
-        `(,(car t) ,@(map elsevier-create-frontmatter (cdr t)))))))
+        (with parts
+          (partition (cdr t) elsarticle-frontmatter?)
+          `(,(car t)
+            ,@(map (lambda (x)
+                     (if (elsarticle-frontmatter? (car x))
+                       `(elsevier-frontmatter (,(car t) ,@x))
+                       `(,(car t) ,@x)))
+                parts))
+        ) ;with
+        `(,(car t) ,@(map elsevier-create-frontmatter (cdr t)))
+      ) ;if
+    ) ;with
+  ) ;if
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier specific customizations
@@ -122,56 +149,74 @@
 
 (tm-define (tmtex-elsevier-frontmatter s l)
   (:mode elsevier-style?)
-  `((!begin "frontmatter") ,(tmtex (car l))))
+  `((!begin "frontmatter") ,(tmtex (car l)))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsarticle specific title macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (tmtex-replace-documents t)
-  (:mode elsevier-style?) t)
+(tm-define (tmtex-replace-documents t) (:mode elsevier-style?) t)
 
 (tm-define (springer-note-ref l r)
   (if (list? r)
     (set! r (tex-concat* (list-intersperse r ",")))
-    (set! r (string-append l r)))
-  `(tnoteref ,r))
+    (set! r (string-append l r))
+  ) ;if
+  `(tnoteref ,r)
+) ;tm-define
 
 (tm-define (tmtex-doc-subtitle-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "sub-" (car l)))
+  (springer-note-ref "sub-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-subtitle-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "sub-" (car l))
-    `(tsubtitletext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "sub-" (car l))
+    `(tsubtitletext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-note-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "note-" (car l)))
+  (springer-note-ref "note-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-note-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "note-" (car l))
-    `(tnotetext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "note-" (car l))
+    `(tnotetext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-date-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "date-" (car l)))
+  (springer-note-ref "date-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-date-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "date-" (car l))
-    `(tdatetext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "date-" (car l))
+    `(tdatetext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-misc-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "misc-" (car l)))
+  (springer-note-ref "misc-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-doc-misc-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "misc-" (car l))
-    `(tmisctext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "misc-" (car l))
+    `(tmisctext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier specific authors macros
@@ -180,67 +225,89 @@
 (tm-define (springer-author-note-ref l r)
   (if (list? r)
     (set! r (tex-concat* (list-intersperse r ",")))
-    (set! r (string-append l r)))
-  `(fnref ,r))
+    (set! r (string-append l r))
+  ) ;if
+  `(fnref ,r)
+) ;tm-define
 
 (tm-define (tmtex-author-note-ref s l)
   (:mode elsevier-style?)
-  (springer-author-note-ref "author-note-" (car l)))
+  (springer-author-note-ref "author-note-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-note-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "author-note-" (car l))
-    `(fntext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-note-" (car l))
+    `(fntext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-misc-ref s l)
   (:mode elsevier-style?)
-  (springer-author-note-ref "author-misc-" (car l)))
+  (springer-author-note-ref "author-misc-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-misc-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "author-misc-" (car l))
-    `(fmtext (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-misc-" (car l))
+    `(fmtext (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-affiliation t)
   (:mode elsevier-style?)
-  `(address ,(tmtex (cadr t))))
+  `(address ,(tmtex (cadr t)))
+) ;tm-define
 
 (tm-define (tmtex-author-affiliation-ref s l)
   (:mode elsevier-style?)
-  (springer-author-note-ref "affiliation-" (car l)))
+  (springer-author-note-ref "affiliation-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-affiliation-label s l)
   (:mode elsevier-style?)
-  (with label (string-append "affiliation-" (car l))
-    `(address (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "affiliation-" (car l))
+    `(address (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-email t)
   (:mode elsevier-style?)
-  `(ead ,(tmtex (cadr t))))
+  `(ead ,(tmtex (cadr t)))
+) ;tm-define
 
 (tm-define (tmtex-author-email-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "author-email-" (car l)))
+  (springer-note-ref "author-email-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-email-label s l)
   (:mode elsevier-style?)
-  `(ead ,(tmtex (cadr l))))
+  `(ead ,(tmtex (cadr l)))
+) ;tm-define
 
 (tm-define (tmtex-author-homepage t)
   (:mode elsevier-style?)
-  `(ead (!option "url") ,(tmtex (cadr t))))
+  `(ead (!option "url") ,(tmtex (cadr t)))
+) ;tm-define
 
 (tm-define (tmtex-author-homepage-ref s l)
   (:mode elsevier-style?)
-  (springer-note-ref "author-url-" (car l)))
+  (springer-note-ref "author-url-" (car l))
+) ;tm-define
 
 (tm-define (tmtex-author-homepage-label s l)
   (:mode elsevier-style?)
-  `(ead (!option "url") ,(tmtex (cadr l))))
+  `(ead (!option "url") ,(tmtex (cadr l)))
+) ;tm-define
 
 (tm-define (tmtex-author-name t)
   (:mode elsevier-style?)
-  `(author ,(tmtex (cadr t))))
+  `(author ,(tmtex (cadr t)))
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsart and IFAC specific title macros
@@ -249,41 +316,60 @@
 (tm-define (tmtex-replace-documents t)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (if (npair? t) t
-    (with (r s) (list (car t) (map tmtex-replace-documents (cdr t)))
-      (if (!= r 'document) `(,r ,@s)
-        `(concat ,@(list-intersperse s '(next-line)))))))
+  (if (npair? t)
+    t
+    (with (r s)
+      (list (car t) (map tmtex-replace-documents (cdr t)))
+      (if (!= r 'document) `(,r ,@s) `(concat ,@(list-intersperse s
+                                                  '(next-line))))
+    ) ;with
+  ) ;if
+) ;tm-define
 
 (tm-define (springer-note-ref l r)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
   (if (list? r)
     `(!concat ,@(map (lambda (x) `(thanksref ,x)) r))
-    `(thanksref ,(string-append l r))))
+    `(thanksref ,(string-append l r))
+  ) ;if
+) ;tm-define
 
 (tm-define (tmtex-doc-subtitle-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "sub-" (car l))
-    `(thankssubtitle (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "sub-" (car l))
+    `(thankssubtitle (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-note-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "note-" (car l))
-    `(thanks (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "note-" (car l))
+    `(thanks (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-date-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "date-" (car l))
-    `(thanksdate (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "date-" (car l))
+    `(thanksdate (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-doc-misc-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "misc-" (car l))
-    `(thanksmisc (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "misc-" (car l))
+    `(thanksmisc (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsart specific authors macros
@@ -292,19 +378,26 @@
 (tm-define (springer-author-note-ref l r)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (springer-note-ref l r))
+  (springer-note-ref l r)
+) ;tm-define
 
 (tm-define (tmtex-author-note-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "author-note-" (car l))
-    `(thanks (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-note-" (car l))
+    `(thanks (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-misc-label s l)
   (:mode elsevier-style?)
   (:require (or (elsart-style?) (jsc-style?) (ifac-style?)))
-  (with label (string-append "author-misc-" (car l))
-    `(thanksamisc (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-misc-" (car l))
+    `(thanksamisc (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; IFAC specific authors macros
@@ -312,13 +405,20 @@
 
 (tm-define (tmtex-author-email-label s l)
   (:mode ifac-style?)
-  (with label (string-append "author-email-" (car l))
-    `(thanksemail (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-email-" (car l))
+    `(thanks (!option ,label)
+       ,(tex-concat (list "Email:" " " (tmtex (cadr l)))))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-author-homepage-label s l)
   (:mode ifac-style?)
-  (with label (string-append "author-url-" (car l))
-    `(thankshomepage (!option ,label) ,(tmtex (cadr l)))))
+  (with label
+    (string-append "author-url-" (car l))
+    `(thankshomepage (!option ,label) ,(tmtex (cadr l)))
+  ) ;with
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier title and author preprocessing
@@ -327,9 +427,10 @@
 (tm-define (tmtex-prepare-doc-data l)
   (:mode elsevier-style?)
   (set! clustered?
-    (or
-      (contains-stree? l '(doc-title-options "cluster-by-affiliation"))
-      (contains-stree? l '(doc-title-options "cluster-all"))))
+    (or (contains-stree? l '(doc-title-options "cluster-by-affiliation"))
+      (contains-stree? l '(doc-title-options "cluster-all"))
+    ) ;or
+  ) ;set!
   (set! l (map tmtex-replace-documents l))
   (set! l (make-references l 'doc-subtitle #f #f))
   (set! l (make-references l 'doc-note #f #f))
@@ -340,48 +441,81 @@
   (if (ifac-style?)
     (begin
       (set! l (make-references l 'author-email #t #f))
-      (set! l (make-references l 'author-homepage #t #f))))
-  (if clustered?
-    (set! l (make-references l 'author-affiliation #t #f)))
-  l)
+      (set! l (make-references l 'author-homepage #t #f))
+    ) ;begin
+  ) ;if
+  (if clustered? (set! l (make-references l 'author-affiliation #t #f)))
+  l
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier title and author presentation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (tmtex-make-doc-data titles subtitles authors dates miscs notes
-                                subtitles-l dates-l miscs-l notes-l tr ar)
+(tm-define (tmtex-make-doc-data titles
+             subtitles
+             authors
+             dates
+             miscs
+             notes
+             subtitles-l
+             dates-l
+             miscs-l
+             notes-l
+             tr
+             ar
+           ) ;tmtex-make-doc-data
   (:mode elsevier-style?)
   (let* ((authors (filter nnull? authors))
-         (authors (if (null? authors) '()
-                    `((!paragraph ,@authors))))
+         (authors (if (null? authors) '() `((!paragraph ,@authors))))
          (titles (tmtex-concat-Sep (map cadr titles)))
-         (notes  `(,@subtitles ,@dates ,@miscs ,@notes))
-         (notes  (if (null? notes) '()
-                   `(,(springer-note-ref "" (map cadr notes)))))
+         (notes `(,@subtitles ,@dates ,@miscs ,@notes))
+         (notes (if (null? notes) '() `(,(springer-note-ref "" (map cadr notes)))))
          (result `(,@titles ,@notes))
          (result (if (null? result) '() `((title (!concat ,@result)))))
-         (result `(,@result ,@subtitles-l ,@notes-l
-                   ,@miscs-l ,@dates-l ,@authors)))
-    (if (null? result) "" `(!document ,@result))))
+         (result `(,@result
+                   ,@subtitles-l
+                   ,@notes-l
+                   ,@miscs-l
+                   ,@dates-l
+                   ,@authors))
+        ) ;
+    (if (null? result) "" `(!document ,@result))
+  ) ;let*
+) ;tm-define
 
-(tm-define (tmtex-make-author names affs emails urls miscs notes
-                              affs* emails* urls* miscs* notes*)
+(tm-define (tmtex-make-author names
+             affs
+             emails
+             urls
+             miscs
+             notes
+             affs*
+             emails*
+             urls*
+             miscs*
+             notes*
+           ) ;tmtex-make-author
   (:mode elsevier-style?)
-  (let* ((names  (tmtex-concat-Sep (map cadr names)))
-         (notes* (if (ifac-style?)
-                   `(,@emails* ,@urls* ,@miscs* ,@notes*)
-                   `(,@miscs* ,@notes*)))
-         (notes* (if (null? notes*) '()
-                   `(,(springer-author-note-ref "" (map cadr notes*)))))
-         (affs*  (if (null? affs*) '()
-                   `((!option
-                       (!concat ,@(list-intersperse (map cadr affs*) ","))))))
+  (let* ((names (tmtex-concat-Sep (map cadr names)))
+         (notes* (if (ifac-style?) `(,@emails* ,@urls* ,@miscs* ,@notes*) `(,@miscs*
+                                                                            ,@notes*))
+         ) ;notes*
+         (notes* (if (null? notes*) '() `(,(springer-author-note-ref ""
+                                             (map cadr notes*))))
+         ) ;notes*
+         (affs* (if (null? affs*)
+                  '()
+                  `((!option (!concat ,@(list-intersperse (map cadr affs*) ","))))
+                ) ;if
+         ) ;affs*
          (result `(,@names ,@notes*))
-         (result (if (null? result) '()
-                   `((author ,@affs* (!concat ,@result)))))
-         (result `(,@result ,@affs ,@emails ,@urls ,@miscs ,@notes)))
-    (if (null? result) '() `(!paragraph ,@result))))
+         (result (if (null? result) '() `((author ,@affs* (!concat ,@result)))))
+         (result `(,@result ,@affs ,@emails ,@urls ,@miscs ,@notes))
+        ) ;
+    (if (null? result) '() `(!paragraph ,@result))
+  ) ;let*
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Elsevier abstract macros
@@ -389,26 +523,38 @@
 
 (tm-define (tmtex-abstract-keywords t)
   (:mode elsevier-style?)
-  (with args (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
-    `((!begin "keyword") (!concat ,@args))))
+  (with args
+    (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
+    `((!begin "keyword") (!concat ,@args))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-abstract-msc t)
   (:mode elsevier-style?)
-  (with args (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
-    `(!concat (MSC) " " (!concat ,@args))))
+  (with args
+    (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
+    `(!concat (MSC) ," " (!concat ,@args))
+  ) ;with
+) ;tm-define
 
 (tm-define (tmtex-abstract-pacs t)
   (:mode elsevier-style?)
-  (with args (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
-    `(!concat (PACS) " " (!concat ,@args))))
+  (with args
+    (list-intersperse (map tmtex (cdr t)) '(!concat (sep) " "))
+    `(!concat (PACS) ," " (!concat ,@args))
+  ) ;with
+) ;tm-define
 
-(tm-define  (tmtex-make-abstract-data keywords acm arxiv msc pacs abstract)
+(tm-define (tmtex-make-abstract-data keywords acm arxiv msc pacs abstract)
   (:mode elsevier-style?)
   (if (or (nnull? msc) (nnull? pacs) (nnull? acm) (nnull? arxiv))
     (set! keywords
-      `(((!begin "keyword") (!document ,@(map cadr keywords)
-                                       ,@pacs ,@msc ,@acm ,@arxiv)))))
-  `(!document ,@abstract ,@keywords))
+      `(((!begin "keyword")
+         (!document ,@(map cadr keywords) ,@pacs ,@msc ,@acm ,@arxiv)))
+    ) ;set!
+  ) ;if
+  `(!document ,@abstract ,@keywords)
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The Elsevier style is quite ugly.
@@ -421,15 +567,19 @@
   (let ((r (tmtex (car l))))
     (tmtex-env-reset "mode")
     (if (== s "equation")
-        (list (list '!begin "eqnarray") r)  ;; FIXME: why do elsequation
-        (list (list '!begin "eqnarray*") r) ;; and elsequation* not work?
-        )))
+      (list (list '!begin "eqnarray") r)
+      ;; FIXME: why do elsequation
+      (list (list '!begin "eqnarray*") r)
+      ;; and elsequation* not work?
+    ) ;if
+  ) ;let
+) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The elsarticle class does not insert a 'References' section title
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;(tm-define (tmtex-bib t)
+;; (tm-define (tmtex-bib t)
 ;;  (:mode elsevier-style?)
 ;;  (:require (elsarticle-style?))
 ;;  (tmtex-biblio (car t) (cdr t) #t))
@@ -441,9 +591,11 @@
 (smart-table latex-texmacs-macro
   (:mode elsevier-style?)
   (:require (elsarticle-style?))
-  (comma #f))
+  (comma #f)
+) ;smart-table
 
 (smart-table latex-texmacs-preamble
   (:mode elsevier-style?)
   (:require (elsarticle-style?))
-  (qed (!append (renewcommand "\\qed" "") "\n")))
+  (qed (!append (renewcommand "\\qed" "") "\n"))
+) ;smart-table

--- a/TeXmacs/progs/convert/latex/tmtex-elsevier.scm
+++ b/TeXmacs/progs/convert/latex/tmtex-elsevier.scm
@@ -52,10 +52,7 @@
   (:mode jsc-style?)
   (init-elsevier body)
   ;; (set! tmtex-packages (cons "cite-author-year" tmtex-packages))
-  (latex-set-packages '("amsthm"
-                        "yjsco"
-                        ;; "natbib")
-  ) ;latex-set-packages
+  (latex-set-packages '("amsthm" "yjsco"))
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/tests/0640.scm
+++ b/TeXmacs/tests/0640.scm
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0640.scm
+;; DESCRIPTION : Tests for thanksemail macro latex export
+;; COPYRIGHT   : (C) 2026  Jack Yansong Li
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(define (export-as-latex-and-load path)
+  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (string-load tmpfile))))
+  
+(define (load-latex path)
+  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path)  "\r\n" "\n")))
+
+
+(define (test_0640)
+  (check (export-as-latex-and-load "0640.tmu") => (load-latex "0640_thanksemail_macro_export.tex"))
+  (check-report))

--- a/TeXmacs/tests/0640.scm
+++ b/TeXmacs/tests/0640.scm
@@ -15,17 +15,29 @@
 (load "./TeXmacs/plugins/latex/progs/init-latex.scm")
 
 (define (export-as-latex-and-load path)
-  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
-    (with tmpfile (url-temp)
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile
+      (url-temp)
       (load-buffer path)
       (buffer-export path tmpfile "latex")
-      (string-load tmpfile))))
-  
+      (string-load tmpfile)
+    ) ;with
+  ) ;with
+) ;define
+
 (define (load-latex path)
-  (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
-    (string-replace (string-load path)  "\r\n" "\n")))
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path) "\r\n" "\n")
+  ) ;with
+) ;define
 
 
 (define (test_0640)
-  (check (export-as-latex-and-load "0640.tmu") => (load-latex "0640_thanksemail_macro_export.tex"))
-  (check-report))
+  (check (export-as-latex-and-load "0640.tmu")
+    =>
+    (load-latex "0640_thanksemail_macro_export.tex")
+  ) ;check
+  (check-report)
+) ;define

--- a/TeXmacs/tests/tex/0640_thanksemail_macro_export.tex
+++ b/TeXmacs/tests/tex/0640_thanksemail_macro_export.tex
@@ -1,0 +1,11 @@
+\documentclass{ifacconf}
+\usepackage[english]{babel}
+\usepackage{natbib}
+\newcommand{\labelitemiii}{\labelitemi}
+\newcommand{\labelitemiv}{\labelitemii}
+
+\begin{document}
+
+\thanks[author-email-mylabel]{Email: test@example.com}
+
+\end{document}

--- a/TeXmacs/tests/tmu/0640.tmu
+++ b/TeXmacs/tests/tmu/0640.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.1.0|2026.5.28>>
+
+<style|<tuple|ifac>>
+
+<\body>
+  <author-email-label|mylabel|test@example.com>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0640.md
+++ b/devel/0640.md
@@ -1,0 +1,53 @@
+# [0640] 移除 thanksemail 自定义宏并在 LaTeX 导出中改用标准原生 inline 宏
+
+## 相关文档
+- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
+
+## 任务相关的代码文件
+- `TeXmacs/progs/convert/latex/latex-texmacs-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm`
+- `TeXmacs/progs/convert/latex/latex-define.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm`
+- `TeXmacs/progs/convert/latex/tmtex-elsevier.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/tmtex-elsevier.scm`
+- `TeXmacs/tests/0640.scm`
+- `TeXmacs/tests/tex/0640_thanksemail_macro_export.tex`
+- `TeXmacs/tests/tmu/0640.tmu`
+
+## 如何测试
+
+### 确定性测试（单元与集成测试）
+```bash
+xmake run 0640
+```
+
+### 非确定性测试（文档验证）
+1. 打开 Mogan STEM，在文档中插入 IFAC 样式作者邮箱（`author-email-label`）。
+2. 导出为 LaTeX，确认导出的 `.tex` 文件的导言区中不再产生自定义的 `\newcommand{\thanksemail}{...}` 宏，而是直接原生输出为标准的 `\thanks` 及其内部 `Email: ` 前缀。
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+一个 PR 至少分为两个 commit：
+1. 第一个 commit 更新 `devel/0640.md` 任务文档
+2. 第二个 commit 为代码改动（包含测试与实现）
+
+```bash
+xmake run 0640
+```
+
+## What
+移除在 LaTeX 导出中，对 IFAC 样式作者邮箱标记（`thanksemail`）所生成的自定义宏，直接在正文中原生输出标准的 `\thanks` 标记并在内容中添加 `Email: ` 前缀。
+
+## Why
+在 TeXmacs 以往的 LaTeX 导出中，定义了一个自定义前置命令：
+```latex
+\newcommand{\thanksemail}[2][]{\thanks[#1]{Email: #2}}
+```
+这不仅造成了导言区污染，也使得非 `elsarticle`/`ifac` 模板在使用类似转换时产生代码耦合。其实直接在翻译时将 `\thanksemail[label]{text}` 转换为原生的 `\thanks[label]{Email: text}`，即可完全免除在 LaTeX 导言区定义该宏。
+
+## How
+1. 修改 `tmtex-elsevier.scm` 中的 `tmtex-author-email-label`，使其直接输出原生的 `thanks`，内容部分拼接 `"Email: "`，不通过 `(thanksemail ...)`。
+2. 从 `latex-texmacs-drd.scm` 的 `latex-texmacs-preamble-command%` 中移除 `thanksemail`。
+3. 从 `latex-define.scm` 的 `latex-texmacs-preamble` 列表中删去对 `thanksemail` 宏的自定义转译定义。


### PR DESCRIPTION
# [0640] 移除 thanksemail 自定义宏并在 LaTeX 导出中改用标准原生 inline 宏

## 相关文档
- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档

## 任务相关的代码文件
- `TeXmacs/progs/convert/latex/latex-texmacs-drd.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm`
- `TeXmacs/progs/convert/latex/latex-define.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm`
- `TeXmacs/progs/convert/latex/tmtex-elsevier.scm`
- `TeXmacs/plugins/latex/progs/convert/latex/tmtex-elsevier.scm`
- `TeXmacs/tests/0640.scm`
- `TeXmacs/tests/tex/0640_thanksemail_macro_export.tex`
- `TeXmacs/tests/tmu/0640.tmu`

## 如何测试

### 确定性测试（单元与集成测试）
```bash
xmake run 0640
```

### 非确定性测试（文档验证）
1. 打开 Mogan STEM，在文档中插入 IFAC 样式作者邮箱（`author-email-label`）。
2. 导出为 LaTeX，确认导出的 `.tex` 文件的导言区中不再产生自定义的 `\newcommand{\thanksemail}{...}` 宏，而是直接原生输出为标准的 `\thanks` 及其内部 `Email: ` 前缀。

## 如何提交

提交前执行以下最少步骤：

一个 PR 至少分为两个 commit：
1. 第一个 commit 更新 `devel/0640.md` 任务文档
2. 第二个 commit 为代码改动（包含测试与实现）

```bash
xmake run 0640
```

## What
移除在 LaTeX 导出中，对 IFAC 样式作者邮箱标记（`thanksemail`）所生成的自定义宏，直接在正文中原生输出标准的 `\thanks` 标记并在内容中添加 `Email: ` 前缀。

## Why
在 TeXmacs 以往的 LaTeX 导出中，定义了一个自定义前置命令：
```latex
\newcommand{\thanksemail}[2][]{\thanks[#1]{Email: #2}}
```
这不仅造成了导言区污染，也使得非 `elsarticle`/`ifac` 模板在使用类似转换时产生代码耦合。其实直接在翻译时将 `\thanksemail[label]{text}` 转换为原生的 `\thanks[label]{Email: text}`，即可完全免除在 LaTeX 导言区定义该宏。

## How
1. 修改 `tmtex-elsevier.scm` 中的 `tmtex-author-email-label`，使其直接输出原生的 `thanks`，内容部分拼接 `"Email: "`，不通过 `(thanksemail ...)`。
2. 从 `latex-texmacs-drd.scm` 的 `latex-texmacs-preamble-command%` 中移除 `thanksemail`。
3. 从 `latex-define.scm` 的 `latex-texmacs-preamble` 列表中删去对 `thanksemail` 宏的自定义转译定义。