### PR TITLE
[1117] 将 page_type 迁移到 moebius

### DIFF
--- a/devel/1117.md
+++ b/devel/1117.md
@@ -1,0 +1,109 @@
+# [1117] 将 page_type 迁移到 moebius
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1112.md](1112.md) - 将 `tm_locale` 迁移到 lolly（同节奏的前置工作样板）
+- [1113.md](1113.md) - 重新实现 `utf8_to_herk` 与 `herk_to_utf8`（同节奏的前置工作）
+- [1116.md](1116.md) - 将 style 相关代码独立为 nimbus 子模块（本任务是其前置工作之一）
+
+## 2 任务相关的代码文件
+- `src/Graphics/Renderer/page_type.hpp` - 当前位置（待迁出）
+- `src/Graphics/Renderer/page_type.cpp` - 当前位置（待迁出）
+- `moebius/moebius/data/page_type.hpp` - 迁入目标
+- `moebius/moebius/data/page_type.cpp` - 迁入目标
+- `moebius/xmake.lua` - 在 `libmoebius` target 中新增上述源文件与头文件
+- `xmake.lua` - 从 `libmogan` 的源文件 glob 中移除 `page_type.cpp`（自然随 `src/Graphics/Renderer/**.cpp` 处理，通常无需改动）
+- `src/Typeset/Env/env.cpp` - 调用方，更新 `#include`
+- `src/Typeset/Env/env_exec.cpp` - 调用方，更新 `#include`
+- `src/Typeset/Env/env_length.cpp` - 调用方，更新 `#include`
+- `src/Typeset/Env/env_semantics.cpp` - 调用方，更新 `#include` 与 `page_get_feature` 调用
+- `src/Typeset/Page/make_pages.cpp` - 调用方，更新 `#include` 与 `page_get_feature` 调用
+- `moebius/tests/moebius/data/page_type_test.cpp` - 新增单元测试
+
+## 3 如何测试
+
+### 3.1 moebius 单元测试
+```bash
+cd moebius
+xmake f --enable_tests=y
+xmake b page_type_test
+xmake r page_type_test
+```
+
+### 3.2 主项目构建验证
+```bash
+xmake b stem
+```
+
+### 3.3 提交前最少步骤
+```bash
+gf fmt --changed-since=main
+xmake b stem
+cd moebius
+xmake f --enable_tests=y
+xmake b page_type_test
+xmake r page_type_test
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+cd moebius
+xmake f --enable_tests=y
+xmake b page_type_test
+xmake r page_type_test
+```
+
+按 `[编号] 简述` 的格式提交，第一个 commit 为本任务文档，后续 commit 为代码改动。
+
+## 5 What
+
+将 `page_type`（页面规格数据库）从 `src/Graphics/Renderer/` 迁移到 `moebius/moebius/data/`，使其成为 moebius 提供的领域数据能力：
+
+1. 在 `moebius/moebius/data/page_type.hpp` 中以命名空间 `moebius::data` 重新声明 `page_get_feature`
+2. 将 `page_type.cpp` 的实现整体迁入 `moebius/moebius/data/page_type.cpp`，仅替换 `#include "hashmap.hpp"` 为 moebius/lolly 等价物（如 `moebius/data/history.hpp` 或 lolly 的 hashmap，视现有惯例而定），保留对 `<moebius/vars.hpp>` 的引用（`PAGE_WIDTH` 等常量本就在 moebius）
+3. 更新 `moebius/xmake.lua`，把新源文件与头文件加入 `libmoebius` target 的 `add_files` / `add_headerfiles`
+4. 删除 `src/Graphics/Renderer/page_type.{hpp,cpp}`
+5. 更新 5 处调用方的 `#include`：
+   - 4 个 `src/Typeset/Env/*.cpp` 改为 `#include <moebius/data/page_type.hpp>`
+   - `src/Typeset/Page/make_pages.cpp` 同上
+6. 在 `moebius/tests/moebius/data/page_type_test.cpp` 中以 doctest 框架固化行为，覆盖：
+   - 常见页面规格（`a4`、`letter`、`a5`、`legal` 等）的 `PAGE_WIDTH` / `PAGE_HEIGHT` / `PAR_WIDTH` / `standard`
+   - portrait（`-P-`）与 landscape（`-L-`）两种方向，验证宽高互换
+   - 各项 margin（`PAGE_ODD` / `PAGE_EVEN` / `PAGE_RIGHT` / `PAGE_TOP` / `PAGE_BOT`）的取值
+   - 未知 `type` 时回退到 `a4` 的行为（见现 cpp 第 163 行）
+
+## 6 Why
+
+`page_type` 是页面规格（A4/Letter 等）的尺寸数据库，被排版环境（`src/Typeset/Env/`）与分页器（`src/Typeset/Page/make_pages.cpp`）共同使用。但它当前放在 `src/Graphics/Renderer/` 下，导致两个问题：
+
+1. **反向依赖的源头**：1116 要把 `src/Typeset/Env/` 独立为 nimbus 子模块，要求 Env 只向下游依赖 `libmoebius`/`liblolly`。但 `env.cpp`/`env_exec.cpp`/`env_length.cpp`/`env_semantics.cpp` 共 4 个文件 `#include "page_type.hpp"`，把 nimbus 反向拽回了应用层。本任务把这 4 处反向依赖一次性清除。
+2. **职责错位**：`page_type` 是文档/排版领域的纯数据表（无 GUI、无 Qt、无 Scheme 回调），与 moebius 的 `Data/Tree`、`Kernel/Types`、`vars.hpp` 同属"领域基础数据"。它依赖的 `<moebius/vars.hpp>` 本就在 moebius，下沉零摩擦。留在 `Graphics/Renderer` 是历史遗留 —— renderer 只是它的消费者之一，并非它的归属层。
+
+下沉到 moebius 后，`page_type` 与其依赖的 `PAGE_WIDTH` 等常量同库，调用方从"跨层引用应用层头"变为"使用 moebius 公共 API"，依赖方向纠正，同时为 1116（nimbus 独立）清掉 4 处反向依赖中影响最广的一类。
+
+## 7 How
+
+### 7.1 实现要点
+
+- **签名保持稳定**：`page_get_feature(string type, string feature, bool landscape) -> string` 的签名不变，只是命名空间从全局移入 `moebius::data`。调用方加 `using moebius::data::page_get_feature;` 或显式限定，最小化调用点改动。
+- **hashmap 依赖**：现 cpp 用 `hashmap<string, string>`。moebius 已有 `moebius/Data/History` 提供 hashmap 风格容器，或可直接用 lolly 的对应容器。优先沿用 moebius 内部已用的等价物，避免引入新依赖。
+- **静态初始化**：`page_data_base_initizalized` 与 `page_data_base` 是文件级静态变量，迁入 moebius 后保持原语义；首次调用 `page_get_feature` 时填充数据库，后续直接查表。
+- **回退语义**：未知 `type` 回退到 `a4`（现 cpp 第 158-163 行），用单元测试固化，防止迁移过程中误改。
+
+### 7.2 迁移步骤
+
+1. 先在 moebius 侧新建 `page_type.{hpp,cpp}` 与单元测试，跑通 moebius 内部测试
+2. 再更新主项目 5 处 `#include`，跑通 `xmake b stem`
+3. 最后删除 `src/Graphics/Renderer/page_type.{hpp,cpp}`
+4. 全程不改变 `page_get_feature` 的行为，仅做物理位置与命名空间的迁移
+
+### 7.3 注意事项
+
+1. 本任务只迁移位置与命名空间，**不做接口重构、不做性能优化**，保持 diff 聚焦
+2. `page_type` 与 1116 是解耦关系而非循环依赖：本任务先于 1116 完成，1116 实施时即可直接 `#include <moebius/data/page_type.hpp>`
+3. 若 moebius 内 hashmap 惯例与主项目 `hashmap<string, string>` 不完全一致，优先选择"最小改动"的等价容器，避免连带改动其它代码

