### PR TITLE
[0193] 文库文档保存路径改为 library 子目录

### DIFF
--- a/devel/0193.md
+++ b/devel/0193.md
@@ -1,0 +1,15 @@
+# [0193] 文库文档保存路径改为 library 子目录
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 问题描述
+
+文库的文档默认保存在 `~/Documents/LiiiSTEM/` 目录下。点击次数多了之后，会产生大量临时文件（如 `xxx(1).tmu`、`xxx(2).tmu`），导致该目录内容混乱，与用户自己创建的文档混在一起。
+
+## 3 修复方案
+
+将文库文档的保存路径从 `~/Documents/LiiiSTEM/` 改为 `~/Documents/LiiiSTEM/library/`，使文库生成的文档与用户文档分开存放。
+
+## 4 修改的代码文件
+- `src/Plugins/Qt/qt_template_utils.cpp`

--- a/src/Plugins/Qt/qt_template_utils.cpp
+++ b/src/Plugins/Qt/qt_template_utils.cpp
@@ -22,7 +22,7 @@ qt_generate_document_save_path (const QString& templateName) {
   if (docsDir.isEmpty ()) {
     docsDir= QStandardPaths::writableLocation (QStandardPaths::HomeLocation);
   }
-  docsDir= QDir (docsDir).filePath ("LiiiSTEM");
+  docsDir= QDir (docsDir).filePath ("LiiiSTEM/library");
 
   QString baseName= templateName;
   baseName.replace (QRegularExpression ("[\\\\/:*?\"<>|]"), "_");


### PR DESCRIPTION
## Summary
- 将文库文档的保存路径从 `~/Documents/LiiiSTEM/` 改为 `~/Documents/LiiiSTEM/library/`，避免文库生成的临时文件（如 `xxx(1).tmu`、`xxx(2).tmu`）与用户文档混在一起

## Test plan
- [ ] 从文库创建文档，确认文件保存到 `~/Documents/LiiiSTEM/library/` 目录
- [ ] 多次创建同名文档，确认递增编号文件也在 `library/` 子目录下

🤖 Generated with [Claude Code](https://claude.com/claude-code)