### PR TITLE
[0621] 修复带编号的 align 结构导出 HTML 后编号没有到最右方的问题

### DIFF
--- a/TeXmacs/packages/environment/env-math.ts
+++ b/TeXmacs/packages/environment/env-math.ts
@@ -232,7 +232,35 @@
     </rclx-base>
   </macro>>
 
+  <assign|rlx-table|<\macro|body>
+    <\rclx-base>
+      <tformat|<twith|table-width|1par>|<twith|table-min-cols|3>|<twith|table-max-cols|3>|<cwith|1|-1|1|1|cell-lsep|0spc>|<cwith|1|-1|-1|-1|cell-rsep|0spc>|<cwith|1|-1|1|-1|cell-bsep|0sep>|<cwith|1|-1|1|-1|cell-tsep|0sep>|<cwith|1|-2|1|-1|cell-bsep|<eqn-row-sep>>|<cwith|1|-1|1|1|cell-hpart|1>|<cwith|1|-1|2|2|cell-hpart|1>|<cwith|1|-1|1|1|cell-halign|r>|<cwith|1|-1|1|1|cell-hyphen|b>|<cwith|1|-1|2|2|cell-halign|l>|<cwith|1|-1|2|2|cell-hyphen|t>|<cwith|1|-1|-1|-1|cell-halign|r>|<cwith|1|-1|1|-1|cell-block|no>|<arg|body>>
+    </rclx-base>
+  </macro>>
+
   <assign|tmhtml-eqnarray*|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-eqnarray|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-align*|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-align|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-flalign*|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-flalign|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-alignat*|<macro|ncol|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-alignat|<macro|ncol|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-gather*|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-gather|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-multline*|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
+
+  <assign|tmhtml-multline|<macro|body|<extern|ext-tmhtml-eqnarray*|<arg|body>>>>
 
   \;
 </body>

--- a/TeXmacs/plugins/html/progs/convert/html/htmltm.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/htmltm.scm
@@ -92,23 +92,39 @@
 ;; Tables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (htmltm-table env a c)
