### PR TITLE
[0180] PDF 阅读器中支持 Ctrl+数字切换标签

### DIFF
--- a/devel/0180.md
+++ b/devel/0180.md
@@ -1,0 +1,48 @@
+# [0180] PDF 阅读器中支持 Ctrl+数字切换标签
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp` - PDF 阅读器 widget，`keyPressEvent` 在第 1350 行
+- `src/Plugins/Qt/QTMWidget.cpp` - 编辑器主 widget，`keyPressEvent` 在第 230 行，通过 `the_gui->process_keypress` 将按键传递给编辑器
+- `src/Plugins/Qt/qt_simple_widget.cpp` - `handle_keypress` 在第 101 行
+- `src/Edit/Interface/edit_keyboard.cpp` - `key_press` 在第 264 行，`handle_keypress` 在第 428 行
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+# 无单元测试，手动验证
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+# 1. 打开多个标签页（首页、Chat、文档等）
+# 2. 在首页按 Ctrl+1~9，确认可以切换标签
+# 3. 打开一个 PDF 文件进入 PDF 阅读器
+# 4. 在 PDF 阅读器中按 Ctrl+1~9，确认可以切换标签
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+在 PDF 阅读器中支持 Ctrl+数字（Ctrl+1~9）快捷键切换标签页。
+
+1. 在 `PDFReaderWidget::keyPressEvent` 中添加 Ctrl+数字的处理逻辑
+2. 通过 Scheme 函数 `window-set-view` 或 C++ 函数 `window_set_view` 切换到对应索引的标签页
+
+## 6 Why
+顶部标签在首页、Chat 页、文档标签页都可以使用 Ctrl+数字切换，但进入 PDF 阅读器后无法使用。这是因为 PDF 阅读器（`PDFReaderWidget`）是独立的 QWidget，拥有自己的 `keyPressEvent`（第 1350 行），拦截了所有键盘事件但没有将 Ctrl+数字传递给标签切换逻辑。正常编辑器中的按键通过 `QTMWidget::keyPressEvent` → `process_keypress` → `handle_keypress` → `key_press` → `try_shortcut` 的链路到达 kbd map，从而触发标签切换。而 PDF 阅读器的 `keyPressEvent` 在第 1415 行将未处理的事件直接交给 `QWidget::keyPressEvent`，没有传递给编辑器的键盘路由系统。
+
+## 7 How
+在 `PDFReaderWidget::keyPressEvent` 中，当检测到 Ctrl+数字组合键时：
+- 获取当前窗口的标签页列表（通过 `tabpage-list` Scheme 函数或 C++ 的 `get_all_views_unsorted`）
+- 根据数字索引切换到对应的标签页（通过 `window-set-view` 或 `window_set_view`）
+- 参考 PDF 阅读器中已有的 Ctrl+W 关闭标签页的实现（第 1403~1413 行）

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -1412,6 +1412,16 @@ PDFReaderWidget::keyPressEvent (QKeyEvent* event) {
     return;
   }
 
+  if (closeModifier) {
+    int key= event->key ();
+    if (key >= Qt::Key_1 && key <= Qt::Key_9) {
+      int index= key - Qt::Key_1;
+      eval ("(switch-to-view-index " * as_string (index) * ")");
+      event->accept ();
+      return;
+    }
+  }
+
   QWidget::keyPressEvent (event);
 }
 


### PR DESCRIPTION
## Summary
- 在 `PDFReaderWidget::keyPressEvent` 中添加 Ctrl+1~9 快捷键处理，调用已有的 `switch-to-view-index` Scheme 函数切换标签页
- 复用 `closeModifier` 变量，兼容 macOS Cmd 键

## Test plan
- [ ] 打开多个标签页，在首页按 Ctrl+1~9 确认可切换
- [ ] 打开 PDF 进入阅读器，按 Ctrl+1~9 确认可切换标签
- [ ] macOS 上确认 Cmd+数字也能切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)