### PR TITLE
[1101] Autosave dummy plugin

### DIFF
--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -2,18 +2,20 @@
 (import (liii path))
 
 (define (welcome)
-  (flush-verbatim "autosave"))
-  
+  (flush-verbatim "autosave")
+) ;define
+
 (define (read-eval-print)
   (let ((code (read-paragraph-by-visible-eof)))
     (path-append-text "/tmp/debug.log" code)
-    (if (string=? code "")
-        #t
-        (flush-verbatim code))))
+    (if (string=? code "") #t (flush-verbatim code))
+  ) ;let
+) ;define
 
 (define (repl)
   (read-eval-print)
-  (repl))
+  (repl)
+) ;define
 
 (welcome)
 (repl)

--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -1,0 +1,17 @@
+(import (texmacs protocol))
+
+(define (welcome)
+  (flush-verbatim "autosave"))
+  
+(define (read-eval-print)
+  (let ((code (read-paragraph-by-visible-eof)))
+    (if (string=? code "")
+        #t
+        (flush-verbatim code))))
+
+(define (repl)
+  (read-eval-print)
+  (repl))
+
+(welcome)
+(repl)

--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -1,10 +1,12 @@
 (import (texmacs protocol))
+(import (liii path))
 
 (define (welcome)
   (flush-verbatim "autosave"))
   
 (define (read-eval-print)
   (let ((code (read-paragraph-by-visible-eof)))
+    (path-append-text "/tmp/debug.log" code)
     (if (string=? code "")
         #t
         (flush-verbatim code))))

--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -1,6 +1,9 @@
 (import (texmacs protocol))
 (import (liii path))
 
+;; 插件进程与主进程的握手：启动时必须 flush 插件名 "autosave"，
+;; 否则主进程不会进入 DATA_COMMAND 状态、无法投递后续负载。
+
 (define (welcome)
   (flush-verbatim "autosave")
 ) ;define

--- a/TeXmacs/plugins/autosave/progs/init-autosave.scm
+++ b/TeXmacs/plugins/autosave/progs/init-autosave.scm
@@ -1,0 +1,35 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-autosave.scm
+;; DESCRIPTION : Initialize the 'autosave' plugin
+;; COPYRIGHT   : (C) 1999  Joris van der Hoeven
+;;                   2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (binary goldfish))
+(import (liii path))
+
+(define (autosave-serialize lan t)
+  (with u (pre-serialize lan t)
+    (with s (texmacs->code (stree->tree u) "SourceCode")
+      (string-append  s  "\n<EOF>\n"))))
+
+(define (launcher)
+  (let* ((user "$TEXMACS_HOME_PATH/plugins/autosave/goldfish/tm-autosave.scm")
+         (sys "$TEXMACS_PATH/plugins/autosave/goldfish/tm-autosave.scm")
+         (entry (if (url-exists? user) user sys)))
+  (string-append (string-quote (url->system (find-binary-goldfish)))
+                 " "
+                 (string-quote (url->system entry)))))
+
+(plugin-configure autosave
+  (:require (has-binary-goldfish?))
+  (:launch ,(launcher))
+  (:serializer ,autosave-serialize)
+  (:session "autosave"))

