### PR TITLE
[1067] LLM session colors adapt to dark/light theme

### DIFF
--- a/TeXmacs/packages/themes/dark/dark.ts
+++ b/TeXmacs/packages/themes/dark/dark.ts
@@ -100,12 +100,6 @@
 
   <assign|gr-grid-aspect|<tuple|<tuple|axes|#999999>|<tuple|1|#666666>|<tuple|10|#003153>>>
 
-  <assign|llm-input-bg-color|#9ba8c2>
-
-  <assign|llm-prompt-color|#4d6cff>
-
-  <assign|llm-input-color|#242938>
-
   <\active*>
     <\src-comment>
       Preamble

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -32,7 +32,7 @@
     <\with|prog-language|<arg|language>|prog-session|<arg|session>>
       <render-session|<arg|body>>
 
-      <new-line>
+      \;
     </with>
   </macro>>
 
@@ -92,7 +92,7 @@
 
   <assign|llm-thinking-dots|<macro|<anim-repeat|<anim-compose|<anim-constant||0.35sec>|<anim-constant|.|0.35sec>|<anim-constant|..|0.35sec>|<anim-constant|...|0.35sec>>>>>
 
-  <assign|script-busy|<macro|msg|<script-status|<if|<equal|<arg|msg>|<uninit>>|<localize|Thinking><llm-thinking-dots>|<arg|msg>>>>>
+  <assign|script-busy|<macro|msg|<script-status|<if|<equal|<arg|msg>|<uninit>>|<concat|<localize|Thinking>|<llm-thinking-dots>>|<arg|msg>>>>>
 </body>
 
 <\initial>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -42,7 +42,7 @@
 
   <assign|llm-prompt-color|#4d6cff>
 
-  <assign|llm-input-color|#242938>
+  <assign|llm-input-color|<macro|<if|<equal|<value|color>|white>|#242938|dark blue>>>
 
   <\active*>
     <\src-comment>
@@ -59,7 +59,7 @@
       <\with|ornament-shape|classic|ornament-color|<llm-input-bg-color>|ornament-border|0ln|ornament-vpadding|0.3fn>
         <\ornament>
           <tabular|<tformat|<twith|table-width|1par>|<cwith|1|1|2|2|cell-hpart|1>|<cwith|1|1|1|1|cell-lsep|0fn>|<cwith|1|1|1|1|cell-rsep|0fn>|<cwith|1|1|2|2|cell-lsep|0fn>|<cwith|1|1|2|2|cell-rsep|0fn>|<cwith|1|1|2|2|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|<id-function|<with|color|<value|llm-prompt-color>|<arg|prompt>>>>|<\cell>
-            <with|color|<value|llm-input-color>|math-display|true|<arg|body>>
+            <with|color|<llm-input-color>|math-display|true|<arg|body>>
           </cell>>>>>
         </ornament>
       </with>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -38,7 +38,7 @@
 
   \;
 
-  <assign|llm-input-bg-color|#f0f4ff>
+  <assign|llm-input-bg-color|<macro|<if|<equal|<value|color>|white>|#9ba8c2|#f0f4ff>>>
 
   <assign|llm-prompt-color|#4d6cff>
 
@@ -56,7 +56,7 @@
 
   <assign|llm-input|<\macro|prompt|body>
     <\indent-both|0.1par|0.1par>
-      <\with|ornament-shape|classic|ornament-color|<if|<equal|<value|color>|white>|#9ba8c2|#f0f4ff>|ornament-border|0ln|ornament-vpadding|0.3fn>
+      <\with|ornament-shape|classic|ornament-color|<llm-input-bg-color>|ornament-border|0ln|ornament-vpadding|0.3fn>
         <\ornament>
           <tabular|<tformat|<twith|table-width|1par>|<cwith|1|1|2|2|cell-hpart|1>|<cwith|1|1|1|1|cell-lsep|0fn>|<cwith|1|1|1|1|cell-rsep|0fn>|<cwith|1|1|2|2|cell-lsep|0fn>|<cwith|1|1|2|2|cell-rsep|0fn>|<cwith|1|1|2|2|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|<id-function|<with|color|<value|llm-prompt-color>|<arg|prompt>>>>|<\cell>
             <with|color|<value|llm-input-color>|math-display|true|<arg|body>>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -38,7 +38,7 @@
 
   \;
 
