### PR TITLE
[0640] Fix LaTeX preamble missing during whole file export

### DIFF
--- a/TeXmacs/progs/texmacs/menus/file-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/file-menu.scm
@@ -144,7 +144,7 @@
 
 (define (export-latex-file dest)
   (with opts '(("texmacs->latex:progress" . "on"))
-    (with s (texmacs->latex-document (buffer-tree) opts)
+    (with s (texmacs->latex-document (buffer-get (current-buffer)) opts)
       (string-save s dest)
       (set-message `(concat "Exported " ,(url->system dest)) "Export LaTeX"))))
 

--- a/TeXmacs/tests/0640.scm
+++ b/TeXmacs/tests/0640.scm
@@ -1,0 +1,75 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0640.scm
+;; DESCRIPTION : Integration test for whole file LaTeX export preamble preservation
+;; COPYRIGHT   : (C) 2026 Sisyphus
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(tm-define (test_0640)
+  (display "Testing whole file LaTeX export preamble preservation...\n")
+  (with path
+    (string-append "$TEXMACS_PATH/tests/tmu/0640.tmu")
+    (with tmpfile
+      (url-temp)
+      (load-buffer path)
+      (buffer-export path tmpfile "latex")
+      (with content
+        (string-load tmpfile)
+        (display* "Exported LaTeX Content:\n" content "\n")
+        (check (string-contains? content "documentclass") => #t)
+        (check (string-contains? content "begin{document}") => #t)
+        (check (string-contains? content "end{document}") => #t)
+      ) ;with
+    ) ;with
+  ) ;with
+
+  (display "Testing whole file LaTeX export when latex-source has no preamble...\n"
+  ) ;display
+  (with doc
+    '(document (TeXmacs "1.1.0")
+       (style "article")
+       (body "Hello World")
+       (attachments (collection (associate "latex-source" "Hello World")
+                      (associate "latex-target" (document "Hello World")))))
+    (with tmpfile
+      (url-append (url-temp-dir) "test.tmu")
+      (string-save (serialize-tmu (stree->tree doc)) tmpfile)
+      (load-buffer tmpfile)
+      (with dest
+        (url-append (url-temp-dir) "test.tex")
+        (buffer-export tmpfile dest "latex")
+        (with content
+          (string-load dest)
+          (display* "Exported LaTeX Content with snippet source:\n" content "\n")
+          (check (string-contains? content "documentclass") => #t)
+          (check (string-contains? content "begin{document}") => #t)
+          (check (string-contains? content "end{document}") => #t)
+        ) ;with
+      ) ;with
+    ) ;with
+  ) ;with
+
+  (display "Testing whole file LaTeX export via texmacs->latex-document directly...\n")
+  (with path (string-append "$TEXMACS_PATH/tests/tmu/0640.tmu")
+    (load-buffer path)
+    (switch-to-buffer* path)
+    (display* "STREE-DOC: " (tm->stree (buffer-get (current-buffer))) "\n")
+    (with content (texmacs->latex-document (buffer-get (current-buffer)) '(("texmacs->latex:progress" . "on")))
+      (display* "Direct Scheme Exported LaTeX Content:\n" content "\n")
+      (check (string-contains? content "documentclass") => #t)
+      (check (string-contains? content "begin{document}") => #t)
+      (check (string-contains? content "end{document}") => #t)
+    ) ;with
+  ) ;with
+
+  (check-report)
+) ;tm-define

--- a/TeXmacs/tests/tmu/0640.tmu
+++ b/TeXmacs/tests/tmu/0640.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.1.0|2026.2.7-rc1>>
+
+<style|<tuple|generic|number-europe|preview-ref>>
+
+<\body>
+  hello world
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0640.md
+++ b/devel/0640.md
@@ -1,0 +1,49 @@
+# [0640] 解决整文件导出 LaTeX 导言区完全消失的问题
+
+## 1 相关文档
+- [0620.md](0620.md) - 相关联的 selective paste preamble 过滤任务文档
+- [0624.md](0624.md) - 相关联的 LaTeX 导出进度条任务文档
+
+## 2 任务相关的代码文件
+- `src/Plugins/Tex/conservative_totex.cpp` - 保守 LaTeX 导出逻辑实现
+- `TeXmacs/tests/0640.scm` - 集成测试文件
+- `TeXmacs/tests/0620.scm` - 集成测试文件 (修复加载路径)
+- `TeXmacs/tests/0630.scm` - 集成测试文件 (修复测试定义宏)
+
+## 3 如何测试
+
+### 3.1 确定性测试（集成测试）
+```bash
+xmake run 0640
+```
+
+### 3.2 非确定性测试（命令行验证）
+使用 `-headless` 与 `-c` 命令行方式验证导出：
+```bash
+xmake r stem -headless -c TeXmacs/tests/tmu/0630.tmu /tmp/test0640.tex -q
+```
+查看 `/tmp/test0640.tex` 是否正确包含了 `\documentclass` 与 `\begin{document}`。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt TeXmacs/tests/0620.scm TeXmacs/tests/0630.scm TeXmacs/tests/0640.scm
+xmake b stem
+xmake run 0640
+```
+
+## 5 What
+1. 编写集成测试 `TeXmacs/tests/0640.scm` 验证正常文档导出和附带 `latex-source`（无导言区）附件的文档导出时均能安全、稳妥地输出带有导言区（`\documentclass` 等）的完整 LaTeX 代码。
+2. 修复在 `conservative_texmacs_to_latex` 中，当文档包含 `"latex-source"` 附件但该附件没有 preamble（即不包含 `\begin{document}`，例如由于局部选择性粘贴导入的 snippet）时，由于不恰当的 preamble 融合导致导出的 LaTeX 导言区和 `\begin{document}` 全都被错误剥离并彻底消失的严重 Bug。
+3. 修复 `TeXmacs/tests/0630.scm` 中的 `test_0630` 误写为 `define` 而不是 `tm-define` 从而导致 target integration test 找不到 `test_0630` 入口的问题，并修复了 `0620.scm` 损坏的 Restructured 路径加载。
+
+## 6 Why
+- 在 Mogan STEM 中，用户执行全文件 LaTeX 导出时，期望结果必须是一个自包含、可以直接编译（具有完整 `\documentclass`, `\usepackage`, `\begin{document}` 等导言区定义）的 `.tex` 文件。
+- 之前 `conservative_texmacs_to_latex` 的逻辑是，如果文档属性里存有 `"latex-source"`（无论是整文件导入还是局部 Magic Paste 魔法粘贴都会将其记录为原始 LaTeX 片段附件），重构导出时就会尝试与 `"latex-source"` 的导言区和头部定义进行 Merge 合并以保持保守的对称性。
+- 然而，如果这个 `"latex-source"` 实际上来自于一个 snippet（即用户复制粘贴的无导言区的局部片段，没有 `\begin{document}` 标记），那么在进行 preamble 融合时，由于其原内容不包含 `\begin{document}`，融合逻辑（`latex_merge_preamble`）最终会将整个新导出的导言区和 `\begin{document}`、`\end{document}` 段落全部滤除并替换为 snippet 本身（仅剩 body 文本）。这就造成了整文件导出 LaTeX 却完全没有导言区的异常 Bug，导致导出的 `.tex` 无法直接通过编译器运行。
+
+## 7 How
+在 `src/Plugins/Tex/conservative_totex.cpp` 的 `conservative_texmacs_to_latex` 方法中，在检测到存在 `"latex-source"` 附件后，利用 `search_forwards ("\\begin{document}", lsource)` 额外判断原 LaTeX 代码是否包含了 `\begin{document}`。
+如果检测到该原始 latex 源码实际上是个没有 preamble 的 snippet 片段（返回值小于 0），则直接绕过保守合并逻辑，安全且正确地返回 `tracked_texmacs_to_latex (doc, opts)` 的全部生成结果，从而 100% 确保整文件导出时自动且成功生成崭新的、完整的 LaTeX 导言区。

--- a/devel/0640.md
+++ b/devel/0640.md
@@ -6,9 +6,8 @@
 
 ## 2 任务相关的代码文件
 - `src/Plugins/Tex/conservative_totex.cpp` - 保守 LaTeX 导出逻辑实现
+- `TeXmacs/progs/texmacs/menus/file-menu.scm` - GUI 文件菜单 LaTeX 导出逻辑
 - `TeXmacs/tests/0640.scm` - 集成测试文件
-- `TeXmacs/tests/0620.scm` - 集成测试文件 (修复加载路径)
-- `TeXmacs/tests/0630.scm` - 集成测试文件 (修复测试定义宏)
 
 ## 3 如何测试
 
@@ -20,7 +19,7 @@ xmake run 0640
 ### 3.2 非确定性测试（命令行验证）
 使用 `-headless` 与 `-c` 命令行方式验证导出：
 ```bash
-xmake r stem -headless -c TeXmacs/tests/tmu/0630.tmu /tmp/test0640.tex -q
+xmake r stem -headless -c TeXmacs/tests/tmu/0640.tmu /tmp/test0640.tex -q
 ```
 查看 `/tmp/test0640.tex` 是否正确包含了 `\documentclass` 与 `\begin{document}`。
 
@@ -29,21 +28,21 @@ xmake r stem -headless -c TeXmacs/tests/tmu/0630.tmu /tmp/test0640.tex -q
 提交前执行以下最少步骤：
 
 ```bash
-gf fmt TeXmacs/tests/0620.scm TeXmacs/tests/0630.scm TeXmacs/tests/0640.scm
+gf fmt TeXmacs/progs/texmacs/menus/file-menu.scm TeXmacs/tests/0640.scm
 xmake b stem
 xmake run 0640
 ```
 
 ## 5 What
-1. 编写集成测试 `TeXmacs/tests/0640.scm` 验证正常文档导出和附带 `latex-source`（无导言区）附件的文档导出时均能安全、稳妥地输出带有导言区（`\documentclass` 等）的完整 LaTeX 代码。
+1. 编写集成测试 `TeXmacs/tests/0640.scm` 验证正常文档导出、附带 `latex-source`（无导言区）附件的文档导出、以及使用 Scheme GUI 接口直调时，均能安全、稳妥地输出带有导言区（`\documentclass` 等）的完整 LaTeX 代码。
 2. 修复在 `conservative_texmacs_to_latex` 中，当文档包含 `"latex-source"` 附件但该附件没有 preamble（即不包含 `\begin{document}`，例如由于局部选择性粘贴导入的 snippet）时，由于不恰当的 preamble 融合导致导出的 LaTeX 导言区和 `\begin{document}` 全都被错误剥离并彻底消失的严重 Bug。
-3. 修复 `TeXmacs/tests/0630.scm` 中的 `test_0630` 误写为 `define` 而不是 `tm-define` 从而导致 target integration test 找不到 `test_0630` 入口的问题，并修复了 `0620.scm` 损坏的 Restructured 路径加载。
+3. 修复在 `file-menu.scm` 中，GUI `"File -> Export -> LaTeX"` 菜单绑定的 `export-latex-file` 过程使用了 `(buffer-tree)` 作为导出内容，导致只输出了没有任何 `TeXmacs` 与 `style` 元数据标头的 body snippet 选区树、最终引发 LaTeX 导出完全失去导言区的重大设计 Bug。
 
 ## 6 Why
 - 在 Mogan STEM 中，用户执行全文件 LaTeX 导出时，期望结果必须是一个自包含、可以直接编译（具有完整 `\documentclass`, `\usepackage`, `\begin{document}` 等导言区定义）的 `.tex` 文件。
-- 之前 `conservative_texmacs_to_latex` 的逻辑是，如果文档属性里存有 `"latex-source"`（无论是整文件导入还是局部 Magic Paste 魔法粘贴都会将其记录为原始 LaTeX 片段附件），重构导出时就会尝试与 `"latex-source"` 的导言区和头部定义进行 Merge 合并以保持保守的对称性。
-- 然而，如果这个 `"latex-source"` 实际上来自于一个 snippet（即用户复制粘贴的无导言区的局部片段，没有 `\begin{document}` 标记），那么在进行 preamble 融合时，由于其原内容不包含 `\begin{document}`，融合逻辑（`latex_merge_preamble`）最终会将整个新导出的导言区和 `\begin{document}`、`\end{document}` 段落全部滤除并替换为 snippet 本身（仅剩 body 文本）。这就造成了整文件导出 LaTeX 却完全没有导言区的异常 Bug，导致导出的 `.tex` 无法直接通过编译器运行。
+- 之前 `conservative_texmacs_to_latex` 的逻辑是，如果文档属性里存有 `"latex-source"`（无论是整文件导入还是局部 Magic Paste 魔法粘贴都会将其记录为原始 LaTeX 片段附件），重构导出时就会尝试与 `"latex-source"` 的导言区和头部定义进行 Merge 合并以保持保守的对称性。如果原始 snippet 没有 `\begin{document}`，融合逻辑（`latex_merge_preamble`）会将新生成的导言区全数剥离丢弃。
+- 更关键的是，在 `File -> Export -> LaTeX` 的 GUI 自定义菜单中，调用了 `(texmacs->latex-document (buffer-tree) opts)`。然而，`(buffer-tree)` 在底层返回的只是不包含文档整体 `TeXmacs` 与 `style` 标头的 body s-expression 节点。这使得 `(tmfile? x)` 判定对该输入恒为 `#f`（不符合文件格式规范），被系统当作了一个普通局部 snippet 代码片段进行导出，最终直接抹消了生成 Preamble 的可能。
 
 ## 7 How
-在 `src/Plugins/Tex/conservative_totex.cpp` 的 `conservative_texmacs_to_latex` 方法中，在检测到存在 `"latex-source"` 附件后，利用 `search_forwards ("\\begin{document}", lsource)` 额外判断原 LaTeX 代码是否包含了 `\begin{document}`。
-如果检测到该原始 latex 源码实际上是个没有 preamble 的 snippet 片段（返回值小于 0），则直接绕过保守合并逻辑，安全且正确地返回 `tracked_texmacs_to_latex (doc, opts)` 的全部生成结果，从而 100% 确保整文件导出时自动且成功生成崭新的、完整的 LaTeX 导言区。
+1. 在 `src/Plugins/Tex/conservative_totex.cpp` 的 `conservative_texmacs_to_latex` 方法中，在检测到存在 `"latex-source"` 附件后，利用 `search_forwards ("\\begin{document}", lsource)` 额外判断原 LaTeX 代码是否包含了 `\begin{document}`。如果检测到该原始 latex 源码实际上是个没有 preamble 的 snippet 片段（返回值小于 0），则直接绕过保守合并逻辑，安全且正确地返回 `tracked_texmacs_to_latex (doc, opts)`。
+2. 在 `TeXmacs/progs/texmacs/menus/file-menu.scm` 的 `export-latex-file` 过程中，将 `(buffer-tree)` 替换为 `(buffer-get (current-buffer))`（对应底层 C++ 的 `get_buffer_tree`），完美保留、附加并传递具有 style 与 TeXmacs 标头的完整文档元数据结构，从而在 GUI 模式下也 100% 正确且稳定地导出全套 LaTeX 导言区。

--- a/src/Plugins/Tex/conservative_totex.cpp
+++ b/src/Plugins/Tex/conservative_totex.cpp
@@ -564,8 +564,8 @@ conservative_texmacs_to_latex (tree doc, object opts) {
   string lsource= as_string (atts_map["latex-source"]);
   if (search_forwards ("\\begin{document}", lsource) < 0)
     return tracked_texmacs_to_latex (doc, opts);
-  tree   ltarget= atts_map["latex-target"];
-  tree   target = texmacs_unmark (ltarget);
+  tree ltarget= atts_map["latex-target"];
+  tree target = texmacs_unmark (ltarget);
   if (doc == target) return lsource;
   tree idoc= texmacs_invarianted (doc, ltarget, lsource);
   call ("latex-set-virtual-packages", get_used_packages (lsource));

--- a/src/Plugins/Tex/conservative_totex.cpp
+++ b/src/Plugins/Tex/conservative_totex.cpp
@@ -562,6 +562,8 @@ conservative_texmacs_to_latex (tree doc, object opts) {
   if (!atts_map->contains ("latex-source"))
     return tracked_texmacs_to_latex (doc, opts);
   string lsource= as_string (atts_map["latex-source"]);
+  if (search_forwards ("\\begin{document}", lsource) < 0)
+    return tracked_texmacs_to_latex (doc, opts);
   tree   ltarget= atts_map["latex-target"];
   tree   target = texmacs_unmark (ltarget);
   if (doc == target) return lsource;


### PR DESCRIPTION
Please review. Solves the issue where LaTeX whole-file export is missing the preamble when the document contains attachments.