### PR TITLE
[0184] 实现 AI 对话侧边栏状态记忆

### DIFF
--- a/devel/0184.md
+++ b/devel/0184.md
@@ -1,0 +1,266 @@
+# [0184] AI 对话侧边栏状态记忆
+
+## 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+- `src/Plugins/Qt/qt_tm_widget.cpp`
+- `src/Plugins/Qt/qt_tm_widget.hpp`
+
+## 如何测试
+
+### 非确定性测试（UI 验证）
+
+以下测试涉及两个层级的"侧边栏"：
+1. **右侧 AI 对话侧边栏 dock**（`chatSideDock`，在编辑器/PDF/首页界面中通过右上角浮动按钮打开）
+2. **Chat 标签页内部左侧会话列表**（`ChatSidebar`，在 Chat 标签页中通过左上角折叠按钮展开/收缩）
+
+两个层级的状态互相独立，修改一个不应影响另一个。
+
+---
+
+#### A. 右侧 dock 状态记忆
+
+##### A1：文档 -> 首页 -> 文档（dock 打开时）
+
+1. 打开一个 TMU 文档（编辑器界面）或 PDF 文档（阅读器界面）
+2. 点击右上角 AI 对话浮动按钮，打开右侧 dock
+3. 切换到首页标签页
+4. 观察：右侧 dock **自动关闭**
+5. 从首页切换回该文档标签页
+6. 观察：右侧 dock **自动恢复显示**
+
+##### A2：文档 -> 首页 -> 文档（dock 关闭时）
+
+1. 打开一个 TMU 文档或 PDF 文档，**不打开**右侧 dock
+2. 切换到首页标签页，再切换回该文档
+3. 观察：右侧 dock **保持关闭**
+4. 打开右侧 dock，再点击 dock 自身的关闭按钮将其关闭
+5. 切换到首页标签页，再切换回该文档
+6. 观察：右侧 dock **保持关闭**
+
+##### A3：文档 -> Chat 标签页 -> 文档（dock 打开时）
+
+1. 打开一个 TMU 文档或 PDF 文档
+2. 点击右上角 AI 对话浮动按钮，打开右侧 dock
+3. 切换到 Chat 标签页
+4. 观察：右侧 dock **自动关闭**（Chat 全屏与 dock 模式互斥）
+5. 从 Chat 标签页切换回该文档标签页
+6. 观察：右侧 dock **自动恢复显示**
+
+##### A4：文档 -> Chat 标签页 -> 文档（dock 关闭时）
+
+1. 打开一个 TMU 文档或 PDF 文档，**不打开**右侧 dock
+2. 切换到 Chat 标签页，再切换回该文档
+3. 观察：右侧 dock **保持关闭**
+
+##### A5：文档 -> 文档（dock 状态全局一致）
+
+1. 打开两个或更多 TMU 文档（或混合 TMU + PDF）
+2. 点击右上角 AI 对话浮动按钮，打开右侧 dock
+3. 在这些文档标签页之间来回切换
+4. 观察：右侧 dock **始终显示**
+5. 关闭右侧 dock，再在这些文档标签页之间来回切换
+6. 观察：右侧 dock **始终关闭**
+
+##### A6：首页与 Chat 之间切换（dock 不应恢复）
+
+1. 打开一个 TMU 文档，打开右侧 dock
+2. 切换到首页标签页（dock 自动关闭）
+3. 从首页直接切换到 Chat 标签页
+4. 观察：右侧 dock **保持关闭**，Chat 标签页**正常显示**
+5. 从 Chat 标签页切换到首页
+6. 观察：右侧 dock **保持关闭**
+7. 从首页切换到 TMU 文档标签页
+8. 观察：右侧 dock **自动恢复显示**
+
+---
+
+#### B. Chat 标签页内部会话列表状态记忆
+
+##### B1：Chat 展开 -> 文档 -> Chat
+
+1. 切换到 Chat 标签页
+2. 确认左侧会话列表默认**展开**
+3. 切换到任意 TMU/PDF 文档标签页
+4. 再切换回 Chat 标签页
+5. 观察：左侧会话列表**保持展开**
+
+##### B2：Chat 收缩 -> 文档 -> Chat
+
+1. 切换到 Chat 标签页
+2. 点击左上角折叠按钮，将左侧会话列表**收缩**
+3. 切换到任意 TMU/PDF 文档标签页
+4. 再切换回 Chat 标签页
+5. 观察：左侧会话列表**保持收缩**
+6. 点击左上角展开按钮恢复展开
+
+##### B3：Chat 展开 -> 文档 + dock -> Chat
+
+1. 切换到 Chat 标签页，确认左侧会话列表**展开**
+2. 切换到 TMU 文档标签页
+3. 点击右上角浮动按钮，打开右侧 dock
+4. 切换回 Chat 标签页
+5. 观察：左侧会话列表**保持展开**，右侧 dock **自动关闭**
+
+##### B4：Chat 收缩 -> 文档 + dock -> Chat
+
+1. 切换到 Chat 标签页，点击折叠按钮将左侧会话列表**收缩**
+2. 切换到 TMU 文档标签页，打开右侧 dock
+3. 切换回 Chat 标签页
+4. 观察：左侧会话列表**保持收缩**，右侧 dock **自动关闭**
+5. 再次确认左上角**存在**浮动展开按钮和浮动新建按钮（两个圆形按钮）
+
+---
+
+#### C. 回归测试（历史上出过 bug 的场景）
+
+##### C1：新建文档 -> 打开 dock -> 首页 -> Chat（Chat 正常显示）
+
+1. 新建一个空白 TMU 文档
+2. 点击右上角浮动按钮，打开右侧 dock
+3. 切换到首页标签页
+4. 切换到 Chat 标签页
+5. 观察：Chat 标签页**正常显示**，不应出现黑屏、空白或控件异常
+
+##### C2：Chat 收缩 -> 新建文档 -> 打开 dock -> Chat（按钮不消失）
+
+1. 切换到 Chat 标签页
+2. 点击左上角折叠按钮，收缩左侧会话列表
+3. 新建一个空白 TMU 文档（或切换到已有文档）
+4. 点击右上角浮动按钮，打开右侧 dock
+5. 切换回 Chat 标签页
+6. 观察：
+   - 如果左侧会话列表应保持**收缩**
+   - 左上角应显示**两个浮动按钮**（展开按钮 + 新建按钮）
+   - 这两个按钮**不可消失**
+
+##### C3：Chat 收缩 -> 首页 -> 文档 -> Chat（状态正确）
+
+1. 切换到 Chat 标签页，收缩左侧会话列表
+2. 切换到首页标签页
+3. 切换到 TMU 文档标签页
+4. 切换回 Chat 标签页
+5. 观察：左侧会话列表**保持收缩**
+
+##### C4：反复快速切换标签页（状态不混乱）
+
+1. 打开右侧 dock
+2. 在 TMU 文档、首页、Chat 标签页之间**反复快速切换**多次
+3. 观察：
+   - 在文档标签页时，dock 状态**始终一致**
+   - 在 Chat 标签页时，界面**正常显示**，无闪烁、无控件消失
+   - 在首页时，dock **始终关闭**
+
+### 确定性测试（编译 + 单元测试）
+
+编译项目：
+
+```bash
+xmake b stem
+```
+
+运行 Chat Tab Widget 单元测试：
+
+```bash
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
+
+预期结果：全部通过。
+
+## 如何提交
+
+提交前编译项目：
+
+```bash
+xmake b stem
+```
+
+## What
+
+让 AI 对话侧边栏的状态在标签页切换时能够被记住和恢复，涉及两个层面的修改：
+
+1. **右侧 AI 对话侧边栏 dock**（`chatSideDock`）：在编辑器/PDF/首页与 Chat 标签页之间切换时，记住用户是否主动打开了侧边栏 dock，并在切回非 Chat 标签页时自动恢复。
+2. **Chat 标签页内部左侧会话列表**（`ChatSidebar`）：在 Chat 标签页中，用户手动展开/收缩左侧会话列表后，切换到其他标签页再切回，保持之前的展开/收缩状态。
+
+涉及以下修改点：
+1. `qt_tm_widget_rep` 新增 `chatSidebarModeMemory_` 成员，记录用户主动设置的 dock 侧边栏状态。
+2. `sync_chat_tab_mode()` 中切换到 Chat 标签页前保存 dock 状态，切回文档时恢复。
+3. `chatSideDock` 关闭事件、`chatSidebarToggleBtn` 点击事件、`QTChatTabWidget::closeSidebarRequested` 信号中同步更新 `chatSidebarModeMemory_`。
+4. `QTChatTabWidget` 新增静态成员 `globalSidebarCollapsed_`，全局记忆 Chat 标签页内部左侧会话列表的折叠状态。
+5. `QTChatTabWidget` 构造函数根据 `globalSidebarCollapsed_` 初始化侧边栏；`toggle_sidebar()` 切换时同步更新全局状态。
+6. `sync_chat_tab_mode()` 和 `sync_chat_sidebar_mode()` 中从 dock 模式恢复全屏 Chat 时，使用记忆的状态代替强制展开。
+
+## Why
+
+之前的实现存在两个问题：
+1. 从文档切换到 Chat 标签页再切回时，右侧 AI 对话侧边栏 dock 默认关闭，用户需要重新手动打开，打断工作流。
+2. Chat 标签页内部的左侧会话列表，在切换到其他标签页再回来后，默认收缩起来，用户需要重新展开才能看到会话列表。
+
+用户期望的状态行为是：侧边栏的展开/收缩状态应该是全局记忆的，切换标签页不应破坏用户已经设定好的界面布局。
+
+## How
+
+### 右侧 dock 状态记忆
+
+在 `qt_tm_widget.hpp` 的 `qt_tm_widget_rep` 中添加 `chatSidebarModeMemory_` 成员：
+
+```cpp
+bool chatSidebarModeMemory_; ///< 记忆用户主动设置的侧边栏模式状态。
+```
+
+在 `qt_tm_widget.cpp` 中的三个用户交互点同步更新该变量：
+
+1. `chatSidebarToggleBtn` 点击时：`chatSidebarModeMemory_ = chatSidebarMode;`
+2. `chatSideDock` 关闭时：`chatSidebarModeMemory_ = false;`
+3. Chat 标签页内点击关闭 sidebar 按钮时：`chatSidebarModeMemory_ = false;`
+
+在 `sync_chat_tab_mode()` 中：
+
+```cpp
+if (chatTabMode) {
+    // 切换到 Chat 标签页前保存用户选择
+    if (chatSidebarMode) {
+      chatSidebarModeMemory_= true;
+      chatSidebarMode= false;
+      ...
+    }
+    ...
+}
+else {
+    // 从 Chat 标签页切回时恢复
+    if (chatSidebarModeMemory_ && !chatSidebarMode) {
+      chatSidebarMode= true;
+      sync_chat_sidebar_mode ();
+    }
+}
+```
+
+### Chat 标签页内部会话列表状态记忆
+
+在 `qt_chat_tab_widget.hpp` 的 `QTChatTabWidget` 中添加静态成员：
+
+```cpp
+static bool globalSidebarCollapsed_; ///< 全局记忆的侧边栏折叠状态
+```
+
+在 `qt_chat_tab_widget.cpp` 中：
+
+1. 定义静态变量：`bool QTChatTabWidget::globalSidebarCollapsed_= false;`
+2. 构造函数末尾根据全局状态初始化：
+   ```cpp
+   if (globalSidebarCollapsed_ && sidebarWidget_ && floatingBtnContainer_) {
+     sidebarWidget_->hide ();
+     floatingBtnContainer_->show ();
+     sidebarCollapsed_= true;
+   }
+   ```
+3. `toggle_sidebar()` 中同步更新：`globalSidebarCollapsed_= sidebarCollapsed_;`
+4. 提供静态接口 `globalSidebarCollapsed()` / `setGlobalSidebarCollapsed()`
+
+在 `sync_chat_tab_mode()` 和 `sync_chat_sidebar_mode()` 中恢复 Chat 全屏时，使用 `chatWidget->setSidebarCollapsed(QTChatTabWidget::globalSidebarCollapsed())` 替代原来的强制展开。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -50,6 +50,8 @@
 
 using namespace moebius;
 
+bool QTChatTabWidget::globalSidebarCollapsed_= false;
+
 namespace {
 
 // ---- Widget 框架相关常量 ----
@@ -1264,6 +1266,13 @@ QTChatTabWidget::QTChatTabWidget (const QList<SessionDisplayInfo>& sessions,
 
   // 右侧内容区
   setup_right_content (mainLayout);
+
+  // 根据全局记忆的状态恢复侧边栏
+  if (globalSidebarCollapsed_ && sidebarWidget_ && floatingBtnContainer_) {
+    sidebarWidget_->hide ();
+    floatingBtnContainer_->show ();
+    sidebarCollapsed_= true;
+  }
 }
 
 QTChatTabWidget::~QTChatTabWidget () {
@@ -1503,6 +1512,7 @@ QTChatTabWidget::toggle_sidebar () {
     }
     sidebarCollapsed_= true;
   }
+  globalSidebarCollapsed_= sidebarCollapsed_;
 }
 
 void
@@ -1523,6 +1533,16 @@ QTChatTabWidget::setSidebarVisible (bool visible) {
 void
 QTChatTabWidget::setCloseSidebarButtonVisible (bool visible) {
   if (closeSidebarBtn_) closeSidebarBtn_->setVisible (visible);
+}
+
+bool
+QTChatTabWidget::globalSidebarCollapsed () {
+  return globalSidebarCollapsed_;
+}
+
+void
+QTChatTabWidget::setGlobalSidebarCollapsed (bool collapsed) {
+  globalSidebarCollapsed_= collapsed;
 }
 
 /******************************************************************************

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -342,7 +342,16 @@ public:
   }
   void setSidebarCollapsed (bool collapsed);
   bool isSidebarCollapsed () const { return sidebarCollapsed_; }
-  bool isSidebarWidgetVisible () const {
+
+  /**
+   * @brief 获取全局记忆的侧边栏折叠状态。
+   */
+  static bool globalSidebarCollapsed ();
+  /**
+   * @brief 设置全局记忆的侧边栏折叠状态。
+   */
+  static void setGlobalSidebarCollapsed (bool collapsed);
+  bool        isSidebarWidgetVisible () const {
     return sidebarWidget_ != nullptr && sidebarWidget_->isVisible ();
   }
   bool isFloatingContainerVisible () const {
@@ -398,6 +407,8 @@ private:
   bool                   sidebarCollapsed_    = false;   ///< 侧边栏是否折叠
   int                    sidebarExpandedWidth_= 0;       ///< 侧边栏展开时宽度
   qt_tm_widget_rep*      parentTmWidget_= nullptr; ///< 关联的 TeXmacs widget
+
+  static bool globalSidebarCollapsed_; ///< 全局记忆的侧边栏折叠状态
 };
 
 #endif // QT_CHAT_TAB_WIDGET_HPP

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -184,7 +184,7 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
       pdfViewerWidget (nullptr), pdfTabMode (false), currentPdfPath (""),
       lastLoadedPdfPath (""), chatContentWidget (nullptr), chatTabMode (false),
       chatSideDock (nullptr), chatSidebarToggleBtn (nullptr),
-      chatSidebarMode (false) {
+      chatSidebarMode (false), chatSidebarModeMemory_ (false) {
   type= texmacs_widget;
 
   main_widget= concrete (::glue_widget (true, true, 1, 1));
@@ -788,7 +788,8 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
   QObject::connect (chatSideDock, &QDockWidget::visibilityChanged,
                     [this] (bool visible) {
                       if (!visible && chatSidebarMode) {
-                        chatSidebarMode= false;
+                        chatSidebarMode       = false;
+                        chatSidebarModeMemory_= false;
                         if (chatContentWidget && chatSideDock &&
                             chatSideDock->widget () == chatContentWidget) {
                           chatSideDock->setWidget (nullptr);
@@ -842,7 +843,8 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
       new ChatSidebarBtnPositioner (chatSidebarToggleBtn, cw));
 
   QObject::connect (chatSidebarToggleBtn, &QPushButton::clicked, [this] () {
-    chatSidebarMode= !chatSidebarMode;
+    chatSidebarMode       = !chatSidebarMode;
+    chatSidebarModeMemory_= chatSidebarMode;
     sync_chat_sidebar_mode ();
   });
 
@@ -1012,6 +1014,13 @@ qt_tm_widget_rep::sync_startup_tab_mode () {
 
   if (startupTabMode) {
     // Show Backstage/Startup view
+    // 进入首页前保存并关闭 dock
+    if (chatSidebarMode) {
+      chatSidebarModeMemory_= true;
+      chatSidebarMode       = false;
+      sync_chat_sidebar_mode ();
+    }
+
     hide_widget_from_layout (editorWidget, layout);
     hide_widget_from_layout (pdfViewerWidget, layout);
     hide_widget_from_layout (chatContentWidget, layout);
@@ -1059,6 +1068,12 @@ qt_tm_widget_rep::sync_startup_tab_mode () {
       url currentView= get_current_view_safe ();
       if (!is_none (currentView)) send_keyboard_focus (abstract (main_widget));
     }
+    // 从首页切回文档时恢复 dock（Chat 标签页模式下不恢复，由 sync_chat_tab_mode
+    // 处理）
+    if (chatSidebarModeMemory_ && !chatSidebarMode && !chatTabMode) {
+      chatSidebarMode= true;
+      sync_chat_sidebar_mode ();
+    }
   }
 }
 
@@ -1077,18 +1092,23 @@ qt_tm_widget_rep::sync_chat_tab_mode () {
 
   if (chatTabMode) {
     // Show Chat tab view
-    // 如果之前处于侧边栏模式，先关闭
+    // 如果之前处于侧边栏模式，先关闭（记住用户选择，切回时恢复）
     if (chatSidebarMode) {
-      chatSidebarMode= false;
+      chatSidebarModeMemory_= true;
+      chatSidebarMode       = false;
       if (chatSideDock && chatContentWidget &&
           chatSideDock->widget () == chatContentWidget) {
         chatSideDock->setWidget (nullptr);
         chatContentWidget->setParent (centralwidget ());
-        // 恢复内部对话列表显示（全屏模式需要）
+        // 恢复内部对话列表显示（全屏模式需要），
+        // 尊重用户记忆的侧边栏展开/收缩状态
         QTChatTabWidget* chatWidget=
             qobject_cast<QTChatTabWidget*> (chatContentWidget);
         if (chatWidget) {
+          // 先从 dock 模式的隐藏状态恢复，再根据用户记忆的状态设置
           chatWidget->setSidebarVisible (true);
+          chatWidget->setSidebarCollapsed (
+              QTChatTabWidget::globalSidebarCollapsed ());
           chatWidget->setCloseSidebarButtonVisible (false);
         }
       }
@@ -1121,6 +1141,12 @@ qt_tm_widget_rep::sync_chat_tab_mode () {
                                                   QSizePolicy::Fixed);
       url currentView= get_current_view_safe ();
       if (!is_none (currentView)) send_keyboard_focus (abstract (main_widget));
+    }
+    // 如果用户之前主动打开了侧边栏，从 Chat 标签页切回时恢复
+    // 注意：从首页切回时由 sync_startup_tab_mode() 负责恢复，这里不再重复处理
+    if (chatSidebarModeMemory_ && !chatSidebarMode && !startupTabMode) {
+      chatSidebarMode= true;
+      sync_chat_sidebar_mode ();
     }
   }
 }
@@ -1185,7 +1211,8 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
       // 连接关闭按钮信号
       QObject::connect (chatWidget, &QTChatTabWidget::closeSidebarRequested,
                         [this] () {
-                          chatSidebarMode= false;
+                          chatSidebarMode       = false;
+                          chatSidebarModeMemory_= false;
                           sync_chat_sidebar_mode ();
                         });
     }
@@ -1227,11 +1254,15 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
       // 不加入布局，保持隐藏
       chatContentWidget->hide ();
 
-      // 恢复内部对话列表显示（全屏模式需要）
+      // 恢复内部对话列表显示（全屏模式需要），
+      // 尊重用户记忆的侧边栏展开/收缩状态
       QTChatTabWidget* chatWidget=
           qobject_cast<QTChatTabWidget*> (chatContentWidget);
       if (chatWidget) {
+        // 先从 dock 模式的隐藏状态恢复，再根据用户记忆的状态设置
         chatWidget->setSidebarVisible (true);
+        chatWidget->setSidebarCollapsed (
+            QTChatTabWidget::globalSidebarCollapsed ());
         chatWidget->setCloseSidebarButtonVisible (false);
       }
     }

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -187,7 +187,8 @@ private:
   QString          lastLoadedPdfPath; ///\< 上次加载的 PDF 路径。
   bool             chatTabMode;       ///\< 聊天标签页视图是否激活。
   bool             chatSidebarMode;   ///\< AI 聊天侧边栏模式是否激活。
-  string           currentEditorFile; ///\< 当前编辑器打开的文件路径。
+  bool   chatSidebarModeMemory_;      ///\< 记忆用户主动设置的侧边栏模式状态。
+  string currentEditorFile;           ///\< 当前编辑器打开的文件路径。
 
 public:
   qt_tm_widget_rep (int mask, command _quit);

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -23,7 +23,11 @@ class TestChatTabWidget : public QObject {
   Q_OBJECT
 
 private slots:
-  void init () { init_lolly (); }
+  void init () {
+    init_lolly ();
+    // 重置全局侧边栏折叠状态，避免测试间互相影响
+    QTChatTabWidget::setGlobalSidebarCollapsed (false);
+  }
 
   void test_count_input_lines_empty_document () {
     tree empty_doc= tree (DOCUMENT, "");
@@ -139,6 +143,72 @@ private slots:
     widget.setSidebarCollapsed (false);
     QVERIFY (widget.isSidebarWidgetVisible ());
     QVERIFY (!widget.isFloatingContainerVisible ());
+  }
+
+  // === globalSidebarCollapsed 全局状态记忆 ===
+  void test_globalSidebarCollapsed_default () {
+    QCOMPARE (QTChatTabWidget::globalSidebarCollapsed (), false);
+  }
+
+  void test_globalSidebarCollapsed_set_and_get () {
+    QTChatTabWidget::setGlobalSidebarCollapsed (true);
+    QVERIFY (QTChatTabWidget::globalSidebarCollapsed ());
+
+    QTChatTabWidget::setGlobalSidebarCollapsed (false);
+    QVERIFY (!QTChatTabWidget::globalSidebarCollapsed ());
+  }
+
+  void test_constructor_respects_global_collapsed () {
+    QTChatTabWidget::setGlobalSidebarCollapsed (true);
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+
+    QVERIFY (widget.isSidebarCollapsed ());
+    QVERIFY (!widget.isSidebarWidgetVisible ());
+    QVERIFY (widget.isFloatingContainerVisible ());
+  }
+
+  void test_constructor_respects_global_expanded () {
+    QTChatTabWidget::setGlobalSidebarCollapsed (false);
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+    widget.show ();
+
+    QVERIFY (!widget.isSidebarCollapsed ());
+    QVERIFY (widget.isSidebarWidgetVisible ());
+    QVERIFY (!widget.isFloatingContainerVisible ());
+  }
+
+  void test_setSidebarCollapsed_updates_global () {
+    QTChatTabWidget::setGlobalSidebarCollapsed (false);
+    QList<SessionDisplayInfo> sessions;
+    QTChatTabWidget           widget (sessions, "", nullptr);
+
+    widget.setSidebarCollapsed (true);
+    QVERIFY (QTChatTabWidget::globalSidebarCollapsed ());
+
+    widget.setSidebarCollapsed (false);
+    QVERIFY (!QTChatTabWidget::globalSidebarCollapsed ());
+  }
+
+  void test_global_state_persists_across_instances () {
+    QTChatTabWidget::setGlobalSidebarCollapsed (false);
+    QList<SessionDisplayInfo> sessions;
+
+    {
+      QTChatTabWidget widget1 (sessions, "", nullptr);
+      widget1.setSidebarCollapsed (true);
+      QVERIFY (QTChatTabWidget::globalSidebarCollapsed ());
+    }
+
+    {
+      QTChatTabWidget widget2 (sessions, "", nullptr);
+      widget2.show ();
+      QVERIFY (widget2.isSidebarCollapsed ());
+      QVERIFY (!widget2.isSidebarWidgetVisible ());
+      QVERIFY (widget2.isFloatingContainerVisible ());
+    }
   }
 
   // === setSidebarVisible (dock 模式专用) ===


### PR DESCRIPTION
## 摘要

实现 AI 对话侧边栏状态记忆功能，涉及两个层级：

1. **右侧 AI 对话侧边栏 dock**：在编辑器/PDF/首页与 Chat 标签页之间切换时，记住用户是否主动打开了侧边栏 dock，并在切回非 Chat 标签页时自动恢复。
2. **Chat 标签页内部左侧会话列表**：在 Chat 标签页中，用户手动展开/收缩左侧会话列表后，切换到其他标签页再切回，保持之前的展开/收缩状态。

## 改动

- `qt_tm_widget_rep` 新增 `chatSidebarModeMemory_` 成员，记录用户主动设置的 dock 侧边栏状态。
- `sync_chat_tab_mode()` / `sync_startup_tab_mode()` 中在切换标签页前保存 dock 状态，切回文档时恢复。
- `chatSideDock` 关闭事件、`chatSidebarToggleBtn` 点击事件中同步更新 `chatSidebarModeMemory_`。
- `QTChatTabWidget` 新增静态成员 `globalSidebarCollapsed_`，全局记忆 Chat 标签页内部左侧会话列表的折叠状态。
- `QTChatTabWidget` 构造函数根据 `globalSidebarCollapsed_` 初始化侧边栏；`toggle_sidebar()` 切换时同步更新全局状态。
- 补充单元测试（`qt_chat_tab_widget_test.cpp`）验证全局状态记忆行为。

## 测试计划

- [x] `xmake b stem` 编译通过
- [x] `xmake b qt_chat_tab_widget_test` 编译通过
- [x] `xmake r qt_chat_tab_widget_test` 全部通过
- [x] 手动测试场景 A1–A6、B1–B4、C1–C4（详见 `devel/0184.md`）

🤖 Generated with [Claude Code](https://claude.com/code)