### PR TITLE
[1113] 为 utf8_to_herk 和 herk_to_utf8 添加完整测试用例

### DIFF
--- a/devel/1113.md
+++ b/devel/1113.md
@@ -1,0 +1,66 @@
+# [1113] 为 utf8_to_herk 与 herk_to_utf8 添加完整单元测试
+
+## 相关文档
+- [66_13.md](66_13.md) - Herk 编码的设计与转换规则
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Data/String/converter.hpp`
+- `src/Data/String/converter.cpp`
+- `tests/Data/String/converter_test.cpp`
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+xmake b converter_test
+xmake r converter_test
+```
+
+### 预期输出
+```
+********* Start testing of TestConverter *********
+Config: ……
+PASS   : TestConverter::initTestCase()
+PASS   : TestConverter::test_utf8_to_cork()
+PASS   : TestConverter::test_cork_to_utf8()
+PASS   : TestConverter::test_utf8_to_herk()
+PASS   : TestConverter::test_herk_to_utf8()
+PASS   : TestConverter::cleanupTestCase()
+Totals: 6 passed, 0 failed, 0 skipped, 0 blacklisted, 9ms
+********* Finished testing of TestConverter *********
+```
+
+## 如何提交
+
+提交前执行以下最少步骤：
+```bash
+gf fmt --changed-since=main
+xmake b converter_test
+xmake r converter_test
+```
+
+## What
+为 `utf8_to_herk` 与 `herk_to_utf8` 编写完整的单元测试用例，覆盖：
+
+1. **utf8_to_herk**
+   - U+0000 ~ U+001F 控制字符转 `<#00>` ~ `<#1F>`（含零填充）
+   - U+0020 ~ U+007F ASCII 可打印字符按 Herk/Cork 表映射为单字节
+   - U+0080 ~ U+00FF 无 Cork 映射字符转 `<#XX>`
+   - U+0100 及以上字符（含 CJK）转 `<#XXXX>`
+   - 组合字符串行为
+
+2. **herk_to_utf8**
+   - 单字节 Herk 内部编码通过字典转回 UTF-8
+   - 特殊映射：`<#17>`→U+200B、`<#18>`→U+2080、`<#1A>`→U+0237、`<#7F>`→U+00AD、`<#DF>`→U+1E9E
+   - `<#XXXX>` 转义形式直接解析为对应 Unicode 字符
+   - 混合内部字节与 `<#XXXX>` 的字符串行为
+
+## Why
+Herk 编码是 TMU 序列化的核心编码，其转换正确性直接影响文档的读写一致性。
+此前 `converter_test.cpp` 仅覆盖 `utf8_to_cork` 与 `cork_to_utf8`，缺少对 Herk 编解码路径的回归测试。
+
+## How
+在 `tests/Data/String/converter_test.cpp` 的 `TestConverter` 类中新增 `test_utf8_to_herk` 与 `test_herk_to_utf8` 两个测试槽。
+使用 `qcompare` 对比实际输出与期望输出；对包含 NUL 字节的边界场景，使用 `QCOMPARE(N(r), 1)` 与字节断言避免 `as_charp` 截断。
+

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -21,6 +21,112 @@ private slots:
   void init () { init_lolly (); };
   void test_utf8_to_cork ();
   void test_cork_to_utf8 ();