-  <assign|llm-input-bg-color|#9ba8c2>
+  <assign|llm-input-bg-color|#f0f4ff>
 
   <assign|llm-prompt-color|#4d6cff>
 
@@ -56,7 +56,7 @@
 
   <assign|llm-input|<\macro|prompt|body>
     <\indent-both|0.1par|0.1par>
-      <\with|ornament-shape|classic|ornament-color|<value|llm-input-bg-color>|ornament-border|0ln|ornament-vpadding|0.3fn>
+      <\with|ornament-shape|classic|ornament-color|<if|<equal|<value|color>|white>|#9ba8c2|#f0f4ff>|ornament-border|0ln|ornament-vpadding|0.3fn>
         <\ornament>
           <tabular|<tformat|<twith|table-width|1par>|<cwith|1|1|2|2|cell-hpart|1>|<cwith|1|1|1|1|cell-lsep|0fn>|<cwith|1|1|1|1|cell-rsep|0fn>|<cwith|1|1|2|2|cell-lsep|0fn>|<cwith|1|1|2|2|cell-rsep|0fn>|<cwith|1|1|2|2|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|<id-function|<with|color|<value|llm-prompt-color>|<arg|prompt>>>>|<\cell>
             <with|color|<value|llm-input-color>|math-display|true|<arg|body>>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -28,9 +28,33 @@
 
   <use-package|session>
 
-  <assign|llm-prompt-color|<value|generic-prompt-color>>
+  <assign|llm-prompt-color|#4d6cff>
 
-  <assign|llm-input-color|<value|generic-input-color>>
+  <assign|llm-input-color|dark blue>
+
+  <assign|llm-input-bg-color|#f0f4ff>
+
+  <\active*>
+    <\src-comment>
+      Input field with background color
+    </src-comment>
+  </active*>
+
+  <macro|indent-both|<\macro|left-indentation|right-indentation|body>
+    <with|par-left|<plus|<value|par-left>|<arg|left-indentation>>|par-right|<plus|<value|par-right>|<arg|right-indentation>>|<arg|body>>
+  </macro>>
+
+  <assign|llm-input|<\macro|prompt|body>
+    <\indent-both|0.1par|0.1par>
+      <\with|ornament-shape|classic|ornament-color|<value|llm-input-bg-color>|ornament-border|0ln|ornament-vpadding|0.3fn>
+        <\ornament>
+          <tabular|<tformat|<twith|table-width|1par>|<cwith|1|1|2|2|cell-hpart|1>|<cwith|1|1|1|1|cell-lsep|0fn>|<cwith|1|1|1|1|cell-rsep|0fn>|<cwith|1|1|2|2|cell-lsep|0fn>|<cwith|1|1|2|2|cell-rsep|0fn>|<cwith|1|1|2|2|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|<id-function|<with|color|<value|llm-prompt-color>|<arg|prompt>>>>|<\cell>
+            <with|color|<value|llm-input-color>|math-display|true|<arg|body>>
+          </cell>>>>>
+        </ornament>
+      </with>
+    </indent-both>
+  </macro>>
 
   <\active*>
     <\src-comment>
@@ -39,11 +63,15 @@
   </active*>
 
   <assign|llm-output|<\macro|body>
-    <\with|info-flag|none|font-family|CMU>
-      <\generic-output>
-        <text|<arg|body>>
-      </generic-output>
-    </with>
+    <\indent-both|0.1par|0.1par>
+      <\with|info-flag|none|font-family|CMU>
+        <\generic-output>
+          <text|<arg|body>>
+
+          \;
+        </generic-output>
+      </with>
+    </indent-both>
   </macro>>
 
   <assign|llm-errput|<\macro|body>
