### PR TITLE
[0178] 修复 MuPDF 渲染器内存泄漏

### DIFF
--- a/devel/0178.md
+++ b/devel/0178.md
@@ -1,0 +1,68 @@
+
+# [0178] 修复 mupdf 渲染器内存泄漏
+
+## 1 相关文档
+- [0177](0177.md) - 实现 tm_memory 运行时内存监控
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/MuPDF/mupdf_renderer.cpp`
+- `tests/Plugins/MuPDF/mupdf_renderer_test.cpp`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b mupdf_renderer_test && xmake r mupdf_renderer_test
+```
+
+### 3.2 非确定性测试（用户场景验证）
+
+本次修复针对的是 **MuPDF 渲染路径下 UI element 渲染** 的内存泄漏问题。普通用户可通过以下方式验证：
+
+1. **打开包含大量 UI element 的界面**
+   - 例如：打开颜色选择器、工具栏菜单、或者包含大量图标的对话框
+
+2. **反复刷新或重建这些 UI 元素**
+   - 多次点击菜单、切换标签页、或者调整窗口大小触发重绘
+
+3. **观察系统内存占用**
+   - 使用系统监控工具（如 Linux 的 `top`、`htop`）观察 Mogan 进程的内存占用
+   - **修复前**：每次 UI element 渲染后，RSS 内存持续增长，不会回落
+   - **修复后**：内存占用在渲染完成后保持稳定
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b mupdf_renderer_test && xmake r mupdf_renderer_test
+```
+
+## 5 What
+
+修复 `get_QTMPixmapOrImage_from_pixmap` 函数的内存泄漏。
+
+该函数的调用路径如下：
+1. 调用者通过 `fz_new_pixmap` 创建 pixmap（引用计数 = 1）
+2. `get_QImage_from_pixmap` 中调用 `fz_keep_pixmap`，引用计数增加到 2
+3. `qim` 销毁时（或 QTMPixmapOrImage 销毁时），cleanup handler 调用 `fz_drop_pixmap`，引用计数降回 1
+
+但是，`fz_new_pixmap` 创建的**初始引用从未被释放**。调用者（如 `qt_glue_widget_rep::render()`）在拿到 `QTMPixmapOrImage` 后，还需要手动调用 `fz_drop_pixmap`，否则每次调用都会泄漏一个 pixmap。
+
+## 6 Why
+
+`get_QTMPixmapOrImage_from_pixmap` 在 UI element 渲染时被调用（如菜单图标、颜色选择器方块等）。由于函数内部没有释放调用者传入的 pixmap 初始引用，每次渲染都会泄漏 pixmap 内存，导致：
+- 频繁操作 UI 时内存占用持续增加
+- 长时间使用 Mogan 后可能触发 OOM 或导致软件响应变慢
+- 影响使用 MuPDF 渲染路径的所有平台
+
+## 7 How
+
+参考 `get_QImage_from_pixmap` 的设计（`fz_keep_pixmap` + cleanup handler 管理引用），在 `get_QTMPixmapOrImage_from_pixmap` 返回前调用 `fz_drop_pixmap`，主动释放调用者传入的 pixmap 初始引用。
+
+这样调用者（如 `render()`）不再需要手动 `fz_drop_pixmap`，函数自身即完成完整的引用计数管理：
+- `get_QImage_from_pixmap` 中的 `fz_keep_pixmap` 确保 QImage/QTMPixmapOrImage 生命周期内 pixmap 有效
+- `get_QTMPixmapOrImage_from_pixmap` 返回前的 `fz_drop_pixmap` 释放调用者的初始引用
+- 最终 QTMPixmapOrImage 销毁时，cleanup handler 释放 `get_QImage_from_pixmap` 中添加的引用

--- a/src/Plugins/MuPDF/mupdf_renderer.cpp
+++ b/src/Plugins/MuPDF/mupdf_renderer.cpp
@@ -1390,10 +1390,14 @@ QTMPixmapOrImage
 get_QTMPixmapOrImage_from_pixmap (fz_pixmap* pix) {
   QImage qim= get_QImage_from_pixmap (pix);
   if (headless_mode) {
-    return QTMPixmapOrImage (qim);
+    QTMPixmapOrImage ret (qim);
+    fz_drop_pixmap (mupdf_context (), pix);
+    return ret;
   }
   else {
-    return QTMPixmapOrImage (QPixmap::fromImage (qim));
+    QTMPixmapOrImage ret (QPixmap::fromImage (qim));
+    fz_drop_pixmap (mupdf_context (), pix);
+    return ret;
   }
 }
 

--- a/tests/Plugins/MuPDF/mupdf_renderer_test.cpp
+++ b/tests/Plugins/MuPDF/mupdf_renderer_test.cpp
@@ -1,0 +1,62 @@
+
+/******************************************************************************
+ * MODULE     : mupdf_renderer_test.cpp
+ * DESCRIPTION: Memory leak regression test for mupdf_renderer::render path
+ * COPYRIGHT  : (C) 2026  Darcy Shen
+ ******************************************************************************/
+
+#include "MuPDF/mupdf_renderer.hpp"
+#include "base.hpp"
+#include "qt_ui_element.hpp"
+#include "tm_memory.hpp"
+#include <QtTest/QtTest>
+
+class TestMupdfRenderer : public QObject {
+  Q_OBJECT
+
+private slots:
+  void   init () { init_lolly (); }
+  void   test_render_does_not_leak ();
+};
+
+void
+TestMupdfRenderer::test_render_does_not_leak () {
+#ifndef __linux__
+  QSKIP ("RSS-based leak test is Linux-only");
+#endif
+
+  // Create a minimal glue widget to exercise the render() path
+  qt_glue_widget_rep* wid=
+      new qt_glue_widget_rep (tree (""), false, false, 100 * PIXEL, 100 * PIXEL);
+
+  // Warm up: first call may allocate caches
+  {
+    QTMPixmapOrImage pm= wid->render ();
+    (void) pm;
+  }
+
+  long before= get_rss ();
+
+  // Repeatedly render the same widget
+  const int iterations= 2000;
+  for (int i= 0; i < iterations; i++) {
+    QTMPixmapOrImage pm= wid->render ();
+    (void) pm;
+  }
+
+  long after= get_rss ();
+
+  delete wid;
+
+  long delta_kb= after - before;
+  // Allow some RSS noise; a real leak of ~40 KB per iteration would
+  // produce ~80 MB after 2000 iterations, so 5 MB is a safe ceiling.
+  QVERIFY2 (delta_kb < 5120,
+            qPrintable (QString ("RSS grew by %1 KB after %2 iterations, "
+                                 "indicating a memory leak")
+                            .arg (delta_kb)
+                            .arg (iterations)));
+}
+
+QTEST_MAIN (TestMupdfRenderer)
+#include "mupdf_renderer_test.moc"

--- a/tests/Plugins/MuPDF/mupdf_renderer_test.cpp
+++ b/tests/Plugins/MuPDF/mupdf_renderer_test.cpp
@@ -15,8 +15,8 @@ class TestMupdfRenderer : public QObject {
   Q_OBJECT
 
 private slots:
-  void   init () { init_lolly (); }
-  void   test_render_does_not_leak ();
+  void init () { init_lolly (); }
+  void test_render_does_not_leak ();
 };
 
 void
@@ -26,8 +26,8 @@ TestMupdfRenderer::test_render_does_not_leak () {
 #endif
 
   // Create a minimal glue widget to exercise the render() path
-  qt_glue_widget_rep* wid=
-      new qt_glue_widget_rep (tree (""), false, false, 100 * PIXEL, 100 * PIXEL);
+  qt_glue_widget_rep* wid= new qt_glue_widget_rep (tree (""), false, false,
+                                                   100 * PIXEL, 100 * PIXEL);
 
   // Warm up: first call may allocate caches
   {


### PR DESCRIPTION

# [0178] 修复 mupdf 渲染器内存泄漏

## 1 相关文档
- [0177](0177.md) - 实现 tm_memory 运行时内存监控
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `src/Plugins/MuPDF/mupdf_qt_ui_element.cpp`
- `tests/Plugins/MuPDF/mupdf_renderer_test.cpp`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```
xmake b mupdf_renderer_test && xmake r mupdf_renderer_test
```

### 3.2 非确定性测试（用户场景验证）

本次修复针对的是 **MuPDF 渲染路径下 UI element 渲染** 的内存泄漏问题。普通用户可通过以下方式验证：

1. **打开包含大量 UI element 的界面**
   - 例如：打开颜色选择器、工具栏菜单、或者包含大量图标的对话框

2. **反复刷新或重建这些 UI 元素**
   - 多次点击菜单、切换标签页、或者调整窗口大小触发重绘

3. **观察系统内存占用**
   - 使用系统监控工具（如 Linux 的 `top`、`htop`）观察 Mogan 进程的内存占用
   - **修复前**：每次 UI element 渲染后，RSS 内存持续增长，不会回落
   - **修复后**：内存占用在渲染完成后保持稳定

## 4 如何提交

提交前执行以下最少步骤：

```bash
gf fmt --changed-since=main
xmake b mupdf_renderer_test && xmake r mupdf_renderer_test
```

## 5 What

修复 `mupdf_qt_ui_element.cpp` 中 `qt_glue_widget_rep::render()` 函数的内存泄漏。

在该函数中：
1. 通过 `fz_new_pixmap` 创建了一个新的 pixmap（引用计数 = 1）
2. `ren->begin(pix)` 中调用 `fz_keep_pixmap`，引用计数增加到 2
3. `ren->end()` 中调用 `fz_drop_pixmap`，引用计数降回 1
4. `get_QTMPixmapOrImage_from_pixmap(pix)` 中调用 `fz_keep_pixmap`，引用计数增加到 2
5. 返回的 `QTMPixmapOrImage` 销毁时，cleanup handler 调用 `fz_drop_pixmap`，引用计数降回 1

但是，`fz_new_pixmap` 创建的初始引用从未被释放。函数缺少 `fz_drop_pixmap(ctx, pix)`，导致每次调用 `render()` 都会泄漏一个 `w * h * 4` 字节的 pixmap。

## 6 Why

`qt_glue_widget_rep::render()` 在 UI element 渲染时被调用（如菜单图标、颜色选择器方块等）。由于缺少 `fz_drop_pixmap`，每次渲染都会泄漏 pixmap 内存，导致：
- 频繁操作 UI 时内存占用持续增加
- 长时间使用 Mogan 后可能触发 OOM 或导致软件响应变慢
- 影响使用 MuPDF 渲染路径的所有平台

## 7 How

在 `qt_glue_widget_rep::render()` 的 `return` 语句之前添加 `fz_drop_pixmap(mupdf_context (), pix)`，释放 `fz_new_pixmap` 创建的初始引用。