### PR TITLE
[0185] Chat 侧边栏欢迎内容居中偏上调整

### DIFF
--- a/devel/0185.md
+++ b/devel/0185.md
@@ -68,8 +68,8 @@ xmake r qt_chat_tab_widget_test
 
 具体修改：
 1. 将 `contentLayout` 顶部固定偏移（240px）改为 0，消除硬编码偏移。
-2. 在 `topPanel` 内部添加顶部和底部弹性空间（`QSpacerItem`，stretch 比例 2:1），利用 Qt 布局的自适应能力将内容推到中心偏上。
-3. 进入会话模式时，将内部弹性空间收缩为 0，避免挤压消息区域。
+2. 重写 `ChatConversationPanel::resizeEvent()`，在欢迎模式下根据面板高度动态计算顶部 spacer 高度，使内容位于容器高度的 2/7 处（中心稍稍偏上）。
+3. 进入会话模式时，顶部 spacer 恢复为固定小偏移（8px），不影响消息区域展开。
 
 ## Why
 
@@ -90,23 +90,19 @@ contentLayout: [topSpacer_ 240px Fixed] -> [topPanel stretch 1, AlignTop]
 
 新方案（欢迎模式）：
 ```
-contentLayout: [topSpacer_ 0px Fixed] -> [topPanel stretch 1, AlignTop]
-topLayout:     [topInnerSpacer_ Expanding stretch 2]
-               -> [welcomeTitle_]
+contentLayout: [topSpacer_ height*2/7 Fixed] -> [topPanel stretch 1, AlignTop]
+topLayout:     [welcomeTitle_]
                -> [sessionTitle_]
                -> [messageFrame_ hidden]
                -> [inputWrap]
-               -> [bottomInnerSpacer_ Expanding stretch 1]
 ```
 
 新方案（会话模式）：
 ```
 contentLayout: [topSpacer_ 8px Fixed] -> [topPanel stretch 1, AlignTop]
-topLayout:     [topInnerSpacer_ 0px Fixed]
-               -> [sessionTitle_]
+topLayout:     [sessionTitle_]
                -> [messageFrame_ stretch 1 visible]
                -> [inputWrap]
-               -> [bottomInnerSpacer_ 0px Fixed]
 ```
 
-`topInnerSpacer_` 和 `bottomInnerSpacer_` 在欢迎模式下为 `Expanding`，stretch 比例 2:1，使内容中心位于面板高度的 1/3 处（中心偏上）。进入会话模式后，二者收缩为 `Fixed(0,0)`，不影响消息区域展开。
+`resizeEvent` 中按 `height() * 2 / 7 - kContentMarginY` 计算顶部 spacer 高度，确保内容始终位于容器高度的 2/7 处（中心稍稍偏上）。窗口大小变化时自动重新计算，无需内部弹性空间。进入会话模式后，`topSpacer_` 收缩为固定小偏移，不影响消息区域展开。

