### PR TITLE
[0189] PDF 阅读器支持 Ctrl+J 切换 AI 聊天侧边栏

### DIFF
--- a/devel/0189.md
+++ b/devel/0189.md
@@ -1,0 +1,34 @@
+# [0189] PDF 阅读器支持 Ctrl+J 切换 AI 聊天侧边栏
+
+## 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp` - PDF 阅读器控件
+
+## 如何测试
+
+1. 打开一个 PDF 文件
+2. 按 Ctrl+J，预期：AI 聊天侧边栏弹出
+3. 再按 Ctrl+J，预期：侧边栏收起
+4. 不按修饰键单独按 J/K，预期：仍正常上下滚动
+
+## 如何提交
+
+```bash
+xmake b stem
+```
+
+## What
+
+在 PDF 阅读器中添加 Ctrl+J 切换 AI 聊天侧边栏的支持。
+
+## Why
+
+`QTMWidget::keyPressEvent` 中已实现 Ctrl+J 切换侧边栏的逻辑，但 PDF 阅读器 (`PDFReaderWidget`) 有独立的 `keyPressEvent`，其中 J/K 键的滚动处理不检查修饰键，Ctrl+J 被当作普通 J 键滚动拦截，无法触发侧边栏。
+
+## How
+
+在 `qt_pdf_reader_widget.cpp` 的 `keyPressEvent` 中，于 J/K 滚动处理之前添加 Ctrl/Cmd+J 的判断：通过 `findChild` 查找 `chatSideDock`，根据可见性调用 `closeSidebarRequested()` 信号或点击展开按钮，逻辑与 `QTMWidget` 一致。

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -11,12 +11,15 @@
 #include <QClipboard>
 #include <QDebug>
 #include <QDesktopServices>
+#include <QDockWidget>
 #include <QFile>
 #include <QFrame>
 #include <QGestureEvent>
 #include <QKeyEvent>
+#include <QMainWindow>
 #include <QMouseEvent>
 #include <QPinchGesture>
+#include <QPushButton>
 #include <QResizeEvent>
 #include <QScreen>
 #include <QScrollBar>
@@ -28,6 +31,7 @@
 #endif
 
 #include "MuPDF/mupdf_renderer.hpp"
+#include "qt_chat_tab_widget.hpp"
 #include "qt_dpi_utils.hpp"
 #include "qt_utilities.hpp"
 #include "scheme.hpp"
@@ -1171,6 +1175,29 @@ PDFReaderWidget::keyPressEvent (QKeyEvent* event) {
       event->accept ();
       return;
     }
+  }
+
+  // Ctrl/Cmd+J：切换 AI 聊天侧边栏
+  if (event->key () == Qt::Key_J &&
+      (event->modifiers () & (Qt::ControlModifier | Qt::MetaModifier))) {
+    QMainWindow* mw= qobject_cast<QMainWindow*> (window ());
+    if (mw) {
+      QDockWidget* dock= mw->findChild<QDockWidget*> ("chatSideDock");
+      if (dock) {
+        if (dock->isVisible ()) {
+          QTChatTabWidget* chatWidget=
+              qobject_cast<QTChatTabWidget*> (dock->widget ());
+          if (chatWidget) emit chatWidget->closeSidebarRequested ();
+        }
+        else {
+          QPushButton* toggleBtn=
+              mw->findChild<QPushButton*> ("chat-tab-collapse-btn");
+          if (toggleBtn) toggleBtn->click ();
+        }
+      }
+    }
+    event->accept ();
+    return;
   }
 
   if (event->key () == Qt::Key_J || event->key () == Qt::Key_K) {

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1274,7 +1274,10 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
     if (chatWidget) {
       chatWidget->setSidebarVisible (false);
       chatWidget->setCloseSidebarButtonVisible (true);
-      // 连接关闭按钮信号
+      // 连接关闭按钮信号（先断开所有旧连接，避免重复触发）
+      QObject::disconnect (chatWidget,
+                           &QTChatTabWidget::closeSidebarRequested, nullptr,
+                           nullptr);
       QObject::connect (chatWidget, &QTChatTabWidget::closeSidebarRequested,
                         [this] () {
                           chatSidebarMode       = false;
@@ -1339,8 +1342,11 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
       }
     }
 
-    // 恢复焦点到编辑器
-    if (editorWidget) editorWidget->setFocus (Qt::OtherFocusReason);
+    // 恢复焦点到当前可见的编辑器或 PDF 阅读器
+    if (pdfTabMode && pdfViewerWidget)
+      pdfViewerWidget->setFocus (Qt::OtherFocusReason);
+    else if (editorWidget)
+      editorWidget->setFocus (Qt::OtherFocusReason);
   }
 
   update_visibility ();

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1275,9 +1275,8 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
       chatWidget->setSidebarVisible (false);
       chatWidget->setCloseSidebarButtonVisible (true);
       // 连接关闭按钮信号（先断开所有旧连接，避免重复触发）
-      QObject::disconnect (chatWidget,
-                           &QTChatTabWidget::closeSidebarRequested, nullptr,
-                           nullptr);
+      QObject::disconnect (chatWidget, &QTChatTabWidget::closeSidebarRequested,
+                           nullptr, nullptr);
       QObject::connect (chatWidget, &QTChatTabWidget::closeSidebarRequested,
                         [this] () {
                           chatSidebarMode       = false;
@@ -1345,8 +1344,7 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
     // 恢复焦点到当前可见的编辑器或 PDF 阅读器
     if (pdfTabMode && pdfViewerWidget)
       pdfViewerWidget->setFocus (Qt::OtherFocusReason);
-    else if (editorWidget)
-      editorWidget->setFocus (Qt::OtherFocusReason);
+    else if (editorWidget) editorWidget->setFocus (Qt::OtherFocusReason);
   }
 
   update_visibility ();


### PR DESCRIPTION
## Summary
- PDF 阅读器的 `keyPressEvent` 中 J/K 滚动处理不检查修饰键，Ctrl+J 被拦截无法切换侧边栏
- 在 J/K 滚动处理前添加 Ctrl/Cmd+J 切换 AI 聊天侧边栏的逻辑，与 QTMWidget 实现一致

## Test plan
- [ ] 打开 PDF 文件，按 Ctrl+J 弹出侧边栏
- [ ] 再按 Ctrl+J 收起侧边栏
- [ ] 单独按 J/K 仍正常上下滚动

🤖 Generated with [Claude Code](https://claude.com/claude-code)