--- a/moebius/moebius/data/page_type.cpp
+++ b/moebius/moebius/data/page_type.cpp
@@ -10,7 +10,11 @@
  ******************************************************************************/
 
 #include "hashmap.hpp"
+#include <moebius/data/page_type.hpp>
 #include <moebius/vars.hpp>
+
+namespace moebius {
+namespace data {
 
 using namespace moebius;
 
@@ -162,3 +166,6 @@ page_get_feature (string type, string feature, bool landscape) {
   if (type == "a4") return "3cm";
   return page_get_feature ("a4", feature, landscape);
 }
+
+} // namespace data
+} // namespace moebius

--- a/moebius/moebius/data/page_type.hpp
+++ b/moebius/moebius/data/page_type.hpp
@@ -9,10 +9,13 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
-#ifndef PAGE_TYPE_H
-#define PAGE_TYPE_H
+#pragma once
 #include "string.hpp"
+
+namespace moebius {
+namespace data {
 
 string page_get_feature (string type, string feature, bool landscape);
 
-#endif // defined PAGE_TYPE_H
+} // namespace data
+} // namespace moebius

--- a/moebius/tests/moebius/data/page_type_test.cpp
+++ b/moebius/tests/moebius/data/page_type_test.cpp
@@ -1,0 +1,61 @@
+/** \file page_type_test.cpp
+ *  \copyright GPLv3
+ *  \details Unit tests for page size data base
+ *  \author Da Shen
+ *  \date   2026
+ */
+
+#include "moe_doctests.hpp"
+#include "string.hpp"
+#include <moebius/data/page_type.hpp>
+#include <moebius/vars.hpp>
+
+using namespace moebius;
+
+using moebius::data::page_get_feature;
+
+TEST_CASE ("test page_get_feature common sizes portrait") {
+  CHECK_EQ (page_get_feature ("a4", PAGE_WIDTH, false) == "210mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAGE_HEIGHT, false) == "297mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAR_WIDTH, false) == "150mm", true);
+  CHECK_EQ (page_get_feature ("a4", "standard", false) == "yes", true);
+
+  CHECK_EQ (page_get_feature ("letter", PAGE_WIDTH, false) == "8.5in", true);
+  CHECK_EQ (page_get_feature ("letter", PAGE_HEIGHT, false) == "11in", true);
+  CHECK_EQ (page_get_feature ("letter", PAR_WIDTH, false) == "6.5in", true);
+
+  CHECK_EQ (page_get_feature ("a5", PAGE_WIDTH, false) == "148mm", true);
+  CHECK_EQ (page_get_feature ("a5", PAGE_HEIGHT, false) == "210mm", true);
+
+  CHECK_EQ (page_get_feature ("legal", PAGE_WIDTH, false) == "8.5in", true);
+  CHECK_EQ (page_get_feature ("legal", PAGE_HEIGHT, false) == "14in", true);
+}
+
+TEST_CASE ("test page_get_feature landscape swaps width and height") {
+  CHECK_EQ (page_get_feature ("a4", PAGE_WIDTH, true) == "297mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAGE_HEIGHT, true) == "210mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAR_WIDTH, true) == "237mm", true);
+
+  CHECK_EQ (page_get_feature ("letter", PAGE_WIDTH, true) == "11in", true);
+  CHECK_EQ (page_get_feature ("letter", PAGE_HEIGHT, true) == "8.5in", true);
+}
+
+TEST_CASE ("test page_get_feature margins") {
+  CHECK_EQ (page_get_feature ("a4", PAGE_ODD, false) == "30mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAGE_EVEN, false) == "30mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAGE_RIGHT, false) == "30mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAGE_TOP, false) == "30mm", true);
+  CHECK_EQ (page_get_feature ("a4", PAGE_BOT, false) == "30mm", true);
+
+  CHECK_EQ (page_get_feature ("letter", PAGE_ODD, false) == "1in", true);
+  CHECK_EQ (page_get_feature ("letter", PAGE_TOP, false) == "1in", true);
+}
+
+TEST_CASE ("test page_get_feature unknown type falls back to a4") {
+  CHECK_EQ (page_get_feature ("unknown", PAGE_WIDTH, false) ==
+                page_get_feature ("a4", PAGE_WIDTH, false),
+            true);
+  CHECK_EQ (page_get_feature ("unknown", PAR_WIDTH, true) ==
+                page_get_feature ("a4", PAR_WIDTH, true),
+            true);
+}

