### PR TITLE
[0804] Julia 会话支持符号计算

### DIFF
--- a/TeXmacs/plugins/julia/julia/MoganJulia.jl
+++ b/TeXmacs/plugins/julia/julia/MoganJulia.jl
@@ -193,8 +193,17 @@ display(d::InlineDisplay, m::MIME"application/pdf", x) =
 display(d::InlineDisplay, m::MIME"text/html", x) = 
     tm_out("html:", limitstringmime(m, x))
 
-display(d::InlineDisplay, m::MIME"text/latex", x) = 
-    tm_out("latex:", limitstringmime(m, x))
+display(d::InlineDisplay, m::MIME"text/latex", x) = begin
+    s = strip(limitstringmime(m, x))
+    # Remove outer $$, $, \[ \], or \( \) math delimiters if present
+    s = replace(s, r"^(\$\$?|\\\[|\\\()|(\$\$?|\\\]|\\\))$" => "")
+    s = strip(s)
+    if occursin(r"^\\begin", s)
+        tm_out("latex:", s)
+    else
+        tm_out("latex:", "\$\\rmfamily{" * s * "}\$")
+    end
+end
 
 display(d::InlineDisplay, m::MIME"text/markdown", x) = 
     display(d, MIME("text/html"), Markdown.html(x))
@@ -216,11 +225,45 @@ const tm_mimetypes = [
     MIME("application/pdf"),
     MIME("image/png"),
     MIME("image/jpg"),
+    MIME("text/latex"),
     MIME("text/html"), 
-    MIME("text/markdown"), 
-    MIME("text/latex")]
+    MIME("text/markdown")]
+
+is_symbolic_type(t::Type) = begin
+    t isa Union && return false
+    s = string(t)
+    (occursin("SymPy", s) || occursin("Symbolics", s) || occursin("SymbolicUtils", s) || s == "Num") && return true
+    try
+        m = parentmodule(t)
+        m_name = string(Symbol(m))
+        return occursin("SymPy", m_name) || occursin("Symbolics", m_name) || occursin("SymbolicUtils", m_name)
+    catch
+        return false
+    end
+end
+
+is_symbolic_object(x) = is_symbolic_type(typeof(x))
+is_symbolic_object(x::AbstractArray) = any(is_symbolic_object, x)
+is_symbolic_object(x::Tuple) = any(is_symbolic_object, x)
+is_symbolic_object(x::Set) = any(is_symbolic_object, x)
+is_symbolic_object(x::Dict) = any(is_symbolic_object, keys(x)) || any(is_symbolic_object, values(x))
 
 function display(d::InlineDisplay, x)
+    if is_symbolic_object(x)
+        if showable(MIME("text/latex"), x)
+            display(d, MIME("text/latex"), x)
+            return
+        elseif isdefined(Main, :Latexify)
+            try
+                lx = Main.Latexify.latexify(x)
+                display(d, MIME("text/latex"), lx)
+                return
+            catch
+                # If latexify fails, fall back to default behavior
+            end
+        end
+    end
+
     for m in tm_mimetypes
         if showable(m, x)
             display(d, m, x)

--- a/TeXmacs/plugins/julia/julia/MoganJulia.jl
+++ b/TeXmacs/plugins/julia/julia/MoganJulia.jl
@@ -195,9 +195,14 @@ display(d::InlineDisplay, m::MIME"text/html", x) =
 
 display(d::InlineDisplay, m::MIME"text/latex", x) = begin
     s = strip(limitstringmime(m, x))
-    # Remove outer $$, $, \[ \], or \( \) math delimiters if present
+    # 去除外层 $$, $, \[ \], or \( \) 修饰符直接解析
     s = replace(s, r"^(\$\$?|\\\[|\\\()|(\$\$?|\\\]|\\\))$" => "")
     s = strip(s)
+    # 去掉环境编号
+    s = replace(s, "begin{equation}" => "begin{equation*}")
+    s = replace(s, "end{equation}" => "end{equation*}")
+    s = replace(s, "begin{align}" => "begin{align*}")
+    s = replace(s, "end{align}" => "end{align*}")
     if occursin(r"^\\begin", s)
         tm_out("latex:", s)
     else

--- a/devel/0804.md
+++ b/devel/0804.md
@@ -6,66 +6,62 @@
 using Pkg
 Pkg.add("Symbolics")
 Pkg.add("Latexify")
