### PR TITLE
[1062] 聊天输入框下方添加 AI 免责提示

### DIFF
--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -1427,6 +1427,12 @@ QWidget#centralWidget QAbstractScrollArea#chat-tab-input-area QScrollBar::handle
   background: #808080;
 }
 
+/* AI 免责提示 */
+QLabel#chat-tab-disclaimer,
+QWidget#centralWidget QLabel#chat-tab-disclaimer {
+  color: rgba(255, 255, 255, 102);
+}
+
 /* 输入框框架 */
 QWidget#chat-tab-input-frame,
 QWidget#centralWidget QWidget#chat-tab-input-frame {

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -1343,6 +1343,11 @@ QAbstractScrollArea#chat-tab-input-area QScrollBar::handle:vertical:hover {
   background: #a0a0a0;
 }
 
+/* AI 免责提示 */
+QLabel#chat-tab-disclaimer {
+  color: rgba(0, 0, 0, 102);
+}
+
 /* 输入框框架 */
 QWidget#chat-tab-input-frame {
   background-color: #ffffff;

--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -3,6 +3,7 @@
 ("1.5 line spacing" "1.5 倍行距")
 ("Upgrade VIP" "升级会员")
 ("Upgrade to unlock AI writing, MathOCR, and more advanced features." "开通会员，立即解锁 AI 写作、MathOCR 等高阶功能。")
+("AI-generated content may be inaccurate. Please verify carefully." "内容由 AI 生成，请仔细甄别。")
 ("All" "全部")
 ("Advanced footer" "高级页脚")
 ("Advanced header" "高级页眉")

--- a/devel/1062.md
+++ b/devel/1062.md
@@ -1,0 +1,42 @@
+# [1062] 聊天输入框下方添加 AI 免责提示
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- src/Plugins/Qt/qt_chat_tab_widget.cpp
+- TeXmacs/misc/themes/liii.css
+- TeXmacs/misc/themes/liii-night.css
+- TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+
+## 3 如何测试
+
+### 3.1 确定性测试
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+打开聊天面板，确认输入框下方显示半透明的"内容由 AI 生成，请仔细甄别。"提示文字，分别在亮色和暗色主题下验证颜色显示正常。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+在聊天输入框（inputFrame）下方添加一行带透明度的 AI 免责提示文字。
+
+1. 在 ChatConversationPanel::setup_ui() 中添加 QLabel#chat-tab-disclaimer
+2. 在 liii.css（亮色主题）中设置 rgba(0,0,0,102) 颜色
+3. 在 liii-night.css（暗色主题）中设置 rgba(255,255,255,102) 颜色
+4. 在 zh_CN.scm 中添加中文翻译条目
+
+## 6 Why
+AI 生成的内容可能存在不准确之处，需要在界面中明确提示用户注意甄别。
+
+## 7 How
+在 inputFrame 之后、inputWrap 之前插入一个居中的 QLabel，字体 11px，颜色通过 CSS 主题文件分别控制亮色/暗色下的透明度，文字通过 qt_translate 支持国际化。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -307,6 +307,16 @@ ChatConversationPanel::setup_ui () {
 
   inputAreaLayout->addWidget (inputFrame, 0);
 
+  // AI disclaimer label
+  QLabel* disclaimerLabel=
+      new QLabel (qt_translate ("AI-generated content may be inaccurate. "
+                                "Please verify carefully."),
+                  inputArea);
+  disclaimerLabel->setObjectName ("chat-tab-disclaimer");
+  disclaimerLabel->setAlignment (Qt::AlignCenter);
+  DpiUtils::applyScaledFont (disclaimerLabel, 11);
+  inputAreaLayout->addWidget (disclaimerLabel, 0);
+
   QHBoxLayout* inputWrap= new QHBoxLayout ();
   inputWrap->addStretch (1);
   inputWrap->addWidget (inputArea, 8);


### PR DESCRIPTION
在聊天输入框下方添加一行带透明度的 AI 免责提示文字"内容由 AI 生成，请仔细甄别。"。

### 改动文件
- `src/Plugins/Qt/qt_chat_tab_widget.cpp` — 添加 QLabel#chat-tab-disclaimer
- `TeXmacs/misc/themes/liii.css` — 亮色主题颜色
- `TeXmacs/misc/themes/liii-night.css` — 暗色主题颜色
- `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` — 中文翻译

🤖 Generated with [Claude Code](https://claude.com/claude-code)