+  void test_utf8_to_herk ();
+  void test_herk_to_utf8 ();
+};
+
+// Helper: encode a Unicode code point as a UTF-8 byte string.
+static string
+utf8_from_code (int code) {
+  if (code < 0x80) return string ((char) code);
+  else if (code < 0x800) {
+    return string ((char) (0xC0 | (code >> 6))) *
+           string ((char) (0x80 | (code & 0x3F)));
+  }
+  else {
+    return string ((char) (0xE0 | (code >> 12))) *
+           string ((char) (0x80 | ((code >> 6) & 0x3F))) *
+           string ((char) (0x80 | (code & 0x3F)));
+  }
+}
+
+// Helper: build a single-byte Herk string, even for the NUL byte.
+static string
+herk_byte (int byte) {
+  return string ((char) byte, 1);
+}
+
+// Helper: build a <#XXXX> hexadecimal escape for a Unicode code point.
+static string
+hex_escape (int code) {
+  static const char* digits= "0123456789ABCDEF";
+  if (code < 16) {
+    char buf[6]= {'<', '#', '0', digits[code], '>', '\0'};
+    return string (buf);
+  }
+  else if (code < 256) {
+    char buf[7]= {'<', '#', digits[code >> 4], digits[code & 0xF], '>', '\0'};
+    return string (buf);
+  }
+  else {
+    char buf[9];
+    int  n  = 0;
+    int  tmp= code;
+    while (tmp > 0) {
+      buf[n++]= digits[tmp & 0xF];
+      tmp>>= 4;
+    }
+    string r= "<#";
+    for (int i= n - 1; i >= 0; i--)
+      r << buf[i];
+    r << ">";
+    return r;
+  }
+}
+
+// Expected Unicode code point for each Herk byte 0x00..0xFF.
+static const int herk_to_utf8_code[256]= {
+    0x0060, 0x00B4, 0x02C6, 0x02DC, 0x00A8, 0x02DD, 0x02DA, 0x02C7, 0x02D8,
+    0x00AF, 0x02D9, 0x00B8, 0x02DB, 0x201A, 0x2039, 0x203A, 0x201C, 0x201D,
+    0x201E, 0x00AB, 0x00BB, 0x2013, 0x2014, 0x200B, 0x2080, 0x0131, 0x0237,
+    0xFB00, 0xFB01, 0xFB02, 0xFB03, 0xFB04, 0x0020, 0x0021, 0x0022, 0x0023,
+    0x0024, 0x0025, 0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B, 0x002C,
+    0x002D, 0x002E, 0x002F, 0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035,
+    0x0036, 0x0037, 0x0038, 0x0039, 0x003A, 0x003B, 0x003C, 0x003D, 0x003E,
+    0x003F, 0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047,
+    0x0048, 0x0049, 0x004A, 0x004B, 0x004C, 0x004D, 0x004E, 0x004F, 0x0050,
+    0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057, 0x0058, 0x0059,
+    0x005A, 0x005B, 0x005C, 0x005D, 0x005E, 0x005F, 0x2018, 0x0061, 0x0062,
+    0x0063, 0x0064, 0x0065, 0x0066, 0x0067, 0x0068, 0x0069, 0x006A, 0x006B,
+    0x006C, 0x006D, 0x006E, 0x006F, 0x0070, 0x0071, 0x0072, 0x0073, 0x0074,
+    0x0075, 0x0076, 0x0077, 0x0078, 0x0079, 0x007A, 0x007B, 0x007C, 0x007D,
+    0x007E, 0x00AD, 0x0102, 0x0104, 0x0106, 0x010C, 0x010E, 0x011A, 0x0118,
+    0x011E, 0x0139, 0x013D, 0x0141, 0x0143, 0x0147, 0x014A, 0x0150, 0x0154,
+    0x0158, 0x015A, 0x0160, 0x015E, 0x0164, 0x0162, 0x0170, 0x016E, 0x0178,
+    0x0179, 0x017D, 0x017B, 0x0132, 0x0130, 0x0111, 0x00A7, 0x0103, 0x0105,
+    0x0107, 0x010D, 0x010F, 0x011B, 0x0119, 0x011F, 0x013A, 0x013E, 0x0142,
+    0x0144, 0x0148, 0x014B, 0x0151, 0x0155, 0x0159, 0x015B, 0x0161, 0x015F,
+    0x0165, 0x0163, 0x0171, 0x016F, 0x00FF, 0x017A, 0x017E, 0x017C, 0x0133,
+    0x00A1, 0x00BF, 0x00A3, 0x00C0, 0x00C1, 0x00C2, 0x00C3, 0x00C4, 0x00C5,
+    0x00C6, 0x00C7, 0x00C8, 0x00C9, 0x00CA, 0x00CB, 0x00CC, 0x00CD, 0x00CE,
+    0x00CF, 0x00D0, 0x00D1, 0x00D2, 0x00D3, 0x00D4, 0x00D5, 0x00D6, 0x0152,
+    0x00D8, 0x00D9, 0x00DA, 0x00DB, 0x00DC, 0x00DD, 0x00DE, 0x1E9E, 0x00E0,
+    0x00E1, 0x00E2, 0x00E3, 0x00E4, 0x00E5, 0x00E6, 0x00E7, 0x00E8, 0x00E9,
+    0x00EA, 0x00EB, 0x00EC, 0x00ED, 0x00EE, 0x00EF, 0x00F0, 0x00F1, 0x00F2,
+    0x00F3, 0x00F4, 0x00F5, 0x00F6, 0x0153, 0x00F8, 0x00F9, 0x00FA, 0x00FB,
+    0x00FC, 0x00FD, 0x00FE, 0x00DF,
+};
+
+// Reverse mapping: Unicode code point 0x00..0xFF -> Herk byte, -1 if none.
+static const int utf8_to_herk_byte[256]= {
+    -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+    -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+    -1,  -1,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+    45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+    60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,
+    75,  76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
+    90,  91,  92,  93,  94,  95,  0,   97,  98,  99,  100, 101, 102, 103, 104,
+    105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 123, 124, 125, 126, -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+    -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+    -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  189, -1,  191, -1,
+    -1,  -1,  159, 4,   -1,  -1,  19,  -1,  127, -1,  9,   -1,  -1,  -1,  -1,
+    1,   -1,  -1,  -1,  11,  -1,  -1,  20,  -1,  -1,  -1,  190, 192, 193, 194,
+    195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
+    210, 211, 212, 213, 214, -1,  216, 217, 218, 219, 220, 221, 222, 255, 224,
+    225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+    240, 241, 242, 243, 244, 245, 246, -1,  248, 249, 250, 251, 252, 253, 254,
+    184,
 };
 
 void
