### PR TITLE
[0806] 使用 find-binary-julia 来定位 Julia

### DIFF
--- a/TeXmacs/plugins/binary/progs/binary/julia.scm
+++ b/TeXmacs/plugins/binary/progs/binary/julia.scm
@@ -1,0 +1,36 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : julia.scm
+;; DESCRIPTION : julia Binary plugin
+;; COPYRIGHT   : (C) 2026 Tianyou Liu
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (binary julia)
+  (:use (binary common)))
+
+(define (julia-binary-candidates)
+  (cond ((os-macos?)
+         (list "/Applications/Julia-*.app/Contents/Resources/julia/bin/julia"
+               "$HOME/Applications/Julia-*.app/Contents/Resources/julia/bin/julia"
+               "/opt/homebrew/bin/julia"
+               "/usr/local/bin/julia"))
+        ((os-win32?)
+         (list "$LOCALAPPDATA/Programs/Julia*/bin/julia.exe"
+               "C:\\Program Files*\\Julia*\\bin\\julia.exe"))
+        (else
+         (list "/usr/bin/julia"))))
+
+(tm-define (find-binary-julia)
+  (:synopsis "Find the url to the julia binary, return (url-none) if not found")
+  (find-binary (julia-binary-candidates) "julia"))
+
+(tm-define (has-binary-julia?)
+  (not (url-none? (find-binary-julia))))
+
+(tm-define (version-binary-julia)
+  (version-binary (find-binary-julia)))

