### PR TITLE
[0644] 在 math-kbd.scm 中添加 top 右角标快捷键

### DIFF
--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -124,6 +124,7 @@
   ("' var var var var" (make-rprime "<dag>"))
   ("' var var var var var" (make-rprime "<ddag>"))
   ("' var var var var var var" (make-rprime "<kreuz>"))
+  ("' var var var var var var var" (make-rprime "<top>"))
   ("\" var" (make-rprime "`") (make-rprime "`"))
   ("\" var var" (make-rprime "<asterisk>") (make-rprime "<asterisk>"))
   ("\" var var var" (make-rprime "<star>") (make-rprime "<star>"))

--- a/devel/0644.md
+++ b/devel/0644.md
@@ -18,7 +18,7 @@
 ("' var var var var var var var" (make-rprime "<top>"))
 ```
 
-启动 Mogan STEM 后，进入数学模式，按 `'`（单引号）后按 `shift` + `Tab`，应插入一个右侧角标 `⊤`（top 符号）。
+启动 Mogan STEM 后，进入数学模式，按 `'`（单引号）后按 `Shift` + `Tab`，应插入一个右侧角标 `⊤`（top 符号）。
 
 ## 4 如何提交
 

--- a/devel/0644.md
+++ b/devel/0644.md
@@ -18,7 +18,7 @@
 ("' var var var var var var var" (make-rprime "<top>"))
 ```
 
-启动 Mogan STEM 后，进入数学编辑模式，连续按 `'`（单引号）后按七次 `Tab`（或触发七次 `var`），应插入一个右侧角标 `⊤`（top 符号）。
+启动 Mogan STEM 后，进入数学模式，按 `'`（单引号）后按 `shift` + `Tab`，应插入一个右侧角标 `⊤`（top 符号）。
 
 ## 4 如何提交
 

--- a/devel/0644.md
+++ b/devel/0644.md
@@ -1,0 +1,44 @@
+# [0644] 在数学键盘快捷键中补充右角标 top 符号
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0644.md](0644.md) - 本任务文档
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/math/math-kbd.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无新增单元测试。本次改动为键盘快捷键条目补充。
+
+### 3.2 非确定性测试（文档验证）
+检查 `TeXmacs/progs/math/math-kbd.scm` 文件中已包含以下条目：
+```scheme
+("' var var var var var var var" (make-rprime "<top>"))
+```
+
+启动 Mogan STEM 后，进入数学编辑模式，连续按 `'`（单引号）后按七次 `Tab`（或触发七次 `var`），应插入一个右侧角标 `⊤`（top 符号）。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+在数学键盘快捷键文件 `math-kbd.scm` 中，为右引号（right prime）序列新增第七级变体，映射到 `<top>` 符号。
+
+## 6 Why
+现有的右引号快捷键序列支持到 `<kreuz>`（六级变体），缺少更进一步的 top 符号快捷输入。补充该快捷键后，用户可以通过连续触发 `var` 循环快速输入右角标 top 符号，提升数学公式编辑效率。
+
+## 7 How
+在 `TeXmacs/progs/math/math-kbd.scm` 的 `kbd-map (:mode in-math?)` 中，紧跟 `("' var var var var var var" (make-rprime "<kreuz>"))` 之后插入：
+
+```scheme
+("' var var var var var var var" (make-rprime "<top>"))
+```
+
+保持与现有右引号 `var` 循环序列的风格和缩进一致。


### PR DESCRIPTION
在数学键盘快捷键中为右引号序列补充第七级变体，映射到 "<top>" 符号。\n\n相关任务文档：devel/0644.md