### PR TITLE
[202_11] 在 font_basename.scm 中登记内置的 DejaVu 字体

### DIFF
--- a/TeXmacs/fonts/font_basename.scm
+++ b/TeXmacs/fonts/font_basename.scm
@@ -1264,4 +1264,10 @@
 "NotoSansSymbols2-Regular.ttf" "$TEXMACS_PATH/fonts/truetype/NotoSansSymbols2-Regular.ttf"
 "NotoSansCJK-Regular.ttc" "$TEXMACS_PATH/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
 "NotoSansCJK-Bold.ttc" "$TEXMACS_PATH/fonts/opentype/noto/NotoSansCJK-Bold.ttc"
+"DejaVuSans.ttf" "$TEXMACS_PATH/fonts/truetype/DejaVuSans.ttf"
+"DejaVuSans-Bold.ttf" "$TEXMACS_PATH/fonts/truetype/DejaVuSans-Bold.ttf"
+"DejaVuSansMono.ttf" "$TEXMACS_PATH/fonts/truetype/DejaVuSansMono.ttf"
+"DejaVuSansMono-Bold.ttf" "$TEXMACS_PATH/fonts/truetype/DejaVuSansMono-Bold.ttf"
+"DejaVuSerif.ttf" "$TEXMACS_PATH/fonts/truetype/DejaVuSerif.ttf"
+"DejaVuSerif-Bold.ttf" "$TEXMACS_PATH/fonts/truetype/DejaVuSerif-Bold.ttf"
 )

--- a/devel/202_11.md
+++ b/devel/202_11.md
@@ -1,14 +1,44 @@
-# 202_11: 修复Windows平台无法显示键盘快捷键的问题
-## 2025/07/15
-### What
-因为Windows平台没有内置的Dejavu字体，所以无法显示键盘快捷键。
+# [202_11] 修复 Windows 平台无法显示键盘快捷键的问题
 
-### How
-点击`工具->字体->清除字体缓存`，然后在`文档->字体`菜单中可以找到Dejavu字体，这样就表示这个内置的字体可以被找到。最后使用`工具->键盘->显示键盘按键`，在Windows上就可以显示键盘的按键了。
+任务编号使用 0000 到 9999 的四位数字格式。
 
-## 2026/06/16
-### What
-内置的 DejaVu 字体没有在 `TeXmacs/fonts/font_basename.scm` 中登记，导致字体缓存索引缺失对应条目。
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
 
-### How
-在 `TeXmacs/fonts/font_basename.scm` 末尾追加六个 DejaVu truetype 字体条目（DejaVuSans、DejaVuSans-Bold、DejaVuSansMono、DejaVuSansMono-Bold、DejaVuSerif、DejaVuSerif-Bold），与已存在的 `font-database.scm`、`font-characteristics.scm` 中的 DejaVu 记录保持一致。
+## 2 任务相关的代码文件
+- TeXmacs/fonts/truetype/DejaVuSans.ttf
+- TeXmacs/fonts/truetype/DejaVuSans-Bold.ttf
+- TeXmacs/fonts/truetype/DejaVuSansMono.ttf
+- TeXmacs/fonts/truetype/DejaVuSansMono-Bold.ttf
+- TeXmacs/fonts/truetype/DejaVuSerif.ttf
+- TeXmacs/fonts/truetype/DejaVuSerif-Bold.ttf
+- TeXmacs/fonts/font_basename.scm
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+# 本任务无对应单元测试
+```
+
+### 3.2 非确定性测试（文档验证）
+点击 `工具->字体->清除字体缓存`，然后在 `文档->字体` 菜单中可以找到 DejaVu 字体，这样就表示这个内置的字体可以被找到。最后使用 `工具->键盘->显示键盘按键`，在 Windows 上就可以显示键盘的按键了。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+1. 内置 DejaVu 字体（DejaVuSans、DejaVuSans-Bold、DejaVuSansMono、DejaVuSansMono-Bold、DejaVuSerif、DejaVuSerif-Bold 六个 truetype 字体），支持在 Windows 平台显示键盘快捷键。
+2. 在 `TeXmacs/fonts/font_basename.scm` 中登记这六个 DejaVu 字体条目，使字体缓存索引在首次加载时即可命中，无需用户手动清除缓存。
+
+## 6 Why
+Windows 平台没有内置的 DejaVu 字体，导致 `工具->键盘->显示键盘按键` 无法显示按键。内置该字体后，`font-database.scm`、`font-characteristics.scm` 已包含对应记录，但 `font_basename.scm` 缺失条目，导致字体缓存索引不完整。
+
+## 7 How
+将六个 DejaVu truetype 字体放入 `TeXmacs/fonts/truetype/`，并在 `font_basename.scm` 末尾追加对应条目，路径格式参照已有的 `NotoSansSymbols*.ttf` 条目，与 `font-database.scm`、`font-characteristics.scm` 中的 DejaVu 记录保持一致。

--- a/devel/202_11.md
+++ b/devel/202_11.md
@@ -22,7 +22,7 @@
 ```
 
 ### 3.2 非确定性测试（文档验证）
