### PR TITLE
[0181] PDF 阅读器隐藏顶部菜单栏

### DIFF
--- a/devel/0181.md
+++ b/devel/0181.md
@@ -1,0 +1,13 @@
+# [0181] PDF 阅读器隐藏顶部菜单栏
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务描述
+PDF 阅读器不应该显示顶部的菜单栏，与 AI Chat 标签页、首页标签页行为一致。
+
+## 3 任务相关的代码文件
+- `src/Plugins/Qt/qt_tm_widget.cpp` - `update_visibility()` 函数中 `pdfTabMode` 分支控制 PDF 阅读器的界面可见性
+
+## 4 修改内容
+在 `update_visibility()` 中，将 `pdfTabMode` 分支的 `new_menuVisibility` 从 `true` 改为 `false`，使 PDF 阅读器不显示顶部菜单栏，与 `startupTabMode` 和 `chatTabMode` 行为一致。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1307,7 +1307,7 @@ qt_tm_widget_rep::update_visibility () {
 
   if (pdfTabMode) {
     new_mainVisibility  = false;
-    new_menuVisibility  = true;
+    new_menuVisibility  = false;
     new_modeVisibility  = false;
     new_focusVisibility = false;
     new_userVisibility  = false;


### PR DESCRIPTION
## Summary
- PDF 阅读器标签页不再显示顶部菜单栏，与 AI Chat 标签页和首页标签页行为一致
- 在 `update_visibility()` 中将 `pdfTabMode` 的 `new_menuVisibility` 从 `true` 改为 `false`

## Test plan
- [ ] 打开 PDF 文件，确认顶部菜单栏不再显示
- [ ] 切换到编辑器标签页，确认菜单栏正常显示
- [ ] 切换到 AI Chat / 首页标签页，确认行为无变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)