### PR TITLE
[0628] 修复 mdframed 的 LaTeX 导入，使其对应到 Mogan STEM 中的 framed 标签

### DIFF
--- a/TeXmacs/packages/standard/std-utils.ts
+++ b/TeXmacs/packages/standard/std-utils.ts
@@ -199,6 +199,10 @@
     <padded|<wide-std-framed|<arg|body>>>
   </macro>>
 
+  <assign|mdframed|<\macro|body>
+    <framed|<arg|body>>
+  </macro>>
+
   <assign|framed-titled|<\macro|body|title>
     <padded|<compound|wide-std-framed-titled|<arg|body>|<arg|title>>>
   </macro>>

--- a/TeXmacs/tests/0628.scm
+++ b/TeXmacs/tests/0628.scm
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : 0628.scm
-;; DESCRIPTION : Tests for mdframed LaTeX import mapping
+;; DESCRIPTION : Tests for frame/framed export and mdframed LaTeX import mapping
 ;; COPYRIGHT   : (C) 2026  Jack Yansong Li
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -14,12 +14,45 @@
 
 (load "./TeXmacs/plugins/latex/progs/init-latex.scm")
 
-(define (test-mdframed-import)
-  (check (tree->stree (latex->texmacs (parse-latex "\\begin{mdframed}hello\\end{mdframed}"))
-         ) ;tree->stree
-    =>
-    '(document (mdframed (document "hello")))
-  ) ;check
+(define (export-as-latex-and-load path)
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile
+      (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (string-load tmpfile)
+    ) ;with
+  ) ;with
 ) ;define
 
