### PR TITLE
[1063] 优化 Chat 面板右侧内容区间距与深色主题背景

### DIFF
--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -1326,10 +1326,23 @@ QWidget#centralWidget QWidget#chat-tab-archive-list {
 
 /* 右侧内容区 */
 QWidget#chat-tab-content,
+QWidget#chat-tab-conversation-stack,
 QWidget#chat-tab-conversation-page,
+QWidget#chat-tab-top-panel,
+QWidget#chat-tab-input-area-wrap,
 QWidget#centralWidget QWidget#chat-tab-content,
-QWidget#centralWidget QWidget#chat-tab-conversation-page {
-  background-color: #202020;
+QWidget#centralWidget QWidget#chat-tab-conversation-stack,
+QWidget#centralWidget QWidget#chat-tab-conversation-page,
+QWidget#centralWidget QWidget#chat-tab-top-panel,
+QWidget#centralWidget QWidget#chat-tab-input-area-wrap {
+  background-color: #404040;
+}
+
+/* 欢迎标题 */
+QLabel#chat-tab-welcome-title,
+QWidget#centralWidget QLabel#chat-tab-welcome-title {
+  color: #ffffff;
+  background-color: #404040;
 }
 
 /* 导航标题 */
@@ -1407,7 +1420,7 @@ QWidget#centralWidget QPushButton#chat-tab-floating-new-btn:hover {
 QLabel#chat-tab-model-label,
 QWidget#centralWidget QLabel#chat-tab-model-label {
   color: #ffffff;
-  background-color: transparent;
+  background-color: #404040;
 }
 
 /* 消息框 */
@@ -1431,6 +1444,7 @@ QWidget#centralWidget QAbstractScrollArea#chat-tab-input-area QScrollBar::handle
 QLabel#chat-tab-disclaimer,
 QWidget#centralWidget QLabel#chat-tab-disclaimer {
   color: rgba(255, 255, 255, 102);
+  background-color: #404040;
 }
 
 /* 输入框框架 */

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -1251,7 +1251,10 @@ QWidget#chat-tab-archive-list {
 
 /* 右侧内容区 */
 QWidget#chat-tab-content,
-QWidget#chat-tab-conversation-page {
+QWidget#chat-tab-conversation-stack,
+QWidget#chat-tab-conversation-page,
+QWidget#chat-tab-top-panel,
+QWidget#chat-tab-input-area-wrap {
   background-color: #ffffff;
 }
 

--- a/devel/1063.md
+++ b/devel/1063.md
@@ -1,0 +1,50 @@
+# [1063] 优化 Chat 面板右侧内容区间距与深色主题背景
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+- `TeXmacs/misc/themes/liii.css`
+- `TeXmacs/misc/themes/liii-night.css`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+本项目无相关单元测试。
+
+### 3.2 非确定性测试（文档验证）
+1. 编译并运行 stem：`xmake b stem && xmake r stem`
+2. 打开 LLM Chat 面板
+3. 验证 Welcome 页面：标题、输入框、disclaimer 之间的间距合理，无过大留白
+4. 发送一条消息进入对话模式，验证消息区和输入框之间间距紧凑
+5. 切换到深色主题（liii-night），验证右侧内容区所有区域背景色一致，无纯黑断层
+6. 在 dock 模式下重复上述验证
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+```
+
+## 5 What
+优化 Chat 面板右侧内容区的布局间距和深色主题下的背景色一致性。
+
+1. 减小内容区 widget 间距（`kContentSpacing` 从 16px 改为 8px）
+2. 减小内容区底部 margin（从 24px 改为 8px）
+3. `topLayout` spacing 设为 0，改为在 session title 和 message area 之间手动加 8px spacing
+4. 为中间层 widget（`topPanel`、`inputArea`）添加 objectName，以便 CSS 选择器能覆盖
+5. 补全深色主题（liii-night.css）中右侧内容区所有层级的背景色，消除纯黑断层
+6. 补全欢迎标题、模型标签、AI 免责提示在深色主题中的背景色
+
+## 6 Why
+Chat 面板右侧内容区存在两个视觉问题：
+1. **间距过大**：message area 和 input area 之间、disclaimer 下方等位置有明显的留白，影响界面紧凑感
+2. **深色主题背景不一致**：`chat-tab-content` 和 `chat-tab-conversation-page` 之间的中间层 widget（topPanel、inputArea、conversationStack 等）没有设置 objectName，CSS 无法选中，导致深色主题下这些区域显示为纯黑，与周围 `#404040` 背景色不协调
+
+## 7 How
+- **间距优化**：将 `kContentSpacing` 从 16 减为 8，`topLayout` spacing 设为 0 并在需要的地方手动加 spacing，底部 margin 改为与 spacing 一致的 8px
+- **深色主题背景**：为 `topPanel`、`inputArea` 添加 objectName（`chat-tab-top-panel`、`chat-tab-input-area-wrap`），在 liii.css 和 liii-night.css 中统一设置所有层级的 `background-color`

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -99,7 +99,7 @@ constexpr int kInputLineHeight       = 22;
 constexpr int kInputDefaultLines     = 3;
 constexpr int kInputMaxLines         = 10;
 constexpr int kContentMarginY        = 24;
