### PR TITLE
[1120] 移除本地 ~ autosave 机制，改为定时静默 save-buffer-save

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -463,7 +463,7 @@
 (display* "memory: " (texmacs-memory) " bytes\n")
 
 (display "------------------------------------------------------\n")
-(delayed (:idle 10000)
+(delayed (:pause 120000)
   (autosave-delayed))
 (catch #t
   (lambda ()

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -465,8 +465,6 @@
 (display "------------------------------------------------------\n")
 (delayed (:idle 10000)
   (autosave-delayed))
-(delayed (:pause 30000)
-  (auto-backup-delayed))
 (catch #t
   (lambda ()
     (use-modules (telemetry telemetry-utils))

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -679,19 +679,11 @@
 
 (define autosave-fixed-interval-ms 120000)
 
-(define auto-backup-fixed-interval-ms 120000)
-
 (tm-define (autosave-enabled?) (!= (get-preference "autosave") "0"))
 
 (tm-define (auto-backup-enabled?) (!= (get-preference "autobackup") "off"))
 
 (tm-define (liiistem-version) (xmacs-version))
-
-(define auto-backup-scheduled? #f)
-
-(define (auto-backup-now-seconds)
-  (time-second (current-time TIME-UTC))
-) ;define
 
 ;; auto-backup-texmacs-path-buffer?
 ;; 判断 buffer 是否位于 get-texmacs-path 返回的目录或其子目录中。
@@ -724,58 +716,6 @@
 
 (define (auto-backup-path->url p)
   (system->url (path->string p))
-) ;define
-
-;; auto-backup-empty-manifest
-;; 创建新的自动备份 manifest。
-;;
-;; 语法
-;; ----
-;; (auto-backup-empty-manifest)
-;;
-;; 参数
-;; ----
-;; 无。
-;;
-;; 返回值
-;; ----
-;; njson
-;; 包含 meta 和 documents 的 manifest 对象，调用者负责释放。
-;;
-;; 逻辑
-;; ----
-;; 初始化版本号、固定调度间隔、单文档 rolling 数量和 manifest 记录最长
-;; 保留天数。
-;;
-;; 注意
-;; ----
-;; manifest 的 njson 句柄需要用 let-njson 包裹，避免泄漏。
-(tm-define (auto-backup-empty-manifest)
-  (let ((manifest (string->njson "{\"meta\":{\"version\":1,\"interval_seconds\":120,\"retention\":7,\"max_record_age_days\":30,\"updated_at\":0},\"documents\":{}}"
-                  ) ;string->njson
-        ) ;manifest
-       ) ;
-    (njson-set! manifest "meta" "updated_at" (auto-backup-now-seconds))
-    manifest
-  ) ;let
-) ;tm-define
-
-(define (auto-backup-manifest-valid? manifest)
-  (catch #t
-    (lambda ()
-      (and (njson-object? manifest)
-        (let-njson ((meta (njson-ref manifest "meta"))
-                    (documents (njson-ref manifest "documents"))
-                   ) ;
-          (and (njson-object? meta)
-            (njson-object? documents)
-            (== (njson-ref meta "version") 1)
-          ) ;and
-        ) ;let-njson
-      ) ;and
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
 ) ;define
 
 (define (auto-backup-format name)
@@ -1055,12 +995,9 @@
 ;;
 ;; kind : string
 ;; 备份类型，例如 "save"、"save-as"、"export-pdf"、"on-open"、"auto"、"manual-open"。
-;;
-;; 逻辑
-;; ----
-;; 仅打印触发参数，不执行实际备份逻辑；后续可在此扩展备份行为。
+
 (tm-define (auto-backup-trig u kind)
-  (when (auto-backup-buffer-eligible? u)
+  (when (and (auto-backup-enabled?) (auto-backup-buffer-eligible? u))
     (receive (s session-id)
       (auto-backup-trig-payload u kind)
       (silent-feed* "autosave"
@@ -1094,28 +1031,6 @@
   (auto-backup-ensure-buffer-doc-id! name)
   (delayed (:pause 100) (auto-backup-trig name "on-open"))
 ) ;define
-
-(tm-define (auto-backup-all)
-  (let ((buffers (buffer-list)))
-    (for-each (lambda (name) (auto-backup-trig name "auto")) buffers)
-  ) ;let
-) ;tm-define
-
-(tm-define (auto-backup-now)
-  (set! auto-backup-scheduled? #f)
-  (if (auto-backup-enabled?) (begin (auto-backup-all) (auto-backup-delayed)))
-) ;tm-define
-
-(tm-define (auto-backup-delayed)
-  (if (auto-backup-enabled?)
-    (if auto-backup-scheduled?
-      (begin
-        (set! auto-backup-scheduled? #t)
-        (delayed (:pause auto-backup-fixed-interval-ms) (auto-backup-now))
-      ) ;begin
-    ) ;if
-  ) ;if
-) ;tm-define
 
 (tm-define (auto-backup-official-url)
   (if (== (get-output-language) "chinese")
@@ -1200,12 +1115,14 @@
             ) ;else
       ) ;cond
     ) ;let*
+    (auto-backup-trig name "auto")
   ) ;when
 ) ;tm-define
 
 (tm-define (autosave-all) (for-each autosave-buffer (buffer-list)))
 
 (tm-define (autosave-now)
+  (display* "autosave-now\n")
   (when (autosave-enabled?)
     (autosave-all)
     (autosave-delayed)

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -380,7 +380,6 @@
         ) ;begin
         (begin
           (if (== (url-suffix name) "ts") (style-clear-cache))
-          (autosave-remove name)
           (buffer-notify-recent name)
           ;; Remember directory for file dialog
           (remember-file-dialog-directory name)
@@ -1048,81 +1047,17 @@
   (auto-backup-trig (current-buffer-url) "visit-cloud-backup")
 ) ;tm-define
 
-(define (more-recent file suffix1 suffix2)
-  (and (url-exists? (url-glue file suffix1))
-    (url-exists? (url-glue file suffix2))
-    (url-newer? (url-glue file suffix1) (url-glue file suffix2))
-  ) ;and
-) ;define
-
-(define (most-recent-suffix file)
-  (if (more-recent file "~" "")
-    (if (not (more-recent file "#" "")) "~" (if (more-recent file "#" "~") "#" "~"))
-    (if (more-recent file "#" "") "#" "")
-  ) ;if
-) ;define
-
-(define (autosave-eligible? name)
-  (and (not (url-rooted-web? name))
-    (or (not (url-rooted-tmfs? name)) (tmfs-autosave name "~"))
-  ) ;and
-) ;define
-
-(define (autosave-propose name)
-  (and (autosave-eligible? name)
-    (with s (most-recent-suffix name) (and (!= s "") (url-glue name s)))
-  ) ;and
-) ;define
-
-(define (autosave-rescue? name)
-  (and (autosave-eligible? name) (== (most-recent-suffix name) "#"))
-) ;define
-
-(define (autosave-remove name)
-  (when (url-exists? (url-glue name "~"))
-    (url-remove (url-glue name "~"))
-  ) ;when
-  (when (url-exists? (url-glue name "#"))
-    (url-remove (url-glue name "#"))
-  ) ;when
-) ;define
-
-(tm-define (autosave-buffer name)
-  (when (and (buffer-modified-since-autosave? name) (url-autosave name "~"))
-    (when (debug-get "io")
-      (debug-message "debug-io" (string-append "Autosave " (url->system name) "\n"))
-    ) ;when
-    ;; FIXME: incorrectly autosaves after cursor movements only
-    (let* ((vname `(verbatim ,(utf8->cork (url->system name))))
-           (suffix (if (rescue-mode?) "#" "~"))
-           (aname (if (url-scratch? name) name (url-autosave name suffix)))
-           (fm (url-format name))
-          ) ;
-      (cond ((nin? fm (list "texmacs" "stm" "mgs" "tmu"))
-             (when (not (rescue-mode?))
-               (set-message `(concat ,"Warning: " ,vname ," not auto-saved") "Auto-save file")
-             ) ;when
-            ) ;
-            ((buffer-export name aname fm)
-             (when (not (rescue-mode?))
-               (set-message `(concat ,"Failed to auto-save " ,vname) "Auto-save file")
-             ) ;when
-            ) ;
-            (else (when (not (rescue-mode?))
-                    (buffer-pretend-autosaved name)
-                    (set-temporary-message `(concat ,"Auto-saved " ,vname) "Auto-save file" 2500)
-                  ) ;when
-            ) ;else
-      ) ;cond
-    ) ;let*
-    (auto-backup-trig name "auto")
-  ) ;when
+(tm-define (autosave-all)
+  (for-each (lambda (name)
+              (when (and (buffer-modified? name) (not (url-scratch? name)))
+                (save-buffer-save name (list) "auto")
+              ) ;when
+            ) ;lambda
+    (buffer-list)
+  ) ;for-each
 ) ;tm-define
 
-(tm-define (autosave-all) (for-each autosave-buffer (buffer-list)))
-
 (tm-define (autosave-now)
-  (display* "autosave-now\n")
   (when (autosave-enabled?)
     (autosave-all)
     (autosave-delayed)
@@ -1141,7 +1076,6 @@
 ) ;tm-define
 
 (tm-define (autosave-delayed)
-  (display* "autosave-delayed\n")
   (when (autosave-enabled?)
     (delayed (:pause autosave-fixed-interval-ms) (autosave-now))
   ) ;when
@@ -1293,31 +1227,7 @@
 
 (define (load-buffer-check-autosave name opts)
   ;; (display* "load-buffer-check-autosave " name ", " opts "\n")
-  (if (and (autosave-propose name) (nin? :strict opts))
-    (with question
-      (if (autosave-rescue? name)
-        "Rescue file from crash?"
-        "Load more recent autosave file?"
-      ) ;if
-      (user-confirm question
-        #t
-        (lambda (answ)
-          (if answ
-            (let* ((autosave-name (autosave-propose name))
-                   (format (url-format name))
-                   (doc (tree-import autosave-name format))
-                  ) ;
-              (buffer-set name doc)
-              (load-buffer-open name opts)
-              (buffer-pretend-modified name)
-            ) ;let*
-            (load-buffer-check-permissions name opts)
-          ) ;if
-        ) ;lambda
-      ) ;user-confirm
-    ) ;with
-    (load-buffer-check-permissions name opts)
-  ) ;if
+  (load-buffer-check-permissions name opts)
 ) ;define
 
 (tm-define (load-buffer-main name . opts)

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1141,13 +1141,14 @@
 ) ;tm-define
 
 (tm-define (autosave-delayed)
+  (display* "autosave-delayed\n")
   (when (autosave-enabled?)
     (delayed (:pause autosave-fixed-interval-ms) (autosave-now))
   ) ;when
 ) ;tm-define
 
 (define (notify-autosave var val)
-  (if (current-view) (begin (autosave-delayed) (auto-backup-delayed)))
+  (if (current-view) (begin (autosave-delayed)))
 ) ;define
 
 (define-preferences ("autosave" "120" notify-autosave))

--- a/devel/1120.md
+++ b/devel/1120.md
@@ -1,0 +1,55 @@
+# [1120] 移除本地 ~ autosave 机制，autosave 改为定时静默 save-buffer-save
+
+## 2026/06/17
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- TeXmacs/progs/texmacs/texmacs/tm-files.scm
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+```bash
+xmake config --yes -vD -m releasedbg
+xmake b stem
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+
+移除本地 `~`/`#` autosave 副本机制，autosave 改为定时遍历 buffer-list 调用 `save-buffer-save`。
+
+1. `autosave-all`：改写为遍历 `buffer-list`，对 `buffer-modified?` 且非 scratch 的 buffer 调 `save-buffer-save name (list) "auto"`
+2. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
+3. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
+4. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
+
+## 6 Why
+
+旧的 `~`/`#` 机制会在源文件目录下产生 `xxx.tmu~` 副本文件，把用户目录弄脏。崩溃恢复对话框功能已不再需要，崩溃恢复改由 `auto-backup-trig` 云备份机制承担。
+
+## 7 How
+
+`save-buffer-save` 覆盖写源文件本身，与原 `autosave-buffer` 写旁路 `~` 副本的语义不同——这次改动接受这个语义变化：autosave 等于定时静默 Ctrl-S。
+
+边界处理：
+- `buffer-modified?` 守卫避免对未改动 buffer 反复写盘
+- `url-scratch?` 守卫跳过未命名 buffer（无磁盘路径，`buffer-save` 无意义）
+- 保留 `save-buffer-save` 全部 UI 副作用（Saved 消息、recent 通知等）
+- `url-autosave`（tm-define，多处同名）保留，删除风险高
+- C++ 侧 `pretend_buffer_autosaved` / `buffer_modified_since_autosave` 及其 glue 声明保留为死代码，本次不动 C++


### PR DESCRIPTION
## Summary
- autosave-all 改为遍历 buffer-list 调 save-buffer-save（覆盖写源文件，保留 Saved 消息等 UI 副作用），不再产生 `xxx.tmu~` 副本
- 删除 autosave-buffer 及 ~/# 相关辅助函数、崩溃恢复对话框入口
- init-research 首次 autosave 延迟从 idle 10s 改为 pause 120s
- 移除 autosave-now / autosave-delayed 中的调试 display*

崩溃恢复改由 auto-backup-trig 云备份机制承担。

## Test plan
- [x] `xmake b stem` 构建通过
- [ ] 手动验证：打开多 buffer，确认定时 autosave 不再产生 `~` 文件
- [ ] 手动验证：修改 buffer 后触发 autosave，源文件被更新、显示 Saved 消息
- [ ] 手动验证：未命名 scratch buffer 不触发保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)