### PR TITLE
[1120] autosave-now 只保存当前 buffer

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -676,7 +676,7 @@
 ;; Autosave
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define autosave-fixed-interval-ms 30000)
+(define autosave-fixed-interval-ms 120000)
 
 (tm-define (autosave-enabled?) (!= (get-preference "autosave") "0"))
 
@@ -1081,7 +1081,7 @@
 
 (tm-define (autosave-delayed)
   (when (autosave-enabled?)
-    (delayed (:idle autosave-fixed-interval-ms) (autosave-now))
+    (delayed (:pause autosave-fixed-interval-ms) (autosave-now))
   ) ;when
 ) ;tm-define
 

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -676,7 +676,7 @@
 ;; Autosave
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define autosave-fixed-interval-ms 120000)
+(define autosave-fixed-interval-ms 30000)
 
 (tm-define (autosave-enabled?) (!= (get-preference "autosave") "0"))
 
@@ -1081,7 +1081,7 @@
 
 (tm-define (autosave-delayed)
   (when (autosave-enabled?)
-    (delayed (:pause autosave-fixed-interval-ms) (autosave-now))
+    (delayed (:idle autosave-fixed-interval-ms) (autosave-now))
   ) ;when
 ) ;tm-define
 

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1059,7 +1059,11 @@
 
 (tm-define (autosave-now)
   (when (autosave-enabled?)
-    (autosave-all)
+    (let ((name (current-buffer)))
+      (when (and (buffer-modified? name) (not (url-scratch? name)))
+        (save-buffer-save name (list) "auto")
+      ) ;when
+    ) ;let
     (autosave-delayed)
   ) ;when
 ) ;tm-define

--- a/devel/1120.md
+++ b/devel/1120.md
@@ -36,9 +36,9 @@ xmake b stem
 
 1. `autosave-now`：检查 `current-buffer`，仅对 `buffer-modified?` 且非 scratch 的 buffer 调 `save-buffer-save name (list) "auto"`，不再遍历所有 buffer
 2. `autosave-all`：保留作为显式保存所有 buffer 的入口（调试用），日常定时 autosave 不再调用
-2. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
-3. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
-4. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
+3. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
+4. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
+5. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
 
 ## 6 Why
 

--- a/devel/1120.md
+++ b/devel/1120.md
@@ -1,4 +1,4 @@
-# [1120] 移除本地 ~ autosave 机制，autosave 改为空闲 30s 后静默 save-buffer-save
+# [1120] 移除本地 ~ autosave 机制，autosave 改为定时静默 save-buffer-save
 
 ## 2026/06/17
 
@@ -32,14 +32,13 @@ xmake b stem
 
 ## 5 What
 
-移除本地 `~`/`#` autosave 副本机制，autosave 改为用户空闲 30 秒后只保存当前 buffer，调用 `save-buffer-save`。
+移除本地 `~`/`#` autosave 副本机制，autosave 改为定时只保存当前 buffer，调用 `save-buffer-save`。
 
 1. `autosave-now`：检查 `current-buffer`，仅对 `buffer-modified?` 且非 scratch 的 buffer 调 `save-buffer-save name (list) "auto"`，不再遍历所有 buffer
 2. `autosave-all`：保留作为显式保存所有 buffer 的入口（调试用），日常定时 autosave 不再调用
-3. `autosave-delayed`：由 `:pause` 改为 `:idle`，`autosave-fixed-interval-ms` 由 10000 改为 30000
-4. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
-5. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
-6. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
+2. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
+3. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
+4. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
 
 ## 6 Why
 
@@ -47,12 +46,11 @@ xmake b stem
 
 ## 7 How
 
-`save-buffer-save` 覆盖写源文件本身，与原 `autosave-buffer` 写旁路 `~` 副本的语义不同——这次改动接受这个语义变化：autosave 等于用户空闲 30 秒后静默 Ctrl-S。
+`save-buffer-save` 覆盖写源文件本身，与原 `autosave-buffer` 写旁路 `~` 副本的语义不同——这次改动接受这个语义变化：autosave 等于定时静默 Ctrl-S。
 
 边界处理：
 - `buffer-modified?` 守卫避免对未改动 buffer 反复写盘
 - `url-scratch?` 守卫跳过未命名 buffer（无磁盘路径，`buffer-save` 无意义）
-- `:idle` 机制避免在用户连续输入时触发保存，减少卡顿和切换 buffer 风险
 - 保留 `save-buffer-save` 全部 UI 副作用（Saved 消息、recent 通知等）
 - `url-autosave`（tm-define，多处同名）保留，删除风险高
 - C++ 侧 `pretend_buffer_autosaved` / `buffer_modified_since_autosave` 及其 glue 声明保留为死代码，本次不动 C++

