### PR TITLE
[0353] autosave 每个 doc-id 最多保留 10 份备份

### DIFF
--- a/TeXmacs/plugins/autosave/goldfish/liii/autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/liii/autosave.scm
@@ -1,3 +1,23 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : autosave.scm
+;; DESCRIPTION : (liii autosave) library: backup path policy and retention
+;; COPYRIGHT   : (C) 2026 Mogan Developers
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define-library (liii autosave)
   (export autosave-keep-max
     autosave-home

--- a/TeXmacs/plugins/autosave/goldfish/liii/autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/liii/autosave.scm
@@ -1,0 +1,97 @@
+(define-library (liii autosave)
+  (export autosave-keep-max
+    autosave-home
+    autosave-dir
+    autosave-target-path
+    ensure-parent-dir
+    autosave-prune-dir
+    document->string
+  ) ;export
+  (import (liii base)
+    (liii error)
+    (liii list)
+    (liii os)
+    (liii path)
+    (liii sort)
+    (liii string)
+    (srfi srfi-13)
+    (srfi srfi-19)
+    (scheme base)
+  ) ;import
+  (begin
+
+    ;; ; 每个 doc-id 目录最多保留的备份份数
+    (define autosave-keep-max 10)
+
+    ;; ; 主目录:取自环境变量 TEXMACS_HOME_PATH
+    (define (autosave-home)
+      (path-from-env "TEXMACS_HOME_PATH")
+    ) ;define
+
+    ;; ; 某文档对应的备份目录:$HOME/system/backup/<doc-id>
+    (define (autosave-dir doc-id)
+      (path-join (autosave-home) "system" "backup" doc-id)
+    ) ;define
+
+    ;; ; 单次备份的目标文件路径:<dir>/<yyyymmdd>_<hhmmss>.tmu
+    (define (autosave-target-path doc-id)
+      (let* ((date (current-date)) (stamp (date->string date "~Y~m~d_~H~M~S")))
+        (path-join (autosave-dir doc-id) (string-append stamp ".tmu"))
+      ) ;let*
+    ) ;define
+
+    ;; ; 确保从 home 到 doc-id 目录的目录链全部存在
+    ;; ; 返回 #t 表示所有目录都已就绪,#f 表示失败
+    (define (ensure-dir path)
+      (when (not (path-exists? path))
+        (mkdir (path->string path))
+      ) ;when
+      (and (path-exists? path) (path-dir? path))
+    ) ;define
+
+    (define (ensure-parent-dir doc-id)
+      (let ((home (autosave-home))
+            (system-dir (path-join (autosave-home) "system"))
+            (backup-dir (path-join (autosave-home) "system" "backup"))
+            (doc-dir (autosave-dir doc-id))
+           ) ;
+        (and home
+          (ensure-dir home)
+          (ensure-dir system-dir)
+          (ensure-dir backup-dir)
+          (ensure-dir doc-dir)
+        ) ;and
+      ) ;let
+    ) ;define
+
+    ;; ; 从 (document "...") stree 提取 JSON 字符串;若已是字符串则直接返回
+    (define (document->string doc)
+      (cond ((and (pair? doc) (eq? (car doc) 'document) (= (length doc) 2)) (cadr doc))
+            ((string? doc) doc)
+            (else "")
+      ) ;cond
+    ) ;define
+
+    ;; ; 把目录内 .tmu 裁剪到 < autosave-keep-max 份
+    ;; ; 按文件名字典序删最老的(时间戳文件名天然单调)
+    ;; ; 目录不存在时直接返回 #t(无操作)
+    ;; ; 返回 #t;异常向上传递
+    (define (autosave-prune-dir dir)
+      (if (not (path-exists? dir))
+        #t
+        (let* ((entries (vector->list (path-list dir)))
+               (tmus (filter (lambda (n) (string-suffix? ".tmu" n)) entries))
+               (excess (max 0 (- (length tmus) (- autosave-keep-max 1))))
+              ) ;
+          (when (> excess 0)
+            (for-each (lambda (n) (path-unlink (path-join dir n) #t))
+              (take (list-sort string<? tmus) excess)
+            ) ;for-each
+          ) ;when
+          #t
+        ) ;let*
+      ) ;if
+    ) ;define
+
+  ) ;begin
+) ;define-library

--- a/TeXmacs/plugins/autosave/goldfish/tests/autosave-prune-test.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tests/autosave-prune-test.scm
@@ -1,0 +1,127 @@
+;; ; 让 (liii autosave) 能被解析:
+;; ; 运行入口是 `cd TeXmacs/plugins/autosave/goldfish && goldfish tests/autosave-prune-test.scm`
+;; ; 所以 (getcwd) = 模块根目录,liii/autosave.scm 在其下
+(import (liii os) (scheme base))
+(set! *load-path* (cons (getcwd) *load-path*))
+
+(import (liii check)
+  (liii autosave)
+  (liii list)
+  (liii path)
+  (liii os)
+  (liii base)
+  (srfi srfi-13)
+) ;import
+
+(check-set-mode! 'report-failed)
+
+;; 辅助:在 dir 下生成名为 name 的空 .tmu 文件
+
+(define (touch-tmu dir name)
+  (path-touch (path-join dir (string-append name ".tmu")))
+) ;define
+
+;; 辅助:统计 dir 下 .tmu 文件数
+
+(define (count-tmu dir)
+  (let ((entries (vector->list (path-list dir))))
+    (length (filter (lambda (n) (string-suffix? ".tmu" n)) entries))
+  ) ;let
+) ;define
+
+;; 辅助:清空 dir 下所有 .tmu,然后 rmdir
+
+(define (wipe dir)
+  (for-each (lambda (n) (when (string-suffix? ".tmu" n) (path-unlink (path-join dir n) #t)))
+    (vector->list (path-list dir))
+  ) ;for-each
+  (path-rmdir dir)
+) ;define
+
+;; 场景 1:目录有 11 份,prune 后保留 keep-max-1 = 9 份(为复制后 +1 让位)
+(let ((base (path-join (os-temp-dir) "autosave-prune-11")))
+  (when (path-exists? base)
+    (wipe base)
+  ) ;when
+  (mkdir (path->string base))
+  (for-each (lambda (n)
+              (touch-tmu base (string-append "2026010" (number->string n) "_120000"))
+            ) ;lambda
+    (list 0 1 2 3 4 5 6 7 8 9 10)
+  ) ;for-each
+  (check (count-tmu base) => 11)
+
+  (autosave-prune-dir base)
+
+  (check (count-tmu base) => (- autosave-keep-max 1))
+  (wipe base)
+) ;let
+
+;; 场景 2:目录恰好 keep-max 份,prune 后保留 keep-max-1 = 9 份
+(let ((base (path-join (os-temp-dir) "autosave-prune-exact")))
+  (when (path-exists? base)
+    (wipe base)
+  ) ;when
+  (mkdir (path->string base))
+  (for-each (lambda (n)
+              (touch-tmu base (string-append "2026010" (number->string n) "_120000"))
+            ) ;lambda
+    (list 0 1 2 3 4 5 6 7 8 9)
+  ) ;for-each
+  (check (count-tmu base) => autosave-keep-max)
+
+  (autosave-prune-dir base)
+
+  (check (count-tmu base) => (- autosave-keep-max 1))
+  (wipe base)
+) ;let
+
+;; 场景 3:目录不足 keep-max 份,prune 后不动
+(let ((base (path-join (os-temp-dir) "autosave-prune-few")))
+  (when (path-exists? base)
+    (wipe base)
+  ) ;when
+  (mkdir (path->string base))
+  (for-each (lambda (n)
+              (touch-tmu base (string-append "2026010" (number->string n) "_120000"))
+            ) ;lambda
+    (list 0 1 2)
+  ) ;for-each
+  (check (count-tmu base) => 3)
+
+  (autosave-prune-dir base)
+
+  (check (count-tmu base) => 3)
+  (wipe base)
+) ;let
+
+;; 场景 4:目录远超 keep-max(20 份),prune 后保留 9 份
+(let ((base (path-join (os-temp-dir) "autosave-prune-many")))
+  (when (path-exists? base)
+    (wipe base)
+  ) ;when
+  (mkdir (path->string base))
+  (for-each (lambda (n)
+              (touch-tmu base
+                (string-append "20260"
+                  (if (< n 10) "10" "11")
+                  (if (< n 10) (number->string n) (number->string (- n 10)))
+                  "_120000"
+                ) ;string-append
+              ) ;touch-tmu
+            ) ;lambda
+    (list 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19)
+  ) ;for-each
+  (check (count-tmu base) => 20)
+
+  (autosave-prune-dir base)
+
+  (check (count-tmu base) => (- autosave-keep-max 1))
+  (wipe base)
+) ;let
+
+;; 场景 5:目录不存在,prune 不报错
+(check-true (autosave-prune-dir (path-join (os-temp-dir) "autosave-prune-nope-xyz"))
+) ;check-true
+
+(check-report)

--- a/TeXmacs/plugins/autosave/goldfish/tests/autosave-prune-test.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tests/autosave-prune-test.scm
@@ -1,3 +1,23 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : autosave-prune-test.scm
+;; DESCRIPTION : Unit tests for (liii autosave) autosave-prune-dir
+;; COPYRIGHT   : (C) 2026 Mogan Developers
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;; ; 让 (liii autosave) 能被解析:
 ;; ; 运行入口是 `cd TeXmacs/plugins/autosave/goldfish && goldfish tests/autosave-prune-test.scm`
 ;; ; 所以 (getcwd) = 模块根目录,liii/autosave.scm 在其下

--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -1,3 +1,23 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-autosave.scm
+;; DESCRIPTION : Autosave plugin entry for goldfish
+;; COPYRIGHT   : (C) 2026 Mogan Developers
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;; ; 让 (liii autosave) 能被解析:
 ;; ; tm-autosave.scm 与 liii/ 同目录,把当前文件所在目录加入 load-path
 (import (liii base) (liii path))

--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -1,10 +1,17 @@
-(import (texmacs protocol))
-(import (liii path))
-(import (liii json))
-(import (liii os))
-(import (srfi srfi-19))
+;; ; 让 (liii autosave) 能被解析:
+;; ; tm-autosave.scm 与 liii/ 同目录,把当前文件所在目录加入 load-path
+(import (liii base) (liii path))
+(set! *load-path*
+  (cons (path->string (path-parent (port-filename))) *load-path*)
+) ;set!
 
-;; 插件进程与主进程的握手：启动时必须 flush 插件名 "autosave"，
+(import (texmacs protocol))
+(import (liii autosave))
+(import (liii json))
+(import (liii path))
+(import (liii os))
+
+;; 插件进程与主进程的握手:启动时必须 flush 插件名 "autosave"，
 ;; 否则主进程不会进入 DATA_COMMAND 状态、无法投递后续负载。
 
 (define (welcome)
@@ -15,60 +22,13 @@
   (path-append-text "/tmp/debug.log" (string-append message "\n"))
 ) ;define
 
-(define (ensure-dir path)
-  (when (not (path-exists? path))
-    (mkdir (path->string path))
-  ) ;when
-  (and (path-exists? path) (path-dir? path))
-) ;define
-
-(define (autosave-home)
-  (path-from-env "TEXMACS_HOME_PATH")
-) ;define
-
-(define (autosave-dir doc-id)
-  (path-join (autosave-home) "system" "backup" doc-id)
-) ;define
-
-(define (autosave-target doc-id)
-  (let* ((date (current-date))
-         (stamp (date->string date "~Y~m~d_~H~M~S"))
-        ) ;
-    (path-join (autosave-dir doc-id) (string-append stamp ".tmu"))
-  ) ;let*
-) ;define
-
-(define (ensure-parent-dir doc-id)
-  (let ((home (autosave-home))
-        (system-dir (path-join (autosave-home) "system"))
-        (backup-dir (path-join (autosave-home) "system" "backup"))
-        (doc-dir (autosave-dir doc-id))
-       ) ;
-    (and home
-      (ensure-dir home)
-      (ensure-dir system-dir)
-      (ensure-dir backup-dir)
-      (ensure-dir doc-dir)
-    ) ;and
-  ) ;let
-) ;define
-
-(define (document->string doc)
-  (cond ((and (pair? doc) (eq? (car doc) 'document) (= (length doc) 2))
-         (cadr doc)
-        ) ;
-        ((string? doc) doc)
-        (else "")
-  ) ;cond
-) ;define
-
 (define (handle-copy payload)
   (catch #t
     (lambda ()
       (let* ((json (string->json payload))
              (source (json-ref json "path"))
              (doc-id (json-ref json "id"))
-             (target (if (string? doc-id) (autosave-target doc-id) ""))
+             (target (if (string? doc-id) (autosave-target-path doc-id) ""))
             ) ;
         (if (or (not (string? source))
               (not (string? doc-id))
@@ -79,6 +39,7 @@
           (if (not (file-exists? source))
             (autosave-log (string-append "autosave copy skipped: source missing " source))
             (when (ensure-parent-dir doc-id)
+              (autosave-prune-dir (autosave-dir doc-id))
               (if (path-copy source target)
                 (autosave-log (string-append "autosave copied " source " -> " target))
                 (autosave-log (string-append "autosave copy failed " source " -> " target))

--- a/devel/0353.md
+++ b/devel/0353.md
@@ -79,3 +79,35 @@ cd TeXmacs/plugins/goldfish
 - `xmake build goldfish` 通过
 - `./bin/goldfish tests/liii/path/path-copy-test.scm` 通过
 - 手工排查 `/tmp/debug.log` 时发现并修复了 `mkdir` 接收 `path` 对象导致的 `(file-exists? path): path should be string`
+
+## 8 后续：每个 doc-id 最多保留 10 份（本期 PR 范围）
+
+原始任务只解决了"复制源文件到 backup 目录"，没有数量上限，长期使用每个 doc-id 目录会无限增长。本期在原链路上追加：每个 doc-id 目录最多保留 10 份 `.tmu`，复制**前**先把最老的若干份删除，使复制完成后目录内恰好保留 10 份。备份/清理策略抽到新模块 `(liii autosave)`，插件入口 `tm-autosave.scm` 改薄为胶水。开发采用 TDD：先写单元测试放至 `TeXmacs/plugins/autosave/goldfish/tests/`，再实现模块。
+
+### 8.1 What
+1. 新增 `(liii autosave)` 模块（`TeXmacs/plugins/autosave/goldfish/liii/autosave.scm`），承载所有"备份策略"：常量 `autosave-keep-max=10`、目录推断（`autosave-home`/`autosave-dir`）、目标路径生成（`autosave-target-path`，时间戳格式 `~Y~m~d_~H~M~S`）、目录链创建（`ensure-parent-dir`）、payload 提取（`document->string`）、清理算法（`autosave-prune-dir`）
+2. `autosave-prune-dir` 把目录内 `.tmu` 裁剪到 `< autosave-keep-max` 份：按文件名字典序（时间戳文件名天然单调）排序后取前 `excess = max(0, n - (keep-max - 1))` 份删除，使复制完成后总数恰好等于 `keep-max`
+3. `tm-autosave.scm` 改为薄入口：`(welcome)` 握手、`(handle-copy payload)` 解析 JSON 并调库完成一次备份（含 prune → copy）、`(read-eval-print)` 主循环；删除原文件内重复的策略函数
+4. 模块解析：`tm-autosave.scm` 与测试文件均在文件顶部通过 `(set! *load-path* (cons <dir> *load-path*))` 把 `autosave/goldfish/` 加入搜索路径，使 `(import (liii autosave))` 能解析到 `liii/autosave.scm`
+
+### 8.2 Why
+- 原始 0353 完成后每次 `auto-backup-trig` 都新增一份备份，没有上限，长期使用会让每个 doc-id 目录无限增长
+- 用户要求：每个 doc-id 独立保留最多 10 份；复制前清理，保证最终恒为 10 份
+- 把策略搬到独立模块 `(liii autosave)`：单元测试可直接喂临时目录验证算法，不依赖 Mogan 运行环境；`tm-autosave.scm` 退化为胶水，便于阅读与后续扩展（例如改保留份数、引入按天数的复合策略时只动库）
+
+### 8.3 How
+- 清理时机选择"复制前"而非"复制后"：语义是"为新备份腾位"，复制完成后总数恰好等于 `autosave-keep-max`；算法实现上等价于"删除到 keep-max-1"
+- "最老"判定按文件名字典序，不读 mtime：时间戳文件名 `~Y~m~d_~H~M~S` 字典序与时间序一致，避免跨平台 mtime 精度差异
+- 模块路径解析不依赖 cwd：测试和入口都用 `(port-filename)`/`(getcwd)` 显式扩展 `*load-path*`，因为 goldfish 启动时 `*load-path*` 只含 goldfish 自带库目录
+- 复用已有原语：`path-list` 返回 vector → 转 list → `(liii sort)` 的 `list-sort` 排序 → `(liii list)` 的 `take` 取前 N → `(path-unlink path #t)` 删除（missing-ok 防竞态）
+- 异常隔离：`tm-autosave.scm` 的 `handle-copy` 仍用 `catch #t` 包裹；`autosave-prune-dir` 内部不 catch，由调用方决定是否吞掉（测试场景希望异常可见）
+
+### 8.4 验证结果
+- `xmake b goldfish` 通过
+- `goldfish tests/autosave-prune-test.scm` 输出 `9 correct, 0 failed`，覆盖：
+  - 11 份输入 → 9 份（删 2）
+  - 恰好 10 份输入 → 9 份（删 1）
+  - 3 份输入 → 3 份（不动）
+  - 20 份输入 → 9 份（删 11）
+  - 目录不存在 → 返回 `#t`，无副作用
+- 手工端到端：临时目录塞 12 份 `.tmu`，调 `autosave-prune-dir` 后剩 9 份，符合"复制前清理到 keep-max-1"的预期


### PR DESCRIPTION
## Summary
- 在 0353 基础上为 autosave 插件加数量上限:每个 doc-id 目录最多保留 10 份 `.tmu`
- 复制前先清理到 `keep-max-1 = 9` 份,使复制完成后总数恰好 = 10
- 把备份/清理策略抽到新模块 `(liii autosave)`,`tm-autosave.scm` 改薄为胶水层

## 改动
- 新增 `TeXmacs/plugins/autosave/goldfish/liii/autosave.scm`:`autosave-keep-max`、`autosave-home/dir/target-path`、`ensure-parent-dir`、`document->string`、`autosave-prune-dir`
- 新增 `TeXmacs/plugins/autosave/goldfish/tests/autosave-prune-test.scm`:5 个场景,9/9 通过
- 修改 `TeXmacs/plugins/autosave/goldfish/tm-autosave.scm`:`handle-copy` 在 `path-copy` 前调用 `autosave-prune-dir`,删除原文件内的策略函数

## 算法
`autosave-prune-dir` 按文件名字典序(时间戳格式 `~Y~m~d_~H~M~S` 天然单调)排序,删掉前 `max(0, n - (keep-max-1))` 份,使目录内 `.tmu` 降到 9 份;然后 `path-copy` 新增一份 → 总数 10。不读 mtime,避免跨平台精度差异。

## Test plan
- [x] `xmake b goldfish` 通过
- [x] `goldfish tests/autosave-prune-test.scm` 输出 `9 correct, 0 failed`
  - 11 份 → 9;10 份 → 9;3 份 → 3(不动);20 份 → 9;目录不存在 → `#t`
- [x] `tm-autosave.scm` 启动握手输出 `verbatim:autosave`
- [x] 手工 e2e:临时目录 12 份 `.tmu` → prune 后剩 9 份
- [ ] 端到端文档验证(Reviewer 在 Mogan 中触发 auto-backup,塞 11 份验证 11→10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)