+Pkg.add("LaTeXStrings")
+```
+
+- 输入命令加载环境 packages：
+```julia
+using Symbolics, Latexify, LaTeXStrings
 ```
 
 - 分别复制粘贴以下代码并执行：
 ```julia
-using Symbolics, Latexify
 @variables x
 x^2
 ```
 应输出一个渲染好的下x^2
 ```julia
-using Symbolics, Latexify
 @variables a b c
 formula = (a + b)^2 / c
 ```
 应输出一个渲染好的此单行公式
 ```julia
-using Symbolics, Latexify
 @variables a b
 [a^2, b]
 ```
 应输出一个渲染好的列向量
 ```julia
-using Symbolics, Latexify
 @variables a b
 (a^2, b)
 ```
 应输出一个渲染好的列向量
 ```julia
-using Symbolics, Latexify
 @variables a b c d
 M = [a b; c d]
 ```
 应输出一个渲染好的矩阵
 ```julia
-using Symbolics, Latexify
 @variables a b
 Dict(a => b)
 ```
 应输出一个矩阵形势的字典
 ```julia
-using LaTeXStrings
 L"\int_{0}^{\infty} e^{-x^2} dx = \frac{\sqrt{\pi}}{2}"
 ```
 应输出一个渲染好的行内 latex 公式
 ```julia
-using Symbolics, Latexify
 @variables x
 D = Differential(x)
 expand_derivatives(D(sin(x) * x^2))
 ```
 应输出一个渲染好的 $2x\sin(x) + x^2\cos(x)$
 ```julia
-using Symbolics, Latexify
 @variables x y
 expr = (x^2 - y^2) / (x - y)
 simplify(expr)
 ```
 应输出一个渲染好的 $x + y$
 ```julia
-using Symbolics, Latexify
 @variables x y
 expr = (x + y)^2
 expand(expr)
@@ -88,4 +84,3 @@ expand(expr)
 1. 提升 `MoganJulia.jl` 交互式会话中 `text/latex` MIME 类型的匹配优先级，确保 `text/latex` 优先于 `text/html` / `text/markdown` 导出
 2. 实现符号对象侦测器 `is_symbolic_object(x)`，通过动态反射检查并自适应对象的类型，并在非原生 LaTeX 格式的容器上自适应激活 `Latexify` 转换
 3. 对输出的 LaTeX 文本进行统一化边界脱壳：自动过滤并剥离多余的 `$$`、`$`、`\[ \]` 或 `\( \)` 等外部数学边界符，对非 `\begin` 起始的代数公式两端注入标准的 `$\rmfamily{...}$` 包裹
-

--- a/devel/0804.md
+++ b/devel/0804.md
@@ -1,0 +1,91 @@
+# [0804] Julia 会话支持符号计算
+
+## 如何测试
+- 打开 Julia 会话，使用如下命令安装 package：
+```julia
+using Pkg
+Pkg.add("Symbolics")
+Pkg.add("Latexify")
+```
+
+- 分别复制粘贴以下代码并执行：
+```julia
+using Symbolics, Latexify
+@variables x
+x^2
+```
+应输出一个渲染好的下x^2
+```julia
+using Symbolics, Latexify
+@variables a b c
+formula = (a + b)^2 / c
+```
+应输出一个渲染好的此单行公式
+```julia
+using Symbolics, Latexify
+@variables a b
+[a^2, b]
+```
+应输出一个渲染好的列向量
+```julia
+using Symbolics, Latexify
+@variables a b
+(a^2, b)
+```
+应输出一个渲染好的列向量
+```julia
+using Symbolics, Latexify
+@variables a b c d
+M = [a b; c d]
+```
+应输出一个渲染好的矩阵
+```julia
+using Symbolics, Latexify
+@variables a b
+Dict(a => b)
+```
+应输出一个矩阵形势的字典
+```julia
+using LaTeXStrings
+L"\int_{0}^{\infty} e^{-x^2} dx = \frac{\sqrt{\pi}}{2}"
+```
+应输出一个渲染好的行内 latex 公式
+```julia
+using Symbolics, Latexify
+@variables x
+D = Differential(x)
+expand_derivatives(D(sin(x) * x^2))
+```
+应输出一个渲染好的 $2x\sin(x) + x^2\cos(x)$
+```julia
+using Symbolics, Latexify
+@variables x y
+expr = (x^2 - y^2) / (x - y)
+simplify(expr)
+```
+应输出一个渲染好的 $x + y$
+```julia
+using Symbolics, Latexify
+@variables x y
+expr = (x + y)^2
+expand(expr)
+```
+应输出一个渲染好的 $x^2 + 2xy + y^2$
+```julia
+1 + 2
+```
+非符号计算，应输出一个普通的数字 3
+```julia
+[1, 2, 3]
+```
+非符号计算，应输出一个普通的提示信息文本
+
+## 2026/6/17
+### What
+支持 Julia 会话的符号计算，可以直接在会话中生成公式，类似于 Python 的 SymPy
+
+### How
+1. 提升 `MoganJulia.jl` 交互式会话中 `text/latex` MIME 类型的匹配优先级，确保 `text/latex` 优先于 `text/html` / `text/markdown` 导出
+2. 实现符号对象侦测器 `is_symbolic_object(x)`，通过动态反射检查并自适应对象的类型，并在非原生 LaTeX 格式的容器上自适应激活 `Latexify` 转换
+3. 对输出的 LaTeX 文本进行统一化边界脱壳：自动过滤并剥离多余的 `$$`、`$`、`\[ \]` 或 `\( \)` 等外部数学边界符，对非 `\begin` 起始的代数公式两端注入标准的 `$\rmfamily{...}$` 包裹
+

