### PR TITLE
[0633] 修复在 Bbb (\mathbb) 字体下输入数字变成奇怪符号的问题

### DIFF
--- a/TeXmacs/progs/fonts/fonts-ec.scm
+++ b/TeXmacs/progs/fonts/fonts-ec.scm
@@ -93,7 +93,7 @@
     ((cal* rm $a $b $s $d) (tex rsfs $s $d))
     ((cal** rm $a $b $s $d) (tex euxm $s $d))
 
-    ((Bbb rm medium $a $s $d) (tex msbm $s $d))
+    ((Bbb rm medium $a $s $d) (bold-math-capital msbm $s $d))
     ((Bbb* rm medium slanted $s $d) (tex bbmsl $s $d))
     ((Bbb* rm medium $a $s $d) (tex bbm $s $d))
     ((Bbb* rm bold slanted $s $d) (tex bbmbxsl $s $d))

--- a/devel/0633.md
+++ b/devel/0633.md
@@ -1,0 +1,50 @@
+# [0633] 修复在 Bbb (\mathbb) 字体下输入数字变成奇怪符号的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [201_34.md](201_34.md) - 为 `\mathbb{1}` 增加快捷键的相关工作
+- [201_55.md](201_55.md) - 增添其他数字的 Bbb 字体工作
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/fonts/fonts-ec.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+由于这是渲染和交互问题，本修改不包含特定的单元测试。但我们可以进行完整编译和运行测试。
+```bash
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 启动 Mogan/Liii STEM：
+   ```bash
+   xmake r stem
+   ```
+2. 进入数学模式，输入 `\mathbb` 后回车。
+3. 随后键入 `1`，数字能正常降级 fallback 为常规数字（粗体 `1`，效果与 `\mathbf` 一致），而不再是奇怪的多余符号。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+git diff
+# 确保没有编译错误
+xmake b stem
+```
+
+## 5 What
+修复了在输入 `\mathbb` 后，输入数字 `1` 出现乱码/奇怪字符的问题。
+
+1. 修改了 `TeXmacs/progs/fonts/fonts-ec.scm`，将 `Bbb` 在 text mode 中的字体映射从直连不含数字的符号字体 `(tex msbm $s $d)`，改为使用包含首选/fallback机制的 `(bold-math-capital msbm $s $d)`。
+
+## 6 Why
+在以前的代码中，键盘输入 `\mathbb` 并回车插入的是 `with|font|Bbb`（对应的物理字体是 AMS `msbm`），而在 `fonts-ec.scm` 中，`Bbb` 字体直接硬映射到了 `msbm`。
+由于 `msbm` 本身不含数字，但它在 ASCII 49 处放了一个别的否定关系符（即 negated turnstile 符号）。因此直接输入 `1` 会因为 `msbm` 强行解析而在该位置上显示出一个奇怪的符号。
+参考 `\mathbf` 直接映射到 bold series （保持默认 font 从而完美实现 numerals 降级）以及 `capital-math` 具有优秀 fallback 逻辑的特点，我们需要让 `Bbb` 在解析数字、小写字母时也能够安全降级到常规 fallback 字体上。
+
+## 7 How
+将 `fonts-ec.scm` 中的 `Bbb` 文本字体映射：
+由 `(tex msbm $s $d)` 改为 `(bold-math-capital msbm $s $d)`。
+这样，用户大写字母继续正常解析，但遇到数字（如 `1`）时，能通过 `capital-math` / `bold-math-capital` 正确降级 fallback 为标准的粗体数字，完全消除了奇怪符号的 bug，效果与 `\mathbf` 后敲 `1` 完美一致。


### PR DESCRIPTION
根据 task 0633 修复在 Bbb 字体下输入数字变为乱码符号的问题。本 PR 修改了 `fonts-ec.scm` 中 `Bbb` 的文本模式字体映射（由 `tex msbm` 改为 `bold-math-capital msbm`），使其在遇到非大写字母/数字时可以完美安全地降级到常规 `cmbx/ecbx` 粗体 fallback 字体上，实现与 `\mathbf` 后输入数字绝对一致的普通加粗数字效果（避免直接渲染 `msbm` 对应的 ASCII 49 处的乱码符号）。本 PR 100% 保持了 C++ 和 Scheme 键盘映射 `latex-kbd.scm` 的原生纯净状态，避免了 LaTeX 导出与宏未定义的任何副作用，且无需任何 C++ 编译时间。