@@ -56,7 +84,7 @@
 
   <assign|llm-thinking-dots|<macro|<anim-repeat|<anim-compose|<anim-constant||0.35sec>|<anim-constant|.|0.35sec>|<anim-constant|..|0.35sec>|<anim-constant|...|0.35sec>>>>>
 
-  <assign|script-busy|<macro|msg|<script-status|<if|<equal|<arg|msg>|<uninit>>|<concat|<localize|Thinking>|<llm-thinking-dots>>|<arg|msg>>>>>}
+  <assign|script-busy|<macro|msg|<script-status|<if|<equal|<arg|msg>|<uninit>>|<concat|<localize|Thinking>|<llm-thinking-dots>>|<arg|msg>>>>>
 </body>
 
 <\initial>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -28,6 +28,16 @@
 
   <use-package|session>
 
+  <assign|session|<\macro|language|session|body>
+    <\with|prog-language|<arg|language>|prog-session|<arg|session>>
+      <render-session|<arg|body>>
+
+      <new-line>
+    </with>
+  </macro>>
+
+  \;
+
   <assign|llm-prompt-color|#4d6cff>
 
   <assign|llm-input-color|dark blue>
@@ -67,8 +77,6 @@
       <\with|info-flag|none|font-family|CMU>
         <\generic-output>
           <text|<arg|body>>
-
-          \;
         </generic-output>
       </with>
     </indent-both>
@@ -84,7 +92,7 @@
 
   <assign|llm-thinking-dots|<macro|<anim-repeat|<anim-compose|<anim-constant||0.35sec>|<anim-constant|.|0.35sec>|<anim-constant|..|0.35sec>|<anim-constant|...|0.35sec>>>>>
 
-  <assign|script-busy|<macro|msg|<script-status|<if|<equal|<arg|msg>|<uninit>>|<concat|<localize|Thinking>|<llm-thinking-dots>>|<arg|msg>>>>>
+  <assign|script-busy|<macro|msg|<script-status|<if|<equal|<arg|msg>|<uninit>>|<localize|Thinking><llm-thinking-dots>|<arg|msg>>>>>
 </body>
 
 <\initial>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -38,11 +38,11 @@
 
   \;
 
+  <assign|llm-input-bg-color|#9ba8c2>
+
   <assign|llm-prompt-color|#4d6cff>
 
