### PR TITLE
[1110] 抽离 liii-libaesgm/liii-pdfhummus 包定义到 3rdparty

### DIFF
--- a/3rdparty/libaesgm.lua
+++ b/3rdparty/libaesgm.lua
@@ -1,0 +1,32 @@
+-------------------------------------------------------------------------------
+--
+-- MODULE      : libaesgm.lua
+-- DESCRIPTION : Xmake package definition for libaesgm
+--
+
+package("liii-libaesgm")
+    set_homepage("https://github.com/xmake-mirror/libaesgm")
+    set_description("https://repology.org/project/libaesgm/packages")
+
+    set_sourcedir(path.join(os.scriptdir(), "libaesgm"))
+
+    on_install("linux", "macosx", "windows", "mingw", function (package)
+        if package:is_plat("windows", "mingw") and package:is_arch("arm", "arm64") then
+            -- Windows is always little endian
+            io.replace("brg_endian.h", [[
+#elif 0     /* **** EDIT HERE IF NECESSARY **** */
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN]], [[
+#elif 1     /* Edited: Windows ARM is little endian */
+#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN]], { plain = true })
+        end
+        local configs = {}
+        if package:config("shared") then
+            configs.kind = "shared"
+        end
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("aes_init", {includes = "aes.h"}))
+    end)
+package_end()

--- a/3rdparty/pdfhummus.lua
+++ b/3rdparty/pdfhummus.lua
@@ -1,0 +1,58 @@
+-------------------------------------------------------------------------------
+--
+-- MODULE      : pdfhummus.lua
+-- DESCRIPTION : Xmake package definition for PDFhummus
+--
+
+package("liii-pdfhummus")
+    set_homepage("https://www.pdfhummus.com/")
+    set_description("High performance library for creating, modiyfing and parsing PDF files in C++ ")
+    set_license("Apache-2.0")
+
+    -- Use the vendored source under 3rdparty/pdfhummus (updated to PDF-Writer v4.9.0).
+    set_sourcedir(path.join(os.scriptdir(), "pdfhummus"))
+
+    add_deps("zlib", "liii-libaesgm")
+    add_deps("freetype", {configs={png=true}})
+
+    add_configs("libtiff", {description = "Supporting tiff image", default = false, type = "boolean"})
+    add_configs("libjpeg", {description = "Support DCT encoding", default = false, type = "boolean"})
+    add_configs("libpng", {description = "Support png image", default = false, type = "boolean"})
+
+    if is_plat("linux") then
+        add_syslinks("m")
+    end
+
+    on_load(function (package)
+        for _, dep in ipairs({"libtiff", "libpng", "libjpeg"}) do
+            if package:config(dep) then
+                package:add("deps", dep)
+            end
+        end
+    end)
+    on_install("linux", "windows", "mingw", "macosx", function (package)
+        local configs = {}
+        if package:config("shared") then
+            configs.kind = "shared"
+        end
+        for _, dep in ipairs({"libtiff", "libpng", "libjpeg"}) do
+            if package:config(dep) then
+                configs[dep] = true
+            end
+        end
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include "PDFWriter/PDFWriter.h"
+            #include <iostream>
+            using namespace std;
+            using namespace PDFHummus;
+            void test() {
+                PDFWriter pdfWriter;
+                pdfWriter.Reset();
+            }
+        ]]}, {configs = {languages = "c++11"}}))
+    end)
+package_end()

--- a/devel/1110.md
+++ b/devel/1110.md
@@ -6,7 +6,8 @@
 ## 2 任务相关的代码文件
 - `3rdparty/pdfhummus/**` —— pdfhummus 源码目录，整体替换为 PDF-Writer v4.9.0
 - `3rdparty/pdfhummus/xmake.lua` —— pdfhummus 的 xmake 构建定义（处理 OpenSSL/图片后端等可选依赖）
-- `xmake.lua` —— `liii-pdfhummus` 包定义与版本常量
+- `3rdparty/pdfhummus.lua` —— `liii-pdfhummus` 包定义（后续从根 `xmake.lua` 迁出，见第 8 节）
+- `3rdparty/libaesgm.lua` —— `liii-libaesgm` 包定义（后续从根 `xmake.lua` 迁出，见第 8 节）
 - `xmake/vars.lua` —— 依赖版本汇总
 
 ## 3 如何测试
@@ -63,3 +64,19 @@ PDF-Writer v4.9.0 包含了上游的若干 bug 修复与改进（如加密、流
    `InputAESDecodeStreamSSL.cpp` / `OutputAESEncodeStreamSSL.cpp`（与上游
    `PDFWriter/CMakeLists.txt` 的二选一逻辑一致，改用纯软件实现的 `Input/OutputAESEncodeStream`）。
 6. 运行 `xmake require -y --force liii-pdfhummus` 或 `xmake f -y` 验证包能正常构建。
