### PR TITLE
[1103] 优化右键菜单（剪贴板操作按模式显式化）

### DIFF
--- a/TeXmacs/progs/texmacs/menus/main-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/main-menu.scm
@@ -98,6 +98,9 @@
 (tm-menu (texmacs-popup-menu)
   (:require (full-screen?))
   (link presentation-popup-menu)
+  ("Magic paste" (kbd-magic-paste))
+  ("Paste special" (interactive-paste-special))
+  (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
 
 (menu-bind focus-popup-menu ("Focus mode" (toggle-focus-mode)))
@@ -105,6 +108,9 @@
 (tm-menu (texmacs-popup-menu)
   (:require (and (focus-mode?) (not (simplest-mode?))))
   (link focus-popup-menu)
+  ("Magic paste" (kbd-magic-paste))
+  ("Paste special" (interactive-paste-special))
+  (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
 
 (menu-bind simplest-popup-menu ("Simplest mode" (toggle-simplest-mode)))
@@ -112,6 +118,9 @@
 (tm-menu (texmacs-popup-menu)
   (:require (simplest-mode?))
   (link simplest-popup-menu)
+  ("Magic paste" (kbd-magic-paste))
+  ("Paste special" (interactive-paste-special))
+  (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
 
 (tm-menu (texmacs-popup-menu)

--- a/TeXmacs/progs/texmacs/menus/main-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/main-menu.scm
@@ -89,13 +89,15 @@
  ("Remote control" (toggle-remote-control-mode))
 ) ;menu-bind
 
-(menu-bind texmacs-popup-menu (link focus-menu))
+(tm-menu (texmacs-popup-menu)
+  ("Magic paste" (kbd-magic-paste))
+  ("Paste special" (interactive-paste-special))
+  (=> "Copy to" (link clipboard-copy-export-menu))
+) ;tm-menu
 
 (tm-menu (texmacs-popup-menu)
   (:require (full-screen?))
   (link presentation-popup-menu)
-  ---
-  (former)
 ) ;tm-menu
 
 (menu-bind focus-popup-menu ("Focus mode" (toggle-focus-mode)))
@@ -103,8 +105,6 @@
 (tm-menu (texmacs-popup-menu)
   (:require (and (focus-mode?) (not (simplest-mode?))))
   (link focus-popup-menu)
-  ---
-  (former)
 ) ;tm-menu
 
 (menu-bind simplest-popup-menu ("Simplest mode" (toggle-simplest-mode)))
@@ -112,8 +112,6 @@
 (tm-menu (texmacs-popup-menu)
   (:require (simplest-mode?))
   (link simplest-popup-menu)
-  ---
-  (former)
 ) ;tm-menu
 
 (tm-menu (texmacs-popup-menu)
@@ -123,14 +121,6 @@
   ("Paste special" (interactive-paste-special))
 ) ;tm-menu
 
-(tm-menu (texmacs-popup-menu)
-  (:require (not (chat-input-buffer? (current-buffer-url))))
-  ("Magic paste" (kbd-magic-paste))
-  ("Paste special" (interactive-paste-special))
-  (=> "Copy to" (link clipboard-copy-export-menu))
-  ---
-  (former)
-) ;tm-menu
 
 (menu-bind texmacs-alternative-popup-menu
   (-> "File" (link file-menu))

--- a/TeXmacs/progs/texmacs/menus/main-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/main-menu.scm
@@ -92,14 +92,7 @@
 (tm-menu (texmacs-popup-menu)
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
-  (=> "Copy to" (link clipboard-copy-export-menu))
-) ;tm-menu
-
-(tm-menu (texmacs-popup-menu)
-  (:require (full-screen?))
-  (link presentation-popup-menu)
-  ("Magic paste" (kbd-magic-paste))
-  ("Paste special" (interactive-paste-special))
+  ("Copy" (kbd-copy))
   (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
 
@@ -109,6 +102,7 @@
   (:require (and (focus-mode?) (not (simplest-mode?))))
   (link focus-popup-menu)
   ("Magic paste" (kbd-magic-paste))
+  ("Copy" (kbd-copy))
   ("Paste special" (interactive-paste-special))
   (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
@@ -120,16 +114,30 @@
   (link simplest-popup-menu)
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
+  ("Copy" (kbd-copy))
   (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
 
 (tm-menu (texmacs-popup-menu)
   (:require (chat-input-buffer? (current-buffer-url)))
-  ("Paste" (kbd-paste))
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
 ) ;tm-menu
 
+(tm-menu (texmacs-popup-menu)
+  (:require (chat-message-buffer? (current-buffer-url)))
+  ("Copy" (kbd-copy))
+  (=> "Copy to" (link clipboard-copy-export-menu))
+) ;tm-menu
+
+(tm-menu (texmacs-popup-menu)
+  (:require (full-screen?))
+  (link presentation-popup-menu)
+  ("Magic paste" (kbd-magic-paste))
+  ("Paste special" (interactive-paste-special))
+  ("Copy" (kbd-copy))
+  (=> "Copy to" (link clipboard-copy-export-menu))
+) ;tm-menu
 
 (menu-bind texmacs-alternative-popup-menu
   (-> "File" (link file-menu))

--- a/TeXmacs/progs/texmacs/menus/main-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/main-menu.scm
@@ -90,6 +90,7 @@
 ) ;menu-bind
 
 (tm-menu (texmacs-popup-menu)
+  ("Paste" (kbd-paste))
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
   ("Copy" (kbd-copy))
@@ -101,9 +102,10 @@
 (tm-menu (texmacs-popup-menu)
   (:require (and (focus-mode?) (not (simplest-mode?))))
   (link focus-popup-menu)
+  ("Paste" (kbd-paste))
   ("Magic paste" (kbd-magic-paste))
-  ("Copy" (kbd-copy))
   ("Paste special" (interactive-paste-special))
+  ("Copy" (kbd-copy))
   (=> "Copy to" (link clipboard-copy-export-menu))
 ) ;tm-menu
 
@@ -112,6 +114,7 @@
 (tm-menu (texmacs-popup-menu)
   (:require (simplest-mode?))
   (link simplest-popup-menu)
+  ("Paste" (kbd-paste))
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
   ("Copy" (kbd-copy))
@@ -120,6 +123,7 @@
 
 (tm-menu (texmacs-popup-menu)
   (:require (chat-input-buffer? (current-buffer-url)))
+  ("Paste" (kbd-paste))
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
 ) ;tm-menu
@@ -133,6 +137,7 @@
 (tm-menu (texmacs-popup-menu)
   (:require (full-screen?))
   (link presentation-popup-menu)
+  ("Paste" (kbd-paste))
   ("Magic paste" (kbd-magic-paste))
   ("Paste special" (interactive-paste-special))
   ("Copy" (kbd-copy))

--- a/devel/1103.md
+++ b/devel/1103.md
@@ -1,0 +1,54 @@
+# [1103] 优化右键菜单
+
+任务编号使用 0000 到 9999 的四位数字格式。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- TeXmacs/progs/texmacs/menus/main-menu.scm
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+
+AI 聊天界面：
+- 在**输入区域**右键，菜单只出现粘贴相关项（Paste / Magic paste / Paste special）
+- 在**聊天记录区域**右键，菜单只出现复制相关项（Copy / Copy to），不应出现粘贴项
+
+View 的各种模式：
+- Focus 模式：右键菜单除剪贴板操作外，应包含「Focus mode」退出项
+- Simplest 模式：右键菜单除剪贴板操作外，应包含「Simplest mode」退出项
+- 演讲模式（Presentation）：右键菜单除剪贴板操作外，应包含 presentation-popup-menu 中的项（Presentation mode / Show panorama / Show all slides / Remote control）
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+优化 `texmacs-popup-menu` 的构建方式，使其在不同模式下显式列出剪贴板相关操作。
+
+1. 移除通过 `(link focus-menu)` 与 `(former)` 组合的旧式弹窗菜单定义，改为在每个 `tm-menu` 分支中显式列出剪贴板操作项（Paste / Magic paste / Paste special / Copy / Copy to）
+2. 调整全屏（presentation）模式分支，使其除展示模式切换项外，同样显式提供剪贴板操作
+3. 将 chat 缓冲区分支的 `:require` 条件由 `(not (chat-input-buffer? ...))` 改为 `(chat-message-buffer? ...)`，使其仅匹配消息缓冲区，且该分支只提供 Copy / Copy to（不含 Paste）
+
+## 6 Why
+原先右键菜单依赖 `(former)` 串联各 `tm-menu` 分支，造成菜单内容在不同模式下不稳定且不直观；同时在聊天相关缓冲区中保留了不合适的 Paste 入口。改为显式列出操作项后，各模式下右键菜单的内容可控、清晰，并避免在 chat 消息缓冲区暴露不应出现的粘贴操作。
+
+## 7 How
+- 对每个模式分支（普通 / focus / simplest / 全屏 / chat 消息缓冲区）直接在 `tm-menu` 中展开所需的剪贴板菜单项，而非通过 `(former)` 复用上层定义。
+- 全屏分支保留 `(link presentation-popup-menu)` 后追加显式剪贴板项。
+- chat 分支改用 `chat-message-buffer?` 精确匹配消息缓冲区，并仅提供 Copy 相关操作。
+
+## 8 已知问题（暂不处理）
+- 代码中相关函数命名存在错误（如全屏相关函数实际对应的是演讲模式），本分支暂不修改，后续单独处理。


### PR DESCRIPTION
## Summary
- 重构 `texmacs-popup-menu`，各模式下显式列出剪贴板操作，弃用 `(former)` 串联
- AI 聊天界面：输入区域仅保留粘贴相关项，聊天记录区域仅保留复制相关项
- Focus / Simplest / 演讲模式下右键菜单额外提供退出该模式的菜单项

## Test plan
- [ ] AI 聊天界面输入区域右键：仅显示 Paste / Magic paste / Paste special
- [ ] AI 聊天界面聊天记录区域右键：仅显示 Copy / Copy to，无粘贴项
- [ ] Focus 模式右键：包含剪贴板项 + 「Focus mode」
- [ ] Simplest 模式右键：包含剪贴板项 + 「Simplest mode」
- [ ] 演讲模式右键：包含剪贴板项 + presentation-popup-menu 中的项

## 备注
- 代码中部分函数命名存在错误（如全屏相关函数实际对应演讲模式），本分支暂不处理，后续单独修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)