### PR TITLE
[0614] 移除引用 TeXmacs 功能

### DIFF
--- a/TeXmacs/packages/header/header-article.ts
+++ b/TeXmacs/packages/header/header-article.ts
@@ -34,9 +34,6 @@
   <assign|cite-website|<macro|<localize|This article has been written using>
   GNU <TeXmacs><if|<equal|<value|language>|french>| ; |; ><localize|see>
   <hlink|<with|font-family|tt|www.texmacs.org>|https://www.texmacs.org>.>>
-
-  <assign|cite-TeXmacs|<xmacro|keys|<localize|This article has been written
-  using> GNU <TeXmacs><nbsp><map-args|identity|cite|keys>.>>
 </body>
 
 <\initial>

--- a/TeXmacs/packages/header/title-base.ts
+++ b/TeXmacs/packages/header/title-base.ts
@@ -55,9 +55,6 @@
   GNU <TeXmacs><if|<equal|<value|language>|french>| ; |; ><localize|see>
   <hlink|<with|font-family|tt|www.texmacs.org>|https://www.texmacs.org>.>>
 
-  <assign|cite-TeXmacs|<xmacro|keys|<localize|This document has been written
-  using> GNU <TeXmacs><nbsp><map-args|identity|cite|keys>.>>
-
   <\active*>
     <\src-comment>
       DRD properties of tags with title and author data.

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
@@ -449,14 +449,6 @@
   (tmieeeemail (!append (textit (!translate "Email:")) " " 1))
   (tmnote (thanks (!append (textit (!translate "Note:")) " " 1)))
   (tmmisc (thanks (!append (textit (!translate "Misc:")) " " 1)))