--- a/TeXmacs/plugins/autosave/progs/init-autosave.scm
+++ b/TeXmacs/plugins/autosave/progs/init-autosave.scm
@@ -16,20 +16,30 @@
 (import (liii path))
 
 (define (autosave-serialize lan t)
-  (with u (pre-serialize lan t)
-    (with s (texmacs->code (stree->tree u) "SourceCode")
-      (string-append  s  "\n<EOF>\n"))))
+  (with u
+    (pre-serialize lan t)
+    (with s
+      (texmacs->code (stree->tree u) "SourceCode")
+      (string-append s "\n<EOF>\n")
+    ) ;with
+  ) ;with
+) ;define
 
 (define (launcher)
   (let* ((user "$TEXMACS_HOME_PATH/plugins/autosave/goldfish/tm-autosave.scm")
          (sys "$TEXMACS_PATH/plugins/autosave/goldfish/tm-autosave.scm")
-         (entry (if (url-exists? user) user sys)))
-  (string-append (string-quote (url->system (find-binary-goldfish)))
-                 " "
-                 (string-quote (url->system entry)))))
+         (entry (if (url-exists? user) user sys))
+        ) ;
+    (string-append (string-quote (url->system (find-binary-goldfish)))
+      " "
+      (string-quote (url->system entry))
+    ) ;string-append
+  ) ;let*
+) ;define
 
 (plugin-configure autosave
   (:require (has-binary-goldfish?))
   (:launch ,(launcher))
   (:serializer ,autosave-serialize)
-  (:session "autosave"))
+  (:session "autosave")
+) ;plugin-configure

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1781,7 +1781,7 @@
 ;; ----
 ;; 仅打印触发参数，不执行实际备份逻辑；后续可在此扩展备份行为。
 (tm-define (auto-backup-trig u kind)
-  (display* "auto-backup-trig: u=" u ", kind=" kind "\n")
+  (silent-feed* "autosave" "default" `(document "hello") (lambda (r) (noop)) '())
 ) ;tm-define
 
 ;; auto-backup-opened-buffer!

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -42,6 +42,7 @@
 ) ;import
 (import (only (liii os) mkdir))
 (import (liii njson))
+(import (liii json))
 (import (only (srfi srfi-1) find))
 (import (only (srfi srfi-1) remove))
 (import (only (srfi srfi-19)
@@ -1762,6 +1763,17 @@
   ) ;let
 ) ;tm-define
 
+(tm-define (auto-backup-trig-payload name kind)
+  (let* ((path (auto-backup-buffer-path name))
+         (doc-id (auto-backup-ensure-buffer-doc-id! name))
+         (payload (string->json "{}")))
+    (set! payload (json-push payload "path" path))
+    (set! payload (json-push payload "type" kind))
+    (set! payload (json-push payload "id" doc-id))
+    (json->string payload)
+  ) ;let*
+) ;tm-define
+
 ;; auto-backup-trig
 ;; 自动备份触发入口，当前仅用于调试输出触发参数。
 ;;
@@ -1781,7 +1793,9 @@
 ;; ----
 ;; 仅打印触发参数，不执行实际备份逻辑；后续可在此扩展备份行为。
 (tm-define (auto-backup-trig u kind)
-  (silent-feed* "autosave" "default" `(document "hello") (lambda (r) (noop)) '())
+  (let ((s (auto-backup-trig-payload u kind)))
+    (silent-feed* "autosave" "default" `(document ,(utf8->cork s)) (lambda (r) (noop)) '())
+  )
 ) ;tm-define
 
 ;; auto-backup-opened-buffer!

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1766,7 +1766,8 @@
 (tm-define (auto-backup-trig-payload name kind)
   (let* ((path (auto-backup-buffer-path name))
          (doc-id (auto-backup-ensure-buffer-doc-id! name))
-         (payload (string->json "{}")))
+         (payload (string->json "{}"))
+        ) ;
     (set! payload (json-push payload "path" path))
     (set! payload (json-push payload "type" kind))
     (set! payload (json-push payload "id" doc-id))
@@ -1795,8 +1796,13 @@
 (tm-define (auto-backup-trig u kind)
   (when (auto-backup-buffer-eligible? u)
     (let ((s (auto-backup-trig-payload u kind)))
-      (silent-feed* "autosave" "default" `(document ,(utf8->cork s)) (lambda (r) (noop)) '())
-    )
+      (silent-feed* "autosave"
+        "default"
+        `(document ,(utf8->cork s))
+        (lambda (r) (noop))
+        '()
+      ) ;silent-feed*
+    ) ;let
   ) ;when
 ) ;tm-define
 

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1793,9 +1793,11 @@
 ;; ----
 ;; 仅打印触发参数，不执行实际备份逻辑；后续可在此扩展备份行为。
 (tm-define (auto-backup-trig u kind)
-  (let ((s (auto-backup-trig-payload u kind)))
-    (silent-feed* "autosave" "default" `(document ,(utf8->cork s)) (lambda (r) (noop)) '())
-  )
+  (when (auto-backup-buffer-eligible? u)
+    (let ((s (auto-backup-trig-payload u kind)))
+      (silent-feed* "autosave" "default" `(document ,(utf8->cork s)) (lambda (r) (noop)) '())
+    )
+  ) ;when
 ) ;tm-define
 
 ;; auto-backup-opened-buffer!

--- a/devel/1101.md
+++ b/devel/1101.md
@@ -1,0 +1,45 @@
+# [1101] Autosave Dummy Plugin
+
+任务编号：1101。新增一个名为 `autosave` 的占位插件（dummy plugin），用于接收并暂存 Mogan 自动备份触发时上报的负载。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/autosave/goldfish/tm-autosave.scm` - 新增：autosave 插件入口脚本，运行于 goldfish 解释器，读取并追加到 `/tmp/debug.log`
+- `TeXmacs/plugins/autosave/progs/init-autosave.scm` - 新增：autosave 插件初始化配置（启动、序列化器、会话）
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` - 修改：新增 `auto-backup-trig-payload` 构造 JSON 负载，并在 `auto-backup-trig` 中通过 `silent-feed*` 推送到 autosave 插件
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+手动验证：启动 Mogan，触发自动备份（编辑缓冲区并等待定时备份触发），观察 autosave 插件会话与 /tmp/debug.log 是否接收到 payload。
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+1. 新增 `autosave` 插件骨架（goldfish 入口脚本与 init 配置），定义 `:launch`、`:serializer` 与 `:session`
+2. 在 `tm-files.scm` 中实现 `auto-backup-trig-payload`，构造包含 `path`、`type`、`id` 的 JSON 负载
+3. 修改 `auto-backup-trig`，对符合条件（`auto-backup-buffer-eligible?`）的缓冲区通过 `silent-feed*` 将负载以 `(document ...)` 形式喂给 autosave 插件
+
+## 6 Why
+为后续真正的自动备份能力打地基：先建立一条从编辑器到外部进程（goldfish 上运行的 Scheme 脚本）的可靠数据通道，把每次备份触发事件的上下文（缓冲区路径、触发类型、doc id）落盘到 `/tmp/debug.log`，便于观察触发时机与负载结构，再逐步演化为真正的备份存储。
+
+## 7 How
+- 插件启动器优先使用 `$TEXMACS_HOME_PATH` 下的用户脚本，回退到系统路径，方便本地修改调试
+- 序列化器复用 `pre-serialize` + `texmacs->code`，以 `<EOF>` 分隔，与 goldfish 端 `read-paragraph-by-visible-eof` 配套
+- 负载构造使用 `(liii json)` 的 `string->json` / `json-push` / `json->string`，保证字段顺序与可扩展性
+- 通过 `silent-feed*` 静默投递，避免污染用户当前会话的输出流


### PR DESCRIPTION
## Summary
- 新增 `autosave` 占位插件（goldfish 入口脚本 + init 配置），定义 `:launch`/`:serializer`/`:session`
- 在 `tm-files.scm` 中实现 `auto-backup-trig-payload` 构造 JSON 负载（path/type/id）
- 修改 `auto-backup-trig`，对 eligible 缓冲区通过 `silent-feed*` 把负载喂给 autosave 插件并落盘 `/tmp/debug.log`

## Test plan
- [x] `gf fmt --changed-since=main` 已通过
- [ ] 手动验证：触发自动备份后观察 autosave 会话与 `/tmp/debug.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)