### PR TITLE
[1101] autosave 插件改用 session-id 驱动的 oneshot 投递

### DIFF
--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -1,5 +1,6 @@
 (import (texmacs protocol))
 (import (liii path))
+(import (liii json))
 
 ;; 插件进程与主进程的握手：启动时必须 flush 插件名 "autosave"，
 ;; 否则主进程不会进入 DATA_COMMAND 状态、无法投递后续负载。
@@ -15,10 +16,5 @@
   ) ;let
 ) ;define
 
-(define (repl)
-  (read-eval-print)
-  (repl)
-) ;define
-
 (welcome)
-(repl)
+(read-eval-print)

--- a/TeXmacs/plugins/autosave/progs/init-autosave.scm
+++ b/TeXmacs/plugins/autosave/progs/init-autosave.scm
@@ -41,5 +41,4 @@
   (:require (has-binary-goldfish?))
   (:launch ,(launcher))
   (:serializer ,autosave-serialize)
-  (:session "autosave")
 ) ;plugin-configure

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1766,12 +1766,14 @@
 (tm-define (auto-backup-trig-payload name kind)
   (let* ((path (auto-backup-buffer-path name))
          (doc-id (auto-backup-ensure-buffer-doc-id! name))
+         (session-id (uuid4))
          (payload (string->json "{}"))
         ) ;
     (set! payload (json-push payload "path" path))
     (set! payload (json-push payload "type" kind))
     (set! payload (json-push payload "id" doc-id))
-    (json->string payload)
+    (set! payload (json-push payload "session-id" session-id))
+    (values (json->string payload) session-id)
   ) ;let*
 ) ;tm-define
 
