### PR TITLE
[1102] 用内置 url 工具替换自研 URL→path 转换

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -693,95 +693,6 @@
   (time-second (current-time TIME-UTC))
 ) ;define
 
-(define (auto-backup-url-stree-tag x)
-  (cond ((symbol? x) (symbol->string x))
-        ((string? x) x)
-        (else "")
-  ) ;cond
-) ;define
-
-(define (auto-backup-url-stree-ref t n)
-  (list-ref t n)
-) ;define
-
-(define (auto-backup-url-stree->path t)
-  (cond ((string? t) t)
-        ((symbol? t) (symbol->string t))
-        ((pair? t)
-         (let ((tag (auto-backup-url-stree-tag (car t))))
-           (cond ((== tag "concat")
-                  (let ((left (auto-backup-url-stree->path (auto-backup-url-stree-ref t 1)))
-                        (right (auto-backup-url-stree->path (auto-backup-url-stree-ref t 2)))
-                       ) ;
-                    (cond ((== left "") right)
-                          ((== right "") left)
-                          (else (path-join left right))
-                    ) ;cond
-                  ) ;let
-                 ) ;
-                 ((== tag "root")
-                  (let ((root (auto-backup-url-stree-tag (auto-backup-url-stree-ref t 1))))
-                    (if (in? root '("default" "file" "blank")) (path->string (path-root)) "")
-                  ) ;let
-                 ) ;
-                 ((== tag "none") "untitled")
-                 ((== tag "or") (auto-backup-url-stree->path (auto-backup-url-stree-ref t 1)))
-                 (else tag)
-           ) ;cond
-         ) ;let
-        ) ;
-        (else "untitled")
-  ) ;cond
-) ;define
-
-(define (auto-backup-buffer-path name)
-  (catch #t
-    (lambda ()
-      (path->string (path-from-string (auto-backup-url-stree->path (url->stree name)))
-      ) ;path->string
-    ) ;lambda
-    (lambda args "untitled")
-  ) ;catch
-) ;define
-
-(define (auto-backup-trim-trailing-separators s)
-  (let loop
-    ((n (string-length s)))
-    (if (and (> n 1)
-          (let ((c (string-ref s (- n 1))))
-            (or (char=? c #\/) (char=? c #\\))
-          ) ;let
-        ) ;and
-      (loop (- n 1))
-      (substring s 0 n)
-    ) ;if
-  ) ;let
-) ;define
-
-(define (auto-backup-path-normal-string path)
-  (auto-backup-trim-trailing-separators (path->string path))
-) ;define
-
-(define (auto-backup-path-descends? child parent)
-  (catch #t
-    (lambda ()
-      (let ((parent-path (auto-backup-path-normal-string (path-from-string parent))))
-        (let loop
-          ((path (path-from-string child)))
-          (let ((current-path (auto-backup-path-normal-string path)))
-            (or (== current-path parent-path)
-              (let* ((next (path-parent path)) (next-path (auto-backup-path-normal-string next)))
-                (and (!= next-path current-path) (loop next))
-              ) ;let*
-            ) ;or
-          ) ;let
-        ) ;let
-      ) ;let
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
-) ;define
-
 ;; auto-backup-texmacs-path-buffer?
 ;; 判断 buffer 是否位于 get-texmacs-path 返回的目录或其子目录中。
 ;;
@@ -808,14 +719,7 @@
 ;; ----
 ;; TeXmacs 安装路径下的文件被视为只读内置资源，不进入自动备份。
 (tm-define (auto-backup-texmacs-path-buffer? name)
-  (catch #t
-    (lambda ()
-      (auto-backup-path-descends? (auto-backup-buffer-path name)
-        (url->system (get-texmacs-path))
-      ) ;auto-backup-path-descends?
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
+  (url-descends? name (get-texmacs-path))
 ) ;tm-define
 
 (define (auto-backup-path->url p)
@@ -1096,7 +1000,7 @@
 ) ;tm-define
 
 (tm-define (auto-backup-trig-payload name kind)
-  (let* ((path (auto-backup-buffer-path name))
+  (let* ((path (url->system name))
          (doc-id (auto-backup-ensure-buffer-doc-id! name))
          (session-id (uuid4))
          (payload (string->json "{}"))

--- a/devel/1102.md
+++ b/devel/1102.md
@@ -1,0 +1,44 @@
+# [1102] 用内置 url 工具替换自研 URL→path 转换
+
+任务编号：1102。在 [[1101]] 建立外部 autosave 插件通道、清理本地落盘逻辑之后，`tm-files.scm` 中仍残留一组自研的 URL→path 转换辅助函数，用于把 buffer 名解析成文件系统路径并判断是否位于 TeXmacs 安装目录下。本期用内置的 `url-descends?` 与 `url->system` 替换这组辅助函数，删除冗余实现，使自动备份触发逻辑复用项目统一的 URL 工具。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1101.md](1101.md) - Autosave Dummy Plugin，建立外部插件通道并清理本地落盘流水线（前期工作）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` - 修改：删除自研 URL→path 转换辅助函数（`auto-backup-url-stree-tag`、`auto-backup-url-stree-ref`、`auto-backup-url-stree->path`、`auto-backup-buffer-path`、`auto-backup-trim-trailing-separators`、`auto-backup-path-normal-string`、`auto-backup-path-descends?`），改用内置 `url-descends?` 实现 `auto-backup-texmacs-path-buffer?`，并用 `url->system` 替换 `auto-backup-trig-payload` 中的路径取值
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+手动验证：启动 Mogan，打开位于 TeXmacs 安装目录下的内置文档与用户目录下的普通文档，触发自动备份，确认内置文档被 auto-backup-texmacs-path-buffer? 正确识别为只读（不进入备份），普通文档的 payload 中 path 字段为正确的系统路径。
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+1. 删除 `tm-files.scm` 中自研的 URL stree→path 转换链：`auto-backup-url-stree-tag`、`auto-backup-url-stree-ref`、`auto-backup-url-stree->path`，以及基于它的 `auto-backup-buffer-path`
+2. 删除路径规范化与父子判定辅助函数：`auto-backup-trim-trailing-separators`、`auto-backup-path-normal-string`、`auto-backup-path-descends?`
+3. 将 `auto-backup-texmacs-path-buffer?` 重写为单次 `(url-descends? name (get-texmacs-path))`，语义等价但复用内置 URL 工具
+4. 将 `auto-backup-trig-payload` 中 `path` 的取值由 `auto-backup-buffer-path` 改为 `url->system`，与系统路径表示保持一致
+
+## 6 Why
+[[1101]] 清理本地落盘流水线后，这组 URL→path 辅助函数仅服务于两个用途：判断 buffer 是否位于 TeXmacs 安装目录（只读资源，不备份）、为 payload 构造系统路径。两件事项目已提供内置工具——`url-descends?` 做父子判定，`url->system` 做 URL→系统路径转换。自研实现不仅重复，还手工处理 stree 结构、尾部分隔符修剪、异常回退等细节，维护成本高且易与内置工具的行为产生分歧。替换后代码更短、行为与项目其余部分一致。
+
+## 7 How
+- `auto-backup-texmacs-path-buffer?` 原本先 `url->stree` 再手工递归求路径、再做 trimmed 路径的逐级父子比较；内置 `url-descends?` 直接在 URL 层完成判定，无需中间表示，故整段 catch 包装与辅助函数均可删除
+- `auto-backup-trig-payload` 的 `path` 字段下游用于标识缓冲区来源，`url->system` 给出系统风格路径，比原来 stree 推导出的 `path-join` 结果更贴近消费端预期
+- 替换不改变对外行为：TeXmacs 安装目录及子目录下的 buffer 仍被判为只读、不进入备份；普通 buffer 的 payload 仍携带路径信息


### PR DESCRIPTION
## Summary
- 按 dddd.md 模板撰写 [1102] 任务文档（devel/1102.md）
- 删除 `tm-files.scm` 中自研的 URL stree→path 转换链与路径父子判定辅助函数（`auto-backup-url-stree-*`、`auto-backup-buffer-path`、`auto-backup-trim-trailing-separators`、`auto-backup-path-normal-string`、`auto-backup-path-descends?`）
- `auto-backup-texmacs-path-buffer?` 改用内置 `url-descends?`；`auto-backup-trig-payload` 的 `path` 字段改用 `url->system`，行为不变

承接 #1101（autosave 插件通道建立 + 本地落盘清理），消除与项目 URL 工具的重复实现。

## Test plan
- [x] `gf fmt --changed-since=main` 已执行
- [ ] `xmake b stem` 构建通过
- [ ] 手动验证：TeXmacs 安装目录下的内置文档被判为只读（不进入备份），用户目录下普通文档的 payload path 字段为正确系统路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)