--- a/devel/0185.md
+++ b/devel/0185.md
@@ -1,0 +1,112 @@
+# [0185] Chat 侧边栏欢迎内容居中偏上调整
+
+## 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+
+编译并运行 Chat Tab Widget 单元测试：
+
+```bash
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
+
+预期结果：全部通过。
+
+### 非确定性测试（UI 验证）
+
+#### A. Chat 标签页欢迎页位置
+
+1. 切换到 Chat 标签页（确保没有活跃会话，显示欢迎页）
+2. 观察："欢迎使用 Liii STEM" 和输入框应位于整个软件界面的竖直方向中心稍稍偏上
+3. 调整窗口高度（放大/缩小）
+4. 观察：欢迎内容应随窗口高度自适应，始终保持中心偏上
+
+#### B. Chat 侧边栏（dock 模式）欢迎页位置
+
+1. 打开一个 TMU 文档或 PDF 文档
+2. 点击右上角 AI 对话浮动按钮，打开右侧 dock
+3. 确保 dock 中显示的是欢迎页（无活跃会话或新建空白会话）
+4. 观察："欢迎使用 Liii STEM" 和输入框应位于整个软件界面的竖直方向中心稍稍偏上
+5. 调整主窗口高度
+6. 观察：欢迎内容应随窗口高度自适应，始终保持中心偏上
+
+#### C. 会话模式不受影响
+
+1. 在 Chat 标签页或 dock 中发送一条消息
+2. 观察：消息区域应贴顶显示（仅有少量顶部偏移），输入框在底部
+3. 观察：不应出现大片空白区域挤压消息区
+
+## 如何提交
+
+提交前编译项目：
+
+```bash
+xmake b stem
+```
+
+提交前运行单元测试：
+
+```bash
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
+
+## What
+
+调整 `ChatConversationPanel` 欢迎模式的竖直布局策略，使其在 Chat 标签页和 Chat 侧边栏（dock）模式下都能将"欢迎使用 Liii STEM"和输入框置于整个软件界面的中心偏上位置。
+
+具体修改：
+1. 将 `contentLayout` 顶部固定偏移（240px）改为 0，消除硬编码偏移。
+2. 在 `topPanel` 内部添加顶部和底部弹性空间（`QSpacerItem`，stretch 比例 2:1），利用 Qt 布局的自适应能力将内容推到中心偏上。
+3. 进入会话模式时，将内部弹性空间收缩为 0，避免挤压消息区域。
+
+## Why
+
+当前实现使用固定的 240px 顶部 spacer（`kWelcomeTopOffsetY`）：
+- 在 Chat 标签页模式下，由于标签页容器高度相对较小，240px 偏移使内容看起来偏上。
+- 在 Chat 侧边栏（dock）模式下，dock 高度通常等于主窗口高度，240px 偏移不足以将内容推到偏上位置，导致内容落在 dock 的竖直方向中心，与 Chat 标签页的视觉效果不一致。
+
+用户期望两种模式下的欢迎页具有统一的视觉位置：整个软件界面的中心稍稍偏上。
+
+## How
+
+### 布局策略调整
+
+原方案：
+```
+contentLayout: [topSpacer_ 240px Fixed] -> [topPanel stretch 1, AlignTop]
+```
+
+新方案（欢迎模式）：
+```
+contentLayout: [topSpacer_ 0px Fixed] -> [topPanel stretch 1, AlignTop]
+topLayout:     [topInnerSpacer_ Expanding stretch 2]
+               -> [welcomeTitle_]
+               -> [sessionTitle_]
+               -> [messageFrame_ hidden]
+               -> [inputWrap]
+               -> [bottomInnerSpacer_ Expanding stretch 1]
+```
+
+新方案（会话模式）：
+```
+contentLayout: [topSpacer_ 8px Fixed] -> [topPanel stretch 1, AlignTop]
+topLayout:     [topInnerSpacer_ 0px Fixed]
+               -> [sessionTitle_]
+               -> [messageFrame_ stretch 1 visible]
+               -> [inputWrap]
+               -> [bottomInnerSpacer_ 0px Fixed]
+```
+
+`topInnerSpacer_` 和 `bottomInnerSpacer_` 在欢迎模式下为 `Expanding`，stretch 比例 2:1，使内容中心位于面板高度的 1/3 处（中心偏上）。进入会话模式后，二者收缩为 `Fixed(0,0)`，不影响消息区域展开。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -137,14 +137,20 @@ ChatConversationPanel::setup_ui () {
   contentLayout->setContentsMargins (0, DpiUtils::scaled (kContentMarginY), 0,
                                      DpiUtils::scaled (kContentMarginY));
   contentLayout->setSpacing (DpiUtils::scaled (kContentSpacing));
-  topSpacer_= new QSpacerItem (0, DpiUtils::scaled (kWelcomeTopOffsetY),
-                               QSizePolicy::Minimum, QSizePolicy::Fixed);
+  topSpacer_= new QSpacerItem (0, 0, QSizePolicy::Minimum, QSizePolicy::Fixed);
   contentLayout->addSpacerItem (topSpacer_);
 
   QWidget*     topPanel = new QWidget (this);
   QVBoxLayout* topLayout= new QVBoxLayout (topPanel);
   topLayout->setContentsMargins (0, 0, 0, 0);
   topLayout->setSpacing (DpiUtils::scaled (kContentSpacing));
+
+  // 顶部弹性空间（欢迎模式下将内容推到中心偏上）
+  topInnerSpacer_= new QSpacerItem (0, 0, QSizePolicy::Minimum,
+                                    QSizePolicy::Expanding);
+  int topInnerIdx= topLayout->count ();
+  topLayout->addSpacerItem (topInnerSpacer_);
+  topLayout->setStretch (topInnerIdx, 2);
 
   // Welcome title
   welcomeTitle_= new QLabel (qt_translate ("Welcome to Liii STEM!"), topPanel);
@@ -308,6 +314,13 @@ ChatConversationPanel::setup_ui () {
   inputWrap->addStretch (1);
   topLayout->addLayout (inputWrap, 0);
 
+  // 底部弹性空间（欢迎模式下与顶部弹性空间配合，将内容推到中心偏上）
+  bottomInnerSpacer_= new QSpacerItem (0, 0, QSizePolicy::Minimum,
+                                       QSizePolicy::Expanding);
+  int bottomInnerIdx= topLayout->count ();
+  topLayout->addSpacerItem (bottomInnerSpacer_);
+  topLayout->setStretch (bottomInnerIdx, 1);
+
   contentLayout->addWidget (topPanel, 1, Qt::AlignTop);
 }
 
@@ -315,9 +328,8 @@ void
 ChatConversationPanel::enterConversationMode () {
   if (conversationMode_) return;
 
-  conversationMode_    = true;
-  const int startOffset= DpiUtils::scaled (kWelcomeTopOffsetY);
-  const int endOffset  = DpiUtils::scaled (kConversationTopOffsetY);
+  conversationMode_  = true;
+  const int endOffset= DpiUtils::scaled (kConversationTopOffsetY);
 
   if (messageFrame_) {
     QGraphicsOpacityEffect* messageEffect=
@@ -356,6 +368,20 @@ ChatConversationPanel::enterConversationMode () {
                             QSizePolicy::Fixed);
     layout ()->invalidate ();
     layout ()->activate ();
+  }
+
+  if (topInnerSpacer_) {
+    topInnerSpacer_->changeSize (0, 0, QSizePolicy::Minimum,
+                                 QSizePolicy::Fixed);
+  }
+  if (bottomInnerSpacer_) {
+    bottomInnerSpacer_->changeSize (0, 0, QSizePolicy::Minimum,
+                                    QSizePolicy::Fixed);
+  }
+  if (welcomeTitle_ && welcomeTitle_->parentWidget () &&
+      welcomeTitle_->parentWidget ()->layout ()) {
+    welcomeTitle_->parentWidget ()->layout ()->invalidate ();
+    welcomeTitle_->parentWidget ()->layout ()->activate ();
   }
 }
 

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -146,11 +146,12 @@ ChatConversationPanel::setup_ui () {
   topLayout->setSpacing (DpiUtils::scaled (kContentSpacing));
 
   // 顶部弹性空间（欢迎模式下将内容推到中心偏上）
-  topInnerSpacer_= new QSpacerItem (0, 0, QSizePolicy::Minimum,
+  topInnerSpacer_= new QSpacerItem (0, DpiUtils::scaled (120),
+                                    QSizePolicy::Minimum,
                                     QSizePolicy::Expanding);
   int topInnerIdx= topLayout->count ();
   topLayout->addSpacerItem (topInnerSpacer_);
-  topLayout->setStretch (topInnerIdx, 2);
+  topLayout->setStretch (topInnerIdx, 1);
 
   // Welcome title
   welcomeTitle_= new QLabel (qt_translate ("Welcome to Liii STEM!"), topPanel);

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -361,7 +361,7 @@ void
 ChatConversationPanel::resizeEvent (QResizeEvent* event) {
   QWidget::resizeEvent (event);
   if (conversationMode_ || !topSpacer_) return;
-  int targetOffset= height () * 2 / 5 - DpiUtils::scaled (kContentMarginY);
+  int targetOffset= height () * 2 / 7 - DpiUtils::scaled (kContentMarginY);
   if (targetOffset < 0) targetOffset= 0;
   topSpacer_->changeSize (0, targetOffset, QSizePolicy::Minimum,
                             QSizePolicy::Fixed);

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -145,14 +145,6 @@ ChatConversationPanel::setup_ui () {
   topLayout->setContentsMargins (0, 0, 0, 0);
   topLayout->setSpacing (DpiUtils::scaled (kContentSpacing));
 
-  // 顶部弹性空间（欢迎模式下将内容推到中心偏上）
-  topInnerSpacer_= new QSpacerItem (0, DpiUtils::scaled (120),
-                                    QSizePolicy::Minimum,
-                                    QSizePolicy::Expanding);
-  int topInnerIdx= topLayout->count ();
-  topLayout->addSpacerItem (topInnerSpacer_);
-  topLayout->setStretch (topInnerIdx, 1);
-
   // Welcome title
   welcomeTitle_= new QLabel (qt_translate ("Welcome to Liii STEM!"), topPanel);
   welcomeTitle_->setObjectName ("chat-tab-welcome-title");
@@ -315,13 +307,6 @@ ChatConversationPanel::setup_ui () {
   inputWrap->addStretch (1);
   topLayout->addLayout (inputWrap, 0);
 
-  // 底部弹性空间（欢迎模式下与顶部弹性空间配合，将内容推到中心偏上）
-  bottomInnerSpacer_= new QSpacerItem (0, 0, QSizePolicy::Minimum,
-                                       QSizePolicy::Expanding);
-  int bottomInnerIdx= topLayout->count ();
-  topLayout->addSpacerItem (bottomInnerSpacer_);
-  topLayout->setStretch (bottomInnerIdx, 1);
-
   contentLayout->addWidget (topPanel, 1, Qt::AlignTop);
 }
 
@@ -370,19 +355,19 @@ ChatConversationPanel::enterConversationMode () {
     layout ()->invalidate ();
     layout ()->activate ();
   }
+}
 
-  if (topInnerSpacer_) {
-    topInnerSpacer_->changeSize (0, 0, QSizePolicy::Minimum,
-                                 QSizePolicy::Fixed);
-  }
-  if (bottomInnerSpacer_) {
-    bottomInnerSpacer_->changeSize (0, 0, QSizePolicy::Minimum,
-                                    QSizePolicy::Fixed);
-  }
-  if (welcomeTitle_ && welcomeTitle_->parentWidget () &&
-      welcomeTitle_->parentWidget ()->layout ()) {
-    welcomeTitle_->parentWidget ()->layout ()->invalidate ();
-    welcomeTitle_->parentWidget ()->layout ()->activate ();
+void
+ChatConversationPanel::resizeEvent (QResizeEvent* event) {
+  QWidget::resizeEvent (event);
+  if (conversationMode_ || !topSpacer_) return;
+  int targetOffset= height () * 2 / 5 - DpiUtils::scaled (kContentMarginY);
+  if (targetOffset < 0) targetOffset= 0;
+  topSpacer_->changeSize (0, targetOffset, QSizePolicy::Minimum,
+                            QSizePolicy::Fixed);
+  if (layout ()) {
+    layout ()->invalidate ();
+    layout ()->activate ();
   }
 }
 

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -364,7 +364,7 @@ ChatConversationPanel::resizeEvent (QResizeEvent* event) {
   int targetOffset= height () * 2 / 7 - DpiUtils::scaled (kContentMarginY);
   if (targetOffset < 0) targetOffset= 0;
   topSpacer_->changeSize (0, targetOffset, QSizePolicy::Minimum,
-                            QSizePolicy::Fixed);
+                          QSizePolicy::Fixed);
   if (layout ()) {
     layout ()->invalidate ();
     layout ()->activate ();

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -133,6 +133,8 @@ private:
   QPushButton* sendButton_       = nullptr;        ///< 发送/停止按钮
   QToolButton* thinkingButton_   = nullptr;        ///< 推理模式开关
   QSpacerItem* topSpacer_        = nullptr;        ///< 欢迎页顶部弹性空间
+  QSpacerItem* topInnerSpacer_   = nullptr;        ///< topPanel 内顶部弹性空间
+  QSpacerItem* bottomInnerSpacer_= nullptr;        ///< topPanel 内底部弹性空间
   widget       messageWidget_;                     ///< 消息区 TeXmacs widget
   widget       inputWidget;                        ///< 输入区 TeXmacs widget
   int          fixedFrameExtra_           = 0;     ///< 输入框额外高度（边框等）

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -114,6 +114,8 @@ signals:
 protected:
   /// 事件过滤器：拦截 Enter 键触发发送
   bool eventFilter (QObject* watched, QEvent* event) override;
+  /// 欢迎模式下按容器高度比例调整顶部偏移
+  void resizeEvent (QResizeEvent* event) override;
 
 private:
   /// 构建面板 UI 布局
@@ -133,8 +135,6 @@ private:
   QPushButton* sendButton_       = nullptr;        ///< 发送/停止按钮
   QToolButton* thinkingButton_   = nullptr;        ///< 推理模式开关
   QSpacerItem* topSpacer_        = nullptr;        ///< 欢迎页顶部弹性空间
-  QSpacerItem* topInnerSpacer_   = nullptr;        ///< topPanel 内顶部弹性空间
-  QSpacerItem* bottomInnerSpacer_= nullptr;        ///< topPanel 内底部弹性空间
   widget       messageWidget_;                     ///< 消息区 TeXmacs widget
   widget       inputWidget;                        ///< 输入区 TeXmacs widget
   int          fixedFrameExtra_           = 0;     ///< 输入框额外高度（边框等）

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -8,8 +8,8 @@
 #include "Qt/qt_chat_tab_widget.hpp"
 #include "Qt/qt_utilities.hpp"
 #include "base.hpp"
-#include <QLabel>
 #include <QInputMethodEvent>
+#include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
 #include <QMouseEvent>

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -8,6 +8,7 @@
 #include "Qt/qt_chat_tab_widget.hpp"
 #include "Qt/qt_utilities.hpp"
 #include "base.hpp"
+#include <QLabel>
 #include <QInputMethodEvent>
 #include <QLineEdit>
 #include <QMenu>
@@ -15,6 +16,7 @@
 #include <QPushButton>
 #include <QSignalSpy>
 #include <QWheelEvent>
+#include <QWidget>
 #include <QtTest/QtTest>
 
 using namespace moebius;


### PR DESCRIPTION
## 修改内容

- 调整 `ChatConversationPanel` 欢迎模式的竖直布局策略，使其在 Chat 标签页和 Chat 侧边栏（dock）模式下都能将"欢迎使用 Liii STEM"和输入框置于容器中心偏上位置。
- 将 `resizeEvent` 中计算顶部偏移的比例从 `2/5` 调整为 `2/7`。

## 实现方式

- 重写 `ChatConversationPanel::resizeEvent()`，在欢迎模式下根据面板高度动态计算顶部 spacer 高度，使内容位于容器高度的 2/7 处。
- 窗口大小变化时自动重新计算，无需内部弹性空间。
- 进入会话模式后，`topSpacer_` 收缩为固定小偏移，不影响消息区域展开。

## 测试

- 单元测试 `qt_chat_tab_widget_test` 82/82 全部通过。
- 编译 `xmake b stem` 通过。

🤖 Generated with [Claude Code](https://claude.com/code)