@@ -1795,14 +1797,15 @@
 ;; 仅打印触发参数，不执行实际备份逻辑；后续可在此扩展备份行为。
 (tm-define (auto-backup-trig u kind)
   (when (auto-backup-buffer-eligible? u)
-    (let ((s (auto-backup-trig-payload u kind)))
+    (receive (s session-id)
+      (auto-backup-trig-payload u kind)
       (silent-feed* "autosave"
-        "default"
+        session-id
         `(document ,(utf8->cork s))
         (lambda (r) (noop))
         '()
       ) ;silent-feed*
-    ) ;let
+    ) ;receive
   ) ;when
 ) ;tm-define
 

--- a/devel/1101.md
+++ b/devel/1101.md
@@ -6,9 +6,9 @@
 - [dddd.md](dddd.md) - 任务文档模板
 
 ## 2 任务相关的代码文件
-- `TeXmacs/plugins/autosave/goldfish/tm-autosave.scm` - 新增：autosave 插件入口脚本，运行于 goldfish 解释器，读取并追加到 `/tmp/debug.log`
-- `TeXmacs/plugins/autosave/progs/init-autosave.scm` - 新增：autosave 插件初始化配置（启动、序列化器、会话）
-- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` - 修改：新增 `auto-backup-trig-payload` 构造 JSON 负载，并在 `auto-backup-trig` 中通过 `silent-feed*` 推送到 autosave 插件
+- `TeXmacs/plugins/autosave/goldfish/tm-autosave.scm` - 新增：autosave 插件入口脚本，运行于 goldfish 解释器，握手后执行单次 `read-eval-print`（移除自定义 `repl` 循环），追加到 `/tmp/debug.log`
+- `TeXmacs/plugins/autosave/progs/init-autosave.scm` - 新增：autosave 插件初始化配置（启动、序列化器），未配置 `:session`
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` - 修改：新增 `auto-backup-trig-payload` 构造 JSON 负载并返回 `(values payload session-id)`，`auto-backup-trig` 通过 `silent-feed*` 以该 session-id 为通道推送负载到 autosave 插件
 
 ## 3 如何测试
 
@@ -31,15 +31,17 @@ gf fmt --changed-since=main
 ```
 
 ## 5 What
-1. 新增 `autosave` 插件骨架（goldfish 入口脚本与 init 配置），定义 `:launch`、`:serializer` 与 `:session`
-2. 在 `tm-files.scm` 中实现 `auto-backup-trig-payload`，构造包含 `path`、`type`、`id` 的 JSON 负载
-3. 修改 `auto-backup-trig`，对符合条件（`auto-backup-buffer-eligible?`）的缓冲区通过 `silent-feed*` 将负载以 `(document ...)` 形式喂给 autosave 插件
+1. 新增 `autosave` 插件骨架（goldfish 入口脚本与 init 配置），定义 `:launch`、`:serializer`（未设置 `:session`，避免主进程复用单一命名会话）
+2. goldfish 入口脚本握手后仅执行单次 `read-eval-print`，由主进程按 session-id 驱动后续交互
+3. 在 `tm-files.scm` 中实现 `auto-backup-trig-payload`，构造包含 `path`、`type`、`id`、`session-id` 的 JSON 负载，并返回 `(values payload session-id)`
+4. 修改 `auto-backup-trig`，对符合条件（`auto-backup-buffer-eligible?`）的缓冲区通过 `silent-feed*` 将负载以 `(document ...)` 形式喂给 autosave 插件，使用本次触发生成的 `session-id` 作为目标会话
 
 ## 6 Why
-为后续真正的自动备份能力打地基：先建立一条从编辑器到外部进程（goldfish 上运行的 Scheme 脚本）的可靠数据通道，把每次备份触发事件的上下文（缓冲区路径、触发类型、doc id）落盘到 `/tmp/debug.log`，便于观察触发时机与负载结构，再逐步演化为真正的备份存储。
+为后续真正的自动备份能力打地基：先建立一条从编辑器到外部进程（goldfish 上运行的 Scheme 脚本）的可靠数据通道，把每次备份触发事件的上下文（缓冲区路径、触发类型、doc id、session-id）落盘到 `/tmp/debug.log`，便于观察触发时机与负载结构，再逐步演化为真正的备份存储。每次触发独立 `session-id` 让多缓冲区并发触发的负载互不串扰，便于 goldfish 端按会话归因。
 
 ## 7 How
 - 插件启动器优先使用 `$TEXMACS_HOME_PATH` 下的用户脚本，回退到系统路径，方便本地修改调试
 - 序列化器复用 `pre-serialize` + `texmacs->code`，以 `<EOF>` 分隔，与 goldfish 端 `read-paragraph-by-visible-eof` 配套
 - 负载构造使用 `(liii json)` 的 `string->json` / `json-push` / `json->string`，保证字段顺序与可扩展性
-- 通过 `silent-feed*` 静默投递，避免污染用户当前会话的输出流
+- `auto-backup-trig-payload` 通过 `uuid4` 为每次触发生成 `session-id`，并以 `(values payload session-id)` 返回；`auto-backup-trig` 用 `receive` 解构，把 session-id 作为 `silent-feed*` 的第二参数，使每次触发落在独立会话上
+- 通过 `silent-feed*` 静默投递，避免污染用户当前会话的输出流；init 中不配置 `:session`，避免主进程把所有投递都复用到固定命名会话


### PR DESCRIPTION
## Summary
- 把 `auto-backup-trig-payload` 改为 `(values payload session-id)`，每次触发用 `uuid4` 生成独立 `session-id` 并写入 JSON 负载
- `auto-backup-trig` 用该 `session-id` 作为 `silent-feed*` 的会话目标，使每次触发落在独立会话上，避免多缓冲区并发触发时负载串扰
- 移除 init 中的 `:session` 配置；goldfish 入口脚本握手后仅执行单次 `read-eval-print`（由主进程按 session-id 驱动）

## Test plan
- [x] `gf fmt --changed-since=main`
- [ ] `xmake b stem`
- [ ] 手动验证：启动 Mogan，触发自动备份，观察 autosave 插件与 `/tmp/debug.log` 是否接收到带 `session-id` 的 payload