--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(use-modules (dynamic session-edit))
+(use-modules (dynamic session-edit) (binary julia))
 
 (define (julia-serialize lan t)
   (let* ((u (pre-serialize lan t))
@@ -25,13 +25,12 @@
         "$TEXMACS_PATH/plugins/julia/julia/julia.jl"))))
 
 (define (julia-launcher)
-  (let* ((boot (string-quote (julia-entry))))
-    (string-append "julia " boot)))
+  (let* ((boot (string-quote (julia-entry)))
+         (cmd  (url->system (find-binary-julia))))
+    (string-append cmd " " boot)))
 
 (plugin-configure julia
-  (:winpath "Julia*" "bin")
-  (:macpath "Julia*" "Contents/Resources/julia/bin")
-  (:require (url-exists-in-path? "julia"))
+  (:require (has-binary-julia?))
   (:serializer ,julia-serialize)
   (:launch ,(julia-launcher))
   (:tab-completion #t)

--- a/TeXmacs/progs/dynamic/session-menu.scm
+++ b/TeXmacs/progs/dynamic/session-menu.scm
@@ -140,6 +140,7 @@
     "hunspell"
     "identify"
     "inkscape"
+    "julia"
     "pandoc"
     "pdftocairo"
     "rsvg-convert"

--- a/TeXmacs/tests/0801.scm
+++ b/TeXmacs/tests/0801.scm
@@ -108,7 +108,8 @@
         (write-physical-input input-path input-lines #t)
 
         ;; Execute the julia session via cross-platform shell command
-        (let* ((julia-bin (if (os-windows?) "julia" "env -u LD_LIBRARY_PATH julia"))
+        (let* ((julia-path (url->system (find-binary-julia)))
+               (julia-bin (if (os-windows?) julia-path (string-append "env -u LD_LIBRARY_PATH " julia-path)))
                (cmd (string-append julia-bin " --startup-file=no " julia-script " < " input-path " > " output-path " 2>&1")))
           (run-shell-command cmd))
 

--- a/TeXmacs/tests/0804.scm
+++ b/TeXmacs/tests/0804.scm
@@ -72,9 +72,9 @@
 ;; Check if Symbolics Julia packages are available
 (define (julia-packages-available?)
   (and (supports-julia?)
-       (== (run-shell-command (if (os-windows?)
-                                  "julia --startup-file=no -e \"using Symbolics, Latexify, LaTeXStrings\""
-                                  "env -u LD_LIBRARY_PATH julia --startup-file=no -e \"using Symbolics, Latexify, LaTeXStrings\"")) 0)))
+       (let* ((julia-path (url->system (find-binary-julia)))
+              (julia-bin (if (os-windows?) julia-path (string-append "env -u LD_LIBRARY_PATH " julia-path))))
+         (== (run-shell-command (string-append julia-bin " --startup-file=no -e \"using Symbolics, Latexify, LaTeXStrings\"")) 0))))
 
 ;; Session execution symbolic math tests
 (define (test-julia-symbolics)
@@ -130,7 +130,8 @@
         (write-physical-input input-path input-lines #t)
 
         ;; Execute the julia session via cross-platform shell command
-        (let* ((julia-bin (if (os-windows?) "julia" "env -u LD_LIBRARY_PATH julia"))
+        (let* ((julia-path (url->system (find-binary-julia)))
+               (julia-bin (if (os-windows?) julia-path (string-append "env -u LD_LIBRARY_PATH " julia-path)))
                (cmd (string-append julia-bin " --startup-file=no " julia-script " < " input-path " > " output-path " 2>&1")))
           (run-shell-command cmd))
 

--- a/devel/0806.md
+++ b/devel/0806.md
@@ -1,0 +1,36 @@
+# [0806] 使用 find-binary-julia 来定位 Julia
+
+## 1 相关文档
+- [0801.md](0801.md) - 集成 Julia 交互式会话
+- [0804.md](0804.md) - Julia 会话支持符号计算
+- [0805.md](0805.md) - Julia 插件重构与测试
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/binary/progs/binary/julia.scm` - 实现 `(binary julia)` 模块，管理 Julia 二进制文件的候选路径
+- `TeXmacs/plugins/julia/progs/init-julia.scm` - 重构 Julia 插件初始化逻辑，移除 `:winpath` 与 `:macpath`，改用 `(find-binary-julia)` 定位执行文件
+- `TeXmacs/progs/dynamic/session-menu.scm` - 在手动设置路径对话框的列表中注册 `julia`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake r 0801
+xmake r 0804
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 在已安装 Julia 环境的 Linux/Windows/macOS 上点击 `插入`->`会话`，检查是否有 Julia 选项，点击后是否能正常打开 Julia 会话。
+2. 点击 `插入`->`会话`->`手动设置路径`，检查下拉选项中是否存在 Julia
+
+## 4 What
+- 废弃 Julia 插件原有的 `:winpath` 和 `:macpath` 配置，实现 `find-binary-julia` 定位 Julia 执行程序
+- 支持在“手动设置路径”界面手动自定义 Julia 命令行位置
+
+## 5 Why
+传统的 `:winpath` 和 `:macpath` 机制非常 buggy
+
+## 6 How
+1. 创建 `TeXmacs/plugins/binary/progs/binary/julia.scm`，实现 `(binary julia)`，定义其在 macOS、Windows、Linux 下的标准安装搜索路径候选
+2. 在 `TeXmacs/progs/dynamic/session-menu.scm` 中将 `"julia"` 增加至 `binary-list`，以支持在“手动设置路径”界面手动自定义 Julia 命令行位置
+3. 重构 `TeXmacs/plugins/julia/progs/init-julia.scm`，引入 `(binary julia)`，将其 `:require` 简化为 `(has-binary-julia?)`，且 `julia-launcher` 直接调用 `(find-binary-julia)` 的具体系统路径启动


### PR DESCRIPTION
# [0806] 使用 find-binary-julia 来定位 Julia

## 1 相关文档
- [0801.md](0801.md) - 集成 Julia 交互式会话
- [0804.md](0804.md) - Julia 会话支持符号计算
- [0805.md](0805.md) - Julia 插件重构与测试

## 2 任务相关的代码文件
- `TeXmacs/plugins/binary/progs/binary/julia.scm` - 实现 `(binary julia)` 模块，管理 Julia 二进制文件的候选路径
- `TeXmacs/plugins/julia/progs/init-julia.scm` - 重构 Julia 插件初始化逻辑，移除 `:winpath` 与 `:macpath`，改用 `(find-binary-julia)` 定位执行文件
- `TeXmacs/progs/dynamic/session-menu.scm` - 在手动设置路径对话框的列表中注册 `julia`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake r 0801
xmake r 0804
xmake b stem
```

### 3.2 非确定性测试（文档验证）
1. 在已安装 Julia 环境的 Linux/Windows/macOS 上点击 `插入`->`会话`，检查是否有 Julia 选项，点击后是否能正常打开 Julia 会话。
2. 点击 `插入`->`会话`->`手动设置路径`，检查下拉选项中是否存在 Julia

## 4 What
- 废弃 Julia 插件原有的 `:winpath` 和 `:macpath` 配置，实现 `find-binary-julia` 定位 Julia 执行程序
- 支持在“手动设置路径”界面手动自定义 Julia 命令行位置

## 5 Why
传统的 `:winpath` 和 `:macpath` 机制非常 buggy

## 6 How
1. 创建 `TeXmacs/plugins/binary/progs/binary/julia.scm`，实现 `(binary julia)`，定义其在 macOS、Windows、Linux 下的标准安装搜索路径候选
2. 在 `TeXmacs/progs/dynamic/session-menu.scm` 中将 `"julia"` 增加至 `binary-list`，以支持在“手动设置路径”界面手动自定义 Julia 命令行位置
3. 重构 `TeXmacs/plugins/julia/progs/init-julia.scm`，引入 `(binary julia)`，将其 `:require` 简化为 `(has-binary-julia?)`，且 `julia-launcher` 直接调用 `(find-binary-julia)` 的具体系统路径启动
