### PR TITLE
[0186] LLM 对话缩进自适应段落宽度

### DIFF
--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -57,7 +57,7 @@
   <assign|llm-indent|<macro|<if|<greater|1par|10cm>|0.1par|0par>>>
 
   <assign|llm-input|<\macro|prompt|body>
-    <\indent-both|<llm-indent>|<llm-indent>>>
+    <\indent-both|<llm-indent>|<llm-indent>>
       <\with|ornament-shape|classic|ornament-color|<llm-input-bg-color>|ornament-border|0ln|ornament-vpadding|0.3fn>
         <\ornament>
           <tabular|<tformat|<twith|table-width|1par>|<cwith|1|1|2|2|cell-hpart|1>|<cwith|1|1|1|1|cell-lsep|0fn>|<cwith|1|1|1|1|cell-rsep|0fn>|<cwith|1|1|2|2|cell-lsep|0fn>|<cwith|1|1|2|2|cell-rsep|0fn>|<cwith|1|1|2|2|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|<id-function|<with|color|<value|llm-prompt-color>|<arg|prompt>>>>|<\cell>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -54,7 +54,7 @@
     <with|par-left|<plus|<value|par-left>|<arg|left-indentation>>|par-right|<plus|<value|par-right>|<arg|right-indentation>>|<arg|body>>
   </macro>>
 
-  <assign|llm-indent|<macro|<if|<greater|1par|10cm>|0.1par|0par>>>
+  <assign|llm-indent|<macro|<if|<greater|1par|20cm>|0.1par|0par>>>
 
   <assign|llm-input|<\macro|prompt|body>
     <\indent-both|<llm-indent>|<llm-indent>>

--- a/TeXmacs/plugins/llm/packages/session/llm.ts
+++ b/TeXmacs/plugins/llm/packages/session/llm.ts
@@ -54,8 +54,10 @@
     <with|par-left|<plus|<value|par-left>|<arg|left-indentation>>|par-right|<plus|<value|par-right>|<arg|right-indentation>>|<arg|body>>
   </macro>>
 
+  <assign|llm-indent|<macro|<if|<greater|1par|10cm>|0.1par|0par>>>
+
   <assign|llm-input|<\macro|prompt|body>
-    <\indent-both|0.1par|0.1par>
+    <\indent-both|<llm-indent>|<llm-indent>>>
       <\with|ornament-shape|classic|ornament-color|<llm-input-bg-color>|ornament-border|0ln|ornament-vpadding|0.3fn>
         <\ornament>
           <tabular|<tformat|<twith|table-width|1par>|<cwith|1|1|2|2|cell-hpart|1>|<cwith|1|1|1|1|cell-lsep|0fn>|<cwith|1|1|1|1|cell-rsep|0fn>|<cwith|1|1|2|2|cell-lsep|0fn>|<cwith|1|1|2|2|cell-rsep|0fn>|<cwith|1|1|2|2|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<cell|<id-function|<with|color|<value|llm-prompt-color>|<arg|prompt>>>>|<\cell>
@@ -73,7 +75,7 @@
   </active*>
 
   <assign|llm-output|<\macro|body>
-    <\indent-both|0.1par|0.1par>
+    <\indent-both|<llm-indent>|<llm-indent>>
       <\with|info-flag|none|font-family|CMU>
         <\generic-output>
           <text|<arg|body>>

--- a/devel/0186.md
+++ b/devel/0186.md
@@ -1,0 +1,65 @@
+# [0186] LLM 对话缩进自适应段落宽度
+
+## 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+
+- `TeXmacs/plugins/llm/packages/session/llm.ts`
+
+## 如何测试
+
+### 非确定性测试（UI 验证）
+
+#### A. Chat 标签页（全屏模式）
+
+1. 切换到 Chat 标签页
+2. 发送一条消息，观察 `llm-input` 和 `llm-output` 区域
+3. 预期：左右两侧有 `0.1par` 的缩进（与之前行为一致）
+
+#### B. Chat 侧边栏（dock 模式，窄面板）
+
+1. 打开一个文档，点击右上角 AI 对话浮动按钮，打开右侧 dock
+2. 发送一条消息，观察 `llm-input` 和 `llm-output` 区域
+3. 预期：左右两侧无缩进（`0par`），内容充分利用窄面板宽度
+
+#### C. 侧边栏宽度变化
+
+1. 在 dock 模式下，拖拽调整侧边栏宽度
+2. 当宽度从窄变宽（跨过 20cm 阈值）时，缩进应从 `0par` 切换为 `0.1par`
+3. 当宽度从宽变窄时，缩进应从 `0.1par` 切换为 `0par`
+
+## 如何提交
+
+提交前编译项目：
+
+```bash
+xmake b stem
+```
+
+## What
+
+在 `llm.ts` 中新增 `llm-indent` 宏，根据当前段落宽度（`1par`）动态决定缩进量：
+- 当 `1par > 20cm` 时（全屏模式），使用 `0.1par` 缩进
+- 当 `1par <= 20cm` 时（侧边栏窄面板），使用 `0par` 无缩进
+
+`llm-input` 和 `llm-output` 的 `indent-both` 参数从硬编码的 `0.1par` 改为调用 `<llm-indent>`。
+
+## Why
+
+当前 `llm-input` 和 `llm-output` 使用 `indent-both` 并硬编码 `0.1par` 的左右缩进。在 Chat 标签页（全屏）下效果合理，但在 Chat 侧边栏（dock 模式）下，面板宽度很窄，`0.1par` 的缩进会浪费宝贵的水平空间，导致内容区域过窄、阅读体验差。
+
+需要根据段落宽度自适应调整缩进量，使全屏模式下保持美观的缩进，窄面板模式下充分利用宽度。
+
+## How
+
+在 `llm.ts` 中新增辅助宏：
+
+```
+<assign|llm-indent|<macro|<if|<greater|1par|20cm>|0.1par|0par>>>
+```
+
+利用 TeXmacs 的 `greater` 原语，`exec_greater` 会通过 `as_length` 将 `1par` 和 `20cm` 各自解析为 SI 像素值再做数值比较，因此可以正确处理不同单位的长度。
+
+`llm-input` 和 `llm-output` 中的 `<indent-both|0.1par|0.1par>` 替换为 `<indent-both|<llm-indent>|<llm-indent>>`。


### PR DESCRIPTION
## Summary

- 新增 `llm-indent` 宏，根据段落宽度（`1par`）动态决定 `llm-input` 和 `llm-output` 的左右缩进量
- 当 `1par > 20cm`（全屏模式）时使用 `0.1par` 缩进，否则（侧边栏窄面板）使用 `0par` 无缩进
- 避免在窄面板下浪费水平空间，提升阅读体验

## Test plan

- [ ] Chat 标签页（全屏）下 `llm-input`/`llm-output` 保持原有 `0.1par` 缩进
- [ ] Chat 侧边栏（dock 窄面板）下无缩进，内容充分利用宽度
- [ ] 调整 dock 宽度跨过 20cm 阈值时缩进自适应切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)