### PR TITLE
[0617] 移除底部 AI 免责提示的中文句号并更新英文文案

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -18,7 +18,7 @@
 ("1.5 line spacing" "1.5 倍行距")
 ("Upgrade VIP" "升级会员")
 ("Upgrade to unlock AI writing, MathOCR, and more advanced features." "开通会员，立即解锁 AI 写作、MathOCR 等高阶功能。")
-("AI-generated content may be inaccurate. Please verify carefully." "内容由 AI 生成，请仔细甄别。")
+("Liii STEM can make mistakes. Check important info." "内容由 AI 生成，请仔细甄别")
 ("All" "全部")
 ("Advanced footer" "高级页脚")
 ("Advanced header" "高级页眉")

--- a/devel/0617.md
+++ b/devel/0617.md
@@ -1,0 +1,39 @@
+# [0617] 移除底部 AI 免责提示的中文句号并更新英文文案
+
+## 1 相关文档
+- [0617.md](0617.md) - 本任务文档
+
+## 2 任务相关的代码文件
+- TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+- src/Plugins/Qt/qt_chat_tab_widget.cpp
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无直接单元测试，此项为 UI 文案改动。
+
+### 3.2 非确定性测试（文档验证）
+运行 Liii STEM 并打开 AI 聊天面板，确认底部免责声明。
+1. 确认中文提示为："内容由 AI 生成，请仔细甄别"（无句号）。
+2. 确认英文提示为："Liii STEM can make mistakes. Check important info."（有句号）。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+移除了底部 AI 生成内容免责提示的中文句号，并更新了英文对应的免责声明。
+
+1. 修改 `src/Plugins/Qt/qt_chat_tab_widget.cpp` 将原英文文案 "AI-generated content may be inaccurate. Please verify carefully." 修改为 "Liii STEM can make mistakes. Check important info."
+2. 修改 `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` 翻译词典，去除中文句号，并更新对应的英文 Key，使其翻译结果为 "内容由 AI 生成，请仔细甄别"
+
+## 6 Why
+1. 中文去句号：参考 Kimi、DeepSeek 等大模型助手的免责声明样式，底部的微型提示一般不加句号，视觉上更清爽。
+2. 英文文案改动：遵循产品经理/设计要求，采用更简洁、直接的英文免责声明。
+
+## 7 How
+编辑对应翻译项和 C++ 中的 QLabel 文本即可。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -311,10 +311,9 @@ ChatConversationPanel::setup_ui () {
   inputAreaLayout->addWidget (inputFrame, 0);
 
   // AI disclaimer label
-  QLabel* disclaimerLabel=
-      new QLabel (qt_translate ("AI-generated content may be inaccurate. "
-                                "Please verify carefully."),
-                  inputArea);
+  QLabel* disclaimerLabel= new QLabel (
+      qt_translate ("Liii STEM can make mistakes. Check important info."),
+      inputArea);
   disclaimerLabel->setObjectName ("chat-tab-disclaimer");
   disclaimerLabel->setAlignment (Qt::AlignCenter);
   DpiUtils::applyScaledFont (disclaimerLabel, 11);


### PR DESCRIPTION
## 任务 0617 描述
移除了底部 AI 生成内容免责提示的中文句号，并更新了英文对应的免责声明。

1. 修改 `src/Plugins/Qt/qt_chat_tab_widget.cpp` 将原英文文案 "AI-generated content may be inaccurate. Please verify carefully." 修改为 "Liii STEM can make mistakes. Check important info."
2. 修改 `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` 翻译词典，去除中文句号，并更新对应的英文 Key，使其翻译结果为 "内容由 AI 生成，请仔细甄别"