### PR TITLE
[0188] 修复无语言参数的代码块导出 LaTeX 时崩溃

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
@@ -3201,10 +3201,12 @@
   (set! l (escape-backslashes l))
   (set! l (escape-braces l))
   (set! s (car (string-decompose s "-")))
-  (with lang
-    (if (or (== s "verbatim") (== s "code")) '() `((!option ,s)))
-    `((!begin* ,"tmcode" ,@lang) ,(tmtex-verbatim* "" l))
-  ) ;with
+  (if (or (== s "verbatim") (== s "code"))
+    `((!begin* ,"alltt") ,(tmtex-verbatim* "" l))
+    (with lang `((!option ,s))
+      `((!begin* ,"tmcode" ,@lang) ,(tmtex-verbatim* "" l))
+    ) ;with
+  ) ;if
 ) ;define
 
 (define (tmtex-add-preview-packages x)

--- a/TeXmacs/tests/0188.scm
+++ b/TeXmacs/tests/0188.scm
@@ -1,0 +1,29 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0188.scm
+;; DESCRIPTION : Test LaTeX export of code block with backslash commands
+;; COPYRIGHT   : (C) 2026
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(define (export-as-latex-and-load path)
+  (with path (string-append "$TEXMACS_PATH/tests/tmu/" path)
+    (with tmpfile (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (string-load tmpfile))))
+
+(tm-define (test_0188)
+  (let ((result (export-as-latex-and-load "0188.tmu")))
+    (check (and (string? result) (> (string-length result) 0)) => #t)
+    (check (string-contains? result "alltt") => #t)
+    (check (string-contains? result "marked") => #t))
+  (check-report))

--- a/TeXmacs/tests/tmu/0188.tmu
+++ b/TeXmacs/tests/tmu/0188.tmu
@@ -1,0 +1,38 @@
+<TMU|<tuple|1.1.0|2026.2.5>>
+
+<style|<tuple|generic|number-europe|preview-ref|llm|chinese|table-captions-above>>
+
+<\body>
+  <\code>
+    \\marked{\\text{Var}}
+  </code>
+
+  \;
+
+  \;
+
+  \;
+
+  \;
+
+  \;
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|dpi|600>
+    <associate|font|sys-chinese>
+    <associate|no-zoom|true>
+    <associate|page-medium|paper>
+    <associate|page-screen-bot|2px>
+    <associate|page-screen-left|4px>
+    <associate|page-screen-margin|false>
+    <associate|page-screen-right|4px>
+    <associate|page-screen-top|2px>
+    <associate|scroll-bars|false>
+    <associate|stem-doc-id|EB5560B6-5AF6-4530-8CC8-867856CE7DA0>
+    <associate|zoom-factor|1>
+  </collection>
+</initial>

--- a/devel/0188.md
+++ b/devel/0188.md
@@ -1,0 +1,31 @@
+# [0188] 修复无语言参数的代码块导出 LaTeX 时崩溃
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm` - LaTeX 导出转换
+- `TeXmacs/tests/0188.scm` - 集成测试
+- `TeXmacs/tests/tmu/0188.tmu` - 测试用 TMU 文件
+
+## 如何测试
+
+### 集成测试
+```bash
+xmake b 0188
+xmake r 0188
+```
+
+验证无语言参数的 `<code>` 块导出 LaTeX 时不崩溃，且输出包含 `alltt` 环境和代码内容。
+
+## What
+
+修复不含语言参数的代码块（如 `<code>...</code>`）导出为 LaTeX 时，`texout` 在处理宏展开结果时因 `symbol->string` 接收到列表对而非符号而崩溃。
+
+## Why
+
+`tmtex-code-block` 对无语言参数的 `code`/`verbatim` 块生成 `((!begin* "tmcode") ...)`，不含 `!option` 参数。`latex-expand-macros` 用 `tmcode` 环境模板 `((!option "") ((!begin "alltt") ---))` 展开后，产生错误结构 `((!option "") ((!begin "alltt") ...))`，其中 `(!option "")` 作为独立元素出现在段落中。`texout` 处理该列表时进入 `texout-apply`，尝试对列表对 `(!option "")` 调用 `symbol->string`，导致 `wrong-type-arg` 错误。
+
+## How
+
+修改 `tmtex-code-block`：当 `s` 为 `"code"` 或 `"verbatim"` 时，直接生成 `(!begin* "alltt")` 环境，绕过 `tmcode` 宏展开。有语言参数时仍走 `(!begin* "tmcode" (!option ,s))` 路径，此时宏展开条件不匹配，不会触发错误。


### PR DESCRIPTION
## Summary
- 修复不含语言参数的 `<code>` 块导出 LaTeX 时 `texout` 崩溃的问题
- 修改 `tmtex-code-block`：对 `code`/`verbatim` 直接生成 `alltt` 环境，绕过 `tmcode` 宏展开的错误路径
- 新增集成测试 `0188.scm` 和测试用文件 `0188.tmu`

## Test plan
- [x] `xmake r 0188` 通过
- [x] `xmake r 0606` 通过（已有测试无回归）
- [x] `xmake r 0624` 无新增失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)