### PR TITLE
[1059] Dock 模式对话区域新增新建会话按钮

### DIFF
--- a/devel/1059.md
+++ b/devel/1059.md
@@ -1,0 +1,41 @@
+# [1059] Dock 模式对话区域新增新建会话按钮
+
+## 1 相关文档
+- [1059.md](1059.md) - 本任务文档
+
+## 2 任务相关的代码文件
+- src/Plugins/Qt/qt_chat_tab_widget.cpp
+- src/Plugins/Qt/qt_chat_tab_widget.hpp
+
+## 3 如何测试
+
+### 3.1 确定性测试
+无单元测试，需手动验证。
+
+### 3.2 非确定性测试（文档验证）
+```
+xmake b stem
+```
+启动 Mogan，在 dock 模式下打开 Chat 面板，确认关闭侧边栏按钮右侧显示新建会话按钮，点击可新建会话。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+在 dock 模式的对话区域左上角（关闭侧边栏按钮右侧）新增一个新建会话按钮。
+
+1. 新增 `newChatSidebarBtn_` 成员变量，与原有侧边栏的 `newChatButton_` 分离
+2. 在 `setup_right_content` 中创建按钮，使用 `make_sidebar_toggle_btn` 样式，图标为 `addchat.svg`
+3. 点击按钮 emit `newChatRequested` 信号，触发新建会话
+4. 按钮显隐与 `closeSidebarBtn_` 同步（由 `setCloseSidebarButtonVisible` 控制）
+
+## 6 Why
+Dock 模式下侧边栏可能被关闭，用户无法通过侧边栏的 "New chat" 按钮新建会话。需要在对话区域提供一个便捷的新建会话入口。
+
+## 7 How
+复用 `make_sidebar_toggle_btn` 工厂函数创建按钮，保证与关闭侧边栏按钮样式一致（`chat-tab-collapse-btn` CSS）。按钮定位在 `closeSidebarBtn_` 右侧（X 偏移 `kToggleBtnSize + kFloatingBtnSpacing`），Y 坐标相同。信号直接 emit `newChatRequested`，由已有的控制器连接处理。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -1297,8 +1297,8 @@ QTChatTabWidget::QTChatTabWidget (const QList<SessionDisplayInfo>& sessions,
     : QWidget (parent), sidebarWidget_ (nullptr), contentWidget_ (nullptr),
       collapseButton_ (nullptr), floatingExpandBtn_ (nullptr),
       floatingNewChatBtn_ (nullptr), floatingBtnContainer_ (nullptr),
-      newChatButton_ (nullptr), sidebarNormalContent_ (nullptr),
-      conversationStack_ (nullptr) {
+      newChatButton_ (nullptr), newChatSidebarBtn_ (nullptr),
+      sidebarNormalContent_ (nullptr), conversationStack_ (nullptr) {
   setFocusPolicy (Qt::StrongFocus);
 
   QHBoxLayout* mainLayout= new QHBoxLayout (this);
@@ -1496,6 +1496,17 @@ QTChatTabWidget::setup_right_content (QHBoxLayout* mainLayout) {
            [this] () { emit closeSidebarRequested (); });
   closeSidebarBtn_->hide ();
 
+  // 对话区域新建会话按钮（dock 模式使用，位于关闭侧边栏按钮右侧）
+  newChatSidebarBtn_= make_sidebar_toggle_btn (content);
+  newChatSidebarBtn_->setIcon (QIcon (":llm-chat/addchat.svg"));
+  newChatSidebarBtn_->move (DpiUtils::scaled (kFloatingBtnMarginX +
+                                              kToggleBtnSize +
+                                              kFloatingBtnSpacing),
+                            DpiUtils::scaled (kCloseSidebarBtnMarginY));
+  connect (newChatSidebarBtn_, &QPushButton::clicked, this,
+           [this] () { emit newChatRequested (); });
+  newChatSidebarBtn_->hide ();
+
   // 浮球按钮容器
   QWidget* floatingContainer= new QWidget (this);
   floatingContainer->setObjectName ("chat-tab-floating-container");
@@ -1589,6 +1600,7 @@ QTChatTabWidget::setSidebarVisible (bool visible) {
 void
 QTChatTabWidget::setCloseSidebarButtonVisible (bool visible) {
   if (closeSidebarBtn_) closeSidebarBtn_->setVisible (visible);
+  if (newChatSidebarBtn_) newChatSidebarBtn_->setVisible (visible);
 }
 
 bool

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -410,6 +410,7 @@ private:
   QPushButton*    floatingNewChatBtn_  = nullptr; ///< 浮动新建按钮
   QWidget*        floatingBtnContainer_= nullptr; ///< 浮动按钮容器
   QPushButton*    newChatButton_       = nullptr; ///< 侧边栏新建按钮
+  QPushButton*    newChatSidebarBtn_   = nullptr; ///< 新建按钮（dock 模式）
   QPushButton*    closeSidebarBtn_     = nullptr; ///< 对话区域关闭侧边栏按钮
   QWidget*        sidebarNormalContent_= nullptr; ///< 侧边栏常规内容区
   QStackedWidget* conversationStack_   = nullptr; ///< 会话面板堆栈


### PR DESCRIPTION
## What

在 dock 模式的对话区域左上角（关闭侧边栏按钮右侧）新增一个新建会话按钮。

## Changes

- 新增 `newChatSidebarBtn_` 成员变量，与原有侧边栏的 `newChatButton_` 分离
- 在 `setup_right_content` 中创建按钮，使用 `chat-tab-collapse-btn` 样式，图标为 `addchat.svg`
- 点击按钮 emit `newChatRequested` 信号，触发新建会话
- 按钮显隐与 `closeSidebarBtn_` 同步

## Why

Dock 模式下侧边栏可能被关闭，用户无法通过侧边栏的 "New chat" 按钮新建会话。需要在对话区域提供便捷的新建会话入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)