+
+## 8 后续：包定义迁移到 3rdparty 目录（2026/06/26）
+
+照 `3rdparty/doctest.lua` 的模式，把原本内联在根 `xmake.lua` 里的两个 `package` 定义抽到独立文件：
+
+- `liii-libaesgm` → `3rdparty/libaesgm.lua`
+- `liii-pdfhummus` → `3rdparty/pdfhummus.lua`
+
+根 `xmake.lua` 通过 `includes("3rdparty/libaesgm.lua")` 与 `includes("3rdparty/pdfhummus.lua")` 引入，紧挨已有的 `includes("3rdparty/doctest.lua")`。
+
+**动机**：`liii-doctest` 早已拆到 `3rdparty/doctest.lua`，但 `liii-libaesgm` / `liii-pdfhummus` 仍内联在根 `xmake.lua` 里，破坏了「每个 vendored 第三方包一个独立 `.lua` 文件」的约定。补齐后根 `xmake.lua` 只保留全局配置与项目入口。
+
+**注意点**：`set_sourcedir` 的路径相对调整——原先 `os.scriptdir()` 指向仓库根，写的是 `"3rdparty/libaesgm"`；迁到 `3rdparty/xxx.lua` 后 `os.scriptdir()` 指向 `3rdparty/`，故改为 `"libaesgm"` / `"pdfhummus"`。顺手删除 `xmake.lua` 里冗余的 `PDFHUMMUS_VERSION = "4.9.0"`（已在 `xmake/vars.lua:34` 定义）。
+
+验证：`xmake b stem`。
+

--- a/xmake.lua
+++ b/xmake.lua
@@ -11,6 +11,8 @@
 
 includes("xmake/vars.lua")
 includes("3rdparty/doctest.lua")
+includes("3rdparty/libaesgm.lua")
+includes("3rdparty/pdfhummus.lua")
 
 includes("moebius")
 includes("lolly")
@@ -106,87 +108,6 @@ add_repositories("liii-repo xmake")
 
 TBOX_VERSION= "1.7.5"
 S7_VERSION = "20240816"
-
-package("liii-libaesgm")
-    set_homepage("https://github.com/xmake-mirror/libaesgm")
-    set_description("https://repology.org/project/libaesgm/packages")
-
-    set_sourcedir(path.join(os.scriptdir(), "3rdparty/libaesgm"))
-
-    on_install("linux", "macosx", "windows", "mingw", function (package)
-        if package:is_plat("windows", "mingw") and package:is_arch("arm", "arm64") then
-            -- Windows is always little endian
-            io.replace("brg_endian.h", [[
-#elif 0     /* **** EDIT HERE IF NECESSARY **** */
-#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN]], [[
-#elif 1     /* Edited: Windows ARM is little endian */
-#  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN]], { plain = true })
-        end
-        local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
-        end
-        import("package.tools.xmake").install(package, configs)
-    end)
-
-    on_test(function (package)
-        assert(package:has_cfuncs("aes_init", {includes = "aes.h"}))
-    end)
-package_end()
-
-PDFHUMMUS_VERSION = "4.9.0"
-package("liii-pdfhummus")
-    set_homepage("https://www.pdfhummus.com/")
-    set_description("High performance library for creating, modiyfing and parsing PDF files in C++ ")
-    set_license("Apache-2.0")
-
-    -- Use the vendored source under 3rdparty/pdfhummus (updated to PDF-Writer v4.9.0).
-    set_sourcedir(path.join(os.scriptdir(), "3rdparty/pdfhummus"))
-
-    add_deps("zlib", "liii-libaesgm")
-    add_deps("freetype", {configs={png=true}})
-
-    add_configs("libtiff", {description = "Supporting tiff image", default = false, type = "boolean"})
-    add_configs("libjpeg", {description = "Support DCT encoding", default = false, type = "boolean"})
-    add_configs("libpng", {description = "Support png image", default = false, type = "boolean"})
-
-    if is_plat("linux") then
-        add_syslinks("m")
-    end
-
-    on_load(function (package)
-        for _, dep in ipairs({"libtiff", "libpng", "libjpeg"}) do
-            if package:config(dep) then
-                package:add("deps", dep)
-            end
-        end
-    end)
-    on_install("linux", "windows", "mingw", "macosx", function (package)
-        local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
-        end
-        for _, dep in ipairs({"libtiff", "libpng", "libjpeg"}) do
-            if package:config(dep) then
-                configs[dep] = true
-            end
-        end
-        import("package.tools.xmake").install(package, configs)
-    end)
-
-    on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
-            #include "PDFWriter/PDFWriter.h"
-            #include <iostream>
-            using namespace std;
-            using namespace PDFHummus;
-            void test() {
-                PDFWriter pdfWriter;
-                pdfWriter.Reset();
-            }
-        ]]}, {configs = {languages = "c++11"}}))
-    end)
-package_end()
 
 includes("@builtin/check")
 configvar_check_cxxtypes("HAVE_INTPTR_T", "intptr_t", {includes = {"memory"}})


### PR DESCRIPTION
## Summary
- 照 `3rdparty/doctest.lua` 的模式，把内联在根 `xmake.lua` 的 `liii-libaesgm` / `liii-pdfhummus` 两个 `package` 定义迁到 `3rdparty/{libaesgm,pdfhummus}.lua`
- `set_sourcedir` 路径相应调整为相对 `3rdparty/`
- 删除冗余的 `PDFHUMMUS_VERSION`（已在 `xmake/vars.lua` 定义）
- 根 `xmake.lua` 收敛为只保留全局配置，统一「每个 vendored 第三方包一个独立 `.lua`」的约定

## Test plan
- [ ] `xmake b stem` 构建通过