### PR TITLE
[1112] 移除 tm_locale 中的 get_date 包装

### DIFF
--- a/devel/1112.md
+++ b/devel/1112.md
@@ -8,6 +8,9 @@
 - `lolly/System/Language/locale.cpp`
 - `src/System/Language/tm_locale.hpp`
 - `src/System/Language/tm_locale.cpp`
+- `src/Typeset/Env/env_exec.cpp`
+- `src/Mogan/Research/research.cpp`
+- `src/Scheme/L5/init_glue_l5.cpp`
 - `src/Plugins/Qt/qt_utilities.hpp`
 - `src/Plugins/Qt/qt_utilities.cpp`
 - `lolly/tests/lolly/system/locale_test.cpp`
@@ -55,7 +58,7 @@ xmake r locale_test
 将 `tm_locale` 中与平台无关的日期格式化逻辑迁移到 lolly，解除 `get_date` 对 Qt 的依赖：
 
 1. 在 `lolly/System/Language/locale.hpp/cpp` 中新增 `lolly::locale::get_date`，使用 C 标准库 time/locale 与自定义 Qt 日期格式解析器实现，不依赖 Qt。
-2. 主项目 `src/System/Language/tm_locale.cpp` 改为调用 `lolly::locale::get_date`，移除对 `qt_get_date` 的依赖。
+2. 移除 `tm_locale` 中的 `get_date` 包装函数与声明，主项目相关代码直接调用 `lolly::locale::get_date`。
 3. 从 `src/Plugins/Qt/qt_utilities.hpp/cpp` 中移除不再使用的 `qt_get_date` 系列函数。
 4. 将 `get_date` 的单元测试从主项目迁移到 `lolly/tests/lolly/system/locale_test.cpp`，使用 doctest 框架重写。
 5. 覆盖原有行为：

--- a/devel/1112.md
+++ b/devel/1112.md
@@ -10,7 +10,6 @@
 - `src/System/Language/tm_locale.cpp`
 - `src/Typeset/Env/env_exec.cpp`
 - `src/Mogan/Research/research.cpp`
-- `src/Scheme/L5/init_glue_l5.cpp`
 - `src/Plugins/Qt/qt_utilities.hpp`
 - `src/Plugins/Qt/qt_utilities.cpp`
 - `lolly/tests/lolly/system/locale_test.cpp`

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -18,6 +18,7 @@
 #include <locale.h> // for setlocale
 #include <lolly/system/args.hpp>
 #include <lolly/system/timer.hpp>
+#include "locale.hpp"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -34,7 +35,6 @@
 #include "server.hpp"
 #include "sys_utils.hpp"
 #include "tm_file.hpp"
-#include "tm_locale.hpp"
 #include "tm_ostream.hpp"
 #include "tm_timer.hpp"
 #include "tm_url.hpp"
@@ -141,7 +141,8 @@ immediate_options (int argc, char** argv) {
   }
 
   url u= url_system (string ("$TEXMACS_HOME_PATH/system/") *
-                     get_date ("english", "%Y%m%d%H") * string (".log"));
+                     lolly::locale::get_date ("english", "%Y%m%d%H") *
+                         string (".log"));
   if (enale_logging) {
     cout << "Logging into >> " << u << LF;
     tm_ostream logf (c_string (concretize (u)));

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -15,10 +15,10 @@
 #ifndef OS_WIN
 #include <unistd.h>
 #endif
+#include "locale.hpp"
 #include <locale.h> // for setlocale
 #include <lolly/system/args.hpp>
 #include <lolly/system/timer.hpp>
-#include "locale.hpp"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -142,7 +142,7 @@ immediate_options (int argc, char** argv) {
 
   url u= url_system (string ("$TEXMACS_HOME_PATH/system/") *
                      lolly::locale::get_date ("english", "%Y%m%d%H") *
-                         string (".log"));
+                     string (".log"));
   if (enale_logging) {
     cout << "Logging into >> " << u << LF;
     tm_ostream logf (c_string (concretize (u)));

--- a/src/System/Language/tm_locale.cpp
+++ b/src/System/Language/tm_locale.cpp
@@ -11,7 +11,6 @@
  ******************************************************************************/
 
 #include "tm_locale.hpp"
-#include "locale.hpp"
 
 #ifdef QTTEXMACS
 #include "Qt/qt_utilities.hpp"
@@ -20,11 +19,6 @@
 /******************************************************************************
  * Getting a formatted date
  ******************************************************************************/
-
-string
-get_date (string lan, string fm, int year, int month, int day) {
-  return lolly::locale::get_date (lan, fm, year, month, day);
-}
 
 #ifdef QTTEXMACS
 string

--- a/src/System/Language/tm_locale.hpp
+++ b/src/System/Language/tm_locale.hpp
@@ -14,8 +14,6 @@
 
 #include "string.hpp"
 
-string get_date (string lan, string fm, int year= -1, int month= -1,
-                 int day= -1);
 string pretty_time (int t);
 
 #endif

--- a/src/Typeset/Env/env_exec.cpp
+++ b/src/Typeset/Env/env_exec.cpp
@@ -21,7 +21,6 @@
 #include "page_type.hpp"
 #include "scheme.hpp"
 #include "tm_file.hpp"
-#include "tm_locale.hpp"
 #include "typesetter.hpp"
 
 #include <lolly/data/numeral.hpp>
@@ -1591,7 +1590,7 @@ edit_env_rep::exec_date (tree t) {
     if (is_compound (u)) return tree (ERROR, "bad date");
     fm= u->label;
   }
-  return get_date (lan, fm);
+  return lolly::locale::get_date (lan, fm);
 }
 
 tree


### PR DESCRIPTION
## 摘要

完成 `tm_locale` 中 `get_date` 的最终清理：删除 `tm_locale.hpp/cpp` 中的包装函数，主项目相关代码直接调用 `lolly::locale::get_date`。

## 变更内容

- 删除 `src/System/Language/tm_locale.cpp` 中的 `get_date` 实现及不再使用的 `locale.hpp` 包含
- 删除 `src/System/Language/tm_locale.hpp` 中的 `get_date` 声明
- `src/Typeset/Env/env_exec.cpp` 直接调用 `lolly::locale::get_date`
- `src/Mogan/Research/research.cpp` 直接调用 `lolly::locale::get_date`
- 更新 `devel/1112.md` 任务文档

## 测试

- [x] `xmake b stem` 构建通过
- [x] `xmake test -P lolly` 中 `lolly_tests/locale_test` 通过