### PR TITLE
[1116] 让 Typeset/Env 不再依赖 Boxes/construct.hpp

### DIFF
--- a/devel/1116.md
+++ b/devel/1116.md
@@ -1,0 +1,74 @@
+# [1116] 让 src/Typeset/Env 不再依赖 Boxes/construct.hpp
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1117.md](1117.md) - 将 `page_type` 迁移到 moebius（前置工作，已清掉 4 处 Env 对应用层头 `page_type.hpp` 的引用）
+- [1113.md](1113.md) - `utf8_to_herk` / `herk_to_utf8` 迁移到 lolly
+
+## 2 任务相关的代码文件
+- `src/Typeset/Env/box_parameters.hpp` - 新增,把 `ornament_parameters` 与 `art_box_parameters` 两个值类从 `Boxes/construct.hpp` 抽出
+- `src/Typeset/Boxes/construct.hpp` - 改为 `#include "Env/box_parameters.hpp"`,删除内嵌的参数类定义
+- `src/Typeset/Env/env_length.cpp` - `#include "Boxes/construct.hpp"` 改为 `#include "Env/box_parameters.hpp"`
+- `src/Typeset/Env/env_semantics.cpp` - 同上
+
+## 3 如何测试
+
+### 3.1 主项目构建验证
+```bash
+xmake b stem
+```
+
+### 3.2 提交前最少步骤
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 4 如何提交
+
+按 `[编号] 简述` 的格式提交,第一个 commit 为本任务文档,后续 commit 为代码改动。
+
+## 5 What
+
+把 `ornament_parameters` 与 `art_box_parameters` 两个值类从 `src/Typeset/Boxes/construct.hpp` 抽到新文件 `src/Typeset/Env/box_parameters.hpp`,然后:
+
+1. `construct.hpp` 改为 `#include "Env/box_parameters.hpp"`,移除原先内嵌的两个类定义。下游 Boxes 代码不需要任何改动 —— `construct.hpp` 仍是统一的 boxes 构造入口,只是把两个参数类的定义转包给新头。
+2. `src/Typeset/Env/env_length.cpp` 与 `src/Typeset/Env/env_semantics.cpp` 的 `#include "Boxes/construct.hpp"` 改为 `#include "Env/box_parameters.hpp"`。
+
+完成后,`src/Typeset/Env/` 下没有任何文件再 `#include` Boxes 的构造接口头。
+
+## 6 Why
+
+`Typeset/Env` 是排版的预处理阶段,`Typeset/Boxes` 是排版输出阶段。Env 不应该依赖 Boxes 的构造接口 —— 预处理只产出描述参数,不构造 box。
+
+实际看 Env 对 `Boxes/construct.hpp` 的使用面非常窄,只用到两个值类:
+- `ornament_parameters`(装饰框参数,由 `edit_env_rep::get_ornament_parameters()` 按值返回)
+- `art_box_parameters`(art box 参数,由 `edit_env_rep::get_art_box_parameters()` 按值返回)
+
+这两个类本质上是预处理阶段产出、供下游 Boxes 消费的描述符,把它们放在 `Env/box_parameters.hpp` 是职责归位:依赖方向变成 Boxes → Env(消费描述符),而不再是 Env → Boxes。
+
+更上层的目标(本任务是其前置步骤之一):把 `Typeset/Env` 这块排版预处理代码从 `libmogan` 分离出来,独立为 nimbus 子模块。独立的前提是 Env 只向下依赖 `libmoebius` / `liblolly`,不再反向引用 Boxes / Edit / Graphics 等应用层。本任务清掉 Env 对 `Boxes/construct.hpp` 这一处反向依赖。
+
+## 7 How
+
+### 7.1 为什么不直接前向声明
+
+`env.hpp` 已经对两个类做了前向声明(`class ornament_parameters;` / `class art_box_parameters;`),但 Env 的两个 `.cpp` 是**按值**返回它们的(`ornament_parameters edit_env_rep::get_ornament_parameters()`),按值返回需要完整类型,前向声明不够。所以必须有一个完整的定义头。
+
+### 7.2 为什么放在 Env/ 而不是 Boxes/
+
+放在 `Boxes/` 下只是拆出小头,Env 仍然依赖 Boxes 目录;放在 `Env/` 下,依赖方向彻底反过来 —— Env 自带它产出的描述符类型,Boxes 作为消费者去 include Env 的头。这符合"预处理产出描述符、排版消费描述符"的语义,也为 1116 的总目标(Env 独立出 libmogan)扫清一处障碍。
+
+### 7.3 include 的最小化
+
+新头只 include:
+- `array.hpp`(用到 `array<brush>`)
+- `basic.hpp`(提供 `SI`)
+- `brush.hpp`(成员用到 `brush`)
+- `tree.hpp`(成员用到 `tree`)
+
+不再 include `boxes.hpp` / `font.hpp` / `player.hpp` / `command.hpp` / `colors.hpp` / `xkerning.hpp` 等 boxes 构造相关的重依赖。Env 文件本身已通过 `env.hpp` 等拉入这些头,但 Env 不再因为参数类而被迫拉入 boxes 构造接口。
+
+### 7.4 construct.hpp 单点入口保持
+
+`construct.hpp` 继续 `#include "Env/box_parameters.hpp"`,所以所有用 `ornament_parameters` / `art_box_parameters` 的 Boxes 代码不需要任何改动,只是这两个类的定义从 `construct.hpp` 内嵌转包给了 `box_parameters.hpp`。

