### PR TITLE
[707] Update .gitignore to exlude goldfish binary products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # binary files
+TeXmacs/plugins/goldfish/bin/*
 *.vs
 *.so
 *.[oa]

--- a/devel/707.md
+++ b/devel/707.md
@@ -1,0 +1,4 @@
+# What
+更新了 .gitignore 排除 goldfish 的构建产物，此前的规则在 WASM 构建中 git 仍然会追踪 WASM 构建产物 (.js, .html, .wasm 等)
+
+另外 fix new line at end of file 


### PR DESCRIPTION
# What
更新了 .gitignore 排除 goldfish 的构建产物，此前的规则在 WASM 构建中 git 仍然会追踪 WASM 构建产物 (.js, .html, .wasm 等)