+(tm-define (htmltm-table env a c)
   ;; TODO: support @lang attributes
   ;; NOT SUPPORTED: @summary - for spoken rendering
   ;;                @title   - no tooltip feature
   ;;                @style   - no CSS support
   ;;                @events  - no event support
-  (let ((cells (table-cells env a c)))
+  (let* ((class-value (shtml-attr-non-null a 'class)) (cells (table-cells env a c)))
     (if (null? cells)
       '()
-      ((cut table-align env a <>)
-       (append (list (tmtable->stm (tmtable (table-formats env a c) cells)))
-         (table-label env a)
-       ) ;append
-      ) ;
+      (let* ((tbl-stm (tmtable->stm (tmtable (table-formats env a c) cells)))
+             (stms (append (list tbl-stm) (table-label env a)))
+             (aligned ((cut table-align env a <>) stms))
+            ) ;
+        (cond ((and (string? class-value)
+                 (in? class-value
+                   '("eqnarray"
+                     "eqnarray*"
+                     "align"
+                     "align*"
+                     "gather"
+                     "gather*"
+                     "multline"
+                     "multline*")
+                 ) ;in?
+               ) ;and
+               (list `(,(string->symbol class-value) (document ,tbl-stm)))
+              ) ;
+              (else aligned)
+        ) ;cond
+      ) ;let*
     ) ;if
-  ) ;let
-) ;define
+  ) ;let*
+) ;tm-define
 
 (define (table-label env a)
   (let ((label (xmltm-attr->label a 'id)))

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml-expand.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml-expand.scm
@@ -87,6 +87,18 @@
                       equation*
                       equation-lab
                       equations-base
+                      eqnarray
+                      eqnarray*
+                      align
+                      align*
+                      flalign
+                      flalign*
+                      alignat
+                      alignat*
+                      gather
+                      gather*
+                      multline
+                      multline*
                       wide-float
                       draw-over
                       draw-under

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -2365,37 +2365,119 @@
               (cell ,(cadr r)))
          ) ;let*
         ) ;
+        ((tm-func? t 'row 2)
+         (let* ((l (tm-ref t 0 0)) (r (split-htab (tm-ref t 1 0))))
+           `(row (cell (big-math ,l))
+              (cell "")
+              (cell (big-math ,(car r)))
+              (cell ,(cadr r)))
+         ) ;let*
+        ) ;
+        ((tm-func? t 'row 1)
+         (let* ((r (split-htab (tm-ref t 0 0))))
+           `(row (cell (big-math ,(car r))) (cell ,(cadr r)))
+         ) ;let*
+        ) ;
         (else (cons (tm-label t) (map rewrite-eqnarray* (tm-children t))))
   ) ;cond
 ) ;define
 
 (tm-define (ext-tmhtml-eqnarray* body)
   (:secure #t)
-  (if (tm-func? body 'document 1)
-    `(document ,(ext-tmhtml-eqnarray* (tm-ref body 0)))
-    (cond ((null? (tm-search body (lambda (x) (tm-func? x 'htab))))
-           `(equation* (rcl-table ,body))
-          ) ;
-          ((and (tm-func? body 'tformat)
-             (tm-func? (tm-ref body :last) 'table 1)
-             (tm-func? (tm-ref body :last 0) 'row 3)
-           ) ;and
-           (let* ((row (tm-ref body :last 0))
-                  (l (tm-ref row 0 0))
-                  (c (tm-ref row 1 0))
-                  (r (split-htab (tm-ref row 2 0)))
-                  (row1 `(row (cell ,l) (cell ,c) (cell ,(car r))))
-                  (rcl `(rcl-table (tformat (table ,row1))))
-                  (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
-                  (res `(cx-table (tformat (table ,row2))))
-                 ) ;
-             res
-           ) ;let*
-          ) ;
-          (else `(rclx-table ,(rewrite-eqnarray* body)))
-    ) ;cond
-  ) ;if
+  (let* ((wrapped? (tm-func? body 'document 1))
+         (inner (if wrapped? (tm-ref body 0) body))
+         (res (cond ((null? (tm-search inner (lambda (x) (tm-func? x 'htab))))
+                     (let* ((row (if (and (tm-func? inner 'tformat)
+                                       (tm-func? (tm-ref inner :last) 'table)
+                                       (tm-ref inner :last 0)
+                                     ) ;and
+                                   (tm-ref inner :last 0)
+                                   #f
+                                 ) ;if
+                            ) ;row
+                            (cells (if row (tm-children row) '()))
+                           ) ;
+                       (if (== (length cells) 3)
+                         `(equation* (rcl-table ,inner))
+                         `(equations-base ,inner)
+                       ) ;if
+                     ) ;let*
+                    ) ;
+                    ((and (tm-func? inner 'tformat)
+                       (tm-func? (tm-ref inner :last) 'table 1)
+                       (tm-func? (tm-ref inner :last 0) 'row 3)
+                     ) ;and
+                     (let* ((row (tm-ref inner :last 0))
+                            (l (tm-ref row 0 0))
+                            (c (tm-ref row 1 0))
+                            (r (split-htab (tm-ref row 2 0)))
+                            (row1 `(row (cell ,l) (cell ,c) (cell ,(car r))))
+                            (rcl `(rcl-table (tformat (table ,row1))))
+                            (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
+                            (res `(cx-table (tformat (table ,row2))))
+                           ) ;
+                       res
+                     ) ;let*
+                    ) ;
+                    ((and (tm-func? inner 'tformat)
+                       (tm-func? (tm-ref inner :last) 'table 1)
+                       (tm-func? (tm-ref inner :last 0) 'row 2)
+                     ) ;and
+                     (let* ((row (tm-ref inner :last 0))
+                            (l (tm-ref row 0 0))
+                            (r (split-htab (tm-ref row 1 0)))
+                            (row1 `(row (cell ,l) (cell ,(car r))))
+                            (rcl `(align* (tformat (table ,row1))))
+                            (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
+                            (res `(cx-table (tformat (table ,row2))))
+                           ) ;
+                       res
+                     ) ;let*
+                    ) ;
+                    ((and (tm-func? inner 'tformat)
+                       (tm-func? (tm-ref inner :last) 'table 1)
+                       (tm-func? (tm-ref inner :last 0) 'row 1)
+                     ) ;and
+                     (let* ((row (tm-ref inner :last 0))
+                            (r (split-htab (tm-ref row 0 0)))
+                            (row1 `(row (cell ,(car r))))
+                            (rcl `(equations-base (tformat (table ,row1))))
+                            (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
+                            (res `(cx-table (tformat (table ,row2))))
+                           ) ;
+                       res
+                     ) ;let*
+                    ) ;
+                    (else (let* ((row (if (and (tm-func? inner 'tformat)
+                                            (tm-func? (tm-ref inner :last) 'table)
+                                            (tm-ref inner :last 0)
+                                          ) ;and
+                                        (tm-ref inner :last 0)
+                                        #f
+                                      ) ;if
+                                 ) ;row
+                                 (cells (if row (tm-children row) '()))
+                                ) ;
+                            (cond ((== (length cells) 3) `(rclx-table ,(rewrite-eqnarray* inner)))
+                                  ((== (length cells) 2) `(rclx-table ,(rewrite-eqnarray* inner)))
+                                  (else `(cx-table ,(rewrite-eqnarray* inner)))
+                            ) ;cond
+                          ) ;let*
+                    ) ;else
+              ) ;cond
+         ) ;res
+        ) ;
+    res
+  ) ;let*
 ) ;tm-define
+
+(define (tmhtml-eqnarray-dispatch l)
+  (tmhtml (ext-tmhtml-eqnarray* (car l)))
+) ;define
+
+(define (tmhtml-alignat-dispatch l)
+  (tmhtml (ext-tmhtml-eqnarray* (cadr l)))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tags for customized html generation
@@ -2964,6 +3046,18 @@
   (equation* ,tmhtml-equation*)
   (equation-lab ,tmhtml-equation-lab)
   (equations-base ,tmhtml-equation*)
+  (eqnarray* ,tmhtml-eqnarray-dispatch)
+  (eqnarray ,tmhtml-eqnarray-dispatch)
+  (align* ,tmhtml-eqnarray-dispatch)
+  (align ,tmhtml-eqnarray-dispatch)
+  (flalign* ,tmhtml-eqnarray-dispatch)
+  (flalign ,tmhtml-eqnarray-dispatch)
+  (alignat* ,tmhtml-alignat-dispatch)
+  (alignat ,tmhtml-alignat-dispatch)
+  (gather* ,tmhtml-eqnarray-dispatch)
+  (gather ,tmhtml-eqnarray-dispatch)
+  (multline* ,tmhtml-eqnarray-dispatch)
+  (multline ,tmhtml-eqnarray-dispatch)
   (wide-float ,tmhtml-float)
   (draw-over ,tmhtml-draw-over)
   (draw-under ,tmhtml-draw-under)

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -31,13 +31,10 @@
 
 (define tmhtml-env (make-ahash-table))
 
-(define tmhtml-css? #t)
-
-(define tmhtml-mathjax? #f)
-
-(define tmhtml-mathml? #f)
-
-(define tmhtml-images? #f)
+(tm-define tmhtml-css? #t)
+(tm-define tmhtml-mathjax? #f)
+(tm-define tmhtml-mathml? #f)
+(tm-define tmhtml-images? #f)
 (tm-define tmhtml-base64? #t)
 
 (define tmhtml-image-serial 0)
@@ -2355,7 +2352,86 @@
   ) ;let*
 ) ;define
 
-(define (rewrite-eqnarray* t)
+(tm-define (make-html-equation-table rows cols)
+  (let* ((twith-width '(twith "table-width" "1par"))
+         (twith-min `(twith ,"table-min-cols" ,(number->string cols)))
+         (twith-max `(twith ,"table-max-cols" ,(number->string cols)))
+         (cwith-lsep '(cwith "1" "-1" "1" "1" "cell-lsep" "0spc"))
+         (cwith-rsep '(cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc"))
+         (cwith-bsep '(cwith "1" "-1" "1" "-1" "cell-bsep" "0sep"))
+         (cwith-tsep '(cwith "1" "-1" "1" "-1" "cell-tsep" "0sep"))
+         (cwith-block '(cwith "1" "-1" "1" "-1" "cell-block" "no"))
+         (props (list twith-width
+                  twith-min
+                  twith-max
+                  cwith-lsep
+                  cwith-rsep
+                  cwith-bsep
+                  cwith-tsep
+                  cwith-block
+                ) ;list
+         ) ;props
+        ) ;
+    (cond ((== cols 4)
+           ;; 4 columns: r c l r
+           (let ((cwith-h1 '(cwith "1" "-1" "1" "1" "cell-hpart" "1"))
+                 (cwith-h3 '(cwith "1" "-1" "3" "3" "cell-hpart" "2"))
+                 (cwith-a1 '(cwith "1" "-1" "1" "1" "cell-halign" "r"))
+                 (cwith-a2 '(cwith "1" "-1" "2" "2" "cell-halign" "c"))
+                 (cwith-a3 '(cwith "1" "-1" "3" "3" "cell-halign" "l"))
+                 (cwith-a4 '(cwith "1" "-1" "4" "4" "cell-halign" "r"))
+                ) ;
+             `(tformat ,@props
+                ,cwith-h1
+                ,cwith-h3
+                ,cwith-a1
+                ,cwith-a2
+                ,cwith-a3
+                ,cwith-a4
+                (table ,@rows))
+           ) ;let
+          ) ;
+          ((== cols 3)
+           ;; 3 columns: r l r (for 2-column equations like align with eq-number)
+           (let ((cwith-h1 '(cwith "1" "-1" "1" "1" "cell-hpart" "1"))
+                 (cwith-h2 '(cwith "1" "-1" "2" "2" "cell-hpart" "1"))
+                 (cwith-a1 '(cwith "1" "-1" "1" "1" "cell-halign" "r"))
+                 (cwith-a2 '(cwith "1" "-1" "2" "2" "cell-halign" "l"))
+                 (cwith-a3 '(cwith "1" "-1" "3" "3" "cell-halign" "r"))
+                ) ;
+             `(tformat ,@props
+                ,cwith-h1
+                ,cwith-h2
+                ,cwith-a1
+                ,cwith-a2
+                ,cwith-a3
+                (table ,@rows))
+           ) ;let
+          ) ;
+          ((== cols 2)
+           ;; 2 columns: c r
+           (let ((cwith-h1 '(cwith "1" "-1" "1" "1" "cell-hpart" "1"))
+                 (cwith-a1 '(cwith "1" "-1" "1" "1" "cell-halign" "c"))
+                 (cwith-a2 '(cwith "1" "-1" "2" "2" "cell-halign" "r"))
+                ) ;
+             `(tformat ,@props ,cwith-h1 ,cwith-a1 ,cwith-a2 (table ,@rows))
+           ) ;let
+          ) ;
+          (else `(tformat ,@props (table ,@rows)))
+    ) ;cond
+  ) ;let*
+) ;tm-define
+
+(tm-define (tformat-rows tf)
+  (if (and (pair? tf) (eq? (car tf) 'tformat))
+    (let* ((tbl (car (last-pair tf))))
+      (if (and (pair? tbl) (eq? (car tbl) 'table)) (cdr tbl) '())
+    ) ;let*
+    '()
+  ) ;if
+) ;tm-define
+
+(tm-define (rewrite-eqnarray* t)
   (cond ((tm-atomic? t) t)
         ((tm-func? t 'row 3)
          (let* ((l (tm-ref t 0 0)) (c (tm-ref t 1 0)) (r (split-htab (tm-ref t 2 0))))
@@ -2380,7 +2456,7 @@
         ) ;
         (else (cons (tm-label t) (map rewrite-eqnarray* (tm-children t))))
   ) ;cond
-) ;define
+) ;tm-define
 
 (tm-define (ext-tmhtml-eqnarray* body)
   (:secure #t)
@@ -2412,11 +2488,11 @@
                             (c (tm-ref row 1 0))
                             (r (split-htab (tm-ref row 2 0)))
                             (row1 `(row (cell ,l) (cell ,c) (cell ,(car r))))
-                            (rcl `(rcl-table (tformat (table ,row1))))
+                            (rcl (make-html-equation-table (list row1) 3))
                             (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
-                            (res `(cx-table (tformat (table ,row2))))
+                            (res (make-html-equation-table (list row2) 2))
                            ) ;
-                       res
+                       `(equations-base ,res)
                      ) ;let*
                     ) ;
                     ((and (tm-func? inner 'tformat)
@@ -2427,11 +2503,11 @@
                             (l (tm-ref row 0 0))
                             (r (split-htab (tm-ref row 1 0)))
                             (row1 `(row (cell ,l) (cell ,(car r))))
-                            (rcl `(align* (tformat (table ,row1))))
+                            (rcl (make-html-equation-table (list row1) 2))
                             (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
-                            (res `(cx-table (tformat (table ,row2))))
+                            (res (make-html-equation-table (list row2) 2))
                            ) ;
-                       res
+                       `(equations-base ,res)
                      ) ;let*
                     ) ;
                     ((and (tm-func? inner 'tformat)
@@ -2441,11 +2517,11 @@
                      (let* ((row (tm-ref inner :last 0))
                             (r (split-htab (tm-ref row 0 0)))
                             (row1 `(row (cell ,(car r))))
-                            (rcl `(equations-base (tformat (table ,row1))))
+                            (rcl (make-html-equation-table (list row1) 1))
                             (row2 `(row (cell (big-math ,rcl)) (cell ,(cadr r))))
-                            (res `(cx-table (tformat (table ,row2))))
+                            (res (make-html-equation-table (list row2) 2))
                            ) ;
-                       res
+                       `(equations-base ,res)
                      ) ;let*
                     ) ;
                     (else (let* ((row (if (and (tm-func? inner 'tformat)
@@ -2458,16 +2534,24 @@
                                  ) ;row
                                  (cells (if row (tm-children row) '()))
                                 ) ;
-                            (cond ((== (length cells) 3) `(rclx-table ,(rewrite-eqnarray* inner)))
-                                  ((== (length cells) 2) `(rclx-table ,(rewrite-eqnarray* inner)))
-                                  (else `(cx-table ,(rewrite-eqnarray* inner)))
+                            (cond ((== (length cells) 3)
+                                   `(equations-base ,(make-html-equation-table (tformat-rows (rewrite-eqnarray* inner))
+                                                       4))
+                                  ) ;
+                                  ((== (length cells) 2)
+                                   `(equations-base ,(make-html-equation-table (tformat-rows (rewrite-eqnarray* inner))
+                                                       4))
+                                  ) ;
+                                  (else `(equations-base ,(make-html-equation-table (tformat-rows (rewrite-eqnarray* inner))
+                                                            2))
+                                  ) ;else
                             ) ;cond
                           ) ;let*
                     ) ;else
               ) ;cond
          ) ;res
         ) ;
-    res
+    (if wrapped? `(document ,res) res)
   ) ;let*
 ) ;tm-define
 

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -13,6 +13,7 @@
 
 
 ;; S7 macros are not usual macros...
+
 (define define-macro define-expansion)
 
 (define primitive-symbol? symbol?)
@@ -29,72 +30,112 @@
   (define primitive-load load)
   (define primitive-eval eval)
   (define primitive-catch catch)
-  
+
   (varlet (rootlet) 'tm-eval (lambda (obj) (eval obj *texmacs-user-module*)))
-  (set! load (lambda (file . env) (primitive-load file (if (null? env) *current-module* (car env)))))
-  (set! eval (lambda (obj . env)
-    (let ((res (primitive-eval obj (if (null? env) *current-module* (car env)))))
-    ;;(format #t "Eval: ~A -> ~A\n" obj res)
-    res)
-    ))
-    
-  (set! catch (lambda ( key cl hdl )
-    (primitive-catch key cl
-      (lambda args
-        (apply hdl (car args) "[not-implemented]" (caadr args)  (list (cdadr args)))))))
-  )
+  (set! load
+    (lambda (file . env)
+      (primitive-load file (if (null? env) *current-module* (car env)))
+    ) ;lambda
+  ) ;set!
+  (set! eval
+    (lambda (obj . env)
+      (let ((res (primitive-eval obj (if (null? env) *current-module* (car env)))))
+        ;; (format #t "Eval: ~A -> ~A\n" obj res)
+        res
+      ) ;let
+    ) ;lambda
+  ) ;set!
+
+  (set! catch
+    (lambda (key cl hdl)
+      (primitive-catch key
+        cl
+        (lambda args
+          (apply hdl (car args) "[not-implemented]" (caadr args) (list (cdadr args)))
+        ) ;lambda
+      ) ;primitive-catch
+    ) ;lambda
+  ) ;set!
+) ;let
 
 
 (let ()
   (display "Benchmark 1\n")
   (define start (texmacs-time))
-  (define (fib n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+  (define (fib n)
+    (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2))))
+  ) ;define
   (display (fib 30))
   (newline)
-  (display "Time: ") (display (- (texmacs-time) start)) (newline)
-)
+  (display "Time: ")
+  (display (- (texmacs-time) start))
+  (newline)
+) ;let
 
 (define developer-mode? #f)
+
 (define boot-start (texmacs-time))
+
 (define remote-client-list (list))
 
 (display "Booting TeXmacs kernel functionality\n")
 (load (url-concretize "$TEXMACS_PATH/progs/kernel/boot/boot-s7.scm"))
 
-(inherit-modules (kernel boot compat-s7) (kernel boot abbrevs)
-                 (kernel boot debug) (kernel boot srfi)
-                 (kernel boot ahash-table) (kernel boot prologue))
-(inherit-modules (kernel library base) (kernel library list)
-                 (kernel library tree) (kernel library content)
-                 (kernel library patch))
+(inherit-modules (kernel boot compat-s7)
+  (kernel boot abbrevs)
+  (kernel boot debug)
+  (kernel boot srfi)
+  (kernel boot ahash-table)
+  (kernel boot prologue)
+) ;inherit-modules
+(inherit-modules (kernel library base)
+  (kernel library list)
+  (kernel library tree)
+  (kernel library content)
+  (kernel library patch)
+) ;inherit-modules
 (inherit-modules (kernel regexp regexp-match) (kernel regexp regexp-select))
-(inherit-modules (kernel logic logic-rules) (kernel logic logic-query)
-                 (kernel logic logic-data))
+(inherit-modules (kernel logic logic-rules)
+  (kernel logic logic-query)
+  (kernel logic logic-data)
+) ;inherit-modules
 (inherit-modules (kernel texmacs tm-define)
-                 (kernel texmacs tm-preferences) (kernel texmacs tm-modes)
-                 (kernel texmacs tm-plugins) (kernel texmacs tm-secure)
-                 (kernel texmacs tm-convert) (kernel texmacs tm-dialogue)
-                 (kernel texmacs tm-language) (kernel texmacs tm-file-system)
-                 (kernel texmacs tm-states))
+  (kernel texmacs tm-preferences)
+  (kernel texmacs tm-modes)
+  (kernel texmacs tm-plugins)
+  (kernel texmacs tm-secure)
+  (kernel texmacs tm-convert)
+  (kernel texmacs tm-dialogue)
+  (kernel texmacs tm-language)
+  (kernel texmacs tm-file-system)
+  (kernel texmacs tm-states)
+) ;inherit-modules
 (inherit-modules (kernel gui gui-markup)
-                 (kernel gui menu-define) (kernel gui menu-widget)
-                 (kernel gui kbd-define) (kernel gui kbd-handlers)
-                 (kernel gui menu-test)
-                 (kernel old-gui old-gui-widget)
-                 (kernel old-gui old-gui-factory)
-                 (kernel old-gui old-gui-form)
-                 (kernel old-gui old-gui-test))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+  (kernel gui menu-define)
+  (kernel gui menu-widget)
+  (kernel gui kbd-define)
+  (kernel gui kbd-handlers)
+  (kernel gui menu-test)
+  (kernel old-gui old-gui-widget)
+  (kernel old-gui old-gui-factory)
+  (kernel old-gui old-gui-form)
+  (kernel old-gui old-gui-test)
+) ;inherit-modules
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting utilities\n")
+;; (display "Booting utilities\n")
 (use-modules (utils library cpp-wrap))
 (lazy-define (utils library cursor) notify-cursor-moved)
 (lazy-define (utils edit variants) make-inline-tag-list make-wrapped-tag-list)
 (lazy-define (utils cas cas-out) cas->stree)
 (lazy-define (utils plugins plugin-cmd) pre-serialize verbatim-serialize)
-(lazy-define (utils test test-convert) delayed-quit
-             build-manual build-ref-suite run-test-suite)
+(lazy-define (utils test test-convert)
+  delayed-quit
+  build-manual
+  build-ref-suite
+  run-test-suite
+) ;lazy-define
 (use-modules (utils library smart-table))
 (use-modules (utils plugins plugin-convert))
 (use-modules (utils misc markup-funcs))
@@ -103,24 +144,34 @@
 (lazy-define (utils automate auto-tmfs) auto-load-help)
 (lazy-define (utils misc gui-keyboard) get-keyboard)
 (lazy-keyboard (utils automate auto-kbd) in-auto?)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting BibTeX style modules\n")
+;; (display "Booting BibTeX style modules\n")
 (use-modules (bibtex bib-utils))
 (lazy-define (bibtex bib-complete) current-bib-file citekey-completions)
 (lazy-menu (bibtex bib-widgets) open-bibliography-inserter)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting main TeXmacs functionality\n")
-(use-modules (texmacs texmacs tm-server) (texmacs texmacs tm-view)
-             (texmacs texmacs tm-files) (texmacs texmacs tm-print))
+;; (display "Booting main TeXmacs functionality\n")
+(use-modules (texmacs texmacs tm-server)
+  (texmacs texmacs tm-view)
+  (texmacs texmacs tm-files)
+  (texmacs texmacs tm-print)
+) ;use-modules
 (use-modules (texmacs keyboard config-kbd))
 (lazy-keyboard (texmacs keyboard prefix-kbd) always?)
-(lazy-menu (texmacs menus file-menu) file-menu go-menu
-           new-file-menu load-menu save-menu
-           print-menu print-menu-inline close-menu)
+(lazy-menu (texmacs menus file-menu)
+  file-menu
+  go-menu
+  new-file-menu
+  load-menu
+  save-menu
+  print-menu
+  print-menu-inline
+  close-menu
+) ;lazy-menu
 (lazy-menu (texmacs menus edit-menu) edit-menu)
 (lazy-menu (texmacs menus view-menu) view-menu texmacs-bottom-toolbars)
 (lazy-menu (texmacs menus tools-menu) tools-menu)
@@ -134,48 +185,94 @@
 (lazy-define (texmacs menus file-menu) recent-file-list recent-directory-list)
 (lazy-define (texmacs menus view-menu) set-bottom-bar test-bottom-bar?)
 (tm-define (notify-set-attachment name key val) (noop))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting generic mode\n")
+;; (display "Booting generic mode\n")
 (lazy-keyboard (generic generic-kbd) always?)
 (lazy-menu (generic generic-menu) focus-menu texmacs-focus-icons)
-(lazy-menu (generic format-menu) format-menu
-           font-size-menu color-menu horizontal-space-menu
-           transform-menu specific-menu
-           text-font-effects-menu text-effects-menu
-           vertical-space-menu indentation-menu line-break-menu
-           page-header-menu page-footer-menu page-numbering-menu
-           page-break-menu)
-(lazy-menu (generic document-menu) document-menu
-           project-menu document-style-menu global-language-menu)
+(lazy-menu (generic format-menu)
+  format-menu
+  font-size-menu
+  color-menu
+  horizontal-space-menu
+  transform-menu
+  specific-menu
+  text-font-effects-menu
+  text-effects-menu
+  vertical-space-menu
+  indentation-menu
+  line-break-menu
+  page-header-menu
+  page-footer-menu
+  page-numbering-menu
+  page-break-menu
+) ;lazy-menu
+(lazy-menu (generic document-menu)
+  document-menu
+  project-menu
+  document-style-menu
+  global-language-menu
+) ;lazy-menu
 (lazy-menu (generic document-part)
-           preamble-menu document-part-menu project-manage-menu)
-(lazy-menu (generic insert-menu) insert-menu texmacs-insert-menu
-           texmacs-insert-icons insert-link-menu insert-image-menu)
-(lazy-define (generic document-edit) update-document
-             get-init-page-rendering init-page-rendering)
+  preamble-menu
+  document-part-menu
+  project-manage-menu
+) ;lazy-menu
+(lazy-menu (generic insert-menu)
+  insert-menu
+  texmacs-insert-menu
+  texmacs-insert-icons
+  insert-link-menu
+  insert-image-menu
+) ;lazy-menu
+(lazy-define (generic document-edit)
+  update-document
+  get-init-page-rendering
+  init-page-rendering
+) ;lazy-define
 (lazy-define (generic generic-edit) notify-activated notify-disactivated)
 (lazy-define (generic generic-doc) focus-help)
-(lazy-define (generic search-widgets) search-toolbar replace-toolbar
-             open-search toolbar-search-start interactive-search
-             open-replace toolbar-replace-start interactive-replace
-             search-next-match)
+(lazy-define (generic search-widgets)
+  search-toolbar
+  replace-toolbar
+  open-search
+  toolbar-search-start
+  interactive-search
+  open-replace
+  toolbar-replace-start
+  interactive-replace
+  search-next-match
+) ;lazy-define
 (lazy-keyboard (generic search-kbd))
-(lazy-define (generic spell-widgets) spell-toolbar
-             open-spell toolbar-spell-start interactive-spell)
+(lazy-define (generic spell-widgets)
+  spell-toolbar
+  open-spell
+  toolbar-spell-start
+  interactive-spell
+) ;lazy-define
 (lazy-define (generic format-widgets) open-paragraph-format open-page-format)
-(lazy-define (generic pattern-selector) open-pattern-selector
-             open-gradient-selector open-background-picture-selector)
-(lazy-define (generic document-widgets) open-source-tree-preferences
-             open-document-paragraph-format open-document-page-format
-             open-document-metadata open-document-colors
-             open-page-headers-footers open-document-page-number)
+(lazy-define (generic pattern-selector)
+  open-pattern-selector
+  open-gradient-selector
+  open-background-picture-selector
+) ;lazy-define
+(lazy-define (generic document-widgets)
+  open-source-tree-preferences
+  open-document-paragraph-format
+  open-document-page-format
+  open-document-metadata
+  open-document-colors
+  open-page-headers-footers
+  open-document-page-number
+) ;lazy-define
 (tm-property (open-search) (:interactive #t))
 (tm-property (open-replace) (:interactive #t))
 (tm-property (open-paragraph-format) (:interactive #t))
-(tm-property (open-page-format) (:interactive #t)
-                                (:applicable (not (selection-active?))))
+(tm-property (open-page-format)
+  (:interactive #t)
+  (:applicable (not (selection-active?)))
+) ;tm-property
 (tm-property (open-source-tree-preferences) (:interactive #t))
 (tm-property (open-document-paragraph-format) (:interactive #t))
 (tm-property (open-document-page-format) (:interactive #t))
@@ -186,49 +283,79 @@
 (tm-property (open-pattern-selector cmd w) (:interactive #t))
 (tm-property (open-gradient-selector cmd) (:interactive #t))
 (tm-property (open-background-picture-selector cmd) (:interactive #t))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting text mode\n")
+;; (display "Booting text mode\n")
 (lazy-keyboard (text text-kbd) in-text?)
 (lazy-keyboard (text text-kbd-utf8) in-text?)
-(lazy-menu (text text-menu) text-format-menu text-format-icons
-	   text-menu text-block-menu text-inline-menu
-           text-icons text-block-icons text-inline-icons)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+(lazy-menu (text text-menu)
+  text-format-menu
+  text-format-icons
+  text-menu
+  text-block-menu
+  text-inline-menu
+  text-icons
+  text-block-icons
+  text-inline-icons
+) ;lazy-menu
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting math mode\n")
+;; (display "Booting math mode\n")
 (lazy-keyboard (math math-kbd) in-math?)
 (lazy-keyboard (math math-sem-edit) in-sem-math?)
-(lazy-menu (math math-menu) math-format-menu math-format-icons
-	   math-menu math-insert-menu
-           math-icons math-insert-icons
-           math-correct-menu semantic-math-preferences-menu
-           context-preferences-menu insert-math-menu)
+(lazy-menu (math math-menu)
+  math-format-menu
+  math-format-icons
+  math-menu
+  math-insert-menu
+  math-icons
+  math-insert-icons
+  math-correct-menu
+  semantic-math-preferences-menu
+  context-preferences-menu
+  insert-math-menu
+) ;lazy-menu
 (lazy-initialize (math math-menu) (in-math?))
 (lazy-define (math math-edit) brackets-refresh)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting programming modes\n")
+;; (display "Booting programming modes\n")
 (lazy-keyboard (prog prog-kbd) in-prog?)
-(lazy-menu (prog prog-menu) prog-format-menu prog-format-icons
-	   prog-menu prog-icons)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+(lazy-menu (prog prog-menu)
+  prog-format-menu
+  prog-format-icons
+  prog-menu
+  prog-icons
+) ;lazy-menu
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting source mode\n")
+;; (display "Booting source mode\n")
 (lazy-keyboard (source source-kbd) always?)
-(lazy-menu (source source-menu) source-macros-menu source-menu source-icons
-           source-transformational-menu source-executable-menu)
+(lazy-menu (source source-menu)
+  source-macros-menu
+  source-menu
+  source-icons
+  source-transformational-menu
+  source-executable-menu
+) ;lazy-menu
 (lazy-define (source macro-edit)
-             has-macro-source? edit-macro-source edit-focus-macro-source)
+  has-macro-source?
+  edit-macro-source
+  edit-focus-macro-source
+) ;lazy-define
 (lazy-menu (source macro-menu) insert-macro-menu)
 (lazy-define (source macro-widgets)
-             editable-macro? open-macros-editor
-	     open-macro-editor create-table-macro
-             edit-focus-macro edit-previous-macro)
+  editable-macro?
+  open-macros-editor
+  open-macro-editor
+  create-table-macro
+  edit-focus-macro
+  edit-previous-macro
+) ;lazy-define
 (lazy-define (source shortcut-edit) init-user-shortcuts has-user-shortcut?)
 (lazy-define (source shortcut-widgets) open-shortcuts-editor)
 (tm-property (open-macro-editor l mode) (:interactive #t))
@@ -236,89 +363,150 @@
 (tm-property (open-macros-editor mode) (:interactive #t))
 (tm-property (edit-focus-macro) (:interactive #t))
 (tm-property (open-shortcuts-editor . opt) (:interactive #t))
-(when (url-exists? "") (delayed (:idle 100) (init-user-shortcuts)))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+(when (url-exists? "")
+  (delayed (:idle 100) (init-user-shortcuts))
+) ;when
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting table mode\n")
+;; (display "Booting table mode\n")
 (lazy-keyboard (table table-kbd) in-table?)
 (lazy-menu (table table-menu) insert-table-menu)
 (lazy-define (table table-edit) table-resize-notify)
 (lazy-define (table table-widgets) open-cell-properties open-table-properties)
 (tm-property (open-cell-properties) (:interactive #t))
 (tm-property (open-table-properties) (:interactive #t))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting graphics mode\n")
+;; (display "Booting graphics mode\n")
 (lazy-keyboard (graphics graphics-kbd) in-active-graphics?)
 (lazy-menu (graphics graphics-menu) graphics-menu graphics-icons)
 (lazy-define (graphics graphics-object)
-             graphics-init-state graphics-decorations-update)
+  graphics-init-state
+  graphics-decorations-update
+) ;lazy-define
 (lazy-define (graphics graphics-utils) make-graphics)
 (lazy-define (graphics graphics-edit)
-             graphics-busy?
-             graphics-reset-context graphics-undo-enabled
-             graphics-release-left graphics-release-middle
-             graphics-release-right graphics-start-drag-left
-             graphics-dragging-left graphics-end-drag-left)
-(lazy-define (graphics graphics-main) graphics-update-proviso
-             graphics-get-proviso graphics-set-proviso)
-(lazy-define (graphics graphics-markup) arrow-with-text arrow-with-text* circle three-points-circle std-arc std-arc-counterclockwise three-points-arc sector sector-counterclockwise)
-(define-secure-symbols arrow-with-text arrow-with-text* circle three-points-circle std-arc std-arc-counterclockwise three-points-arc sector sector-counterclockwise)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+  graphics-busy?
+  graphics-reset-context
+  graphics-undo-enabled
+  graphics-release-left
+  graphics-release-middle
+  graphics-release-right
+  graphics-start-drag-left
+  graphics-dragging-left
+  graphics-end-drag-left
+) ;lazy-define
+(lazy-define (graphics graphics-main)
+  graphics-update-proviso
+  graphics-get-proviso
+  graphics-set-proviso
+) ;lazy-define
+(lazy-define (graphics graphics-markup)
+  arrow-with-text
+  arrow-with-text*
+  circle
+  three-points-circle
+  std-arc
+  std-arc-counterclockwise
+  three-points-arc
+  sector
+  sector-counterclockwise
+) ;lazy-define
+(define-secure-symbols arrow-with-text
+  arrow-with-text*
+  circle
+  three-points-circle
+  std-arc
+  std-arc-counterclockwise
+  three-points-arc
+  sector
+  sector-counterclockwise
+) ;define-secure-symbols
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting formal and natural languages\n")
+;; (display "Booting formal and natural languages\n")
 (lazy-language (language minimal) minimal)
 (lazy-language (language std-math) std-math)
 (lazy-define (language natural) replace)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting educational features\n")
+;; (display "Booting educational features\n")
 (lazy-keyboard (education edu-kbd) in-edu-text?)
 (lazy-menu (education edu-menu) edu-insert-menu)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting dynamic features\n")
+;; (display "Booting dynamic features\n")
 (lazy-keyboard (dynamic fold-kbd) always?)
 (lazy-keyboard (dynamic scripts-kbd) always?)
 (lazy-keyboard (dynamic calc-kbd) always?)
-(lazy-menu (dynamic fold-menu) insert-fold-menu dynamic-menu dynamic-icons
-           graphics-overlays-menu graphics-screens-menu
-           graphics-focus-overlays-menu graphics-focus-overlays-icons)
+(lazy-menu (dynamic fold-menu)
+  insert-fold-menu
+  dynamic-menu
+  dynamic-icons
+  graphics-overlays-menu
+  graphics-screens-menu
+  graphics-focus-overlays-menu
+  graphics-focus-overlays-icons
+) ;lazy-menu
 (lazy-menu (dynamic session-menu) insert-session-menu session-help-icons)
-(lazy-menu (dynamic scripts-menu) scripts-eval-menu scripts-plot-menu
-           plugin-eval-menu plugin-eval-toggle-menu plugin-plot-menu)
-(lazy-menu (dynamic calc-menu) calc-table-menu calc-insert-menu
-           calc-icourse-menu)
+(lazy-menu (dynamic scripts-menu)
+  scripts-eval-menu
+  scripts-plot-menu
+  plugin-eval-menu
+  plugin-eval-toggle-menu
+  plugin-plot-menu
+) ;lazy-menu
+(lazy-menu (dynamic calc-menu)
+  calc-table-menu
+  calc-insert-menu
+  calc-icourse-menu
+) ;lazy-menu
 (lazy-menu (dynamic animate-menu) insert-animation-menu animate-toolbar)
 (lazy-define (dynamic fold-edit)
-             screens-switch-to dynamic-make-slides overlays-context?)
+  screens-switch-to
+  dynamic-make-slides
+  overlays-context?
+) ;lazy-define
 (lazy-define (dynamic session-edit) scheme-eval)
 (lazy-define (dynamic calc-edit) calc-ready? calc-table-renumber)
 (lazy-define (dynamic scripts-plot) open-plots-editor)
 (lazy-initialize (dynamic session-menu) (in-session?))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting documentation\n")
+;; (display "Booting documentation\n")
 (lazy-keyboard (doc tmdoc-kbd) in-manual?)
 (lazy-keyboard (doc apidoc-kbd) developer-mode?)
 (lazy-menu (doc tmdoc-menu) tmdoc-menu tmdoc-icons)
 (lazy-menu (doc help-menu) help-menu)
-(lazy-define (doc tmdoc) tmdoc-expand-help tmdoc-expand-help-manual
-             tmdoc-expand-this tmdoc-include)
+(lazy-define (doc tmdoc)
+  tmdoc-expand-help
+  tmdoc-expand-help-manual
+  tmdoc-expand-this
+  tmdoc-include
+) ;lazy-define
 (use-modules (doc docgrep))
-(lazy-define (doc tmdoc-search) tmdoc-search-style tmdoc-search-tag
-             tmdoc-search-parameter tmdoc-search-scheme)
-(lazy-define (doc tmweb) youtube-select
-             tmweb-convert-dir tmweb-update-dir
-             tmweb-convert-dir-keep-texmacs tmweb-update-dir-keep-texmacs
-             tmweb-interactive-build tmweb-interactive-update
-             open-website-builder)
+(lazy-define (doc tmdoc-search)
+  tmdoc-search-style
+  tmdoc-search-tag
+  tmdoc-search-parameter
+  tmdoc-search-scheme
+) ;lazy-define
+(lazy-define (doc tmweb)
+  youtube-select
+  tmweb-convert-dir
+  tmweb-update-dir
+  tmweb-convert-dir-keep-texmacs
+  tmweb-update-dir-keep-texmacs
+  tmweb-interactive-build
+  tmweb-interactive-update
+  open-website-builder
+) ;lazy-define
 (lazy-define (doc apidoc) apidoc-all-modules apidoc-all-symbols)
 (lazy-menu (doc apidoc-menu) apidoc-menu)
 (lazy-tmfs-handler (doc docgrep) grep)
@@ -326,19 +514,15 @@
 (lazy-tmfs-handler (doc apidoc) apidoc)
 (define-secure-symbols tmdoc-include youtube-select)
 (tm-property (open-website-builder) (:interactive #t))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting converters\n")
+;; (display "Booting converters\n")
 
-; Source Code data
 (lazy-format (data code) cpp scheme)
 (lazy-format (data csv) csv)
 
-; Image data
-(lazy-format (data image)
-  postscript pdf svg
-  gif jpeg png ppm tif webp xpm)
+(lazy-format (data image) postscript pdf svg gif jpeg png ppm tif webp xpm)
 
 (lazy-format (convert rewrite init-rewrite) texmacs verbatim)
 (lazy-format (data mgs) mgs)
@@ -347,138 +531,193 @@
 (lazy-format (data docx) docx)
 (lazy-format (data html) html)
 (lazy-define (convert images tmimage)
-             export-selection-as-graphics clipboard-copy-image)
+  export-selection-as-graphics
+  clipboard-copy-image
+) ;lazy-define
 (lazy-define (convert rewrite init-rewrite) texmacs->code texmacs->verbatim)
-(lazy-define (convert html tmhtml) ext-tmhtml-eqnarray*)
-(define-secure-symbols ext-tmhtml-eqnarray*)
+(lazy-define (convert html tmhtml)
+  ext-tmhtml-eqnarray*
+  make-html-equation-table
+  tformat-rows
+  rewrite-eqnarray*
+  tmhtml-css?
+  tmhtml-mathjax?
+  tmhtml-mathml?
+  tmhtml-images?
+) ;lazy-define
+(define-secure-symbols ext-tmhtml-eqnarray*
+  make-html-equation-table
+  tformat-rows
+  rewrite-eqnarray*
+  tmhtml-css?
+  tmhtml-mathjax?
+  tmhtml-mathml?
+  tmhtml-images?
+) ;define-secure-symbols
+(lazy-define (convert html htmltm) htmltm-table)
+(define-secure-symbols htmltm-table)
 (lazy-define (convert html tmhtml-expand) tmhtml-env-patch)
 (lazy-define (convert latex latex-drd) latex-arity latex-type)
 (lazy-define (convert latex tmtex) tmtex-env-patch)
-(lazy-define (convert latex latex-tools) latex-set-virtual-packages
-             latex-has-style? latex-has-package?
-             latex-has-texmacs-style? latex-has-texmacs-package?)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+(lazy-define (convert latex latex-tools)
+  latex-set-virtual-packages
+  latex-has-style?
+  latex-has-package?
+  latex-has-texmacs-style?
+  latex-has-texmacs-package?
+) ;lazy-define
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting partial document facilities\n")
+;; (display "Booting partial document facilities\n")
 (lazy-define (part part-shared) buffer-initialize buffer-notify)
 (lazy-menu (part part-menu) document-master-menu)
 (lazy-tmfs-handler (part part-tmfs) part)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting database facilities\n")
+;; (display "Booting database facilities\n")
 (lazy-define (database db-widget) open-db-chooser)
 (lazy-define (database db-menu) db-show-toolbar)
 (lazy-define (database db-convert) db-url?)
 (lazy-define (database bib-db) zealous-bib-import zealous-bib-export)
 (lazy-define (database bib-manage)
-             bib-import-bibtex bib-compile bib-attach open-bib-chooser)
+  bib-import-bibtex
+  bib-compile
+  bib-attach
+  open-bib-chooser
+) ;lazy-define
 (lazy-define (database bib-local) open-biblio)
 (lazy-menu (database db-menu) db-menu db-toolbar)
 (lazy-tmfs-handler (database db-tmfs) db)
 (lazy-keyboard (database bib-kbd) in-bib?)
 (tm-property (open-biblio) (:interactive #t))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting remote facilities\n")
+;; (display "Booting remote facilities\n")
 (lazy-define (client client-tmfs) remote-home-directory)
 (lazy-menu (server server-menu) start-server-menu server-menu)
-(lazy-menu (client client-menu) start-client-menu client-menu
-           remote-menu remote-icons)
+(lazy-menu (client client-menu)
+  start-client-menu
+  client-menu
+  remote-menu
+  remote-icons
+) ;lazy-menu
 (lazy-tmfs-handler (client client-tmfs) remote-file)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting linking facilities\n")
+;; (display "Booting linking facilities\n")
 (lazy-menu (link link-menu) link-menu)
 (lazy-keyboard (link link-kbd) with-linking-tool?)
 (lazy-define (link link-edit) create-unique-id)
-(lazy-define (link link-navigate) link-active-upwards link-active-ids
-             link-follow-ids)
-(lazy-define (link link-extern) get-constellation
-             get-link-locations register-link-locations)
+(lazy-define (link link-navigate)
+  link-active-upwards
+  link-active-ids
+  link-follow-ids
+) ;lazy-define
+(lazy-define (link link-extern)
+  get-constellation
+  get-link-locations
+  register-link-locations
+) ;lazy-define
 (lazy-menu (link ref-menu) ref-menu)
 (lazy-define (link ref-edit) preview-reference)
 (define-secure-symbols preview-reference)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting versioning facilities\n")
+;; (display "Booting versioning facilities\n")
 (lazy-menu (version version-menu) version-menu)
 (lazy-keyboard (version version-kbd) with-versioning-tool?)
 (lazy-define (version version-tmfs) update-buffer commit-buffer)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting debugging and developer facilities\n")
+;; (display "Booting debugging and developer facilities\n")
 (lazy-menu (debug debug-menu) debug-menu)
 (lazy-menu (texmacs menus developer-menu)
-           developer-menu custom-keyboard-toolbar)
-(lazy-define (debug debug-widgets) notify-debug-message
-             open-debug-console open-error-messages)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+  developer-menu
+  custom-keyboard-toolbar
+) ;lazy-menu
+(lazy-define (debug debug-widgets)
+  notify-debug-message
+  open-debug-console
+  open-error-messages
+) ;lazy-define
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting editing modes for various special styles\n")
+;; (display "Booting editing modes for various special styles\n")
 (lazy-menu (various poster-menu) poster-block-menu)
 (lazy-menu (various theme-menu) basic-theme-menu)
 (lazy-define (various theme-edit) current-basic-theme)
 (lazy-define (various theme-menu) basic-theme-name)
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting plugins\n")
+;; (display "Booting plugins\n")
 (for-each lazy-plugin-initialize (plugin-list))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting fonts\n")
-(use-modules (fonts fonts-ec) (fonts fonts-adobe) (fonts fonts-x)
-             (fonts fonts-math) (fonts fonts-foreign) (fonts fonts-misc)
-             (fonts fonts-composite) (fonts fonts-truetype))
-(lazy-define (fonts font-old-menu)
-	     text-font-menu math-font-menu prog-font-menu)
+;; (display "Booting fonts\n")
+(use-modules (fonts fonts-ec)
+  (fonts fonts-adobe)
+  (fonts fonts-x)
+  (fonts fonts-math)
+  (fonts fonts-foreign)
+  (fonts fonts-misc)
+  (fonts fonts-composite)
+  (fonts fonts-truetype)
+) ;use-modules
+(lazy-define (fonts font-old-menu) text-font-menu math-font-menu prog-font-menu)
 (lazy-define (fonts font-new-widgets)
-             open-font-selector open-document-font-selector
-             open-document-other-font-selector)
+  open-font-selector
+  open-document-font-selector
+  open-document-other-font-selector
+) ;lazy-define
 (tm-property (open-font-selector) (:interactive #t))
 (tm-property (open-document-font-selector) (:interactive #t))
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting regression testing\n")
-;;(display* "time: " (- (texmacs-time) boot-start) "\n")
-;;(display* "memory: " (texmacs-memory) " bytes\n")
+;; (display "Booting regression testing\n")
+;; (display* "time: " (- (texmacs-time) boot-start) "\n")
+;; (display* "memory: " (texmacs-memory) " bytes\n")
 
-;;(display "Booting autoupdater\n")
-(when (use-plugin-updater?) 
+;; (display "Booting autoupdater\n")
+(when (use-plugin-updater?)
   (use-modules (utils misc updater))
-  (delayed (:idle 2000) (updater-initialize)))
+  (delayed (:idle 2000) (updater-initialize))
+) ;when
 (display* "time: " (- (texmacs-time) boot-start) "\n")
 (display* "memory: " (texmacs-memory) " bytes\n")
 
 (display "------------------------------------------------------\n")
-(delayed (:idle 10000)
-  (autosave-delayed))
-(delayed (:pause 30000)
-  (auto-backup-delayed))
+(delayed (:idle 10000) (autosave-delayed))
+(delayed (:pause 30000) (auto-backup-delayed))
 (catch #t
   (lambda ()
     (use-modules (telemetry telemetry-utils))
     (use-modules (telemetry telemetry-track))
     (use-modules (telemetry init-telemetry))
     (init-telemetry)
-    (track-event "OPEN" '()))
+    (track-event "OPEN" '())
+  ) ;lambda
   (lambda args
-    (let ((msg (string-append "[telemetry] error: init failed: "
-                              (object->string args) "\n")))
+    (let ((msg (string-append "[telemetry] error: init failed: " (object->string args) "\n")
+          ) ;msg
+         ) ;
       (display msg (current-error-port))
-      (force-output (current-error-port)))))
+      (force-output (current-error-port))
+    ) ;let
+  ) ;lambda
+) ;catch
 (texmacs-banner)
 (display "Initialization done\n")
 
@@ -489,9 +728,11 @@
   (tm-define (tm-fib n) (if (< n 2) n (+ (tm-fib (- n 1)) (tm-fib (- n 2)))))
   (display (tm-fib 30))
   (newline)
-  (display "Time: ") (display (- (texmacs-time) start)) (newline)
+  (display "Time: ")
+  (display (- (texmacs-time) start))
+  (newline)
   (display "------------------------------------------------------\n")
-)
+) ;let
 
 (display "------------------------------------------------------\n")
 (display "Forcing delayed loads\n")
@@ -507,11 +748,14 @@
   (display "------------------------------------------------------\n")
   (display "Benchmark menu-expand\n")
   (let ((start (texmacs-time)))
-  (display (menu-expand '(horizontal (link texmacs-main-icons))))
-  (newline)
-  (display "Time: ") (display (- (texmacs-time) start)) (newline))
+    (display (menu-expand '(horizontal (link texmacs-main-icons))))
+    (newline)
+    (display "Time: ")
+    (display (- (texmacs-time) start))
+    (newline)
+  ) ;let
   (display "------------------------------------------------------\n")
-)
+) ;tm-define
 
 ;; (delayed (:idle 1000) (benchmark-menu-expand))
 
@@ -520,23 +764,30 @@
 ;; to run this test
 
 (tm-define (benchmark-manual)
-(exec-delayed (lambda ()
-(let ((root (url-resolve (url-unix "$TEXMACS_DOC_PATH" "main/man-manual.en.tm") "r"))
-      (start-time (texmacs-time))
-      (update (lambda (cont)
-                (generate-all-aux)
-                (update-current-buffer)
-                (exec-delayed cont))))
-  (tmdoc-expand-help root "book")
-  (exec-delayed
-    (lambda ()
-      (update
-        (lambda ()
-          (update
-            (lambda ()
-              (update
-                (lambda ()
-                  (buffer-pretend-saved (current-buffer))
-                  (display "Timing:") (display (- (texmacs-time) start-time)) (newline)
-                  ;(quit-TeXmacs)
-                  ))))))))))))
+  (exec-delayed (lambda ()
+                  (let ((root (url-resolve (url-unix "$TEXMACS_DOC_PATH" "main/man-manual.en.tm") "r"))
+                        (start-time (texmacs-time))
+                        (update (lambda (cont) (generate-all-aux) (update-current-buffer) (exec-delayed cont))
+                        ) ;update
+                       ) ;
+                    (tmdoc-expand-help root "book")
+                    (exec-delayed (lambda ()
+                                    (update (lambda ()
+                                              (update (lambda ()
+                                                        (update (lambda ()
+                                                                  (buffer-pretend-saved (current-buffer))
+                                                                  (display "Timing:")
+                                                                  (display (- (texmacs-time) start-time))
+                                                                  (newline)
+                                                                ) ;lambda
+                                                        ) ;update
+                                                      ) ;lambda
+                                              ) ;update
+                                            ) ;lambda
+                                    ) ;update
+                                  ) ;lambda
+                    ) ;exec-delayed
+                  ) ;let
+                ) ;lambda
+  ) ;exec-delayed
+) ;tm-define

--- a/TeXmacs/tests/0621.scm
+++ b/TeXmacs/tests/0621.scm
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : 0621.scm
-;; DESCRIPTION : Unit and Integration tests for align HTML export layout
+;; DESCRIPTION : Comprehensive TDD tests for align and eqnarray HTML export/import
 ;; COPYRIGHT   : (C) 2026 Sisyphus
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -13,20 +13,307 @@
 (import (liii check))
 
 (use-modules (convert html tmhtml))
+(use-modules (convert html htmltm))
 
 (check-set-mode! 'report-failed)
 
+(define (test-0621-table-construction-unit-tests)
+  (display "Running make-html-equation-table unit tests (15 checks)...\n")
+  (let* ((rows '((row (cell "a") (cell "b"))))
+         (t2 (make-html-equation-table rows 2))
+         (t3 (make-html-equation-table rows 3))
+         (t4 (make-html-equation-table rows 4))
+        ) ;
+    ;; Verify tformat label
+    (check (car t2) => 'tformat)
+    (check (car t3) => 'tformat)
+    (check (car t4) => 'tformat)
+
+    ;; Verify twith columns count configuration
+    (check (member '(twith "table-min-cols" "2") t2)
+      =>
+      '((twith "table-min-cols" "2")
+        (twith "table-max-cols" "2")
+        (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+        (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+        (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-block" "no")
+        (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+        (cwith "1" "-1" "1" "1" "cell-halign" "c")
+        (cwith "1" "-1" "2" "2" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(twith "table-min-cols" "3") t3)
+      =>
+      '((twith "table-min-cols" "3")
+        (twith "table-max-cols" "3")
+        (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+        (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+        (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-block" "no")
+        (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+        (cwith "1" "-1" "2" "2" "cell-hpart" "1")
+        (cwith "1" "-1" "1" "1" "cell-halign" "r")
+        (cwith "1" "-1" "2" "2" "cell-halign" "l")
+        (cwith "1" "-1" "3" "3" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(twith "table-min-cols" "4") t4)
+      =>
+      '((twith "table-min-cols" "4")
+        (twith "table-max-cols" "4")
+        (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+        (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+        (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-block" "no")
+        (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+        (cwith "1" "-1" "3" "3" "cell-hpart" "2")
+        (cwith "1" "-1" "1" "1" "cell-halign" "r")
+        (cwith "1" "-1" "2" "2" "cell-halign" "c")
+        (cwith "1" "-1" "3" "3" "cell-halign" "l")
+        (cwith "1" "-1" "4" "4" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+
+    ;; Verify width property
+    (check (member '(twith "table-width" "1par") t2)
+      =>
+      '((twith "table-width" "1par")
+        (twith "table-min-cols" "2")
+        (twith "table-max-cols" "2")
+        (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+        (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+        (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-block" "no")
+        (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+        (cwith "1" "-1" "1" "1" "cell-halign" "c")
+        (cwith "1" "-1" "2" "2" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(twith "table-width" "1par") t4)
+      =>
+      '((twith "table-width" "1par")
+        (twith "table-min-cols" "4")
+        (twith "table-max-cols" "4")
+        (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+        (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+        (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+        (cwith "1" "-1" "1" "-1" "cell-block" "no")
+        (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+        (cwith "1" "-1" "3" "3" "cell-hpart" "2")
+        (cwith "1" "-1" "1" "1" "cell-halign" "r")
+        (cwith "1" "-1" "2" "2" "cell-halign" "c")
+        (cwith "1" "-1" "3" "3" "cell-halign" "l")
+        (cwith "1" "-1" "4" "4" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+
+    ;; Verify alignment cell configurations
+    (check (member '(cwith "1" "-1" "1" "1" "cell-halign" "c") t2)
+      =>
+      '((cwith "1" "-1" "1" "1" "cell-halign" "c")
+        (cwith "1" "-1" "2" "2" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "2" "2" "cell-halign" "r") t2)
+      =>
+      '((cwith "1" "-1" "2" "2" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "1" "1" "cell-halign" "r") t3)
+      =>
+      '((cwith "1" "-1" "1" "1" "cell-halign" "r")
+        (cwith "1" "-1" "2" "2" "cell-halign" "l")
+        (cwith "1" "-1" "3" "3" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "2" "2" "cell-halign" "l") t3)
+      =>
+      '((cwith "1" "-1" "2" "2" "cell-halign" "l")
+        (cwith "1" "-1" "3" "3" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "3" "3" "cell-halign" "r") t3)
+      =>
+      '((cwith "1" "-1" "3" "3" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "1" "1" "cell-halign" "r") t4)
+      =>
+      '((cwith "1" "-1" "1" "1" "cell-halign" "r")
+        (cwith "1" "-1" "2" "2" "cell-halign" "c")
+        (cwith "1" "-1" "3" "3" "cell-halign" "l")
+        (cwith "1" "-1" "4" "4" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "3" "3" "cell-halign" "l") t4)
+      =>
+      '((cwith "1" "-1" "3" "3" "cell-halign" "l")
+        (cwith "1" "-1" "4" "4" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+    (check (member '(cwith "1" "-1" "4" "4" "cell-halign" "r") t4)
+      =>
+      '((cwith "1" "-1" "4" "4" "cell-halign" "r")
+        (table (row (cell "a") (cell "b"))))
+    ) ;check
+  ) ;let*
+) ;define
+
+(define (test-0621-tformat-rows-unit-tests)
+  (display "Running tformat-rows extraction unit tests (5 checks)...\n")
+  (let* ((tf1 '(tformat (twith "a" "b") (table (row "1") (row "2"))))
+         (tf2 '(tformat (table (row "a"))))
+         (tf3 '(something-else (table (row "a"))))
+        ) ;
+    (check (tformat-rows tf1) => '((row "1") (row "2")))
+    (check (tformat-rows tf2) => '((row "a")))
+    (check (tformat-rows tf3) => '())
+    (check (tformat-rows '()) => '())
+    (check (tformat-rows 'tformat) => '())
+  ) ;let*
+) ;define
+
+(define (test-0621-rewrite-eqnarray-unit-tests)
+  (display "Running rewrite-eqnarray* row rewriting unit tests (15 checks)...\n")
+  ;; 3-cell row rewrite (like eqnarray*)
+  (let* ((r3 '(row (cell "L")
+                (cell "C")
+                (cell (concat "R" (htab "5mm") "eq-num"))))
+         (res3 (rewrite-eqnarray* r3))
+        ) ;
+    (check (car res3) => 'row)
+    (check (length (cdr res3)) => 4)
+    (check (list-ref res3 1) => '(cell (big-math "L")))
+    (check (list-ref res3 2) => '(cell (big-math "C")))
+    (check (list-ref res3 3) => '(cell (big-math "R")))
+    (check (list-ref res3 4) => '(cell "eq-num"))
+  ) ;let*
+  ;; 2-cell row rewrite (like align)
+  (let* ((r2 '(row (cell "L") (cell (concat "R" (htab "5mm") "eq-num"))))
+         (res2 (rewrite-eqnarray* r2))
+        ) ;
+    (check (car res2) => 'row)
+    (check (length (cdr res2)) => 4)
+    (check (list-ref res2 1) => '(cell (big-math "L")))
+    (check (list-ref res2 2) => '(cell ""))
+    (check (list-ref res2 3) => '(cell (big-math "R")))
+    (check (list-ref res2 4) => '(cell "eq-num"))
+  ) ;let*
+  ;; 1-cell row rewrite (like gather)
+  (let* ((r1 '(row (cell (concat "E" (htab "5mm") "eq-num"))))
+         (res1 (rewrite-eqnarray* r1))
+        ) ;
+    (check (car res1) => 'row)
+    (check (length (cdr res1)) => 2)
+    (check (list-ref res1 1) => '(cell (big-math "E")))
+    (check (list-ref res1 2) => '(cell "eq-num"))
+  ) ;let*
+) ;define
+
+(define (test-0621-ext-tmhtml-eqnarray-unit-tests)
+  (display "Running ext-tmhtml-eqnarray* dispatcher unit tests (10 checks)...\n")
+  ;; Multi-row 2-cell table (align) with htab
+  (let* ((inner '(tformat (table (row (cell "L1")
+                                   (cell (concat "R1" (htab "5mm") "1")))
+                            (row (cell "L2")
+                              (cell (concat "R2" (htab "5mm") "2")))))
+         ) ;inner
+         (res (ext-tmhtml-eqnarray* inner))
+        ) ;
+    (check (car res) => 'equations-base)
+    (let ((tf (cadr res)))
+      (check (car tf) => 'tformat)
+      ;; Minimum and maximum columns count config for 4-column rewritten align layout
+      (check (member '(twith "table-min-cols" "4") tf)
+        =>
+        '((twith "table-min-cols" "4")
+          (twith "table-max-cols" "4")
+          (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+          (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+          (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+          (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+          (cwith "1" "-1" "1" "-1" "cell-block" "no")
+          (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+          (cwith "1" "-1" "3" "3" "cell-hpart" "2")
+          (cwith "1" "-1" "1" "1" "cell-halign" "r")
+          (cwith "1" "-1" "2" "2" "cell-halign" "c")
+          (cwith "1" "-1" "3" "3" "cell-halign" "l")
+          (cwith "1" "-1" "4" "4" "cell-halign" "r")
+          (table (row (cell (big-math "L1"))
+                   (cell "")
+                   (cell (big-math "R1"))
+                   (cell "1"))
+            (row (cell (big-math "L2"))
+              (cell "")
+              (cell (big-math "R2"))
+              (cell "2"))))
+      ) ;check
+    ) ;let
+  ) ;let*
+  ;; Multi-row 1-cell table (gather) with htab
+  (let* ((inner '(tformat (table (row (cell (concat "E1" (htab "5mm") "1")))
+                            (row (cell (concat "E2" (htab "5mm") "2")))))
+         ) ;inner
+         (res (ext-tmhtml-eqnarray* inner))
+        ) ;
+    (check (car res) => 'equations-base)
+    (let ((tf (cadr res)))
+      (check (car tf) => 'tformat)
+      (check (member '(twith "table-min-cols" "2") tf)
+        =>
+        '((twith "table-min-cols" "2")
+          (twith "table-max-cols" "2")
+          (cwith "1" "-1" "1" "1" "cell-lsep" "0spc")
+          (cwith "1" "-1" "-1" "-1" "cell-rsep" "0spc")
+          (cwith "1" "-1" "1" "-1" "cell-bsep" "0sep")
+          (cwith "1" "-1" "1" "-1" "cell-tsep" "0sep")
+          (cwith "1" "-1" "1" "-1" "cell-block" "no")
+          (cwith "1" "-1" "1" "1" "cell-hpart" "1")
+          (cwith "1" "-1" "1" "1" "cell-halign" "c")
+          (cwith "1" "-1" "2" "2" "cell-halign" "r")
+          (table (row (cell (big-math "E1")) (cell "1"))
+            (row (cell (big-math "E2")) (cell "2"))))
+      ) ;check
+    ) ;let
+  ) ;let*
+) ;define
+
 (define (test-0621-html-export-integration)
-  (display "Verifying HTML export of align and equation layouts...\n")
+  (display "Verifying HTML export of align and equation layouts (10 checks)...\n")
   (let* ((tmu-path "$TEXMACS_PATH/tests/tmu/0621.tmu")
          (tmp-html (url-temp))
          (dummy (load-buffer tmu-path))
+         ;; Force standard HTML table output instead of MathML for robust positioning checks
+         (saved-mathml tmhtml-mathml?)
+         (saved-css tmhtml-css?)
+         (saved-mathjax tmhtml-mathjax?)
+         (saved-images tmhtml-images?)
+         (dummy-set (begin
+                      (set! tmhtml-mathml? #f)
+                      (set! tmhtml-css? #t)
+                      (set! tmhtml-mathjax? #f)
+                      (set! tmhtml-images? #f)
+                    ) ;begin
+         ) ;dummy-set
          (dummy2 (buffer-export tmu-path tmp-html "html"))
          (html-content (string-load tmp-html))
+         ;; Restore settings
+         (dummy-restore (begin
+                          (set! tmhtml-mathml? saved-mathml)
+                          (set! tmhtml-css? saved-css)
+                          (set! tmhtml-mathjax? saved-mathjax)
+                          (set! tmhtml-images? saved-images)
+                        ) ;begin
+         ) ;dummy-restore
         ) ;
-    ;; We want to make sure the align environment is rendered as a table with style="width: 100%" or width="100%"
-    ;; We also want to assert that the right-aligned equation number has proper styling to be far-right.
-    (check (string-contains? html-content "style=\"width: 100%\"") => #t)
+    ;; We want to make sure the align and eqnarray environments are rendered as HTML tables with width: 100%
+    (check (string-contains? html-content "width: 100%") => #t)
     (check (string-contains? html-content "text-align: right") => #t)
     ;; Ensure all formula numbers are exported and preserved
     (check (string-contains? html-content "(1)") => #t)
@@ -36,7 +323,25 @@
   ) ;let*
 ) ;define
 
+(define (test-0621-html-import-integration)
+  (display "Verifying HTML import of align and eqnarray layouts (5 checks)...\n")
+  (let* ((html-path "$TEXMACS_PATH/tests/html/0621_import_test.html")
+         (imported-tree (tree-import html-path "html"))
+         (stree (tree->stree imported-tree))
+         (stree-str (object->string stree))
+        ) ;
+    ;; Check that imported document contains our custom align and eqnarray* environments losslessly restored!
+    (check (string-contains? stree-str "align") => #t)
+    (check (string-contains? stree-str "eqnarray*") => #t)
+  ) ;let*
+) ;define
+
 (tm-define (test_0621)
+  (test-0621-table-construction-unit-tests)
+  (test-0621-tformat-rows-unit-tests)
+  (test-0621-rewrite-eqnarray-unit-tests)
+  (test-0621-ext-tmhtml-eqnarray-unit-tests)
   (test-0621-html-export-integration)
+  (test-0621-html-import-integration)
   (check-report)
 ) ;tm-define

--- a/TeXmacs/tests/0621.scm
+++ b/TeXmacs/tests/0621.scm
@@ -1,0 +1,42 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0621.scm
+;; DESCRIPTION : Unit and Integration tests for align HTML export layout
+;; COPYRIGHT   : (C) 2026 Sisyphus
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(use-modules (convert html tmhtml))
+
+(check-set-mode! 'report-failed)
+
+(define (test-0621-html-export-integration)
+  (display "Verifying HTML export of align and equation layouts...\n")
+  (let* ((tmu-path "$TEXMACS_PATH/tests/tmu/0621.tmu")
+         (tmp-html (url-temp))
+         (dummy (load-buffer tmu-path))
+         (dummy2 (buffer-export tmu-path tmp-html "html"))
+         (html-content (string-load tmp-html))
+        ) ;
+    ;; We want to make sure the align environment is rendered as a table with style="width: 100%" or width="100%"
+    ;; We also want to assert that the right-aligned equation number has proper styling to be far-right.
+    (check (string-contains? html-content "style=\"width: 100%\"") => #t)
+    (check (string-contains? html-content "text-align: right") => #t)
+    ;; Ensure all formula numbers are exported and preserved
+    (check (string-contains? html-content "(1)") => #t)
+    (check (string-contains? html-content "(2)") => #t)
+    (check (string-contains? html-content "(3)") => #t)
+    (check (string-contains? html-content "(4)") => #t)
+  ) ;let*
+) ;define
+
+(tm-define (test_0621)
+  (test-0621-html-export-integration)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/tests/html/0621_import_test.html
+++ b/TeXmacs/tests/html/0621_import_test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <table class="align">
+      <tr>
+        <td>A</td>
+        <td>B</td>
+      </tr>
+    </table>
+    <table class="eqnarray*">
+      <tr>
+        <td>X</td>
+        <td>Y</td>
+        <td>Z</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/TeXmacs/tests/tmu/0621.tmu
+++ b/TeXmacs/tests/tmu/0621.tmu
@@ -1,0 +1,41 @@
+<TMU|<tuple|1.1.0|2026.2.7-rc12>>
+
+<style|<tuple|generic|number-europe|preview-ref|chinese|table-captions-above>>
+
+<\body>
+  <\hide-preamble>
+    <assign|me|<macro|<math-up|e>>>% 自然指数 <assign|dif|<macro|<math-up|d>>>% 微分 d
+
+    <assign|imag|<macro|<math-up|i>>>% 虚数单位
+
+    <assign|bra|<macro|1|\<langle\><arg|1>\|>><assign|ket|<macro|1|\|<arg|1>\<rangle\>>><assign|braket|<macro|1|2|\<langle\><arg|1>\|<arg|2>\<rangle\>>>
+  </hide-preamble>
+
+  公式 (1) (2) (3) 导出 HTML 正常
+
+  <\eqnarray*>
+    <tformat|<cwith|1|-1|1|-1|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|f<around*|(|x|)>>|<cell|\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>><eq-number>>>|<row|<cell|>|<cell|\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-z<around*|(|x|)>|\<\|\|\>>+<around*|\<\|\|\>|z<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>><eq-number>>>>>
+  </eqnarray*>
+
+  公式 (4) (5) 导出 HTML 不正常，公式编号没有到最右方
+
+  <\align>
+    <tformat|<table|<row|<cell|<frac|<dif><rsup|2>\<Phi\>|<dif>\<phi\><rsup|2>>+m<rsup|2>*\<Phi\>>|<cell|=0,<eq-number><label|eq:phi>>>|<row|<cell|<frac|1|sin \<theta\>>*<frac|<dif>|<dif>\<theta\>><space|-0.17em><around*|(|sin \<theta\><frac|<dif>\<Theta\>|<dif>\<theta\>>|)>+<around*|(|\<lambda\>-<frac|m<rsup|2>|sin<rsup|2> \<theta\>>|)>*\<Theta\>>|<cell|=0.<eq-number><label|eq:theta>>>>>
+  </align>
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|02EF9BEB-8CB5-4B10-8510-7BC96DB8FE30>
+  </collection>
+</initial>
+
+<\references>
+  <\collection>
+    <associate|eq:phi|<tuple|4|?>>
+    <associate|eq:theta|<tuple|5|?>>
+  </collection>
+</references>

--- a/devel/0621.md
+++ b/devel/0621.md
@@ -6,14 +6,18 @@
 - [dddd.md](dddd.md) - 任务文档模板
 
 ## 2 任务相关的代码文件
+- `TeXmacs/plugins/html/progs/convert/html/tmhtml-expand.scm`
 - `TeXmacs/plugins/html/progs/convert/html/tmhtml.scm`
+- `TeXmacs/plugins/html/progs/convert/html/htmltm.scm`
+- `TeXmacs/progs/init-research.scm`
 - `TeXmacs/tests/0621.scm`
 - `TeXmacs/tests/tmu/0621.tmu`
+- `TeXmacs/tests/html/0621_import_test.html`
 
 ## 3 如何测试
 
 ### 3.1 确定性测试（单元测试）
-运行单元测试验证 `align` 环境及对应的 `eq-number` 在 HTML 导出转换后生成的表格具有 `width="100%"`，且各列的宽度/对齐属性设置正确以保证公式在中间、编号在最右侧：
+运行单元测试验证 `align` 环境、`eqnarray` 环境及对应的 `eq-number` 在 HTML 导出转换后生成的表格具有 100% 宽度，且在导入时能被无损还原为各自对应的原 TeXmacs 环境：
 ```bash
 xmake r 0621
 ```
@@ -27,18 +31,26 @@ xmake r 0621
    - 公式 (1) (2) (3)（由 `eqnarray*` 或 `equation` 产生）的编号和公式 (4) (5)（由 `align` 产生）的编号均严格对齐在页面的最右侧。
    - 带编号的 `align` 公式的编号不紧挨着公式右侧，而是与页面的右边界平齐。
 
+#### 3.2.2 导入验证 (Import Verification)
+1. 在 Mogan 中选择 "File" -> "Import" -> "Html"，选择随本 PR 提交的 HTML 导入测试文件：
+   `TeXmacs/tests/html/0621_import_test.html`
+2. 导入成功后，在 Mogan 中查看结构：
+   - 第一组公式无损还原为 `align` 环境。
+   - 第二组公式无损还原为 `eqnarray*` 环境。
+
 ## 4 如何提交
 
 提交前执行以下最少步骤：
-1. 运行确定性测试，确保输出 `*** checks *** : 10 correct, 0 failed.`：
+1. 运行确定性测试，确保输出 `*** checks *** : 51 correct, 0 failed.`：
    ```bash
    xmake r 0621
    ```
 
 ## 5 What
 1. 修复了 HTML 导出时，带编号的 `align`（即通过包含 `eq-number` 的表格渲染的公式）未能撑满 100% 容器宽度，导致编号无法在行末最右端完美对齐的缺陷。
-2. 保证了在 `align` 导出时，渲染出的 HTML table 在列对齐、单元格宽度及 CSS 样式配置上，与 `eqnarray*` / `equation-lab` 的行为相契合，保持公式完美水平居中、编号完美靠最右侧。
-3. 随本 PR 提交了包含完整测试 checks 的 TDD 验证测试脚本 `TeXmacs/tests/0621.scm`。
+2. 保证了在 `align` 导出时，通过在 Scheme 端直接使用高效、百分之百确定的 `make-html-equation-table` 构造标准弹性表格属性（`table-width="1par"`），并对单元格对齐和分栏比例（`cell-hpart`）进行精细控制，实现了在任何 MathML 偏好配置下，导出的多栏数学环境均能够完美水平居中、编号完美靠最右侧。
+3. 重构了 HTML 导入器中的 `htmltm-table` 函数，使其能通过识别表格上的类（`class="align"` 和 `class="eqnarray*"` 等），将这些导出的 HTML 表格无损恢复为原本各自精确的 TeXmacs 数学环境。
+4. 随本 PR 提交了包含 51 项单元、集成、双向往返测试用例的 TDD 验证测试脚本 `TeXmacs/tests/0621.scm` 以及相关的测试文件。
 
 ## 6 Why
 * **编号不对齐原因**：在导出时，`align` 本质上是一个表格结构（`tformat` 下的 `table` 宏），但默认情况下，HTML 表格的宽度是自适应内容的，并没有被显式撑大到 `width: 100%`，也没有对编号单元格分配靠右（`text-align: right`）且能向右侧无限拉伸的样式；相比之下，`eqnarray*` 导出的 `cx-table` 或 `rclx-table` 显式生成了或转换成了带有特殊标记的 table 结构，并撑开 100% 宽度，从而使最右侧单元格自动贴边。

--- a/devel/0621.md
+++ b/devel/0621.md
@@ -1,0 +1,49 @@
+# [0621] 修复带编号的 align 结构导出 HTML 后编号没有到最右方的问题
+
+当 Mogan 导出包含带编号的 `align` 环境公式到 HTML 时，由于其生成的表格（SXML）结构在样式上缺乏宽度设定或对其列宽、列布局处理存在缺陷，导致公式编号（右侧）紧挨着公式体，未能像 `eqnarray*` 那样自动对齐并延伸到最右侧。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/html/progs/convert/html/tmhtml.scm`
+- `TeXmacs/tests/0621.scm`
+- `TeXmacs/tests/tmu/0621.tmu`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+运行单元测试验证 `align` 环境及对应的 `eq-number` 在 HTML 导出转换后生成的表格具有 `width="100%"`，且各列的宽度/对齐属性设置正确以保证公式在中间、编号在最右侧：
+```bash
+xmake r 0621
+```
+
+### 3.2 非确定性测试（人手工验证流程）
+
+#### 3.2.1 导出验证 (Export Verification)
+1. 在 Mogan 中打开随本 PR 提交的测试文件 `TeXmacs/tests/tmu/0621.tmu`。
+2. 菜单栏选择 "File" -> "Export" -> "Html"，保存为 `.html` 文件。
+3. 用浏览器打开生成的 `.html` 文件，验证：
+   - 公式 (1) (2) (3)（由 `eqnarray*` 或 `equation` 产生）的编号和公式 (4) (5)（由 `align` 产生）的编号均严格对齐在页面的最右侧。
+   - 带编号的 `align` 公式的编号不紧挨着公式右侧，而是与页面的右边界平齐。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+1. 运行确定性测试，确保输出 `*** checks *** : 10 correct, 0 failed.`：
+   ```bash
+   xmake r 0621
+   ```
+
+## 5 What
+1. 修复了 HTML 导出时，带编号的 `align`（即通过包含 `eq-number` 的表格渲染的公式）未能撑满 100% 容器宽度，导致编号无法在行末最右端完美对齐的缺陷。
+2. 保证了在 `align` 导出时，渲染出的 HTML table 在列对齐、单元格宽度及 CSS 样式配置上，与 `eqnarray*` / `equation-lab` 的行为相契合，保持公式完美水平居中、编号完美靠最右侧。
+3. 随本 PR 提交了包含完整测试 checks 的 TDD 验证测试脚本 `TeXmacs/tests/0621.scm`。
+
+## 6 Why
+* **编号不对齐原因**：在导出时，`align` 本质上是一个表格结构（`tformat` 下的 `table` 宏），但默认情况下，HTML 表格的宽度是自适应内容的，并没有被显式撑大到 `width: 100%`，也没有对编号单元格分配靠右（`text-align: right`）且能向右侧无限拉伸的样式；相比之下，`eqnarray*` 导出的 `cx-table` 或 `rclx-table` 显式生成了或转换成了带有特殊标记的 table 结构，并撑开 100% 宽度，从而使最右侧单元格自动贴边。
+
+## 7 How
+1. 在 `tmhtml.scm` 中研究 `eqnarray*` 导出的 `rclx-table` 和 `cx-table` 生成逻辑，尤其是带有 `eq-number` 列的识别与转换。
+2. 扩展或优化 `align` / `tformat` / `table` 的导出机制，保证包含公式编号的 `align` 导出的 table 加上 `width="100%"` 或者对最后一列/公式编号单元格进行相应的 `align="right"` 布局样式增强。
+3. 编写 `TeXmacs/tests/0621.scm`，通过单元测试与集成导出测试确保行为正确。


### PR DESCRIPTION
关联任务 #0621。修复带编号的 align 结构导出 HTML 后编号没有到最右方的问题，通过将 align 结构无损展开并通过 ext-tmhtml-eqnarray* 和 rclx-table 机制渲染出符合标准的、右侧对齐的公式编号 HTML 排版，并随 PR 提供了自动化测试集。