--- a/devel/1120.md
+++ b/devel/1120.md
@@ -32,9 +32,10 @@ xmake b stem
 
 ## 5 What
 
-移除本地 `~`/`#` autosave 副本机制，autosave 改为定时遍历 buffer-list 调用 `save-buffer-save`。
+移除本地 `~`/`#` autosave 副本机制，autosave 改为定时只保存当前 buffer，调用 `save-buffer-save`。
 
-1. `autosave-all`：改写为遍历 `buffer-list`，对 `buffer-modified?` 且非 scratch 的 buffer 调 `save-buffer-save name (list) "auto"`
+1. `autosave-now`：检查 `current-buffer`，仅对 `buffer-modified?` 且非 scratch 的 buffer 调 `save-buffer-save name (list) "auto"`，不再遍历所有 buffer
+2. `autosave-all`：保留作为显式保存所有 buffer 的入口（调试用），日常定时 autosave 不再调用
 2. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
 3. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
 4. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框

--- a/devel/1120.md
+++ b/devel/1120.md
@@ -1,4 +1,4 @@
-# [1120] 移除本地 ~ autosave 机制，autosave 改为定时静默 save-buffer-save
+# [1120] 移除本地 ~ autosave 机制，autosave 改为空闲 30s 后静默 save-buffer-save
 
 ## 2026/06/17
 
@@ -32,13 +32,14 @@ xmake b stem
 
 ## 5 What
 
-移除本地 `~`/`#` autosave 副本机制，autosave 改为定时只保存当前 buffer，调用 `save-buffer-save`。
+移除本地 `~`/`#` autosave 副本机制，autosave 改为用户空闲 30 秒后只保存当前 buffer，调用 `save-buffer-save`。
 
 1. `autosave-now`：检查 `current-buffer`，仅对 `buffer-modified?` 且非 scratch 的 buffer 调 `save-buffer-save name (list) "auto"`，不再遍历所有 buffer
 2. `autosave-all`：保留作为显式保存所有 buffer 的入口（调试用），日常定时 autosave 不再调用
-2. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
-3. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
-4. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
+3. `autosave-delayed`：由 `:pause` 改为 `:idle`，`autosave-fixed-interval-ms` 由 10000 改为 30000
+4. 删除 `autosave-buffer`、`autosave-propose`、`autosave-rescue?`、`autosave-eligible?`、`autosave-remove`、`most-recent-suffix`、`more-recent`
+5. `save-buffer-save`：删除保存成功后的 `(autosave-remove name)` 调用
+6. `load-buffer-check-autosave`：简化为直接调 `load-buffer-check-permissions`，移除崩溃恢复对话框
 
 ## 6 Why
 
@@ -46,11 +47,12 @@ xmake b stem
 
 ## 7 How
 
-`save-buffer-save` 覆盖写源文件本身，与原 `autosave-buffer` 写旁路 `~` 副本的语义不同——这次改动接受这个语义变化：autosave 等于定时静默 Ctrl-S。
+`save-buffer-save` 覆盖写源文件本身，与原 `autosave-buffer` 写旁路 `~` 副本的语义不同——这次改动接受这个语义变化：autosave 等于用户空闲 30 秒后静默 Ctrl-S。
 
 边界处理：
 - `buffer-modified?` 守卫避免对未改动 buffer 反复写盘
 - `url-scratch?` 守卫跳过未命名 buffer（无磁盘路径，`buffer-save` 无意义）
+- `:idle` 机制避免在用户连续输入时触发保存，减少卡顿和切换 buffer 风险
 - 保留 `save-buffer-save` 全部 UI 副作用（Saved 消息、recent 通知等）
 - `url-autosave`（tm-define，多处同名）保留，删除风险高
 - C++ 侧 `pretend_buffer_autosaved` / `buffer_modified_since_autosave` 及其 glue 声明保留为死代码，本次不动 C++


### PR DESCRIPTION
## 摘要

将 `autosave-now` 从调用 `autosave-all`（遍历所有 buffer）改为只检查并保存 `(current-buffer)`，避免全量保存过慢以及切换 buffer 带来的风险。

- `autosave-all` 仍保留作为调试用显式入口（`src/Texmacs/Server/tm_debug.cpp` 仍会调用）
- 日常定时 autosave 不再遍历 `buffer-list`

## 改动

- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`: `autosave-now` 仅对当前 buffer 判断 `buffer-modified?` 且非 scratch 后调用 `save-buffer-save`
- `devel/1120.md`: 更新任务说明

🤖 Generated with [Claude Code](https://claude.com/claude-code)