--- a/src/Typeset/Boxes/construct.hpp
+++ b/src/Typeset/Boxes/construct.hpp
@@ -12,6 +12,7 @@
 #ifndef CONSTRUCT_H
 #define CONSTRUCT_H
 #include "Boxes/xkerning.hpp"
+#include "Env/box_parameters.hpp"
 #include "array.hpp"
 #include "boxes.hpp"
 #include "colors.hpp"
@@ -20,78 +21,6 @@
 #include "player.hpp"
 
 class frame;
-
-/******************************************************************************
- * Ornament parameters
- ******************************************************************************/
-
-class ornament_parameters_rep : concrete_struct {
-public:
-  tree         shape, tst;
-  SI           lw, bw, rw, tw;
-  double       lext, bext, rext, text;
-  SI           lpad, bpad, rpad, tpad;
-  SI           lcor, bcor, rcor, tcor;
-  brush        bg, xc;
-  array<brush> border;
-
-  inline ornament_parameters_rep (tree shape2, tree tst2, SI lw2, SI bw2,
-                                  SI rw2, SI tw2, double lx, double bx,
-                                  double rx, double tx, SI lpad2, SI bpad2,
-                                  SI rpad2, SI tpad2, SI lcor2, SI bcor2,
-                                  SI rcor2, SI tcor2, brush bg2, brush xc2,
-                                  array<brush> border2)
-      : shape (shape2), tst (tst2), lw (lw2), bw (bw2), rw (rw2), tw (tw2),
-        lext (lx), bext (bx), rext (rx), text (tx), lpad (lpad2), bpad (bpad2),
-        rpad (rpad2), tpad (tpad2), lcor (lcor2), bcor (bcor2), rcor (rcor2),
-        tcor (tcor2), bg (bg2), xc (xc2), border (border2) {}
-  friend class ornament_parameters;
-};
-
-class ornament_parameters {
-  CONCRETE (ornament_parameters);
-  inline ornament_parameters (tree shape2, tree tst2, SI lw2, SI bw2, SI rw2,
-                              SI tw2, double lx, double bx, double rx,
-                              double tx, SI lpad2, SI bpad2, SI rpad2, SI tpad2,
-                              SI lcor2, SI bcor2, SI rcor2, SI tcor2, brush bg2,
-                              brush xc2, array<brush> border2)
-      : rep (tm_new<ornament_parameters_rep> (
-            shape2, tst2, lw2, bw2, rw2, tw2, lx, bx, rx, tx, lpad2, bpad2,
-            rpad2, tpad2, lcor2, bcor2, rcor2, tcor2, bg2, xc2, border2)) {}
-};
-CONCRETE_CODE (ornament_parameters);
-
-inline ornament_parameters
-copy (ornament_parameters ps) {
-  return ornament_parameters (
-      ps->shape, ps->tst, ps->lw, ps->bw, ps->rw, ps->tw, ps->lext, ps->bext,
-      ps->rext, ps->text, ps->lpad, ps->bpad, ps->rpad, ps->tpad, ps->lcor,
-      ps->bcor, ps->rcor, ps->tcor, ps->bg, ps->xc, ps->border);
-}
-
-class art_box_parameters_rep : concrete_struct {
-public:
-  tree data;
-  SI   lpad, bpad, rpad, tpad;
-
-  inline art_box_parameters_rep (tree data2, SI lpad2, SI bpad2, SI rpad2,
-                                 SI tpad2)
-      : data (data2), lpad (lpad2), bpad (bpad2), rpad (rpad2), tpad (tpad2) {}
-  friend class art_box_parameters;
-};
-
-class art_box_parameters {
-  CONCRETE (art_box_parameters);
-  inline art_box_parameters (tree data2, SI lpad2, SI bpad2, SI rpad2, SI tpad2)
-      : rep (tm_new<art_box_parameters_rep> (data2, lpad2, bpad2, rpad2,
-                                             tpad2)) {}
-};
-CONCRETE_CODE (art_box_parameters);
-
-inline art_box_parameters
-copy (art_box_parameters ps) {
-  return art_box_parameters (ps->data, ps->lpad, ps->bpad, ps->rpad, ps->tpad);
-}
 
 /******************************************************************************
  * Construction routines for boxes

--- a/src/Typeset/Env/box_parameters.hpp
+++ b/src/Typeset/Env/box_parameters.hpp
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * MODULE     : box_parameters.hpp
+ * DESCRIPTION: value types describing ornament / art-box layout parameters
+ * COPYRIGHT  : (C) 1999  Joris van der Hoeven
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#ifndef BOX_PARAMETERS_H
+#define BOX_PARAMETERS_H
+#include "array.hpp"
+#include "basic.hpp"
+#include "brush.hpp"
+#include "tree.hpp"
+
+class ornament_parameters_rep : concrete_struct {
+public:
+  tree         shape, tst;
+  SI           lw, bw, rw, tw;
+  double       lext, bext, rext, text;
+  SI           lpad, bpad, rpad, tpad;
+  SI           lcor, bcor, rcor, tcor;
+  brush        bg, xc;
+  array<brush> border;
+
+  inline ornament_parameters_rep (tree shape2, tree tst2, SI lw2, SI bw2,
+                                  SI rw2, SI tw2, double lx, double bx,
+                                  double rx, double tx, SI lpad2, SI bpad2,
+                                  SI rpad2, SI tpad2, SI lcor2, SI bcor2,
+                                  SI rcor2, SI tcor2, brush bg2, brush xc2,
+                                  array<brush> border2)
+      : shape (shape2), tst (tst2), lw (lw2), bw (bw2), rw (rw2), tw (tw2),
+        lext (lx), bext (bx), rext (rx), text (tx), lpad (lpad2), bpad (bpad2),
+        rpad (rpad2), tpad (tpad2), lcor (lcor2), bcor (bcor2), rcor (rcor2),
+        tcor (tcor2), bg (bg2), xc (xc2), border (border2) {}
+  friend class ornament_parameters;
+};
+
+class ornament_parameters {
+  CONCRETE (ornament_parameters);
+  inline ornament_parameters (tree shape2, tree tst2, SI lw2, SI bw2, SI rw2,
+                              SI tw2, double lx, double bx, double rx,
+                              double tx, SI lpad2, SI bpad2, SI rpad2, SI tpad2,
+                              SI lcor2, SI bcor2, SI rcor2, SI tcor2, brush bg2,
+                              brush xc2, array<brush> border2)
+      : rep (tm_new<ornament_parameters_rep> (
+            shape2, tst2, lw2, bw2, rw2, tw2, lx, bx, rx, tx, lpad2, bpad2,
+            rpad2, tpad2, lcor2, bcor2, rcor2, tcor2, bg2, xc2, border2)) {}
+};
+CONCRETE_CODE (ornament_parameters);
+
+inline ornament_parameters
+copy (ornament_parameters ps) {
+  return ornament_parameters (
+      ps->shape, ps->tst, ps->lw, ps->bw, ps->rw, ps->tw, ps->lext, ps->bext,
+      ps->rext, ps->text, ps->lpad, ps->bpad, ps->rpad, ps->tpad, ps->lcor,
+      ps->bcor, ps->rcor, ps->tcor, ps->bg, ps->xc, ps->border);
+}
+
+class art_box_parameters_rep : concrete_struct {
+public:
+  tree data;
+  SI   lpad, bpad, rpad, tpad;
+
+  inline art_box_parameters_rep (tree data2, SI lpad2, SI bpad2, SI rpad2,
+                                 SI tpad2)
+      : data (data2), lpad (lpad2), bpad (bpad2), rpad (rpad2), tpad (tpad2) {}
+  friend class art_box_parameters;
+};
+
+class art_box_parameters {
+  CONCRETE (art_box_parameters);
+  inline art_box_parameters (tree data2, SI lpad2, SI bpad2, SI rpad2, SI tpad2)
+      : rep (tm_new<art_box_parameters_rep> (data2, lpad2, bpad2, rpad2,
+                                             tpad2)) {}
+};
+CONCRETE_CODE (art_box_parameters);
+
+inline art_box_parameters
+copy (art_box_parameters ps) {
+  return art_box_parameters (ps->data, ps->lpad, ps->bpad, ps->rpad, ps->tpad);
+}
+
+#endif // defined BOX_PARAMETERS_H

--- a/src/Typeset/Env/env_length.cpp
+++ b/src/Typeset/Env/env_length.cpp
@@ -9,7 +9,7 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
-#include "Boxes/construct.hpp"
+#include "Env/box_parameters.hpp"
 #include "analyze.hpp"
 #include "convert.hpp"
 #include "env.hpp"

--- a/src/Typeset/Env/env_semantics.cpp
+++ b/src/Typeset/Env/env_semantics.cpp
@@ -9,7 +9,7 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
-#include "Boxes/construct.hpp"
+#include "Env/box_parameters.hpp"
 #include "analyze.hpp"
 #include "env.hpp"
 #include "font.hpp"


### PR DESCRIPTION
## Summary
- 把 `ornament_parameters` 与 `art_box_parameters` 从 `src/Typeset/Boxes/construct.hpp` 抽到新文件 `src/Typeset/Env/box_parameters.hpp`
- `construct.hpp` 改为 `#include "Env/box_parameters.hpp"`,下游 Boxes 代码无任何改动(单点入口保持)
- `src/Typeset/Env/env_length.cpp` 与 `env_semantics.cpp` 改 include 新头,Env 目录下不再有任何文件依赖 `Boxes/construct.hpp`

## Why
`Typeset/Env` 是排版预处理,`Typeset/Boxes` 是排版输出。Env 不应依赖 Boxes 的构造接口 —— 预处理只产出描述参数,不构造 box。Env 对 `construct.hpp` 的实际使用面只有这两个按值返回的参数类,本质是预处理产出、供下游 Boxes 消费的描述符。放到 `Env/` 下依赖方向归正(Boxes → Env),也为 `Typeset/Env` 独立出 `libmogan`(nimbus 子模块)扫清一处反向依赖。

## Test plan
- [x] `xmake b stem` 构建通过
- [x] `gf fmt --changed-since=main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)