-  <assign|llm-input-color|dark blue>
-
-  <assign|llm-input-bg-color|#f0f4ff>
+  <assign|llm-input-color|#242938>
 
   <\active*>
     <\src-comment>

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -585,7 +585,7 @@
 ) ;tm-define
 
 (tm-define (chat-tab-sync-dark-style! session-id)
-  ;; 在 llm 样式包之后加载暗色主题，确保 dark 中的覆盖值生效
+  ;; C++ 侧创建 panel 后调用，同步暗色样式包
   (when (== (get-preference "gui theme") "liii-night")
     (let ((msg-buf (chat-tab-session->message-buffer session-id))
           (in-buf (chat-tab-session->input-buffer session-id))
@@ -637,8 +637,6 @@
           (chat-tab-add-default-style-packages!)
         ) ;with-buffer
         (with-buffer in-buf (chat-tab-add-default-style-packages!))
-        ;; dark 必须在 llm 之后加载，确保覆盖值生效
-        (chat-tab-sync-dark-style! session-id)
         (chat-tab-set-style-loaded! session-id)
         st
       ) ;let*

--- a/TeXmacs/progs/dynamic/chat-tab-session.scm
+++ b/TeXmacs/progs/dynamic/chat-tab-session.scm
@@ -585,7 +585,7 @@
 ) ;tm-define
 
 (tm-define (chat-tab-sync-dark-style! session-id)
-  ;; C++ 侧创建 panel 后调用，同步暗色样式包
+  ;; 在 llm 样式包之后加载暗色主题，确保 dark 中的覆盖值生效
   (when (== (get-preference "gui theme") "liii-night")
     (let ((msg-buf (chat-tab-session->message-buffer session-id))
           (in-buf (chat-tab-session->input-buffer session-id))
@@ -637,6 +637,8 @@
           (chat-tab-add-default-style-packages!)
         ) ;with-buffer
         (with-buffer in-buf (chat-tab-add-default-style-packages!))
+        ;; dark 必须在 llm 之后加载，确保覆盖值生效
+        (chat-tab-sync-dark-style! session-id)
         (chat-tab-set-style-loaded! session-id)
         st
       ) ;let*

--- a/devel/1067.md
+++ b/devel/1067.md
@@ -5,6 +5,7 @@
 
 ## 2 任务相关的代码文件
 - TeXmacs/packages/themes/dark/dark.ts
+- TeXmacs/plugins/llm/packages/session/llm.ts
 
 ## 3 如何测试
 
@@ -26,15 +27,17 @@ xmake b stem
 ```
 
 ## 5 What
-为暗色主题添加 `llm-input-bg-color` 变量，设置 LLM 输入区在暗色模式下的背景色，修改输入字体颜色。
+为 LLM 输入区添加 dark/light 主题自适应配色。
 
-1. 在 dark.ts 中添加 `<assign|llm-input-bg-color|#9ba8c2>`
-2. 在 dark.ts 中添加 `<assign|llm-prompt-color|#4d6cff>`
-3. 在 dark.ts 中添加 `<assign|llm-input-color|#242938>`
+1. 在 dark.ts 中添加 `<assign|llm-input-bg-color|#9ba8c2>`、`<assign|llm-prompt-color|#4d6cff>`、`<assign|llm-input-color|#242938>`
 2. 在 dark.ts 中修改 `<assign|generic-input-color|#242938>`
+3. 在 llm.ts 中将 `llm-input-bg-color` 和 `llm-input-color` 改为条件宏，通过 `<if|<equal|<value|color>|white>|dark-value|light-value>` 动态适配主题
+4. 使用处从 `<value|...>` 改为宏调用 `<llm-input-bg-color>`、`<llm-input-color>`
 
 ## 6 Why
 暗色主题下 LLM 输入区使用默认背景色，与深色界面不协调，需要设置专用的暗色背景色以提升视觉一致性。
 
 ## 7 How
-- 参照其他主题变量（如 `gr-grid-aspect`）的格式，在 dark.ts 中新增 `llm-input-bg-color` 变量赋值，色值为 `#9ba8c2`（柔和蓝灰色），与暗色主题整体色调保持一致
+- 在 dark.ts 中新增 `llm-input-bg-color`、`llm-prompt-color`、`llm-input-color` 变量赋值
+- 在 llm.ts 中将 `llm-input-bg-color` 和 `llm-input-color` 定义为无参条件宏（`<macro|<if|<equal|<value|color>|white>|dark-val|light-val>>`），在宏展开时动态判断当前主题
+- 使用处从 `<value|...>` 改为 `<llm-input-bg-color>`、`<llm-input-color>` 宏调用，确保条件判断在渲染时求值


### PR DESCRIPTION
## Summary
- `llm-input-bg-color` 和 `llm-input-color` 改为条件宏，根据 `<value|color>` 是否为 `white` 动态切换 dark/light 配色
- Light 模式：bg=`#f0f4ff`，input color=`dark blue`
- Dark 模式：bg=`#9ba8c2`，input color=`#242938`

## Test plan
- [ ] 验证 light 主题下 LLM session 输入区域颜色为 `#f0f4ff` 背景 + `dark blue` 文字
- [ ] 验证 dark 主题下 LLM session 输入区域颜色为 `#9ba8c2` 背景 + `#242938` 文字

🤖 Generated with [Claude Code](https://claude.com/claude-code)