### PR TITLE
[1106] 修复数学符号补全弹窗在 Alt+Tab 切换后仍显示的问题

### DIFF
--- a/devel/1106.md
+++ b/devel/1106.md
@@ -1,0 +1,49 @@
+# [1106] 修复数学符号补全弹窗在 Alt+Tab 切换后仍显示的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [src/Plugins/Qt/QTMMathCompletionPopup.cpp](/src/Plugins/Qt/QTMMathCompletionPopup.cpp) - 数学符号补全弹窗实现
+- [src/Plugins/Qt/QTMMathCompletionPopup.hpp](/src/Plugins/Qt/QTMMathCompletionPopup.hpp) - 数学符号补全弹窗头文件
+- [src/Plugins/Qt/qt_simple_widget.cpp](/src/Plugins/Qt/qt_simple_widget.cpp) - 弹窗创建/显示/隐藏接口
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/QTMMathCompletionPopup.cpp`
+- `src/Plugins/Qt/QTMMathCompletionPopup.hpp`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b qt_math_completion_popup_test
+xmake r qt_math_completion_popup_test
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 打开 Mogan，进入数学模式（例如输入 `$` 进入行间公式）。
+2. 输入字母 `a`，然后按 `Tab` 键，触发数学符号补全弹窗。
+3. 按 `Alt+Tab` 切换到其他应用程序窗口。
+4. 验证：数学符号补全弹窗应当自动隐藏，不应继续悬浮在其他软件界面之上。
+5. 切换回 Mogan 窗口，重新按 `Tab` 触发弹窗，确认弹窗仍可正常显示和使用。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+xmake b qt_math_completion_popup_test
+xmake r qt_math_completion_popup_test
+```
+
+## 5 What
+修复数学符号补全弹窗（`QTMMathCompletionPopup`）在主窗口失去焦点（如 `Alt+Tab` 切换窗口）后仍然置顶显示的问题。
+
+1. 在 `QTMMathCompletionPopup` 的事件过滤器中增加对顶层窗口 `QEvent::WindowDeactivate` 事件的处理。
+2. 当主窗口失活时，自动隐藏数学符号补全弹窗。
+
+## 6 Why
+`QTMMathCompletionPopup` 使用 `Qt::ToolTip | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint` 创建为独立顶层窗口，因此不会跟随主窗口自动隐藏。当前实现仅监听 `WindowStateChange`（最小化）和 `Hide` 事件，未处理窗口失活事件，导致用户通过 `Alt+Tab` 切换窗口时，补全弹窗仍停留在其他应用窗口之上，影响用户体验。
+
+## 7 How
+在 `QTMMathCompletionPopup::eventFilter` 中增加分支：当事件类型为 `QEvent::WindowDeactivate` 且事件来源是已监听的顶层窗口时，调用 `hide()` 隐藏弹窗。该处理与现有的 `WindowStateChange` 和 `Hide` 处理并列，保持代码结构一致。

--- a/src/Plugins/Qt/QTMMathCompletionPopup.cpp
+++ b/src/Plugins/Qt/QTMMathCompletionPopup.cpp
@@ -186,7 +186,7 @@ QTMMathCompletionPopup::scrollBy (int x, int y) {
 
 void
 QTMMathCompletionPopup::installTopLevelWindowFilter () {
-  // 监听所属顶层窗口的状态变化，当主窗口最小化/隐藏时自动隐藏 popup。
+  // 监听所属顶层窗口的状态变化，当主窗口最小化/隐藏/失活时自动隐藏 popup。
   // 由于 popup 是独立顶层窗口（Qt::ToolTip），不会跟随主窗口自动隐藏。
   QWidget* w= parentWidget ();
   while (w) {
@@ -209,6 +209,10 @@ QTMMathCompletionPopup::eventFilter (QObject* obj, QEvent* event) {
   }
   else if (event->type () == QEvent::Hide) {
     // 主窗口被隐藏时隐藏 popup
+    hide ();
+  }
+  else if (event->type () == QEvent::WindowDeactivate) {
+    // 主窗口失去焦点（如 Alt+Tab 切换窗口）时隐藏 popup
     hide ();
   }
   else if (event->type () == QEvent::MouseButtonPress) {

--- a/tests/Plugins/Qt/qt_math_completion_popup_test.cpp
+++ b/tests/Plugins/Qt/qt_math_completion_popup_test.cpp
@@ -24,8 +24,8 @@ private slots:
 
 void
 TestQTMMathCompletionPopup::test_hide_on_parent_window_deactivate () {
-  QWidget                    mainWindow;
-  QTMMathCompletionPopup     popup (&mainWindow, nullptr);
+  QWidget                mainWindow;
+  QTMMathCompletionPopup popup (&mainWindow, nullptr);
 
   mainWindow.show ();
   popup.show ();

--- a/tests/Plugins/Qt/qt_math_completion_popup_test.cpp
+++ b/tests/Plugins/Qt/qt_math_completion_popup_test.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * MODULE     : qt_math_completion_popup_test.cpp
+ * DESCRIPTION: Tests for QTMMathCompletionPopup widget
+ * COPYRIGHT  : (C) 2026 Da Shen
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "QTMMathCompletionPopup.hpp"
+#include "base.hpp"
+#include <QtTest/QtTest>
+
+class TestQTMMathCompletionPopup : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+  void cleanup () { cleanup_qt_top_level_widgets (); }
+
+  void test_hide_on_parent_window_deactivate ();
+};
+
+void
+TestQTMMathCompletionPopup::test_hide_on_parent_window_deactivate () {
+  QWidget                    mainWindow;
+  QTMMathCompletionPopup     popup (&mainWindow, nullptr);
+
+  mainWindow.show ();
+  popup.show ();
+  QVERIFY (popup.isVisible ());
+
+  // 模拟主窗口失活（如 Alt+Tab 切换窗口），popup 应当自动隐藏
+  QEvent deactivateEvent (QEvent::WindowDeactivate);
+  QApplication::sendEvent (&mainWindow, &deactivateEvent);
+
+  QVERIFY (!popup.isVisible ());
+}
+
+QTEST_MAIN (TestQTMMathCompletionPopup)
+#include "qt_math_completion_popup_test.moc"


### PR DESCRIPTION
## Summary

修复数学符号补全弹窗（`QTMMathCompletionPopup`）在主窗口通过 `Alt+Tab` 切换失去焦点后仍然置顶显示的问题。

- 在 `QTMMathCompletionPopup::eventFilter` 中增加对 `QEvent::WindowDeactivate` 事件的处理，主窗口失活时自动隐藏 popup。
- 更新 `installTopLevelWindowFilter` 注释，说明同时监听最小化/隐藏/失活三种场景。
- 新增单元测试 `tests/Plugins/Qt/qt_math_completion_popup_test.cpp`，验证主窗口失活时 popup 自动隐藏。

## Test plan

- [ ] 手动验证：在数学模式下输入 `a` 并按 `Tab` 触发弹窗，然后 `Alt+Tab` 切换到其他窗口，确认弹窗自动隐藏。
- [ ] 单元测试通过：
  ```bash
  xmake b qt_math_completion_popup_test
  xmake r qt_math_completion_popup_test
  ```
- [ ] 主项目构建通过：
  ```bash
  xmake b stem
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)