@@ -35,6 +141,78 @@ TestConverter::test_cork_to_utf8 () {
   qcompare (cork_to_utf8 ("<#4E2D>"), "中");
   qcompare (cork_to_utf8 ("\x10"), "“");
   qcompare (cork_to_utf8 ("\x11"), "”");
+}
+
+void
+TestConverter::test_utf8_to_herk () {
+  // U+0000..U+00FF are covered exhaustively.
+  for (int code= 0; code <= 0xFF; code++) {
+    int    mapped= utf8_to_herk_byte[code];
+    string input = utf8_from_code (code);
+    if (mapped > 0) {
+      qcompare (utf8_to_herk (input), herk_byte (mapped));
+    }
+    else if (mapped == 0) {
+      // U+0060 (`) maps to Herk byte 0x00; qcompare cannot check NUL bytes.
+      string r= utf8_to_herk (input);
+      QCOMPARE (N (r), 1);
+      QCOMPARE ((int) (unsigned char) r[0], 0);
+    }
+    else if (code < 32 || code >= 128) {
+      qcompare (utf8_to_herk (input), hex_escape (code));
+    }
+    else {
+      // U+007F is the only unmapped code point in 0x20..0x7F.
+      qcompare (utf8_to_herk (input), input);
+    }
+  }
+
+  // Characters outside the Cork range use <#XXXX> escapes.
+  qcompare (utf8_to_herk ("—"), herk_byte (0x16)); // U+2014 has a mapping
+  qcompare (utf8_to_herk ("’"), "<#2019>");        // U+2019 has no mapping
+  qcompare (utf8_to_herk ("中"), "<#4E2D>");       // CJK
+  qcompare (utf8_to_herk ("。"), "<#3002>");       // CJK punctuation
+
+  // <#XXXX> and named escapes pass through unchanged.
+  qcompare (utf8_to_herk ("<#FF>"), "<#FF>");
+  qcompare (utf8_to_herk ("<#0FF>"), "<#0FF>");
+  qcompare (utf8_to_herk ("<#00FF>"), "<#00FF>");
+  qcompare (utf8_to_herk ("<less>"), "<less>");
+
+  // Mixed strings.
+  qcompare (utf8_to_herk ("A中B"),
+            herk_byte (0x41) * string ("<#4E2D>") * herk_byte (0x42));
+}
+
+void
+TestConverter::test_herk_to_utf8 () {
+  // Every Herk byte 0x00..0xFF must decode to the expected Unicode code point.
+  for (int byte= 0; byte < 256; byte++)
+    qcompare (herk_to_utf8 (herk_byte (byte)),
+              utf8_from_code (herk_to_utf8_code[byte]));
+
+  // <#XXXX> escapes are parsed literally as Unicode code points.
+  qcompare (herk_to_utf8 ("<#0F>"), utf8_from_code (0x0F));
+  qcompare (herk_to_utf8 ("<#10>"), utf8_from_code (0x10));
+  qcompare (herk_to_utf8 ("<#1F>"), utf8_from_code (0x1F));
+  qcompare (herk_to_utf8 ("<#FF>"), "ÿ");
+  qcompare (herk_to_utf8 ("<#0FF>"), "ÿ");
+  qcompare (herk_to_utf8 ("<#00FF>"), "ÿ");
+  qcompare (herk_to_utf8 ("<#2019>"), "’");
+  qcompare (herk_to_utf8 ("<#4E2D>"), "中");
+
+  // NUL cannot be compared with qcompare because as_charp truncates at '\0'.
+  string r= herk_to_utf8 ("<#00>");
+  QCOMPARE (N (r), 1);
+  QCOMPARE ((int) (unsigned char) r[0], 0);
+
+  // Named escapes pass through unchanged.
+  qcompare (herk_to_utf8 ("<less>"), "<less>");
+
+  // Mixed internal bytes and escapes.
+  qcompare (
+      herk_to_utf8 (herk_byte (0x41) * string ("<#2019>") * herk_byte (0x42)),
+      "A’B");
 }
 
 QTEST_MAIN (TestConverter)


### PR DESCRIPTION
## Summary
为 `utf8_to_herk` 与 `herk_to_utf8` 添加完整的单元测试，覆盖 Herk 编码 0x00-0xFF 全范围，并补充转义、边界与混合字符串用例。

## 覆盖范围
- `herk_to_utf8`：0x00-0xFF 全部 256 个 Herk 字节，对照 `TeXmacs/langs/encoding/herktounicode.scm` 验证解码结果
- `utf8_to_herk`：0x0000-0x00FF 全部 256 个 Unicode 码点，验证 Cork 映射与 `<#XX>` 回退
- `<#XXXX>` 转义、`<less>` 等命名转义的透传行为
- NUL 字节的边界处理
- 混合内部字节与转义的字符串

## Test plan
- [x] `xmake b converter_test`
- [x] `xmake r converter_test`（6 passed, 0 failed）
- [x] `gf fmt --changed-since=main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)