### PR TITLE
[0183] 对话列表当前选中项默认展示更多按钮

### DIFF
--- a/devel/0183.md
+++ b/devel/0183.md
@@ -1,0 +1,66 @@
+# [0183] 对话列表当前选中项默认展示更多按钮
+
+## 相关文档
+
+## 任务相关的代码文件
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+
+## 如何测试
+
+### 非确定性测试（UI 验证）
+1. 打开 Mogan 的 LLM Chat 界面
+2. 在对话列表中，观察当前选中的对话项：右侧 "..." 按钮默认可见
+3. 观察其他未选中的对话项：右侧 "..." 按钮默认不可见
+4. 将鼠标悬浮到未选中的对话项上："..." 按钮出现
+5. 鼠标移开后："..." 按钮消失
+6. 点击切换选中另一个对话：新选中的对话 "..." 按钮默认可见，原选中的对话 "..." 按钮隐藏
+
+## 如何提交
+
+提交前编译项目：
+
+```bash
+xmake b stem
+```
+
+## What
+
+在对话列表（`ChatSidebar`）中，每一项右侧有一个 "..." 更多按钮（`moreButton`）。
+
+- **修改前**：所有对话项的 "..." 按钮默认隐藏，只有鼠标悬浮时才显示。
+- **修改后**：当前选中的对话项，"..." 按钮默认展示；其他未选中的对话项，"..." 按钮默认隐藏，只有鼠标悬浮时才展示。
+
+涉及以下修改点：
+1. 构造 `ChatSidebar` 初始化列表项时，如果是当前 active item，默认显示 `moreButton`。
+2. `setActiveItem` 切换选中项时，新的 active item 显示 `moreButton`，旧的 active item 隐藏 `moreButton`（如果不是 archived）。
+3. `eventFilter` 的 `HoverLeave` 事件中，如果离开的 item 是当前 active item，保持 `moreButton` 可见。
+4. `moveFromArchive` 将对话从归档移回列表时，根据是否为 active item 设置 `moreButton` 可见性。
+
+## Why
+
+当前实现中，`moreButton` 的可见性完全由 hover 状态驱动（archived item 除外）。用户希望当前正在进行的对话的更多操作按钮始终可见，减少一步悬浮操作，提升交互效率；同时保持其他未选中项的界面简洁。
+
+## How
+
+修改 `qt_chat_tab_widget.cpp` 中的四个位置：
+
+1. 构造函数初始化 item 时（约第 710 行）：
+   ```cpp
+   if (item.moreButton)
+     item.moreButton->setVisible (info.archived || isActive);
+   ```
+
+2. `setActiveItem` 方法中（约第 768 行）：
+   - 先隐藏旧 active item 的 `moreButton`
+   - 再显示新 active item 的 `moreButton`
+
+3. `eventFilter` 的 `HoverLeave` 处理中（约第 1198 行）：
+   ```cpp
+   it->moreButton->setVisible (it->isArchived || it.key () == activeSessionId_);
+   ```
+
+4. `moveFromArchive` 中（约第 843 行）：
+   ```cpp
+   if (item.moreButton) item.moreButton->setVisible (activeSessionId_ == sessionId);
+   ```

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -707,7 +707,8 @@ ChatSidebar::ChatSidebar (const QList<SessionDisplayInfo>& sessions,
     item.sidebarButton->setText (to_qstring (info.displayTitle));
     bool isActive= (info.sessionId == activeSessionId && !info.archived);
     item.sidebarButton->setChecked (isActive);
-    if (item.moreButton) item.moreButton->setVisible (info.archived);
+    if (item.moreButton)
+      item.moreButton->setVisible (info.archived || isActive);
     item.isArchived= info.archived;
 
     if (info.archived) {
@@ -766,10 +767,17 @@ ChatSidebar::updateItemTitle (const string& sessionId,
 
 void
 ChatSidebar::setActiveItem (const string& sessionId) {
+  if (activeSessionId_ != sessionId) {
+    auto oldIt= items_.find (activeSessionId_);
+    if (oldIt != items_.end () && oldIt->moreButton && !oldIt->isArchived) {
+      oldIt->moreButton->hide ();
+    }
+  }
   activeSessionId_= sessionId;
   for (auto it= items_.begin (); it != items_.end (); ++it) {
     bool isActive= (it.key () == sessionId && !it->isArchived);
     if (it->sidebarButton) it->sidebarButton->setChecked (isActive);
+    if (isActive && it->moreButton) it->moreButton->show ();
   }
 }
 
@@ -840,7 +848,8 @@ ChatSidebar::moveFromArchive (const string& sessionId) {
   if (item.isArchived) {
     item.isArchived= false;
     conversationListLayout_->insertWidget (0, item.itemWidget);
-    if (item.moreButton) item.moreButton->hide ();
+    if (item.moreButton)
+      item.moreButton->setVisible (activeSessionId_ == sessionId);
   }
 
   // 更新 sessionCache_ 中的 archived 状态
@@ -1195,7 +1204,7 @@ ChatSidebar::eventFilter (QObject* watched, QEvent* event) {
   else if (event->type () == QEvent::HoverLeave) {
     for (auto it= items_.constBegin (); it != items_.constEnd (); ++it) {
       if (it->itemWidget == watched && it->moreButton) {
-        it->moreButton->setVisible (it->isArchived);
+        it->moreButton->setVisible (it->isArchived || it.key () == activeSessionId_);
         break;
       }
     }

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -1204,7 +1204,8 @@ ChatSidebar::eventFilter (QObject* watched, QEvent* event) {
   else if (event->type () == QEvent::HoverLeave) {
     for (auto it= items_.constBegin (); it != items_.constEnd (); ++it) {
       if (it->itemWidget == watched && it->moreButton) {
-        it->moreButton->setVisible (it->isArchived || it.key () == activeSessionId_);
+        it->moreButton->setVisible (it->isArchived ||
+                                    it.key () == activeSessionId_);
         break;
       }
     }


### PR DESCRIPTION
## Summary
- 当前选中的对话项，右侧 "..." 按钮默认展示
- 其他未选中的对话项，"..." 按钮默认隐藏，仅悬浮时展示
- 切换选中项时，新旧项的按钮可见性自动更新

## Test plan
- [ ] 打开 LLM Chat 界面，确认当前选中项的 "..." 按钮默认可见
- [ ] 确认其他未选中项的 "..." 按钮默认隐藏
- [ ] 鼠标悬浮到未选中项，确认 "..." 按钮出现
- [ ] 鼠标移开，确认 "..." 按钮消失
- [ ] 点击切换选中对话，确认新选中项的 "..." 按钮保持可见，原选中项隐藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)