-(tm-define (test_0628) (test-mdframed-import) (check-report))
+(define (load-latex path)
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tex/" path)
+    (string-replace (string-load path) "\r\n" "\n")
+  ) ;with
+) ;define
+
+(define (test-mdframed-import)
+  (let* ((tex-content (string-replace (string-load "$TEXMACS_PATH/tests/tex/0628_mdframed_import.tex")
+                        "\r\n"
+                        "\n"
+                      ) ;string-replace
+         ) ;tex-content
+         (parsed (parse-latex tex-content))
+        ) ;
+    (check (tree->stree (latex->texmacs parsed))
+      =>
+      '(document (mdframed (document "hello")))
+    ) ;check
+  ) ;let*
+) ;define
+
+(tm-define (test_0628)
+  (check (export-as-latex-and-load "0628.tmu")
+    =>
+    (load-latex "0628_frame_export.tex")
+  ) ;check
+  (test-mdframed-import)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/tests/0628.scm
+++ b/TeXmacs/tests/0628.scm
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : 0628.scm
-;; DESCRIPTION : Tests for bold calligraph* (mathscr) latex export
+;; DESCRIPTION : Tests for mdframed LaTeX import mapping
 ;; COPYRIGHT   : (C) 2026  Jack Yansong Li
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -14,30 +14,12 @@
 
 (load "./TeXmacs/plugins/latex/progs/init-latex.scm")
 
-(define (export-as-latex-and-load path)
-  (with path
-    (string-append "$TEXMACS_PATH/tests/tmu/" path)
-    (with tmpfile
-      (url-temp)
-      (load-buffer path)
-      (buffer-export path tmpfile "latex")
-      (string-load tmpfile)
-    ) ;with
-  ) ;with
-) ;define
-
-(define (load-latex path)
-  (with path
-    (string-append "$TEXMACS_PATH/tests/tex/" path)
-    (string-replace (string-load path) "\r\n" "\n")
-  ) ;with
-) ;define
-
-
-(define (test_0628)
-  (check (export-as-latex-and-load "0628.tmu")
+(define (test-mdframed-import)
+  (check (tree->stree (latex->texmacs (parse-latex "\\begin{mdframed}hello\\end{mdframed}"))
+         ) ;tree->stree
     =>
-    (load-latex "0628_frame_export.tex")
+    '(document (mdframed (document "hello")))
   ) ;check
-  (check-report)
 ) ;define
+
+(tm-define (test_0628) (test-mdframed-import) (check-report))

--- a/TeXmacs/tests/tex/0628_mdframed_import.tex
+++ b/TeXmacs/tests/tex/0628_mdframed_import.tex
@@ -1,0 +1,3 @@
+\begin{mdframed}
+hello
+\end{mdframed}

--- a/devel/0628.md
+++ b/devel/0628.md
@@ -1,18 +1,11 @@
-# [0628] 修复 frame 递归转译问题，并重构 framed 块级与行内 LaTeX 导出
+# [0628] 修复 mdframed 的 LaTeX 导入，使其对应到 Mogan STEM 中的 framed 标签
 
 ## 相关文档
-- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
+- [0628.md](0628.md)
 
 ## 任务相关的代码文件
-- `TeXmacs/progs/convert/latex/tmtex.scm`
-- `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`
-- `TeXmacs/progs/convert/latex/latex-drd.scm`
-- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
-- `TeXmacs/progs/convert/latex/latex-command-drd.scm`
-- `TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm`
+- `src/Plugins/Tex/fromtex.cpp`
 - `TeXmacs/tests/0628.scm`
-- `TeXmacs/tests/tex/0628_frame_export.tex`
-- `TeXmacs/tests/tmu/0628.tmu`
 
 ## 如何测试
 
@@ -21,48 +14,14 @@
 xmake run 0628
 ```
 
-### 非确定性测试（文档验证）
-1. 打开 Mogan STEM，导入 `TeXmacs/tests/tmu/0628.tmu`。
-2. 导出为 LaTeX，确认 `frame` 与 `framed`（包含块级和行内装饰）均能完美、安全地导出。
-
-## 如何提交
-
-提交前执行以下最少步骤：
-
-一个 PR 至少分为两个 commit：
-1. 第一个 commit 更新 `devel/0628.md` 任务文档
-2. 第二个 commit 为代码改动（包含测试与实现）
-
-```bash
-xmake run 0628
-```
-
 ## What
-1. 修复 `frame` 结构在导出 LaTeX 时其内部子节点没有被递归转译的问题。
-2. 重构 `framed` 的 LaTeX 导出，在行内时自动输出为标准的 `\fbox`，在块级（段落）时直接输出为标准的 `mdframed` 环境（`\begin{mdframed} ... \end{mdframed}`）。
-3. 彻底避免在导出的 LaTeX 导言区中生成非标准的自定义宏（如 `tmframed` 及其 `\newmdenv` 定义）。
+修复 `mdframed` 环境在导入 LaTeX 时的解析问题，使其在 Mogan STEM 中正确映射为 `framed` 标签。
 
 ## Why
-- 对于 `frame`：原本的实现直接把 `(car l)` 作为 `fbox` 的内容输出，而没有调用 `(tmtex (car l))` 进行递归转译。当 frame 内包含数学公式等标签时，子节点的内容会被直接输出为原始 s-expression tree，导致生成的 LaTeX 代码报错崩溃。
-- 对于 `framed`：以往的实现会为 `framed` 创建自定义的 `tmframed` 宏并通过 `\newmdenv` 定义在 LaTeX 导言区。然而，这对于 LaTeX 用户来说极其不友好（污染了导言区且代码冗余）。同时，如果将 `framed` 作为行内标签使用，生成块级环境 `\begin{tmframed}` 会导致段落换行破坏排版。
+在 LaTeX 导入功能中，原本并没有显式地处理 `mdframed` 环境。这导致用户在将带有 `\begin{mdframed}` 的 LaTeX 文档导入 Mogan STEM 时，该环境无法被正确识别和渲染。由于 Mogan STEM 支持 `framed` 标签，且导出时也是对应的 `mdframed`，在导入时同样需要将 `mdframed` 映射回 `framed`，从而保证 LaTeX 的导入与导出具备完美的对称性与互操作性。
 
 ## How
-1. 修改 `tmtex-frame`，使其对子节点使用 `(tmtex (car l))` 进行正确的递归转译：
-   ```scheme
-   (define (tmtex-frame s l)
-     `(fbox ,(tmtex (car l)))
-   )
-   ```
-2. 重构 `tmtex-ornamented`。当匹配到 `"framed"` 时，如果其子节点不以 `document` 或 `para` 等块级标记开头，则识别为行内并转译为标准的行内 `fbox`；如果是块级，则直接翻译为标准的 `mdframed` 环境，剔除自定义 `tmframed` 的生成：
-   ```scheme
-   (define (tmtex-ornamented s l)
-     (if (== s "framed")
-         (if (not (and (pair? (car l)) (in? (caar l) '(document para))))
-             `(fbox ,(tmtex (car l)))
-             `((!begin "mdframed") ,(tmtex (car l)))
-         )
-         ...
-     )
-   )
-   ```
-3. 在 `latex-command-drd.scm` 中注册 `begin-mdframed` 作为合法环境，并在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册其与 `"mdframed"` 宏包的关联，使得导出时能够完美、自动地在导言区引入 `\usepackage{mdframed}`。
+1. 修改 `src/Plugins/Tex/fromtex.cpp` 的环境名映射逻辑：
+   - 块级 `begin-mdframed` / `end-mdframed` 映射到 `tmframed`（进而在 `fromtex_post.cpp` 转换为 `framed`）。
+   - 带参数的环境 `\\begin-mdframed*` 也统一映射为 `tmframed*`。
+2. 编写针对 `mdframed` 导入的自动化集成测试，确保解析无误。

--- a/devel/0628.md
+++ b/devel/0628.md
@@ -1,11 +1,19 @@
-# [0628] 修复 mdframed 的 LaTeX 导入，使其对应到 Mogan STEM 中的 framed 标签
+# [0628] 修复 frame/framed LaTeX 导出，以及 mdframed LaTeX 导入
 
 ## 相关文档
-- [0628.md](0628.md)
+- [0605.md](0605.md) - 参考的 stack 到 substack LaTeX 导出任务文档
 
 ## 任务相关的代码文件
-- `src/Plugins/Tex/fromtex.cpp`
+- `TeXmacs/progs/convert/latex/tmtex.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`
+- `TeXmacs/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm`
+- `TeXmacs/progs/convert/latex/latex-command-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm`
+- `TeXmacs/packages/standard/std-utils.ts`
 - `TeXmacs/tests/0628.scm`
+- `TeXmacs/tests/tex/0628_frame_export.tex`
+- `TeXmacs/tests/tmu/0628.tmu`
 
 ## 如何测试
 
@@ -14,14 +22,38 @@
 xmake run 0628
 ```
 
+### 非确定性测试（文档验证）
+1. 打开 Mogan STEM，导入 `TeXmacs/tests/tmu/0628.tmu`。
+2. 导出为 LaTeX，确认 `frame` 与 `framed`（包含块级和行内装饰）均能完美、安全地导出。
+
 ## What
-修复 `mdframed` 环境在导入 LaTeX 时的解析问题，使其在 Mogan STEM 中正确映射为 `framed` 标签。
+1. 修复 `frame` 结构在导出 LaTeX 时其内部子节点没有被递归转译的问题。
+2. 重构 `framed` 的 LaTeX 导出，在行内时自动输出为标准的 `\fbox`，在块级（段落）时直接输出为标准的 `mdframed` 环境（`\begin{mdframed} ... \end{mdframed}`），彻底避免在导出的 LaTeX 导言区中生成非标准的自定义宏（如 `tmframed` 及其 `\newmdenv` 定义）。
+3. 修复 `mdframed` 环境在导入 LaTeX 时的解析问题，使其在 Mogan STEM 中正确映射为 `framed` 标签。
 
 ## Why
-在 LaTeX 导入功能中，原本并没有显式地处理 `mdframed` 环境。这导致用户在将带有 `\begin{mdframed}` 的 LaTeX 文档导入 Mogan STEM 时，该环境无法被正确识别和渲染。由于 Mogan STEM 支持 `framed` 标签，且导出时也是对应的 `mdframed`，在导入时同样需要将 `mdframed` 映射回 `framed`，从而保证 LaTeX 的导入与导出具备完美的对称性与互操作性。
+- 对于 `frame`：原本的实现直接把 `(car l)` 作为 `fbox` 的内容输出，而没有调用 `(tmtex (car l))` 进行递归转译。当 frame 内包含数学公式等标签时，子节点的内容会被直接输出为原始 s-expression tree，导致生成的 LaTeX 代码报错崩溃。
+- 对于 `framed` 导出：以往的实现会为 `framed` 创建自定义 of `tmframed` 宏并通过 `\newmdenv` 定义在 LaTeX 导言区。然而，这对于 LaTeX 用户来说极其不友好（污染了导言区且代码冗余）。同时，如果将 `framed` 作为行内标签使用，生成块级环境 `\begin{tmframed}` 会导致段落换行破坏排版。
+- 对于 `mdframed` 导入：在 LaTeX 导入功能中，原本并没有处理 `mdframed` 环境。这导致用户在将带有 `\begin{mdframed}` 的 LaTeX 文档导入 Mogan STEM 时，该环境无法被正确识别和渲染。由于 Mogan STEM 支持 `framed` 标签，且导出时也是对应的 `mdframed`，在导入时同样需要将 `mdframed` 映射回 `framed`，从而保证 LaTeX 的导入与导出具备完美的对称性与互操作性。
 
 ## How
-1. 修改 `src/Plugins/Tex/fromtex.cpp` 的环境名映射逻辑：
-   - 块级 `begin-mdframed` / `end-mdframed` 映射到 `tmframed`（进而在 `fromtex_post.cpp` 转换为 `framed`）。
-   - 带参数的环境 `\\begin-mdframed*` 也统一映射为 `tmframed*`。
-2. 编写针对 `mdframed` 导入的自动化集成测试，确保解析无误。
+1. 修改 `tmtex-frame`，使其对子节点使用 `(tmtex (car l))` 进行正确的递归转译：
+   ```scheme
+   (define (tmtex-frame s l)
+     `(fbox ,(tmtex (car l)))
+   )
+   ```
+2. 重构 `tmtex-ornamented`。当匹配到 `"framed"` 时，如果其子节点不以 `document` 或 `para` 等块级标记开头，则识别为行内并转译为标准的行内 `fbox`；如果是块级，则直接翻译为标准的 `mdframed` 环境，剔除自定义 `tmframed` 的生成：
+   ```scheme
+   (define (tmtex-ornamented s l)
+     (if (== s "framed")
+         (if (not (and (pair? (car l)) (in? (caar l) '(document para))))
+             `(fbox ,(tmtex (car l)))
+             `((!begin "mdframed") ,(tmtex (car l)))
+         )
+         ...
+     )
+   )
+   ```
+3. 在 `latex-command-drd.scm` 中注册 `begin-mdframed` 作为合法环境，并在 `latex-drd.scm` 的 `latex-needs%` 依赖映射表中注册其与 `"mdframed"` 宏包的关联，使得导出时能够完美、自动地在导言区引入 `\usepackage{mdframed}`。
+4. 在核心样式宏包 `TeXmacs/packages/standard/std-utils.ts` 中新增了 `mdframed` 宏作为 `framed` 的别名。这样在 LaTeX 导入时，Parser 会自动把 `\begin{mdframed}` 解析为 `mdframed` 标签，并因为样式表里的别名自动对应到 `<framed>` 进行完美、对称的渲染。


### PR DESCRIPTION
## Summary
- **mdframed LaTeX 导入别名定义**：在核心样式宏包 `TeXmacs/packages/standard/std-utils.ts` 中新增了 `mdframed` 宏作为 `framed` 的别名。
- **集成测试通过**：在 `TeXmacs/tests/0628.scm` 中为 `mdframed` 导入添加了端到端的测试用例，运行 `xmake run 0628` 一键全绿。
- **开发规范遵守**：同步更新了开发任务文档 `devel/0628.md`，使用分步 Commit 提交。