-点击 `工具->字体->清除字体缓存`，然后在 `文档->字体` 菜单中可以找到 DejaVu 字体，这样就表示这个内置的字体可以被找到。最后使用 `工具->键盘->显示键盘按键`，在 Windows 上就可以显示键盘的按键了。
+点击 `工具->字体->清除字体缓存`，然后在 `文档->字体` 菜单中可以找到 DejaVu 字体，这样就表示这个内置的字体可以被找到。
 
 ## 4 如何提交
 
@@ -38,7 +38,7 @@ xmake b stem
 2. 在 `TeXmacs/fonts/font_basename.scm` 中登记这六个 DejaVu 字体条目，使字体缓存索引在首次加载时即可命中，无需用户手动清除缓存。
 
 ## 6 Why
-Windows 平台没有内置的 DejaVu 字体，导致 `工具->键盘->显示键盘按键` 无法显示按键。内置该字体后，`font-database.scm`、`font-characteristics.scm` 已包含对应记录，但 `font_basename.scm` 缺失条目，导致字体缓存索引不完整。
+Windows 平台没有内置的 DejaVu 字体，原本依赖该字体的键盘快捷键显示等功能无法正常工作。内置该字体后，`font-database.scm`、`font-characteristics.scm` 已包含对应记录，但 `font_basename.scm` 缺失条目，导致字体缓存索引不完整。
 
 ## 7 How
 将六个 DejaVu truetype 字体放入 `TeXmacs/fonts/truetype/`，并在 `font_basename.scm` 末尾追加对应条目，路径格式参照已有的 `NotoSansSymbols*.ttf` 条目，与 `font-database.scm`、`font-characteristics.scm` 中的 DejaVu 记录保持一致。

--- a/devel/202_11.md
+++ b/devel/202_11.md
@@ -5,3 +5,10 @@
 
 ### How
 点击`工具->字体->清除字体缓存`，然后在`文档->字体`菜单中可以找到Dejavu字体，这样就表示这个内置的字体可以被找到。最后使用`工具->键盘->显示键盘按键`，在Windows上就可以显示键盘的按键了。
+
+## 2026/06/16
+### What
+内置的 DejaVu 字体没有在 `TeXmacs/fonts/font_basename.scm` 中登记，导致字体缓存索引缺失对应条目。
+
+### How
+在 `TeXmacs/fonts/font_basename.scm` 末尾追加六个 DejaVu truetype 字体条目（DejaVuSans、DejaVuSans-Bold、DejaVuSansMono、DejaVuSansMono-Bold、DejaVuSerif、DejaVuSerif-Bold），与已存在的 `font-database.scm`、`font-characteristics.scm` 中的 DejaVu 记录保持一致。


### PR DESCRIPTION
## Summary
- 内置 DejaVu 字体（!416）时遗漏了 `TeXmacs/fonts/font_basename.scm` 的登记，导致字体缓存索引缺失对应条目。
- 在 `font_basename.scm` 末尾追加六个 DejaVu truetype 字体条目（DejaVuSans、DejaVuSans-Bold、DejaVuSansMono、DejaVuSansMono-Bold、DejaVuSerif、DejaVuSerif-Bold），与已存在的 `font-database.scm`、`font-characteristics.scm` 中的 DejaVu 记录保持一致。
- 先更新 `devel/202_11.md` 记录该问题，再追加 scm 改动。

## Test plan
- [ ] 在 Windows 上启动 Mogan，确认 `文档->字体` 菜单能找到 DejaVu 字体
- [ ] `工具->键盘->显示键盘按键` 能正常显示按键
- [ ] 无需点击"清除字体缓存"即可直接生效（即 font_basename.scm 已被正确加载）

🤖 Generated with [Claude Code](https://claude.com/claude-code)