-  (citetexmacs (!append (!translate "This document has been written using")
-                 " GNU "
-                 (!group (!recurse (TeXmacs)))
-                 " "
-                 (cite 1)
-                 "."
-               ) ;!append
-  ) ;citetexmacs
   (key (!append (fcolorbox "black"
                   "gray!25!white"
                   (raisebox "0pt" (!option "5pt") (!option "0pt") (texttt 1))

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm
@@ -278,7 +278,6 @@
 
 (logic-group latex-texmacs-1%
   three-line-table
-  citetexmacs
   key
   tmrsub
   tmrsup

--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
@@ -3858,10 +3858,6 @@
   (tex-apply 'nocite (tmtex-cite-list l))
 ) ;define
 
-(define (tmtex-cite-TeXmacs s l)
-  (tex-apply 'citetexmacs (tmtex-cite-list l))
-) ;define
-
 (tm-define (tmtex-cite-detail s l)
   (with c
     (tmtex-cite-list (list (car l)))
@@ -4585,7 +4581,6 @@
  (tm-made (,(tmtex-rename 'tmmade) 0))
  (cite (,tmtex-cite -1))
  (nocite (,tmtex-nocite -1))
- (cite-TeXmacs (,tmtex-cite-TeXmacs -1))
  (cite-detail (,tmtex-cite-detail-hook 2))
  (cite-raw (,tmtex-cite-raw -1))
  (cite-raw* (,tmtex-cite-raw* -1))

--- a/TeXmacs/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/progs/convert/latex/latex-define.scm
@@ -449,14 +449,6 @@
   (tmieeeemail (!append (textit (!translate "Email:")) " " 1))
   (tmnote (thanks (!append (textit (!translate "Note:")) " " 1)))
   (tmmisc (thanks (!append (textit (!translate "Misc:")) " " 1)))
-  (citetexmacs (!append (!translate "This document has been written using")
-                 " GNU "
-                 (!group (!recurse (TeXmacs)))
-                 " "
-                 (cite 1)
-                 "."
-               ) ;!append
-  ) ;citetexmacs
   (key (!append (fcolorbox "black"
                   "gray!25!white"
                   (raisebox "0pt" (!option "5pt") (!option "0pt") (texttt 1))

--- a/TeXmacs/progs/convert/latex/latex-texmacs-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-texmacs-drd.scm
@@ -278,7 +278,6 @@
 
 (logic-group latex-texmacs-1%
   three-line-table
-  citetexmacs
   key
   tmrsub
   tmrsup

--- a/TeXmacs/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/progs/convert/latex/tmtex.scm
@@ -3859,10 +3859,6 @@
   (tex-apply 'nocite (tmtex-cite-list l))
 ) ;define
 
-(define (tmtex-cite-TeXmacs s l)
-  (tex-apply 'citetexmacs (tmtex-cite-list l))
-) ;define
-
 (tm-define (tmtex-cite-detail s l)
   (with c
     (tmtex-cite-list (list (car l)))
@@ -4585,7 +4581,6 @@
  (tm-made (,(tmtex-rename 'tmmade) 0))
  (cite (,tmtex-cite -1))
  (nocite (,tmtex-nocite -1))
- (cite-TeXmacs (,tmtex-cite-TeXmacs -1))
  (cite-detail (,tmtex-cite-detail-hook 2))
  (cite-raw (,tmtex-cite-raw -1))
  (cite-raw* (,tmtex-cite-raw* -1))

--- a/TeXmacs/progs/database/bib-menu.scm
+++ b/TeXmacs/progs/database/bib-menu.scm
@@ -130,5 +130,5 @@
        (when (and key
                   (tree->path u)
 		  (tree-in? (tree-up u)
-                            '(cite nocite cite-detail cite-TeXmacs)))
+                            '(cite nocite cite-detail)))
 	 (tree-set! u key))))))

--- a/TeXmacs/progs/generic/document-edit.scm
+++ b/TeXmacs/progs/generic/document-edit.scm
@@ -551,13 +551,6 @@
   (safe-car (tree-search (buffer-tree) (cut tree-is? <> lab)))
 ) ;define
 
-(define (acknowledged-texmacs? . refs)
-  (if (null? refs)
-    (document-search-first 'cite-website)
-    (document-search-first 'cite-TeXmacs)
-  ) ;if
-) ;define
-
 (define (tail-document doc)
   (when (and (tm-is? doc 'document)
           (tm-is? (tm-ref doc :last) 'screens)
@@ -588,120 +581,6 @@
   (update-document "bibliography")
   (delayed (:idle 1) (update-document "bibliography"))
 ) ;define
-
-(tm-define (acknowledge-texmacs . refs)
-  (:synopsis "Acknowledge that a document has been written using TeXmacs")
-  (:check-mark "v" acknowledged-texmacs?)
-  (let* ((tit (document-search-first 'doc-data))
-         (bib (document-search-first 'bibliography))
-         (aweb (document-search-first 'cite-website))
-         (nweb (and aweb (tree-search-upwards aweb 'doc-note)))
-         (acit (document-search-first 'cite-TeXmacs))
-         (ncit (and acit (tree-search-upwards acit 'doc-note)))
-        ) ;
-    (cond ((and nweb (nnull? refs))
-           (tree-set! aweb `(cite-TeXmacs ,@refs))
-           (update-biblio)
-          ) ;
-          ((and ncit (null? refs)) (tree-set! acit '(cite-website)) (update-biblio))
-          ((and nweb (null? refs))
-           (tree-remove (tree-up nweb) (tree-index nweb) 1)
-           (update-biblio)
-          ) ;
-          ((and aweb (null? refs)) (tree-cut aweb))
-          ((and ncit (nnull? refs))
-           (tree-remove (tree-up ncit) (tree-index ncit) 1)
-           (update-biblio)
-          ) ;
-          ((and tit (nnull? refs))
-           (add-biblio)
-           (tree-insert! tit
-             (tree-arity tit)
-             `((doc-note (document (cite-TeXmacs ,@refs))))
-           ) ;tree-insert!
-           (update-biblio)
-          ) ;
-          ((and tit (null? refs))
-           (tree-insert! tit (tree-arity tit) '((doc-note (document (cite-website)))))
-          ) ;
-          ((nnull? refs) (add-biblio) (insert `(cite-TeXmacs ,@refs)) (update-biblio))
-          (else (make 'cite-website))
-    ) ;cond
-  ) ;let*
-) ;tm-define
-
-(define (is-cite? t)
-  (tree-in? t '(cite nocite cite-TeXmacs))
-) ;define
-
-(define (is-citation? t ref types)
-  (and (tm-equal? t ref) (tree-up t) (tree-in? (tree-up t) types))
-) ;define
-
-(define (cited-texmacs? ref)
-  (let* ((l '(cite nocite cite-TeXmacs))
-         (pred? (cut is-citation? <> ref l))
-         (alt-pred? (cut is-citation? <> ref '(cite-TeXmacs)))
-        ) ;
-    (cond ((is-cite? (cursor-tree)) (safe-car (tree-search (cursor-tree) pred?)))
-          ((is-cite? (tree-up (cursor-tree)))
-           (safe-car (tree-search (tree-up (cursor-tree)) pred?))
-          ) ;
-          ((document-search-first 'doc-data)
-           (safe-car (tree-search (buffer-tree) alt-pred?))
-          ) ;
-          (else (safe-car (tree-search (buffer-tree) pred?)))
-    ) ;cond
-  ) ;let*
-) ;define
-
-(tm-define (cite-texmacs ref)
-  (:synopsis "Cite a paper or other work on TeXmacs")
-  (:check-mark "v" cited-texmacs?)
-  (cond ((cited-texmacs? ref)
-         (with t
-           (cited-texmacs? ref)
-           (cond ((and (== (tree-arity (tree-up t)) 1) (tree-search-upwards t 'doc-note))
-                  (with note
-                    (tree-search-upwards t 'doc-note)
-                    (tree-remove (tree-up note) (tree-index note) 1)
-                    (update-biblio)
-                  ) ;with
-                 ) ;
-                 ((> (tree-arity (tree-up t)) 1)
-                  (tree-remove (tree-up t) (tree-index t) 1)
-                  (update-biblio)
-                 ) ;
-           ) ;cond
-         ) ;with
-        ) ;
-        ((tree-in? (cursor-tree) '(cite nocite cite-TeXmacs))
-         (tree-insert (cursor-tree) (tree-arity (cursor-tree)) (list ref))
-         (update-biblio)
-        ) ;
-        ((and (tree-in? (tree-up (cursor-tree)) '(cite nocite cite-TeXmacs))
-           (tm-equal? (cursor-tree) "")
-         ) ;and
-         (tree-set (cursor-tree) ref)
-        ) ;
-        ((tree-in? (tree-up (cursor-tree)) '(cite nocite cite-TeXmacs))
-         (with i
-           (+ (tree-index (cursor-tree)) 1)
-           (tree-insert (tree-up (cursor-tree)) i (list ref))
-           (tree-go-to (tree-up (cursor-tree)) i :end)
-         ) ;with
-        ) ;
-        ((document-search-first 'cite-TeXmacs)
-         (with t
-           (document-search-first 'cite-TeXmacs)
-           (tree-insert t (tree-arity t) (list ref))
-           (update-biblio)
-         ) ;with
-        ) ;
-        ((document-search-first 'doc-data) (acknowledge-texmacs ref))
-        (else (add-biblio) (insert `(cite ,ref)) (update-biblio))
-  ) ;cond
-) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Document updates

--- a/TeXmacs/progs/generic/document-menu.scm
+++ b/TeXmacs/progs/generic/document-menu.scm
@@ -1125,74 +1125,7 @@
   ) ;assuming
 ) ;tm-menu
 
-(menu-bind cite-texmacs-only-menu
- ("The Jolly Writer" (cite-texmacs "TeXmacs:vdH:book"))
- ("TeXmacs website" (cite-texmacs "TeXmacs:website"))
- ("TeXmacs manual" (cite-texmacs "TeXmacs:manual"))
-) ;menu-bind
 
-(menu-bind cite-texmacs-related-menu
-  (-> "Tutorials"
-   ("GNU TeXmacs: a scientific editing platform"
-     (cite-texmacs "TeXmacs:vdH2:2006")
-   ) ;
-   ("TeXmacs in 60 minutes" (cite-texmacs "TeXmacs:Seidl:2003"))
-   ("TeXmacs Quick-Start Guide" (cite-texmacs "TeXmacs:Ratier:2005"))
-  ) ;->
-  (-> "Surveys"
-   ("GNU TeXmacs (ASCM 2005)" (cite-texmacs "TeXmacs:vdH:2005"))
-   ("GNU TeXmacs (Dagstuhl 2006)" (cite-texmacs "TeXmacs:vdH1:2006"))
-   ("GNU TeXmacs: a scientific editing platform"
-     (cite-texmacs "TeXmacs:HGGLPR:2012")
-   ) ;
-   ("GNU TeXmacs: Towards a Scientific Office Suite"
-     (cite-texmacs "TeXmacs:GHPR:2014")
-   ) ;
-  ) ;->
-  (-> "Research papers"
-   ("GNU TeXmacs, a free, structured, wysiwyg and technical text editor"
-     (cite-texmacs "TeXmacs:vdH:2001")
-   ) ;
-   ("Conservative conversion between LaTeX and TeXmacs"
-     (cite-texmacs "TeXmacs:HP:2014")
-   ) ;
-   ("Towards semantic mathematical editing" (cite-texmacs "TeXmacs:vdH:2015"))
-   ("Preserving syntactic correctness while editing mathematical formulas"
-     (cite-texmacs "TeXmacs:HLR:2015")
-   ) ;
-   ("Mathematical Font Art" (cite-texmacs "TeXmacs:vdH:2016"))
-  ) ;->
-  (-> "Plug-ins"
-   ("TeXmacs interfaces to Maxima, Mupad and Reduce"
-     (cite-texmacs "TeXmacs:Grozin:2001")
-   ) ;
-   ("TeXmacs-Maxima interface" (cite-texmacs "TeXmacs:Grozin:2005"))
-   ("TeXmacs-Reduce interface" (cite-texmacs "TeXmacs:Grozin:2012"))
-   ("TeXmacs as an authoring tool for formal developments"
-     (cite-texmacs "TeXmacs:AR:2004")
-   ) ;
-   ("A Document-Oriented Coq Plugin for TeXmacs" (cite-texmacs "TeXmacs:MG:2006"))
-  ) ;->
-) ;menu-bind
-
-(menu-bind cite-texmacs-menu
-  (assuming (or (in-beamer?) (in-seminar?) (in-browser?))
-    (group "Acknowledge")
-    ("Written with TeXmacs" (acknowledge-texmacs))
-    ---
-  ) ;assuming
-  (group "Cite")
-  (link cite-texmacs-only-menu)
-  ---
-  (group "Cite related work")
-  (link cite-texmacs-related-menu)
-) ;menu-bind
-
-(menu-bind cite-texmacs-short-menu
-  (link cite-texmacs-only-menu)
-  ---
-  (link cite-texmacs-related-menu)
-) ;menu-bind
 
 (tm-menu (focus-style-menu t)
   (group "Style")
@@ -1260,7 +1193,6 @@
   (dynamic (focus-style-menu t))
   ---
   (dynamic (focus-document-menu t))
-  (-> "Cite TeXmacs" (link cite-texmacs-menu))
   (dynamic (focus-document-extra-menu t))
   ---
   ("Help" (focus-help))
@@ -1306,12 +1238,6 @@
     ) ;=>
     (assuming (tree-is-buffer? t)
      ((balloon (icon "tm_focus_help.xpm") "Describe tag") (focus-help))
-    ) ;assuming
-    (assuming (and (!= (get-preference "gui theme") "liii")
-                (!= (get-preference "gui theme") "liii-night")
-                (!= (get-preference "gui theme") "default")
-              ) ;and
-      (=> (balloon (icon "tm_like.xpm") "Cite TeXmacs") (link cite-texmacs-menu))
     ) ;assuming
   ) ;minibar
 ) ;tm-menu

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1171,7 +1171,7 @@
 ) ;tm-define
 
 (tm-define (bib-cite-context? t)
-  (and (tree-in? t '(cite nocite cite-detail cite-TeXmacs)) (cursor-inside? t))
+  (and (tree-in? t '(cite nocite cite-detail)) (cursor-inside? t))
 ) ;tm-define
 
 (tm-define (kbd-variant t forwards?)

--- a/TeXmacs/progs/generic/generic-menu.scm
+++ b/TeXmacs/progs/generic/generic-menu.scm
@@ -788,9 +788,6 @@
   ) ;assuming
   ("Describe" (focus-help))
   ("Delete" (remove-structure-upwards))
-  (assuming (tree-in? t '(cite nocite cite-TeXmacs))
-    (-> "Cite TeXmacs" (link cite-texmacs-short-menu))
-  ) ;assuming
   (assuming (focus-has-search-menu? t)
     (-> "Search" (dynamic (focus-search-menu t)))
   ) ;assuming
@@ -988,13 +985,6 @@
     ) ;=>
   ) ;assuming
   ((balloon (icon "tm_focus_help.xpm") "Describe tag") (focus-help))
-  (assuming (tree-in? t '(cite nocite cite-TeXmacs))
-    (=> (balloon (icon "tm_like.xpm") "Cite TeXmacs-related work")
-      (group "TeXmacs-related work")
-      ---
-      (link cite-texmacs-short-menu)
-    ) ;=>
-  ) ;assuming
   (assuming (focus-has-search-menu? t)
     (=> (balloon (icon "tm_focus_search.xpm") "Search")
       (dynamic (focus-search-menu t))

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -148,7 +148,6 @@
            page-header-menu page-footer-menu page-numbering-menu
            page-break-menu)
 (lazy-menu (generic document-menu) document-menu
-           cite-texmacs-menu cite-texmacs-short-menu
            project-menu document-style-menu global-language-menu)
 (lazy-menu (generic document-part)
            preamble-menu document-part-menu project-manage-menu)

--- a/TeXmacs/progs/kernel/gui/menu-widget.scm
+++ b/TeXmacs/progs/kernel/gui/menu-widget.scm
@@ -1265,8 +1265,6 @@
        load-menu
        save-menu
        close-menu
-       cite-texmacs-menu
-       cite-texmacs-related-menu
        color-menu
        document-encryption-menu
        document-columns-menu)

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -717,8 +717,7 @@
   ("Date" (make-doc-data-element 'doc-date))
   ("Today" (begin (make-doc-data-element 'doc-date) (make 'date 0)))
   ("Miscellaneous" (make-doc-data-element 'doc-misc))
-  ("Note" (make-doc-data-element 'doc-note))
-  (-> "Cite TeXmacs" (link cite-texmacs-menu)))
+  ("Note" (make-doc-data-element 'doc-note)))
 
 (tm-menu (focus-title-hidden-menu)
   ("Running title" (make-doc-data-element 'doc-running-title))
@@ -743,9 +742,7 @@
       (link focus-title-menu)
       (-> "Hidden" (link focus-title-hidden-menu)))
   (=> (balloon (icon "tm_focus_prefs.xpm") "Title presentation options")
-      (link focus-title-option-menu))
-  (=> (balloon (icon "tm_like.xpm") "Cite TeXmacs")
-      (link cite-texmacs-menu)))
+      (link focus-title-option-menu)))
 
 (tm-menu (focus-ancestor-menu t)
   (:require (doc-title-context? t))

--- a/TeXmacs/progs/utils/edit/variants.scm
+++ b/TeXmacs/progs/utils/edit/variants.scm
@@ -370,10 +370,10 @@
   reference pageref eqref smart-ref)
 
 (define-group n-ary-citation-tag
-  cite nocite cite-TeXmacs)
+  cite nocite)
 
 (define-group citation-tag
-  cite nocite cite-TeXmacs cite-detail)
+  cite nocite cite-detail)
 
 (define-group mini-flow-tag
   table graphics ornament ornamented tree)

--- a/devel/0614.md
+++ b/devel/0614.md
@@ -1,0 +1,64 @@
+# [0614] 移除引用 TeXmacs 功能
+
+## 1 相关文档
+- [0614.md](0614.md) - 任务文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/database/bib-menu.scm`
+- `TeXmacs/progs/kernel/gui/menu-widget.scm`
+- `TeXmacs/progs/text/text-menu.scm`
+- `TeXmacs/progs/generic/document-edit.scm`
+- `TeXmacs/progs/generic/generic-edit.scm`
+- `TeXmacs/progs/generic/document-menu.scm`
+- `TeXmacs/progs/generic/generic-menu.scm`
+- `TeXmacs/progs/utils/edit/variants.scm`
+- `TeXmacs/progs/init-research.scm`
+- `TeXmacs/packages/header/title-base.ts`
+- `TeXmacs/packages/header/header-article.ts`
+- `TeXmacs/progs/convert/latex/latex-define.scm`
+- `TeXmacs/progs/convert/latex/latex-texmacs-drd.scm`
+- `TeXmacs/progs/convert/latex/tmtex.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm`
+- `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+# 验证代码编译正常
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+```markdown
+1. 打开 Mogan STEM
+2. 检查标准菜单和标题菜单中是否不再包含 "Cite TeXmacs" 选项
+3. 检查工具栏中是否不再包含 "Cite TeXmacs" 的点赞(tm_like.xpm)图标/动作
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+# 格式化变更的 .scm 文件
+gf fmt --changed-since=main
+```
+
+## 5 What
+删除引用 TeXmacs (Cite TeXmacs) 功能及其菜单、相关代码。
+
+1. 删除 `document-menu.scm` / `generic-menu.scm` / `text-menu.scm` 中引用 TeXmacs 的菜单项、快捷菜单和图标绑定
+2. 从 `menu-widget.scm` 的静态菜单链接缓存、`init-research.scm` 的延迟加载菜单中移除 `cite-texmacs-menu` 和 `cite-texmacs-short-menu`
+3. 删除 `document-edit.scm` 中的 `cite-texmacs`、`cited-texmacs?`、`acknowledge-texmacs`、`acknowledged-texmacs?` 编辑命令和辅助定义
+4. 从 `variants.scm` 变体组定义及 `generic-edit.scm` 的 bib-cite-context 中移除 `cite-TeXmacs`
+5. 从 `title-base.ts` 和 `header-article.ts` 中删除 `cite-TeXmacs` 宏定义
+6. 删除 LaTeX 格式转换代码中关于 `cite-TeXmacs` / `citetexmacs` 的映射及宏定义
+
+## 6 Why
+Mogan STEM 不需要引用 TeXmacs (Cite TeXmacs) 这一专属于 TeXmacs 本身的功能。移除该功能可以简化菜单界面，提升 Mogan 的品牌自主性，并保持 codebase 简洁。
+
+## 7 How
+安全移除 Scheme 代码、配置文件和 TeXmacs 宏包中关于引用 TeXmacs (cite-TeXmacs / cite-texmacs) 的定义和引用，重新整理括号结构，确保编译正常，并使用 `gf fmt` 进行格式化。


### PR DESCRIPTION
此 PR 移除了专属于 TeXmacs 的 "Cite TeXmacs" (引用 TeXmacs) 功能的菜单、图标/动作以及相应的代码，包括 TeXmacs 宏包和 LaTeX 转换逻辑中的相关映射。