### PR TITLE
[0182] PDF 阅读器支持 Ctrl+T 新建标签页

### DIFF
--- a/devel/0182.md
+++ b/devel/0182.md
@@ -1,0 +1,36 @@
+# [0182] PDF 阅读器 Ctrl+T 新建标签页
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp` - PDF 阅读器键盘事件处理
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无
+
+### 3.2 非确定性测试（文档验证）
+1. 打开一个 PDF 文件
+2. 在 PDF 阅读器中按 Ctrl+T
+3. 观察是否成功新建一个空白标签页
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+在 PDF 阅读器模式下，支持使用 Ctrl+T 快捷键新建标签页。
+
+1. 在 `PDFReaderWidget::keyPressEvent` 中添加 Ctrl+T 处理
+
+## 6 Why
+PDF 阅读器模式下，Ctrl+T 无法新建标签页，而 Ctrl+W 可以关闭标签页，两者不对称，影响用户体验。
+
+## 7 How
+在 `qt_pdf_reader_widget.cpp` 的 `keyPressEvent` 函数中，参照已有的 `Ctrl+W` 关闭标签页逻辑，添加 `Ctrl+T` 调用 `(new-document)` 新建标签页的逻辑。

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -1406,6 +1406,11 @@ PDFReaderWidget::keyPressEvent (QKeyEvent* event) {
 #else
   bool closeModifier= event->modifiers () & Qt::ControlModifier;
 #endif
+  if (closeModifier && event->key () == Qt::Key_T) {
+    eval ("(new-document)");
+    event->accept ();
+    return;
+  }
   if (closeModifier && event->key () == Qt::Key_W) {
     eval ("(safely-kill-tabpage)");
     event->accept ();


### PR DESCRIPTION
## Summary
在 PDF 阅读器模式下支持使用 Ctrl+T 快捷键新建标签页。

## What
- 在 `PDFReaderWidget::keyPressEvent` 中添加 Ctrl+T 处理逻辑
- 与已有的 Ctrl+W 关闭标签页保持对称

## Test plan
- [ ] 打开一个 PDF 文件
- [ ] 在 PDF 阅读器中按 Ctrl+T
- [ ] 观察是否成功新建一个空白标签页

🤖 Generated with [Claude Code](https://claude.com/claude-code)