### PR TITLE
[1061] 修复 chat 思考按钮点击后图标不立即切换的问题

### DIFF
--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -1449,17 +1449,11 @@ QWidget#centralWidget QToolButton#chat-tab-thinking-btn {
   background: transparent;
   qproperty-iconNormal: url(":/llm-chat/thinking-white.svg");
   qproperty-iconChecked: url(":/llm-chat/thinking.svg");
-  qproperty-iconHovered: url(":/llm-chat/thinking-white.svg");
 }
 QToolButton#chat-tab-thinking-btn:checked,
 QWidget#centralWidget QToolButton#chat-tab-thinking-btn:checked {
   background: #ffffff;
   color: #215a6a;
-}
-QToolButton#chat-tab-thinking-btn:hover,
-QWidget#centralWidget QToolButton#chat-tab-thinking-btn:hover {
-  background: rgba(255,255,255,0.15);
-  color: #ffffff;
 }
 
 /* 发送按钮 */

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -1362,15 +1362,10 @@ QToolButton#chat-tab-thinking-btn {
   background: transparent;
   qproperty-iconNormal: url(":/llm-chat/thinking.svg");
   qproperty-iconChecked: url(":/llm-chat/thinking-white.svg");
-  qproperty-iconHovered: url(":/llm-chat/thinking.svg");
 }
 QToolButton#chat-tab-thinking-btn:checked {
   background: #215a6a;
   color: #ffffff;
-}
-QToolButton#chat-tab-thinking-btn:hover {
-  background: rgba(33,90,106,0.15);
-  color: #215a6a;
 }
 
 /* 发送按钮 */

--- a/devel/1061.md
+++ b/devel/1061.md
@@ -1,0 +1,47 @@
+# [1061] 修复 chat 思考按钮点击后图标不立即切换的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/QTMStateToolButton.hpp`
+- `TeXmacs/misc/themes/liii.css`
+- `TeXmacs/misc/themes/liii-night.css`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+本项目无相关单元测试。
+
+### 3.2 非确定性测试（文档验证）
+1. 编译并运行 stem：`xmake b stem && xmake r stem`
+2. 打开 LLM Chat 面板
+3. 将鼠标悬停在输入框左下角的「Deep Reasoning」思考按钮上
+4. 点击按钮，观察图标是否立即从 thinking.svg 切换为 thinking-white.svg（或深色主题下的反向切换）
+5. 保持鼠标悬停在按钮上，确认图标已切换且背景色/文字颜色同步变化
+6. 再次点击取消选中，确认图标立即恢复
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+修复 chat 面板中思考按钮（`chat-tab-thinking-btn`）在点击后图标不立即切换的问题。
+
+1. 重构 `QTMStateToolButton` 的图标状态切换机制，从 `checkStateSet()` 移至 `toggled` 信号槽，使用 `Qt::DirectConnection` 确保状态稳定后执行
+2. 移除 `checkStateSet()` 重载，避免 Qt 内部状态同步时机导致的图标更新失效
+3. 清理 `liii.css` 和 `liii-night.css` 中思考按钮的 `:hover` 样式和 `qproperty-iconHovered`，消除 hover 状态对 checked 图标显示的干扰
+
+## 6 Why
+`QTMStateToolButton` 原本在 `checkStateSet()` 中调用 `reloadIcon()` 来根据 `isChecked()` 切换图标。但在 Qt6 中，`checkStateSet()` 被调用时，`setIcon()` 之后的状态同步与样式表绘制路径存在微妙的时序问题，导致点击后图标不会立即更新，需要等待鼠标移出/移入（触发 `Enter`/`Leave` 事件）才能刷新。
+
+同时，CSS 中为思考按钮定义了 `:hover` 背景色和 `qproperty-iconHovered`，这在鼠标悬停时会引入额外的绘制状态，与 checked 状态的图标切换产生视觉冲突。
+
+## 7 How
+- **图标切换时序修复**：不再依赖 `checkStateSet()` 虚函数，而是在构造函数中将 `toggled` 信号直接连接到 `reloadIcon()` 私有方法，并使用 `Qt::DirectConnection`。`toggled` 在 `setChecked()` 完全走完后发射，此时 `isChecked()` 和内部绘制状态都已稳定，`reloadIcon()` 中的状态判断和 `setIcon()` 调用能够正确生效。
+- **保留悬停支持**：`Enter`/`Leave` 事件仍触发 `reloadIcon()`，确保鼠标移入移出时的图标更新（若未来需要 `iconHovered` 仍可正常工作）。
+- **CSS 清理**：移除 `liii.css` 和 `liii-night.css` 中思考按钮的 `:hover` 规则（背景色和文字颜色变化）以及 `qproperty-iconHovered`，简化状态矩阵，让按钮在悬停时保持与 normal 状态一致的图标，仅在 checked 时切换图标和反色背景。

--- a/src/Plugins/Qt/QTMStateToolButton.hpp
+++ b/src/Plugins/Qt/QTMStateToolButton.hpp
@@ -22,7 +22,12 @@ class QTMStateToolButton : public QToolButton {
   Q_PROPERTY (QIcon iconHovered READ iconHovered WRITE setIconHovered FINAL)
 public:
   explicit QTMStateToolButton (QWidget* parent= nullptr)
-      : QToolButton (parent) {}
+      : QToolButton (parent) {
+    // toggled 在 setChecked() 完全结束后发射，此时 isChecked() 已稳定，
+    // 比 checkStateSet() 更可靠地触发图标切换。
+    connect (this, &QTMStateToolButton::toggled, this,
+             &QTMStateToolButton::reloadIcon, Qt::DirectConnection);
+  }
 
   QIcon iconNormal () const { return iconNormal_; }
   void  setIconNormal (const QIcon& icon) {
@@ -43,11 +48,6 @@ public:
   }
 
 protected:
-  void checkStateSet () override {
-    QToolButton::checkStateSet ();
-    reloadIcon ();
-  }
-
   bool event (QEvent* event) override {
     if (event->type () == QEvent::Enter || event->type () == QEvent::Leave) {
       reloadIcon ();


### PR DESCRIPTION
## What
修复 chat 面板中思考按钮（chat-tab-thinking-btn）在点击后图标不立即切换的问题。

## 修改内容
1. 重构 QTMStateToolButton 图标状态切换机制，从 checkStateSet() 移至 toggled 信号槽（Qt::DirectConnection），避免 Qt 内部状态同步时序问题
2. 清理 liii.css 和 liii-night.css 中思考按钮的 :hover 样式和 qproperty-iconHovered，消除 hover 对 checked 图标显示的干扰

## 测试
- 编译通过：xmake b stem
- 手动测试：点击思考按钮，图标立即随 checked 状态切换

相关文档：devel/1061.md