-constexpr int kContentSpacing        = 16;
+constexpr int kContentSpacing        = 8;
 constexpr int kWelcomeTopOffsetY     = 240;
 constexpr int kConversationTopOffsetY= 8;
 constexpr int kInputFrameRadius      = 8;
@@ -146,7 +146,7 @@ ChatConversationPanel::setup_ui () {
   QWidget*     topPanel = new QWidget (this);
   QVBoxLayout* topLayout= new QVBoxLayout (topPanel);
   topLayout->setContentsMargins (0, 0, 0, 0);
-  topLayout->setSpacing (DpiUtils::scaled (kContentSpacing));
+  topLayout->setSpacing (0);
 
   // Welcome title
   welcomeTitle_= new QLabel (qt_translate ("Welcome to Liii STEM!"), topPanel);
@@ -161,6 +161,7 @@ ChatConversationPanel::setup_ui () {
   sessionTitle_->setAlignment (Qt::AlignCenter);
   DpiUtils::applyScaledFont (sessionTitle_, kSessionTitleFontPx);
   topLayout->addWidget (sessionTitle_, 0, Qt::AlignHCenter);
+  topLayout->addSpacing (DpiUtils::scaled (kContentSpacing));
 
   // Message area
   qreal chatZoom = DpiUtils::scaled (100) / 100.0;

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -138,12 +138,13 @@ void
 ChatConversationPanel::setup_ui () {
   QVBoxLayout* contentLayout= new QVBoxLayout (this);
   contentLayout->setContentsMargins (0, DpiUtils::scaled (kContentMarginY), 0,
-                                     DpiUtils::scaled (kContentMarginY));
+                                     DpiUtils::scaled (kContentSpacing));
   contentLayout->setSpacing (DpiUtils::scaled (kContentSpacing));
   topSpacer_= new QSpacerItem (0, 0, QSizePolicy::Minimum, QSizePolicy::Fixed);
   contentLayout->addSpacerItem (topSpacer_);
 
-  QWidget*     topPanel = new QWidget (this);
+  QWidget* topPanel= new QWidget (this);
+  topPanel->setObjectName ("chat-tab-top-panel");
   QVBoxLayout* topLayout= new QVBoxLayout (topPanel);
   topLayout->setContentsMargins (0, 0, 0, 0);
   topLayout->setSpacing (0);
@@ -206,6 +207,7 @@ ChatConversationPanel::setup_ui () {
 
   // Input area
   QWidget* inputArea= new QWidget (topPanel);
+  inputArea->setObjectName ("chat-tab-input-area-wrap");
   inputArea->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Preferred);
   QVBoxLayout* inputAreaLayout= new QVBoxLayout (inputArea);
   inputAreaLayout->setContentsMargins (0, 0, 0, 0);


### PR DESCRIPTION
## 改动内容

### 间距优化
- `kContentSpacing` 从 16px 减为 8px
- `topLayout` spacing 设为 0，在 session title 和 message area 之间手动加 8px spacing
- 内容区底部 margin 从 24px 减为 8px

### 深色主题背景一致性
- 为中间层 widget 添加 objectName（`chat-tab-top-panel`、`chat-tab-input-area-wrap`）
- liii.css 和 liii-night.css 中统一设置所有层级的 `background-color`，消除深色主题下的纯黑断层
- 补全欢迎标题、模型标签、AI 免责提示在深色主题中的背景色

🤖 Generated with [Claude Code](https://claude.com/claude-code)