--- a/src/Typeset/Env/env.cpp
+++ b/src/Typeset/Env/env.cpp
@@ -17,9 +17,10 @@ extern hashmap<string, int>  default_var_type;
 void                         initialize_default_var_type ();
 extern hashmap<string, tree> default_env;
 void                         initialize_default_env ();
-#include "page_type.hpp"
+#include <moebius/data/page_type.hpp>
 
 using namespace moebius;
+using moebius::data::page_get_feature;
 
 /******************************************************************************
  * Initialization

--- a/src/Typeset/Env/env_exec.cpp
+++ b/src/Typeset/Env/env_exec.cpp
@@ -18,7 +18,9 @@
 #include "image_files.hpp"
 #include "locale.hpp"
 #include "observers.hpp"
-#include "page_type.hpp"
+#include <moebius/data/page_type.hpp>
+
+using moebius::data::page_get_feature;
 #include "scheme.hpp"
 #include "tm_file.hpp"
 #include "typesetter.hpp"

--- a/src/Typeset/Env/env_length.cpp
+++ b/src/Typeset/Env/env_length.cpp
@@ -13,7 +13,9 @@
 #include "analyze.hpp"
 #include "convert.hpp"
 #include "env.hpp"
-#include "page_type.hpp"
+#include <moebius/data/page_type.hpp>
+
+using moebius::data::page_get_feature;
 #include "typesetter.hpp"
 
 using namespace moebius;

--- a/src/Typeset/Env/env_semantics.cpp
+++ b/src/Typeset/Env/env_semantics.cpp
@@ -13,10 +13,11 @@
 #include "analyze.hpp"
 #include "env.hpp"
 #include "font.hpp"
-#include "page_type.hpp"
 #include "tm_debug.hpp"
 #include "typesetter.hpp"
+#include <moebius/data/page_type.hpp>
 
+using moebius::data::page_get_feature;
 using namespace moebius;
 
 /******************************************************************************

--- a/src/Typeset/Page/make_pages.cpp
+++ b/src/Typeset/Page/make_pages.cpp
@@ -12,7 +12,9 @@
 #include "Format/page_item.hpp"
 #include "Format/stack_border.hpp"
 #include "new_breaker.hpp"
-#include "page_type.hpp"
+#include <moebius/data/page_type.hpp>
+
+using moebius::data::page_get_feature;
 #include "pager.hpp"
 #include "tm_debug.hpp"
 


### PR DESCRIPTION
## Summary
- 将 `page_type` 从 `src/Graphics/Renderer/` 迁入 `moebius/moebius/data/`，`page_get_feature` 移入 `moebius::data` 命名空间，行为保持不变
- 删除旧文件 `src/Graphics/Renderer/page_type.{hpp,cpp}`
- 5 处调用方（4 个 `src/Typeset/Env/*.cpp` 与 `src/Typeset/Page/make_pages.cpp`）改 `#include <moebius/data/page_type.hpp>` 并加 `using moebius::data::page_get_feature;`
- 新增 `moebius/tests/moebius/data/page_type_test.cpp`：覆盖常见规格（a4/letter/a5/legal）、portrait/landscape 宽高互换、各项 margin、以及未知 type 回退到 a4 的行为

## Why
`page_type` 是纯数据表（依赖 `<moebius/vars.hpp>`，无 GUI/Qt/Scheme），却放在 `Graphics/Renderer/` 下。Env 与分页器引用它形成跨层依赖，是 1116（nimbus 独立）的前置阻塞。下沉到 moebius 后依赖方向纠正，且为 1116 清掉 4 处反向依赖中影响最广的一类。

## Test plan
- [x] `gf fmt --changed-since=main`
- [x] `xmake b stem` 构建通过
- [x] `xmake test "moebius_tests/page_type_test"` 100% passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)