--- a/devel/0804.md
+++ b/devel/0804.md
@@ -19,7 +19,7 @@ using Symbolics, Latexify, LaTeXStrings
 @variables x
 x^2
 ```
-应输出一个渲染好的下x^2
+应输出一个渲染好的 $x^2$
 ```julia
 @variables a b c
 formula = (a + b)^2 / c
@@ -44,7 +44,7 @@ M = [a b; c d]
 @variables a b
 Dict(a => b)
 ```
-应输出一个矩阵形势的字典
+应输出一个矩阵形式的字典
 ```julia
 L"\int_{0}^{\infty} e^{-x^2} dx = \frac{\sqrt{\pi}}{2}"
 ```


### PR DESCRIPTION
# [0804] Julia 会话支持符号计算

## 如何测试
- 打开 Julia 会话，使用如下命令安装 package：
```julia
using Pkg
Pkg.add("Symbolics")
Pkg.add("Latexify")
Pkg.add("LaTeXStrings")
```

- 输入命令加载环境 packages：
```julia
using Symbolics, Latexify, LaTeXStrings
```

- 分别复制粘贴以下代码并执行：
```julia
@variables x
x^2
```
应输出一个渲染好的下x^2
```julia
@variables a b c
formula = (a + b)^2 / c
```
应输出一个渲染好的此单行公式
```julia
@variables a b
[a^2, b]
```
应输出一个渲染好的列向量
```julia
@variables a b
(a^2, b)
```
应输出一个渲染好的列向量
```julia
@variables a b c d
M = [a b; c d]
```
应输出一个渲染好的矩阵
```julia
@variables a b
Dict(a => b)
```
应输出一个矩阵形势的字典
```julia
L"\int_{0}^{\infty} e^{-x^2} dx = \frac{\sqrt{\pi}}{2}"
```
应输出一个渲染好的行内 latex 公式
```julia
@variables x
D = Differential(x)
expand_derivatives(D(sin(x) * x^2))
```
应输出一个渲染好的 $2x\sin(x) + x^2\cos(x)$
```julia
@variables x y
expr = (x^2 - y^2) / (x - y)
simplify(expr)
```
应输出一个渲染好的 $x + y$
```julia
@variables x y
expr = (x + y)^2
expand(expr)
```
应输出一个渲染好的 $x^2 + 2xy + y^2$
```julia
1 + 2
```
非符号计算，应输出一个普通的数字 3
```julia
[1, 2, 3]
```
非符号计算，应输出一个普通的提示信息文本

## 2026/6/17
### What
支持 Julia 会话的符号计算，可以直接在会话中生成公式，类似于 Python 的 SymPy

### How
1. 提升 `MoganJulia.jl` 交互式会话中 `text/latex` MIME 类型的匹配优先级，确保 `text/latex` 优先于 `text/html` / `text/markdown` 导出
2. 实现符号对象侦测器 `is_symbolic_object(x)`，通过动态反射检查并自适应对象的类型，并在非原生 LaTeX 格式的容器上自适应激活 `Latexify` 转换
3. 对输出的 LaTeX 文本进行统一化边界脱壳：自动过滤并剥离多余的 `$$`、`$`、`\[ \]` 或 `\( \)` 等外部数学边界符，对非 `\begin` 起始的代数公式两端注入标准的 `$\rmfamily{...}$` 包裹
