### PR TITLE
[1119] 将所有用 regression-test-group 的测试改用 (liii check)

### DIFF
--- a/TeXmacs/plugins/cite/progs/contrib/cite/cite-sort-test.scm
+++ b/TeXmacs/plugins/cite/progs/contrib/cite/cite-sort-test.scm
@@ -11,71 +11,87 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (contrib cite cite-sort-test)
-  (:use (contrib cite cite-sort)))
+(texmacs-module (contrib cite cite-sort-test) (:use (contrib cite cite-sort)))
 
-(define (regtest-indice-sort)
-  (regression-test-group
-   "test indice sorting and merging" "indice-sort"
-   indice-sort :none 
-   (test "unmerged two element"
-     '(("1" (concat (write "bib1") (reference "bib1")))
-       ("2" (concat (write "bib2") (reference "bib2")))
-       ("4" (concat (write "bib4") (reference "bib4")))
-       ("5" (concat (write "bib5") (reference "bib5"))))
-     '((concat (write "bib1") (reference "bib1"))
-       (concat (write "bib2") (reference "bib2"))
-       (concat (write "bib4") (reference "bib4"))
-       (concat (write "bib5") (reference "bib5"))))
-   (test "unmerged one element"
-     '(("1" (concat (write "bib1") (reference "bib1")))
-       ("3" (concat (write "bib3") (reference "bib3"))))
-     '((concat (write "bib1") (reference "bib1"))
-       (concat (write "bib3") (reference "bib3"))))
-   (test "discontinue merge"
-     '(("1" (concat (write "bib1") (reference "bib1")))
-       ("3" (concat (write "bib3") (reference "bib3")))
-       ("4" (concat (write "bib4") (reference "bib4")))
-       ("5" (concat (write "bib5") (reference "bib5")))
-       ("7" (concat (write "bib7") (reference "bib7"))))
-     '((concat (write "bib1") (reference "bib1"))
-       (concat
-         (write "bib3")
-         (write "bib4")
-         (write "bib5")
-         (reference "bib3")
-         "-"
-         (reference "bib5"))
-       (concat (write "bib7") (reference "bib7"))))
-   (test "merge at lease three elements"
-     '(("1" (concat (write "bib1") (reference "bib1")))
-       ("2" (concat (write "bib2") (reference "bib2")))
-       ("3" (concat (write "bib3") (reference "bib3"))))
-     '((concat
-         (write "bib1")
-         (write "bib2")
-         (write "bib3")
-         (reference "bib1")
-         "-"
-         (reference "bib3"))))
-   (test "merge five elements"
-     '(("1" (concat (write "bib1") (reference "bib1")))
-       ("3" (concat (write "bib3") (reference "bib3")))
-       ("4" (concat (write "bib4") (reference "bib4")))
-       ("2" (concat (write "bib2") (reference "bib2")))
-       ("5" (concat (write "bib5") (reference "bib5"))))
-     '((concat
-         (write "bib1")
-         (write "bib2")
-         (write "bib3")
-         (write "bib4")
-         (write "bib5")
-         (reference "bib1")
-         "-"
-         (reference "bib5"))))
-))
+(import (liii check))
 
-(tm-define (regtest-cite-sort)
-  (let ((n (+ (regtest-indice-sort))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of cite-sort: ok\n")))
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for indice-sort
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-indice-sort)
+  (check (indice-sort '(("1" (concat (write "bib1") (reference "bib1")))
+                        ("2" (concat (write "bib2") (reference "bib2")))
+                        ("4" (concat (write "bib4") (reference "bib4")))
+                        ("5" (concat (write "bib5") (reference "bib5"))))
+         ) ;indice-sort
+    =>
+    '((concat (write "bib1") (reference "bib1"))
+      (concat (write "bib2") (reference "bib2"))
+      (concat (write "bib4") (reference "bib4"))
+      (concat (write "bib5") (reference "bib5")))
+  ) ;check
+
+  (check (indice-sort '(("1" (concat (write "bib1") (reference "bib1")))
+                        ("3" (concat (write "bib3") (reference "bib3"))))
+         ) ;indice-sort
+    =>
+    '((concat (write "bib1") (reference "bib1"))
+      (concat (write "bib3") (reference "bib3")))
+  ) ;check
+
+  (check (indice-sort '(("1" (concat (write "bib1") (reference "bib1")))
+                        ("3" (concat (write "bib3") (reference "bib3")))
+                        ("4" (concat (write "bib4") (reference "bib4")))
+                        ("5" (concat (write "bib5") (reference "bib5")))
+                        ("7" (concat (write "bib7") (reference "bib7"))))
+         ) ;indice-sort
+    =>
+    '((concat (write "bib1") (reference "bib1"))
+      (concat (write "bib3")
+        (write "bib4")
+        (write "bib5")
+        (reference "bib3")
+        "-"
+        (reference "bib5"))
+      (concat (write "bib7") (reference "bib7")))
+  ) ;check
+
+  (check (indice-sort '(("1" (concat (write "bib1") (reference "bib1")))
+                        ("2" (concat (write "bib2") (reference "bib2")))
+                        ("3" (concat (write "bib3") (reference "bib3"))))
+         ) ;indice-sort
+    =>
+    '((concat (write "bib1")
+        (write "bib2")
+        (write "bib3")
+        (reference "bib1")
+        "-"
+        (reference "bib3")))
+  ) ;check
+
+  (check (indice-sort '(("1" (concat (write "bib1") (reference "bib1")))
+                        ("3" (concat (write "bib3") (reference "bib3")))
+                        ("4" (concat (write "bib4") (reference "bib4")))
+                        ("2" (concat (write "bib2") (reference "bib2")))
+                        ("5" (concat (write "bib5") (reference "bib5"))))
+         ) ;indice-sort
+    =>
+    '((concat (write "bib1")
+        (write "bib2")
+        (write "bib3")
+        (write "bib4")
+        (write "bib5")
+        (reference "bib1")
+        "-"
+        (reference "bib5")))
+  ) ;check
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-cite-sort) (test-indice-sort) (check-report))

--- a/TeXmacs/plugins/html/progs/convert/mathml/mathtm-test.scm
+++ b/TeXmacs/plugins/html/progs/convert/mathml/mathtm-test.scm
@@ -11,20 +11,27 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (convert mathml mathtm-test)
-  (:use (convert html htmltm)))
+(texmacs-module (convert mathml mathtm-test) (:use (convert html htmltm)))
 
-(tm-define (regtest-mathtm)
-  (define (math->tree x) (htmltm-as-serial (cons 'math x)))
-  (regression-test-group
-   "mathtm" "mathtm"
-   math->tree :none 
-   (test "identifier" '((mi "x")) "x")
-   (test "operator" '((mi "x") (mo "+") (mi "y")) "x+y")
-   (test "numeral" '((mn "2") (mo "+") (mi "x")) "2+x")
-   ;; (test "exponent" '(msup (mi "x") (mn "2")) '(concat "x" (rsup "2")))
-   ;; (test "special ops"
-   ;;   '(mrow (mn "3") (mo "&InvisibleTimes;") (mi "x")
-   ;;      (mo "*") (msup (mi "y") (mn "4")))
-   ;;   '(concat "3*x<ast>y" (rsup "4")))   
-))
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for mathtm
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-mathtm)
+  (define (math->tree x)
+    (htmltm-as-serial (cons 'math x))
+  ) ;define
+  (check (math->tree '((mi "x"))) => "x")
+  (check (math->tree '((mi "x") (mo "+") (mi "y"))) => "x+y")
+  (check (math->tree '((mn "2") (mo "+") (mi "x"))) => "2+x")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-mathtm) (test-mathtm) (check-report))

--- a/TeXmacs/progs/convert/tools/environment-test.scm
+++ b/TeXmacs/progs/convert/tools/environment-test.scm
@@ -15,49 +15,40 @@
   (:use (convert tools environment))
 ) ;texmacs-module
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Dynamic environments
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-environment-base)
-  (define (error-or-value thunk)
-    (catch 'texmacs-error thunk (lambda (key msg . args) key))
-  ) ;define
-  (regression-test-group "environment basic tools"
-    "env-base"
-    :none
-    :none
-    (test "simple"
-      (let ((env (environment)))
-        (with-environment env
-         ((foo "bar") (spam (string-append "eg" "gs")))
-         (list (environment-ref env foo) (environment-ref env spam))
-        ) ;with-environment
-      ) ;let
-      '("bar" "eggs")
-    ) ;test
-    (test "nested"
-      (let ((env (environment)) (out '()))
-        (with-environment env
-         ((foo "bar"))
-         (set-rcons! out (environment-ref env foo))
-         (with-environment env ((foo "baz")) (set-rcons! out (environment-ref env foo)))
-         (set-rcons! out (environment-ref env foo))
-        ) ;with-environment
-        out
-      ) ;let
-      '("bar" "baz" "bar")
-    ) ;test
-  ) ;regression-test-group
+(define (test-environment-base)
+  (check (let ((env (environment)))
+           (with-environment env
+            ((foo "bar") (spam (string-append "eg" "gs")))
+            (list (environment-ref env foo) (environment-ref env spam))
+           ) ;with-environment
+         ) ;let
+    =>
+    '("bar" "eggs")
+  ) ;check
+  (check (let ((env (environment)) (out '()))
+           (with-environment env
+            ((foo "bar"))
+            (set-rcons! out (environment-ref env foo))
+            (with-environment env ((foo "baz")) (set-rcons! out (environment-ref env foo)))
+            (set-rcons! out (environment-ref env foo))
+           ) ;with-environment
+           out
+         ) ;let
+    =>
+    '("bar" "baz" "bar")
+  ) ;check
 ) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Test suite
+;; Test entry point
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (regtest-environment)
-  (let ((n (+ (regtest-environment-base))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of environment: ok\n")
-  ) ;let
-) ;tm-define
+(tm-define (regtest-environment) (test-environment-base) (check-report))

--- a/TeXmacs/progs/convert/tools/tmlength-test.scm
+++ b/TeXmacs/progs/convert/tools/tmlength-test.scm
@@ -13,44 +13,45 @@
 
 (texmacs-module (convert tools tmlength-test) (:use (convert tools tmlength)))
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Regtest routines for tmlength
+;; Tests for string->tmlength
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-string->tmlength)
+(define (test-string->tmlength)
   (define (list->tmlength l)
     (apply tmlength l)
   ) ;define
-  (regression-test-group "tmlength tools"
-    "tmlength"
-    string->tmlength
-    list->tmlength
-    (test "null length" "" '())
-    (test "zero length" "0cm" '(0 cm))
-    (test "implicit zero" "px" '(0 px))
-    (test "decimal length" "123.456mm" '(123.456 mm))
-    (test "negative length" "-1in" '(-1 in))
-    (test "negative^2 length" "--2fns" '(2 fns))
-  ) ;regression-test-group
+  (check (string->tmlength "") => (list->tmlength '()))
+  (check (string->tmlength "0cm") => (list->tmlength '(0 cm)))
+  (check (string->tmlength "px") => (list->tmlength '(0 px)))
+  (check (string->tmlength "123.456mm") => (list->tmlength '(123.456 mm)))
+  (check (string->tmlength "-1in") => (list->tmlength '(-1 in)))
+  (check (string->tmlength "--2fns") => (list->tmlength '(2 fns)))
 ) ;define
 
-(define (regtest-length-decode)
-  (regression-test-group "length in string"
-    "tmpt in number"
-    length-decode
-    :none
-    (test "inch" "1in" 153600)
-    (test "tmpt" "1tmpt" 1)
-    (test "cm" "1cm" 60472)
-    (test "mm" "1mm" 6047)
-    (test "pt: 1/72.27 of an inch" "1pt" 2125)
-    (test "bp: 1/72 of an inch" "1bp" 2133)
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for length-decode
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-length-decode)
+  (check (length-decode "1in") => 153600)
+  (check (length-decode "1tmpt") => 1)
+  (check (length-decode "1cm") => 60472)
+  (check (length-decode "1mm") => 6047)
+  (check (length-decode "1pt") => 2125)
+  (check (length-decode "1bp") => 2133)
 ) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-tmlength)
-  (let ((n (+ (regtest-string->tmlength) (regtest-length-decode))))
-    (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of tmlength: ok\n")
-  ) ;let
+  (test-string->tmlength)
+  (test-length-decode)
+  (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/dynamic/session-edit-test.scm
+++ b/TeXmacs/progs/dynamic/session-edit-test.scm
@@ -8,127 +8,106 @@
 
 (import (liii check))
 
+(check-set-mode! 'report-failed)
+
 (load "./TeXmacs/progs/dynamic/session-edit.scm")
 
-;; regtest-tree-contains-label?
+;; test-tree-contains-label
 ;; 测试 tree-contains-label? 的递归查找能力
 
-(define (regtest-tree-contains-label)
-  (regression-test-group "test tree-contains-label?"
-    "tree-contains-label"
-    :none
-    :none
-    (test "find label in direct child"
-      (tree-contains-label? (stree->tree '(document (reasoning-delta "hello")))
-        'reasoning-delta
-      ) ;tree-contains-label?
-      #t
-    ) ;test
-    (test "not find label"
-      (tree-contains-label? (stree->tree '(document (text "hello"))) 'reasoning-delta)
-      #f
-    ) ;test
-    (test "find label in nested concat"
-      (tree-contains-label? (stree->tree '(document (concat (reasoning-delta "nested"))))
-        'reasoning-delta
-      ) ;tree-contains-label?
-      #t
-    ) ;test
-    (test "find fold-explain-reasoning label"
-      (tree-contains-label? (stree->tree '(document (fold-explain-reasoning)))
-        'fold-explain-reasoning
-      ) ;tree-contains-label?
-      #t
-    ) ;test
-  ) ;regression-test-group
+(define (test-tree-contains-label)
+  (check (tree-contains-label? (stree->tree '(document (reasoning-delta "hello")))
+           'reasoning-delta
+         ) ;tree-contains-label?
+    =>
+    #t
+  ) ;check
+  (check (tree-contains-label? (stree->tree '(document (text "hello"))) 'reasoning-delta)
+    =>
+    #f
+  ) ;check
+  (check (tree-contains-label? (stree->tree '(document (concat (reasoning-delta "nested"))))
+           'reasoning-delta
+         ) ;tree-contains-label?
+    =>
+    #t
+  ) ;check
+  (check (tree-contains-label? (stree->tree '(document (fold-explain-reasoning)))
+           'fold-explain-reasoning
+         ) ;tree-contains-label?
+    =>
+    #t
+  ) ;check
 ) ;define
 
-;; regtest-tree-extract-reasoning-delta
+;; test-tree-extract-reasoning-delta
 ;; 测试 tree-extract-reasoning-delta! 提取文本并清除节点
 
-(define (regtest-tree-extract-reasoning-delta)
-  (regression-test-group "test tree-extract-reasoning-delta!"
-    "tree-extract-reasoning-delta"
-    :none
-    :none
-    (test "extract single reasoning-delta"
-      (let ((t (stree->tree '(document (reasoning-delta "hello") (text "world")))))
-        (list (tree-extract-reasoning-delta! t) (tree->stree t))
-      ) ;let
-      '("hello" (document (text "world")))
-    ) ;test
-    (test "extract empty reasoning-delta"
-      (let ((t (stree->tree '(document (reasoning-delta) (text "x")))))
-        (list (tree-extract-reasoning-delta! t) (tree->stree t))
-      ) ;let
-      '("" (document (text "x")))
-    ) ;test
-  ) ;regression-test-group
+(define (test-tree-extract-reasoning-delta)
+  (check (let ((t (stree->tree '(document (reasoning-delta "hello")
+                                  (text "world")))))
+           (list (tree-extract-reasoning-delta! t) (tree->stree t))
+         ) ;let
+    =>
+    '("hello" (document (text "world")))
+  ) ;check
+  (check (let ((t (stree->tree '(document (reasoning-delta) (text "x")))))
+           (list (tree-extract-reasoning-delta! t) (tree->stree t))
+         ) ;let
+    =>
+    '("" (document (text "x")))
+  ) ;check
 ) ;define
 
-;; regtest-tree-remove-label
+;; test-tree-remove-label
 ;; 测试 tree-remove-label-from-children! 移除指定 label
 
-(define (regtest-tree-remove-label)
-  (regression-test-group "test tree-remove-label-from-children!"
-    "tree-remove-label"
-    :none
-    :none
-    (test "remove direct child"
-      (let ((t (stree->tree '(document (reasoning-delta "a") (text "b")))))
-        (tree-remove-label-from-children! t 'reasoning-delta)
-        (tree->stree t)
-      ) ;let
-      '(document (text "b"))
-    ) ;test
-    (test "remove from concat"
-      (let ((t (stree->tree '(document (concat (reasoning-delta "a") (text "b"))))))
-        (tree-remove-label-from-children! t 'reasoning-delta)
-        (tree->stree t)
-      ) ;let
-      '(document (concat (text "b")))
-    ) ;test
-  ) ;regression-test-group
+(define (test-tree-remove-label)
+  (check (let ((t (stree->tree '(document (reasoning-delta "a") (text "b")))))
+           (tree-remove-label-from-children! t 'reasoning-delta)
+           (tree->stree t)
+         ) ;let
+    =>
+    '(document (text "b"))
+  ) ;check
+  (check (let ((t (stree->tree '(document (concat (reasoning-delta "a")
+                                            (text "b"))))))
+           (tree-remove-label-from-children! t 'reasoning-delta)
+           (tree->stree t)
+         ) ;let
+    =>
+    '(document (concat (text "b")))
+  ) ;check
 ) ;define
 
-;; regtest-session-find-last-unfolded-explain
+;; test-session-find-last-unfolded-explain
 ;; 测试 session-find-last-unfolded-explain 向前搜索
 
-(define (regtest-session-find-last-unfolded-explain)
-  (regression-test-group "test session-find-last-unfolded-explain"
-    "session-find-last-unfolded-explain"
-    :none
-    :none
-    (test "find direct child"
-      (tree->stree (session-find-last-unfolded-explain (stree->tree '(document (unfolded-explain (document "a"))))
-                     1
-                   ) ;session-find-last-unfolded-explain
-      ) ;tree->stree
-      '(unfolded-explain (document "a"))
-    ) ;test
-    (test "find in concat"
-      (tree->stree (session-find-last-unfolded-explain (stree->tree '(document (concat (unfolded-explain (document "b")))))
-                     1
-                   ) ;session-find-last-unfolded-explain
-      ) ;tree->stree
-      '(unfolded-explain (document "b"))
-    ) ;test
-    (test "not found"
-      (session-find-last-unfolded-explain (stree->tree '(document (text "x"))) 1)
-      #f
-    ) ;test
-  ) ;regression-test-group
+(define (test-session-find-last-unfolded-explain)
+  (check (tree->stree (session-find-last-unfolded-explain (stree->tree '(document (unfolded-explain (document "a"))))
+                        1
+                      ) ;session-find-last-unfolded-explain
+         ) ;tree->stree
+    =>
+    '(unfolded-explain (document "a"))
+  ) ;check
+  (check (tree->stree (session-find-last-unfolded-explain (stree->tree '(document (concat (unfolded-explain (document "b")))))
+                        1
+                      ) ;session-find-last-unfolded-explain
+         ) ;tree->stree
+    =>
+    '(unfolded-explain (document "b"))
+  ) ;check
+  (check (session-find-last-unfolded-explain (stree->tree '(document (text "x"))) 1)
+    =>
+    #f
+  ) ;check
 ) ;define
 
 (tm-define (regtest-session-edit)
-  (let ((n (+ (regtest-tree-contains-label)
-             (regtest-tree-extract-reasoning-delta)
-             (regtest-tree-remove-label)
-             (regtest-session-find-last-unfolded-explain)
-           ) ;+
-        ) ;n
-       ) ;
-    (display* "Total: " (object->string n) " tests.\n")
-    n
-  ) ;let
+  (test-tree-contains-label)
+  (test-tree-extract-reasoning-delta)
+  (test-tree-remove-label)
+  (test-session-find-last-unfolded-explain)
+  (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/generic/generic-test.scm
+++ b/TeXmacs/progs/generic/generic-test.scm
@@ -14,28 +14,26 @@
   (:use (generic generic-menu) (table table-menu))
 ) ;texmacs-module
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; generic menu functions
+;; Tests for focus-tag-name
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-focus-tag-name)
-  (regression-test-group "focus-tag-name"
-    "string"
-    focus-tag-name
-    :none
-    (test "bmatrix" 'bmatrix "bmatrix")
-    (test "Bmatrix" 'Bmatrix "Bmatrix")
-    (test "tabular" 'tabular "tabular")
-    (test "tabular*" 'tabular* "centered tabular")
-    (test "block" 'block "block")
-    (test "block*" 'block* "centered block")
-    (test "big-table" 'big-table "big table")
-  ) ;regression-test-group
+(define (test-focus-tag-name)
+  (check (focus-tag-name 'bmatrix) => "bmatrix")
+  (check (focus-tag-name 'Bmatrix) => "Bmatrix")
+  (check (focus-tag-name 'tabular) => "tabular")
+  (check (focus-tag-name 'tabular*) => "centered tabular")
+  (check (focus-tag-name 'block) => "block")
+  (check (focus-tag-name 'block*) => "centered block")
+  (check (focus-tag-name 'big-table) => "big table")
 ) ;define
 
-(tm-define (regtest-generic)
-  (let ((n (+ (regtest-focus-tag-name))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of generic: ok\n")
-  ) ;let
-) ;tm-define
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-generic) (test-focus-tag-name) (check-report))

--- a/TeXmacs/progs/graphics/graphics-group-test.scm
+++ b/TeXmacs/progs/graphics/graphics-group-test.scm
@@ -10,51 +10,71 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (graphics graphics-group-test)
-  (:use (graphics graphics-group)))
+(texmacs-module (graphics graphics-group-test) (:use (graphics graphics-group)))
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Regtest routines for get-paste-offset-by-pos
+;; Tests for get-paste-offset-by-pos
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-get-paste-offset-by-pos)
+(define (test-get-paste-offset-by-pos)
   (let* ((paste-offset-constant-property (get-preference "paste-offset-constant"))
-         (paste-offset-constant 
-           (if (== paste-offset-constant-property "default")
-             0.3
-             (string->float paste-offset-constant-property))))
-    (regression-test-group
-    "graphics group" "get-paste-offset-by-pos"
-    values values
-    (test "Left Up" 
-      (get-paste-offset-by-pos '(carc (point "-1" "1") (point "-2" "2") (point "-3" "3")))
-      (list (+ paste-offset-constant) (- paste-offset-constant)))
-    (test "Left Down" 
-      (get-paste-offset-by-pos '(carc (point "-1" "-1") (point "-2" "-2") (point "-3" "-3")))
-      (list (+ paste-offset-constant) (+ paste-offset-constant)))
-    (test "Right Up" 
-      (get-paste-offset-by-pos '(carc (point "1" "1") (point "2" "2") (point "3" "3")))
-      (list (- paste-offset-constant) (- paste-offset-constant)))
-    (test "Right Down" 
-      (get-paste-offset-by-pos '(carc (point "1" "-1") (point "2" "-2") (point "3" "-3")))
-      (list (- paste-offset-constant) (+ paste-offset-constant)))
-    (test "Coordinate Origin" 
-      (get-paste-offset-by-pos '(carc (point "-2" "0") (point "-1" "2") (point "3" "-2")))
-      (list (- paste-offset-constant) (- paste-offset-constant)))   
-    (test "X-axis positive semi-axis" 
-      (get-paste-offset-by-pos '(point "1" "0"))
-      (list (- paste-offset-constant) (- paste-offset-constant))) 
-    (test "Y-axis positive semi-axis" 
-      (get-paste-offset-by-pos '(point "0" "1"))
-      (list (- paste-offset-constant) (- paste-offset-constant))) 
-    (test "X-axis negative semi-axis" 
-      (get-paste-offset-by-pos '(point "-1" "0"))
-      (list (+ paste-offset-constant) (- paste-offset-constant))) 
-    (test "Y-axis negative semi-axis" 
-      (get-paste-offset-by-pos '(point "0" "-1"))
-      (list (- paste-offset-constant) (+ paste-offset-constant))))))
+         (c (if (== paste-offset-constant-property "default")
+              0.3
+              (string->float paste-offset-constant-property)
+            ) ;if
+         ) ;c
+        ) ;
+    (check (get-paste-offset-by-pos '(carc (point "-1" "1")
+                                       (point "-2" "2")
+                                       (point "-3" "3"))
+           ) ;get-paste-offset-by-pos
+      =>
+      (list (+ c) (- c))
+    ) ;check
+    (check (get-paste-offset-by-pos '(carc (point "-1" "-1")
+                                       (point "-2" "-2")
+                                       (point "-3" "-3"))
+           ) ;get-paste-offset-by-pos
+      =>
+      (list (+ c) (+ c))
+    ) ;check
+    (check (get-paste-offset-by-pos '(carc (point "1" "1")
+                                       (point "2" "2")
+                                       (point "3" "3"))
+           ) ;get-paste-offset-by-pos
+      =>
+      (list (- c) (- c))
+    ) ;check
+    (check (get-paste-offset-by-pos '(carc (point "1" "-1")
+                                       (point "2" "-2")
+                                       (point "3" "-3"))
+           ) ;get-paste-offset-by-pos
+      =>
+      (list (- c) (+ c))
+    ) ;check
+    (check (get-paste-offset-by-pos '(carc (point "-2" "0")
+                                       (point "-1" "2")
+                                       (point "3" "-2"))
+           ) ;get-paste-offset-by-pos
+      =>
+      (list (- c) (- c))
+    ) ;check
+    (check (get-paste-offset-by-pos '(point "1" "0")) => (list (- c) (- c)))
+    (check (get-paste-offset-by-pos '(point "0" "1")) => (list (- c) (- c)))
+    (check (get-paste-offset-by-pos '(point "-1" "0")) => (list (+ c) (- c)))
+    (check (get-paste-offset-by-pos '(point "0" "-1")) => (list (- c) (+ c)))
+  ) ;let*
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-graphics-group)
-  (let ((n (regtest-get-paste-offset-by-pos)))
-    (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-graphics-group: ok\n")))
+  (test-get-paste-offset-by-pos)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/menu-test.scm
+++ b/TeXmacs/progs/kernel/gui/menu-test.scm
@@ -15,6 +15,10 @@
 
 (texmacs-module (kernel gui menu-test) (:use (kernel gui menu-widget)))
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Some test widgets
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -298,33 +302,23 @@
 ;; Regtest routines for menu widgets
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-menu-widgets)
+(define (test-menu-widgets)
   ;; Basic test to ensure menu module loads without errors
-  (regression-test-group "menu"
-    "widgets"
-    values
-    values
-    (test "module loaded successfully" #t #t)
-    (test "tm-widget macro available" (defined? 'tm-widget) #t)
-    (test "show function available" (defined? 'show) #t)
-    (test "show-form function available" (defined? 'show-form) #t)
-    (test "tm-define macro available" (defined? 'tm-define) #t)
-    (test "menu-bind macro available" (defined? 'menu-bind) #t)
-    (test "display* function available" (defined? 'display*) #t)
-    (test "noop function available" (defined? 'noop) #t)
-    (test "refresh-now function available" (defined? 'refresh-now) #t)
-    (test "stree->tree function available" (defined? 'stree->tree) #t)
-    (test "buffer-tree function available" (defined? 'buffer-tree) #t)
-    (test "widget-hmenu function available" (defined? 'widget-hmenu) #t)
-    (test "widget-text function available" (defined? 'widget-text) #t)
-    (test "widget-vlist function available" (defined? 'widget-vlist) #t)
-    (test "widget-hlist function available" (defined? 'widget-hlist) #t)
-  ) ;regression-test-group
+  (check #t => #t)
+  (check (defined? 'tm-widget) => #t)
+  (check (defined? 'show) => #t)
+  (check (defined? 'show-form) => #t)
+  (check (defined? 'tm-define) => #t)
+  (check (defined? 'menu-bind) => #t)
+  (check (defined? 'display*) => #t)
+  (check (defined? 'noop) => #t)
+  (check (defined? 'refresh-now) => #t)
+  (check (defined? 'stree->tree) => #t)
+  (check (defined? 'buffer-tree) => #t)
+  (check (defined? 'widget-hmenu) => #t)
+  (check (defined? 'widget-text) => #t)
+  (check (defined? 'widget-vlist) => #t)
+  (check (defined? 'widget-hlist) => #t)
 ) ;define
 
-(tm-define (regtest-menu)
-  (let ((n (regtest-menu-widgets)))
-    (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-menu: ok\n")
-  ) ;let
-) ;tm-define
+(tm-define (regtest-menu) (test-menu-widgets) (check-report))

--- a/TeXmacs/progs/kernel/old-gui/old-gui-test.scm
+++ b/TeXmacs/progs/kernel/old-gui/old-gui-test.scm
@@ -13,6 +13,10 @@
 
 (texmacs-module (kernel old-gui old-gui-test))
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 (tm-define (open-test-widget)
   ;; NOTE: close with Done in order to test other widgets
   (widget-popup "Test" '(widget-4))
@@ -258,32 +262,22 @@
 ;; Regtest routines for old-gui widgets
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-old-gui-widgets)
+(define (test-old-gui-widgets)
   ;; Basic test to ensure old-gui module loads without errors
-  (regression-test-group "old-gui"
-    "widgets"
-    values
-    values
-    (test "module loaded successfully" #t #t)
-    (test "tm-build-widget macro available" (defined? 'tm-build-widget) #t)
-    (test "widget-popup function available" (defined? 'widget-popup) #t)
-    (test "widget-ref function available" (defined? 'widget-ref) #t)
-    (test "widget-set! function available" (defined? 'widget-set!) #t)
-    (test "widget-delayed function available" (defined? 'widget-delayed) #t)
-    (test "widget->script function available" (defined? 'widget->script) #t)
-    (test "script->widget function available" (defined? 'script->widget) #t)
-    (test "display* function available" (defined? 'display*) #t)
-    (test "noop function available" (defined? 'noop) #t)
-    (test "tree->string function available" (defined? 'tree->string) #t)
-    (test "string-append function available" (defined? 'string-append) #t)
-    (test "list function available" (defined? 'list) #t)
-    (test "concat function available" (defined? 'concat) #t)
-  ) ;regression-test-group
+  (check #t => #t)
+  (check (defined? 'tm-build-widget) => #t)
+  (check (defined? 'widget-popup) => #t)
+  (check (defined? 'widget-ref) => #t)
+  (check (defined? 'widget-set!) => #t)
+  (check (defined? 'widget-delayed) => #t)
+  (check (defined? 'widget->script) => #t)
+  (check (defined? 'script->widget) => #t)
+  (check (defined? 'display*) => #t)
+  (check (defined? 'noop) => #t)
+  (check (defined? 'tree->string) => #t)
+  (check (defined? 'string-append) => #t)
+  (check (defined? 'list) => #t)
+  (check (defined? 'concat) => #t)
 ) ;define
 
-(tm-define (regtest-old-gui)
-  (let ((n (regtest-old-gui-widgets)))
-    (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-old-gui: ok\n")
-  ) ;let
-) ;tm-define
+(tm-define (regtest-old-gui) (test-old-gui-widgets) (check-report))

--- a/TeXmacs/progs/kernel/regexp/regexp-test.scm
+++ b/TeXmacs/progs/kernel/regexp/regexp-test.scm
@@ -15,6 +15,10 @@
 
 (texmacs-module (kernel regexp regexp-test) (:use (kernel regexp regexp-match)))
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Example of a grammar for regular expressions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -27,39 +31,27 @@
 ;; Regtest routines for regexp
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (regtest-regexp-match)
+(define (test-regexp-match)
   ;; Basic test to ensure regexp module loads without errors
-  (regression-test-group "regexp"
-    "match"
-    values
-    values
-    (test "module loaded successfully" #t #t)
-    (test "match? function available" (defined? 'match?) #t)
-    (test "define-regexp-grammar macro available"
-      (defined? 'define-regexp-grammar)
-      #t
-    ) ;test
-    (test "match function available" (defined? 'match) #t)
-    (test "match-term table available" (defined? 'match-term) #t)
-    (test "bindings-add function available" (defined? 'bindings-add) #t)
-    (test "define-regexp-grammar-decls function available"
-      (defined? 'define-regexp-grammar-decls)
-      #t
-    ) ;test
-    (test "display* function available" (defined? 'display*) #t)
-    (test "cons function available" (defined? 'cons) #t)
-    (test "list function available" (defined? 'list) #t)
-    (test "append function available" (defined? 'append) #t)
-    (test "for-each function available" (defined? 'for-each) #t)
-    (test "ahash-set! function available" (defined? 'ahash-set!) #t)
-    (test "ahash-ref function available" (defined? 'ahash-ref) #t)
-    (test "make-ahash-table function available" (defined? 'make-ahash-table) #t)
-  ) ;regression-test-group
+  (check #t => #t)
+  (check (defined? 'match?) => #t)
+  (check (defined? 'define-regexp-grammar) => #t)
+  (check (defined? 'match) => #t)
+  (check (defined? 'match-term) => #t)
+  (check (defined? 'bindings-add) => #t)
+  (check (defined? 'define-regexp-grammar-decls) => #t)
+  (check (defined? 'display*) => #t)
+  (check (defined? 'cons) => #t)
+  (check (defined? 'list) => #t)
+  (check (defined? 'append) => #t)
+  (check (defined? 'for-each) => #t)
+  (check (defined? 'ahash-set!) => #t)
+  (check (defined? 'ahash-ref) => #t)
+  (check (defined? 'make-ahash-table) => #t)
 ) ;define
 
-(tm-define (regtest-regexp)
-  (let ((n (regtest-regexp-match)))
-    (display* "Total: " (number->string n) " tests.\n")
-    (display "Test suite of regtest-regexp: ok\n")
-  ) ;let
-) ;tm-define
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-regexp) (test-regexp-match) (check-report))

--- a/TeXmacs/progs/language/minimal-test.scm
+++ b/TeXmacs/progs/language/minimal-test.scm
@@ -12,6 +12,10 @@
 
 (texmacs-module (language minimal-test) (:use (language minimal)))
 
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 (define (test-symbol symbol)
   (lambda (input)
     (let* ((tree (car input))
@@ -28,124 +32,108 @@
   ) ;lambda
 ) ;define
 
-(define (regtest-while)
-  (regression-test-group "while(*) operator of packrat"
-    "operators-packrat-while"
-    (test-symbol "Spc")
-    :none
-    (test "no space" '("" (0)) '((0) #t ()))
-    (test "one space, cursor before" '(" " (0)) '((1) #t ()))
-    (test "one space, cursor after" '(" " (1)) '((1) #t ()))
-    (test "one space as tree subnode, cursor after"
-      '((concat " ") (1))
-      '((0 1) #t ())
-    ) ;test
-    (test "multiple space, cursor in" '("     " (2)) '((5) #t ((Spc (0) (5)))))
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for while(*) operator of packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-while)
+  (define f (test-symbol "Spc"))
+  (check (f '("" (0))) => '((0) #t ()))
+  (check (f '(" " (0))) => '((1) #t ()))
+  (check (f '(" " (1))) => '((1) #t ()))
+  (check (f '((concat " ") (1))) => '((0 1) #t ()))
+  (check (f '("     " (2))) => '((5) #t ((Spc (0) (5)))))
 ) ;define
 
-(define (regtest-repeat)
-  (regression-test-group "repeat(+) operator of packrat"
-    "operators-packrat-repeat"
-    (test-symbol "Space")
-    :none
-    (test "no space" '("" (0)) '(rejected #f ()))
-    (test "one space" '(" " (0)) '((1) #t ()))
-    (test "multiple space" '("     " (1)) '((5) #t ((Space (0) (5)))))
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for repeat(+) operator of packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-repeat)
+  (define f (test-symbol "Space"))
+  (check (f '("" (0))) => '(rejected #f ()))
+  (check (f '(" " (0))) => '((1) #t ()))
+  (check (f '("     " (1))) => '((5) #t ((Space (0) (5)))))
 ) ;define
 
-(define (regtest-sequential)
-  (regression-test-group "sequential of operators in packrat"
-    "operators-packrat-sequential"
-    (test-symbol "End")
-    :none
-    (test "no space" '(";" (0)) '((1) #t ()))
-    (test "one space, cursor after space" '(" ;" (1)) '((2) #t ((End (0) (2)))))
-    (test "multiple space, cursor inside space"
-      '("     ;" (1))
-      '((6) #t ((Spc (0) (5)) (End (0) (6))))
-    ) ;test
-    (test "not end" '("     a" (0)) '(rejected #f ()))
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for sequential of operators in packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-sequential)
+  (define f (test-symbol "End"))
+  (check (f '(";" (0))) => '((1) #t ()))
+  (check (f '(" ;" (1))) => '((2) #t ((End (0) (2)))))
+  (check (f '("     ;" (1))) => '((6) #t ((Spc (0) (5)) (End (0) (6)))))
+  (check (f '("     a" (0))) => '(rejected #f ()))
 ) ;define
 
-(define (regtest-combination)
-  (regression-test-group "prefix operator of packrat"
-    "operators-packrat-prefix"
-    (test-symbol "If-prefix")
-    :none
-    (test "no space" '("if" (0)) '(rejected #f ()))
-    (test "one space, cursor before" '("if " (0)) '((3) #t ()))
-    (test "one space, cursor on if" '("if " (1)) '((3) #t ((If-prefix (0) (3)))))
-    (test "multiple space, cursor on space"
-      '("if     " (5))
-      '((7) #t ((Space (2) (7)) (If-prefix (0) (7))))
-    ) ;test
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for prefix operator of packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-combination)
+  (define f (test-symbol "If-prefix"))
+  (check (f '("if" (0))) => '(rejected #f ()))
+  (check (f '("if " (0))) => '((3) #t ()))
+  (check (f '("if " (1))) => '((3) #t ((If-prefix (0) (3)))))
+  (check (f '("if     " (5))) => '((7) #t ((Space (2) (7)) (If-prefix (0) (7)))))
 ) ;define
 
-(define (regtest-or)
-  (regression-test-group "or(or) operator of packrat"
-    "operators-packrat-or"
-    (test-symbol "Relation-infix")
-    :none
-    (test "no space" '("!=" (0)) '((2) #t ()))
-    (test "one space, cursor before" '(" != " (0)) '((4) #t ()))
-    (test "one space, cursor before" '(" = " (0)) '((3) #t ()))
-    (test "one space, cursor before" '(" <less> " (0)) '((8) #t ()))
-    (test "one space as tree surround, cursor before"
-      '((surround " " " " "<less>") (0))
-      '((1 1) #t ())
-    ) ;test
-    (test "one space, cursor after"
-      '(" != " (3))
-      '((4) #t ((Relation-infix (0) (4))))
-    ) ;test
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for or(or) operator of packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-or)
+  (define f (test-symbol "Relation-infix"))
+  (check (f '("!=" (0))) => '((2) #t ()))
+  (check (f '(" != " (0))) => '((4) #t ()))
+  (check (f '(" = " (0))) => '((3) #t ()))
+  (check (f '(" <less> " (0))) => '((8) #t ()))
+  (check (f '((surround " " " " "<less>") (0))) => '((1 1) #t ()))
+  (check (f '(" != " (3))) => '((4) #t ((Relation-infix (0) (4)))))
 ) ;define
 
-(define (regtest-except)
-  (regression-test-group "except(except) operator of packrat"
-    "operators-packrat-except"
-    (test-symbol "Error-curly")
-    :none
-    (test "any char" '("char" (1)) '((4) #t ((Error-curly (0) (4)))))
-    (test "matched curly" '("{{char}}" (0)) '((8) #t ()))
-    (test "matched curly, cursor inside"
-      '("{{char}}" (3))
-      '((8)
-        #t
-        ((Error-curly (2) (6)) (Error-curly (1) (7)) (Error-curly (0) (8))))
-    ) ;test
-    (test "unmatched curly 1" '("{{char}}}" (0)) '(rejected #f ()))
-    (test "unmatched curly 2" '("{{char}" (0)) '(rejected #f ()))
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for except(except) operator of packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-except)
+  (define f (test-symbol "Error-curly"))
+  (check (f '("char" (1))) => '((4) #t ((Error-curly (0) (4)))))
+  (check (f '("{{char}}" (0))) => '((8) #t ()))
+  (check (f '("{{char}}" (3)))
+    =>
+    '((8)
+      #t
+      ((Error-curly (2) (6)) (Error-curly (1) (7)) (Error-curly (0) (8))))
+  ) ;check
+  (check (f '("{{char}}}" (0))) => '(rejected #f ()))
+  (check (f '("{{char}" (0))) => '(rejected #f ()))
 ) ;define
 
-(define (regtest-range)
-  (regression-test-group "range(-) operator of packrat"
-    "operators-packrat-range"
-    (test-symbol "Identifier")
-    :none
-    (test "lower case" '("char" (1)) '((4) #t ((Identifier (0) (4)))))
-    (test "mixed case" '("cHaR" (1)) '((4) #t ((Identifier (0) (4)))))
-    (test "non alphabet" '("cH?aR" (1)) '(rejected #f ()))
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for range(-) operator of packrat
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-range)
+  (define f (test-symbol "Identifier"))
+  (check (f '("char" (1))) => '((4) #t ((Identifier (0) (4)))))
+  (check (f '("cHaR" (1))) => '((4) #t ((Identifier (0) (4)))))
+  (check (f '("cH?aR" (1))) => '(rejected #f ()))
 ) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-minimal)
-  (let ((n (+ (regtest-while)
-             (regtest-repeat)
-             (regtest-sequential)
-             (regtest-combination)
-             (regtest-or)
-             (regtest-except)
-             (regtest-range)
-           ) ;+
-        ) ;n
-       ) ;
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of packrat: ok\n")
-  ) ;let
+  (test-while)
+  (test-repeat)
+  (test-sequential)
+  (test-combination)
+  (test-or)
+  (test-except)
+  (test-range)
+  (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/lolly/data-test.scm
+++ b/TeXmacs/progs/lolly/data-test.scm
@@ -13,73 +13,66 @@
 
 (texmacs-module (lolly data-test))
 
-(define (regtest-int-to-hex)
-  (regression-test-group "int"
-    "hex"
-    integer->hexadecimal
-    :none
-    (test "integer->hexadecimal 1" 1 "1")
-    (test "integer->hexadecimal 10" 10 "A")
-    (test "integer->hexadecimal 255" 255 "FF")
-  ) ;regression-test-group
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for integer->hexadecimal / padded variant
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-int-to-hex)
+  (check (integer->hexadecimal 1) => "1")
+  (check (integer->hexadecimal 10) => "A")
+  (check (integer->hexadecimal 255) => "FF")
 ) ;define
 
-(define (regtest-int-to-padded-hex)
-  (regression-test-group "int"
-    "padded-hex"
-    (lambda (args) (apply integer->padded-hexadecimal args))
-    :none
-    (test "integer->padded-hexadecimal 1 4" '(1 4) "0001")
-    (test "integer->padded-hexadecimal 10 4" '(10 4) "000A")
-    (test "integer->padded-hexadecimal 100 4" '(100 4) "0064")
-    (test-fails "integer->padded-hexadecimal 255 4" '(255 4) "AA")
-  ) ;regression-test-group
+(define (test-int-to-padded-hex)
+  (define (f . args)
+    (apply integer->padded-hexadecimal args)
+  ) ;define
+  (check (f 1 4) => "0001")
+  (check (f 10 4) => "000A")
+  (check (f 100 4) => "0064")
+  (check (not (== (f 255 4) "AA")) => #t)
 ) ;define
 
-(define (regtest-hex-to-int)
-  (regression-test-group "hex"
-    "int"
-    hexadecimal->integer
-    :none
-    (test "hexadecimal->integer 1" "1" 1)
-    (test "hexadecimal->integer 0x05" "0x05" 5)
-    (test "hexadecimal->integer 00F6" "00F6" 246)
-    (test-fails "hexadecimal->integer 255" "255" "597")
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for hexadecimal->integer
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-hex-to-int)
+  (check (hexadecimal->integer "1") => 1)
+  (check (hexadecimal->integer "0x05") => 5)
+  (check (hexadecimal->integer "00F6") => 246)
+  (check (not (== (hexadecimal->integer "255") "597")) => #t)
 ) ;define
 
-(define (regtest-encode-base64)
-  (regression-test-group "encode-base64"
-    "encode"
-    encode-base64
-    :none
-    (test "encode-base64 abc" "abc" "YWJj")
-    (test "encode-base64 123456" "123456" "MTIzNDU2")
-    (test "encode-base64 what" "what" "d2hhdA==")
-  ) ;regression-test-group
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for base64
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-encode-base64)
+  (check (encode-base64 "abc") => "YWJj")
+  (check (encode-base64 "123456") => "MTIzNDU2")
+  (check (encode-base64 "what") => "d2hhdA==")
 ) ;define
 
-(define (regtest-decode-base64)
-  (regression-test-group "decode-base64"
-    "decode"
-    decode-base64
-    :none
-    (test "decode-base64 YWJj" "YWJj" "abc")
-    (test "decode-base64 MTIzNDU2" "MTIzNDU2" "123456")
-    (test "decode-base64 d2hhdA==" "d2hhdA==" "what")
-  ) ;regression-test-group
+(define (test-decode-base64)
+  (check (decode-base64 "YWJj") => "abc")
+  (check (decode-base64 "MTIzNDU2") => "123456")
+  (check (decode-base64 "d2hhdA==") => "what")
 ) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-data)
-  (let ((n (+ (regtest-int-to-hex)
-             (regtest-int-to-padded-hex)
-             (regtest-hex-to-int)
-             (regtest-encode-base64)
-             (regtest-decode-base64)
-           ) ;+
-        ) ;n
-       ) ;
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of lolly::data: ok\n")
-  ) ;let
+  (test-int-to-hex)
+  (test-int-to-padded-hex)
+  (test-hex-to-int)
+  (test-encode-base64)
+  (test-decode-base64)
+  (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/moebius/cork-test.scm
+++ b/TeXmacs/progs/moebius/cork-test.scm
@@ -33,8 +33,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (test-angle)
-  (check (uint32->utf8 (cork->utf8 "<langle>")) => #x27E8)
-  (check (uint32->utf8 (cork->utf8 "<rangle>")) => #x27E9)
+  (check (cork->utf8 "<langle>") => (uint32->utf8 #x27E8))
+  (check (cork->utf8 "<rangle>") => (uint32->utf8 #x27E9))
   (check (utf8->cork (uint32->utf8 #x27E8)) => "<langle>")
   (check (utf8->cork (uint32->utf8 #x27E9)) => "<rangle>")
 ) ;define

--- a/TeXmacs/progs/moebius/cork-test.scm
+++ b/TeXmacs/progs/moebius/cork-test.scm
@@ -13,42 +13,38 @@
 
 (texmacs-module (lolly cork-test))
 
-(define (regtest-alphanum)
-  (begin
-    (regression-test-group
-      "cork" "utf8"
-      cork->utf8 :none
-      (test "locased alpha" "abcdefghijklmnopgrstuvwxyz" "abcdefghijklmnopgrstuvwxyz")
-      (test "number" "0123456789" "0123456789")
-    )
-    (regression-test-group
-      "utf8" "cork"
-      utf8->cork :none
-      (test "locased alpha" "abcdefghijklmnopgrstuvwxyz" "abcdefghijklmnopgrstuvwxyz")
-      (test "number" "0123456789" "0123456789")
-    )
-  )
-)
+(import (liii check))
 
-(define (regtest-angle)
-  (begin
-    (regression-test-group
-      "cork" "utf8"
-      cork->utf8 uint32->utf8
-      (test "langle" "<langle>" #x27E8)
-      (test "rangle" "<rangle>" #x27E9)
-    )
-    (regression-test-group
-      "utf8" "cork"
-      (lambda (x) (utf8->cork (uint32->utf8 x))) :none
-      (test "langle" #x27E8 "<langle>")
-      (test "rangle" #x27E9 "<rangle>")
-    )
-  )
-)
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for cork<->utf8 on alphanumeric
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-alphanum)
+  (check (cork->utf8 "abcdefghijklmnopgrstuvwxyz") => "abcdefghijklmnopgrstuvwxyz")
+  (check (cork->utf8 "0123456789") => "0123456789")
+  (check (utf8->cork "abcdefghijklmnopgrstuvwxyz") => "abcdefghijklmnopgrstuvwxyz")
+  (check (utf8->cork "0123456789") => "0123456789")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for cork<->utf8 on angle brackets
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-angle)
+  (check (uint32->utf8 (cork->utf8 "<langle>")) => #x27E8)
+  (check (uint32->utf8 (cork->utf8 "<rangle>")) => #x27E9)
+  (check (utf8->cork (uint32->utf8 #x27E8)) => "<langle>")
+  (check (utf8->cork (uint32->utf8 #x27E9)) => "<rangle>")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-cork)
-  (let ((n (+ (regtest-alphanum)
-              (regtest-angle))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of cork encoding ok\n")))
+  (test-alphanum)
+  (test-angle)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/network/url-test.scm
+++ b/TeXmacs/progs/network/url-test.scm
@@ -13,57 +13,53 @@
 
 (texmacs-module (network url-test) (:use (network url)))
 
-(define (regtest-zotero-url)
-  (regression-test-group "url"
-    "(url-or? u)"
-    url-or?
-    :none
-    (test "case 1" "zotero://a/b/c" #f)
-  ) ;regression-test-group
-  (regression-test-group "url"
-    "(url-complete u flags)"
-    (lambda (x)
-      (== (url-complete "zotero://a/b/c" x) (string->url "zotero://a/b/c"))
-    ) ;lambda
-    :none
-    (test "r" "r" #t)
-    (test "df" "df" #t)
-    (test "rf" "rf" #t)
-  ) ;regression-test-group
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for url-or?, url-complete, url-host
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-zotero-url)
+  (check (url-or? "zotero://a/b/c") => #f)
+  (check (== (url-complete "zotero://a/b/c" "r") (string->url "zotero://a/b/c"))
+    =>
+    #t
+  ) ;check
+  (check (== (url-complete "zotero://a/b/c" "df") (string->url "zotero://a/b/c"))
+    =>
+    #t
+  ) ;check
+  (check (== (url-complete "zotero://a/b/c" "rf") (string->url "zotero://a/b/c"))
+    =>
+    #t
+  ) ;check
 ) ;define
 
-(define (regtest-url-host)
-  (regression-test-group "url"
-    "host of the url"
-    url-host
-    :none
-    (test "http 1" "http://mogan.app" "mogan.app")
-    (test "http 2" "http://git.tmml.wiki/XmacsLabs/mogan" "git.tmml.wiki")
-    (test "local file 1" "/tmp" "")
-  ) ;regression-test-group
+(define (test-url-host)
+  (check (url-host "http://mogan.app") => "mogan.app")
+  (check (url-host "http://git.tmml.wiki/XmacsLabs/mogan") => "git.tmml.wiki")
+  (check (url-host "/tmp") => "")
 ) ;define
 
-(define (regtest-drive-letter)
-  (regression-test-group "url"
-    "drive letter of windows path"
-    url-drive-letter
-    :none
-    (test "windows absolute path 1" "C:\\Users\\test" (if (os-win32?) "C" ""))
-    (test "windows absolute path 2"
-      "D:\\program files\\app"
-      (if (os-win32?) "D" "")
-    ) ;test
-    (test "windows absolute path 3" "Z:\\" (if (os-win32?) "Z" ""))
-    (test "network path" "\\\\server\\share" "")
-    (test "linux path" "/home/user" "")
-    (test "relative path" "docs\\file.txt" "")
-    (test "single slash" "/" "")
-  ) ;regression-test-group
+(define (test-drive-letter)
+  (check (url-drive-letter "C:\\Users\\test") => (if (os-win32?) "C" ""))
+  (check (url-drive-letter "D:\\program files\\app") => (if (os-win32?) "D" ""))
+  (check (url-drive-letter "Z:\\") => (if (os-win32?) "Z" ""))
+  (check (url-drive-letter "\\\\server\\share") => "")
+  (check (url-drive-letter "/home/user") => "")
+  (check (url-drive-letter "docs\\file.txt") => "")
+  (check (url-drive-letter "/") => "")
 ) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-url)
-  (let ((n (+ (regtest-url-host) (regtest-zotero-url) (regtest-drive-letter))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of url: ok\n")
-  ) ;let
+  (test-zotero-url)
+  (test-url-host)
+  (test-drive-letter)
+  (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/prog/scheme-tools-test.scm
+++ b/TeXmacs/progs/prog/scheme-tools-test.scm
@@ -13,27 +13,29 @@
 
 (texmacs-module (prog scheme-tools-test) (:use (prog scheme-tools-test)))
 
-(define (regtest-word-at)
-  (define (test-word-at i)
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for word-at
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-word-at)
+  (define (f i)
     (word-at "(sys)" i)
   ) ;define
-  (regression-test-group "index"
-    "word"
-    test-word-at
-    :none
-    (test "index 0" 0 "")
-    (test "index 1" 1 "sys")
-    (test "index 2" 2 "sys")
-    (test "index 3" 3 "sys")
-    (test "index 4" 4 "sys")
-    (test "index 5" 5 "")
-    (test "invalid index" 6 "")
-  ) ;regression-test-group
+  (check (f 0) => "")
+  (check (f 1) => "sys")
+  (check (f 2) => "sys")
+  (check (f 3) => "sys")
+  (check (f 4) => "sys")
+  (check (f 5) => "")
+  (check (f 6) => "")
 ) ;define
 
-(tm-define (regtest-scheme-tools)
-  (let ((n (+ (regtest-word-at))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of scheme-tools: ok\n")
-  ) ;let
-) ;tm-define
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-scheme-tools) (test-word-at) (check-report))

--- a/TeXmacs/tests/11_4.scm
+++ b/TeXmacs/tests/11_4.scm
@@ -12,41 +12,32 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-(texmacs-module (fonts fonts-test)
-  (:use (kernel texmacs tm-define)))
+(texmacs-module (fonts fonts-test) (:use (kernel texmacs tm-define)))
 
-(define (regtest-default-chinese-font)
-  (cond ((os-macos?)
-         (regression-test-group
-          "fun" "result"
-          (default-chinese-font) :none
-          (test "macOS" :none "Singti SC")))
-        ((os-mingw?)
-         (regression-test-group
-          "fun" "result"
-          (default-chinese-font) :none
-          (test "Windows" :none "simsun")))
-        (else
-         (regression-test-group
-          "fun" "result"
-          (default-chinese-font) :none
-          (test "GNU Linux" :none "Noto CJK SC")))))
+(import (liii check))
 
-(define (regtest-family-and-master)
-  (+ (if (font-exists-in-tt? "NotoSerifCJK-Regular")
-      (regression-test-group
-       "font-family" "font-master"
-       font-family->master :none
-       (test "Noto CJK" "Noto Serif CJK SC" "Noto CJK SC"))
-      0)
-     (if (font-exists-in-tt? "Songti")
-      (regression-test-group
-       "font-family" "font-master"
-       font-family->master :none
-       (test "Songti" "Songti SC" "Songti SC"))
-      0)))
+(check-set-mode! 'report-failed)
+
+(define (test-default-chinese-font)
+  (cond ((os-macos?) (check (default-chinese-font) => "Singti SC"))
+        ((os-mingw?) (check (default-chinese-font) => "simsun"))
+        (else (check (default-chinese-font) => "Noto CJK SC"))
+  ) ;cond
+) ;define
+
+(define (test-family-and-master)
+  (if (font-exists-in-tt? "NotoSerifCJK-Regular")
+    (check (font-family->master "Noto Serif CJK SC") => "Noto CJK SC")
+    (check #t => #t)
+  ) ;if
+  (if (font-exists-in-tt? "Songti")
+    (check (font-family->master "Songti SC") => "Songti SC")
+    (check #t => #t)
+  ) ;if
+) ;define
 
 (define (test_11_4)
-  (let ((n (+ (regtest-family-and-master))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of fonts: ok\n")))
+  (test-default-chinese-font)
+  (test-family-and-master)
+  (check-report)
+) ;define

--- a/TeXmacs/tests/12_1.scm
+++ b/TeXmacs/tests/12_1.scm
@@ -10,9 +10,9 @@
 ) ;define
 
 (define (test-get-tag-name)
-  (check (utf8->cork (get-tag-name "$TEXMACS_PATH/tests/bib/12_1.bib"))
+  (check (get-tag-name "$TEXMACS_PATH/tests/bib/12_1.bib")
     =>
-    "数理逻辑2010汪芳庭"
+    (utf8->cork "数理逻辑2010汪芳庭")
   ) ;check
 ) ;define
 

--- a/TeXmacs/tests/12_1.scm
+++ b/TeXmacs/tests/12_1.scm
@@ -1,14 +1,19 @@
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 (define (get-tag-name bib_file)
- (with bib (tree->stree (parse-bib (string-load bib_file)))
-  (bib-car (bib-cdr (bib-cdr (bib-car (bib-cdr bib)))))))
+  (with bib
+    (tree->stree (parse-bib (string-load bib_file)))
+    (bib-car (bib-cdr (bib-cdr (bib-car (bib-cdr bib)))))
+  ) ;with
+) ;define
 
 (define (test-get-tag-name)
-  (regression-test-group
-   "get-tag-name" "tag-name"
-   get-tag-name utf8->cork 
-   (test "get-tag-name" "$TEXMACS_PATH/tests/bib/12_1.bib" "数理逻辑2010汪芳庭")))
+  (check (utf8->cork (get-tag-name "$TEXMACS_PATH/tests/bib/12_1.bib"))
+    =>
+    "数理逻辑2010汪芳庭"
+  ) ;check
+) ;define
 
-(tm-define (test_12_1)
-  (let ((n (+ (test-get-tag-name))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 12_1: ok\n")))
+(tm-define (test_12_1) (test-get-tag-name) (check-report))

--- a/TeXmacs/tests/15_3_1.scm
+++ b/TeXmacs/tests/15_3_1.scm
@@ -1,12 +1,11 @@
-(define (test-cpp-string-number?)
-  (regression-test-group
-   "cpp-string-number?" "bool"
-   cpp-string-number? :none
-   (test "normal floating number" "1.1" #t)
-   (test "integer" "1" #t)
-   (test "empty string" "" #f)))
+(import (liii check))
 
-(tm-define (test_15_3_1)
-  (let ((n (+ (test-cpp-string-number?))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 15_3_1: ok\n")))
+(check-set-mode! 'report-failed)
+
+(define (test-cpp-string-number?)
+  (check (cpp-string-number? "1.1") => #t)
+  (check (cpp-string-number? "1") => #t)
+  (check (cpp-string-number? "") => #f)
+) ;define
+
+(tm-define (test_15_3_1) (test-cpp-string-number?) (check-report))

--- a/TeXmacs/tests/15_3_2.scm
+++ b/TeXmacs/tests/15_3_2.scm
@@ -1,10 +1,9 @@
-(define (test-tree-atomic?)
-  (regression-test-group
-   "tree-atomic?" "bool"
-   tree-atomic? :none
-   (test "The result of string->tree is atomic" (string->tree "a string") #t)))
+(import (liii check))
 
-(tm-define (test_15_3_2)
-  (let ((n (+ (test-tree-atomic?))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 15_3_2: ok\n")))
+(check-set-mode! 'report-failed)
+
+(define (test-tree-atomic?)
+  (check (tree-atomic? (string->tree "a string")) => #t)
+) ;define
+
+(tm-define (test_15_3_2) (test-tree-atomic?) (check-report))

--- a/TeXmacs/tests/15_3_3.scm
+++ b/TeXmacs/tests/15_3_3.scm
@@ -1,27 +1,28 @@
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 (define (test-string-alpha?)
-  (regression-test-group
-     "string-alpha?" "bool"
-     string-alpha? :none
-     (test "string-alpha? of a is true" "a" #t)
-     (test "string-alpha? of b is true" "b" #t)
-     (test "string-alpha? of Z is true" "Z" #t)
-     (test "string-alpha? of ? is false" "?" #f)
-     (test "string-alpha? of empty string is false" "" #f)))
+  (check (string-alpha? "a") => #t)
+  (check (string-alpha? "b") => #t)
+  (check (string-alpha? "Z") => #t)
+  (check (string-alpha? "?") => #f)
+  (check (string-alpha? "") => #f)
+) ;define
 
 (define (test-string-occurs?)
-  (define (test-string-1 x)
-    (string-occurs? x "This is a love letter to S7 scheme."))
-  (regression-test-group
-   "string_occurs case 1" "bool"
-   test-string-1 :none
-   (test "leading word" "This" #t)
-   (test "word in middle" "S7" #t)
-   (test "string contains space" "ve l" #t)
-   (test "should not contain" "notcontain" #f)
-   (test "empty string" "" #t)))
+  (define (f x)
+    (string-occurs? x "This is a love letter to S7 scheme.")
+  ) ;define
+  (check (f "This") => #t)
+  (check (f "S7") => #t)
+  (check (f "ve l") => #t)
+  (check (f "notcontain") => #f)
+  (check (f "") => #t)
+) ;define
 
 (tm-define (test_15_3_3)
-  (let ((n (+ (test-string-alpha?)
-              (test-string-occurs?))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 15_3_3: ok\n")))
+  (test-string-alpha?)
+  (test-string-occurs?)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/tests/15_3_5.scm
+++ b/TeXmacs/tests/15_3_5.scm
@@ -1,11 +1,10 @@
-(define (test-url-none?)
-  (regression-test-group
-   "url-none" "bool"
-   url-none? :none
-   (test "(url-none? (url-none)) is true" (url-none) #t)
-   (test "url-none? of /tmp is false" (system->url "/tmp") #f)))
+(import (liii check))
 
-(tm-define (test_15_3_5)
-  (let ((n (+ (test-url-none?))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 15_3_5: ok\n")))
+(check-set-mode! 'report-failed)
+
+(define (test-url-none?)
+  (check (url-none? (url-none)) => #t)
+  (check (url-none? (system->url "/tmp")) => #f)
+) ;define
+
+(tm-define (test_15_3_5) (test-url-none?) (check-report))

--- a/TeXmacs/tests/15_3_7.scm
+++ b/TeXmacs/tests/15_3_7.scm
@@ -1,12 +1,9 @@
-(define (test-url-format)
-  (regression-test-group
-   "url-format" "format name"
-   url-format :none
-   (test "format of init-texmacs.scm"
-    "$TEXMACS_PATH/progs/init-texmacs.scm"
-    "scheme")))
+(import (liii check))
 
-(tm-define (test_15_3_7)
-  (let ((n (+ (test-url-format))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 15_3_7: ok\n")))
+(check-set-mode! 'report-failed)
+
+(define (test-url-format)
+  (check (url-format "$TEXMACS_PATH/progs/init-texmacs.scm") => "scheme")
+) ;define
+
+(tm-define (test_15_3_7) (test-url-format) (check-report))

--- a/TeXmacs/tests/64_1.scm
+++ b/TeXmacs/tests/64_1.scm
@@ -1,49 +1,75 @@
-(define (file-under-path path)
-  (lambda (file)
-    (url-concretize (url-append path file))))
+(import (liii check))
 
-(define embedded-propose-4th
-  (lambda (tree)
-    (embedded-propose tree 4)))
+(check-set-mode! 'report-failed)
+
+(define (file-under-path path)
+  (lambda (file) (url-concretize (url-append path file)))
+) ;define
+
+(define embedded-propose-4th (lambda (tree) (embedded-propose tree 4)))
 
 (define (test-ascii-filename)
   (load-buffer "$TEXMACS_PATH/tests/64_1.tm")
   (let ((image-ascii (tree-ref (root-tree) 1 1))
         (image-untitled (tree-ref (root-tree) 1 2))
-        (image-cork (tree-ref (root-tree) 1 3)))
-    (regression-test-group
-      "embedded-propose on latin filename" "embedded-propose-latin"
-      embedded-propose-4th (file-under-path "$TEXMACS_PATH/tests")
-      (test "cork encoding" image-cork "学生：张佳.png")
-      (test "ascii"  image-ascii "64_1.png")
-      (test "extension only" image-untitled "64_1-image-4.png"))))
+        (image-cork (tree-ref (root-tree) 1 3))
+        (expected (file-under-path "$TEXMACS_PATH/tests"))
+       ) ;
+    (check (embedded-propose-4th image-cork) => (expected "学生：张佳.png"))
+    (check (embedded-propose-4th image-ascii) => (expected "64_1.png"))
+    (check (embedded-propose-4th image-untitled) => (expected "64_1-image-4.png"))
+  ) ;let
+) ;define
 
 (define (test-cjk-filename)
   (load-buffer "$TEXMACS_PATH/tests/64_1_中文文件名.tm")
   (let ((image-ascii (tree-ref (root-tree) 1 1))
         (image-untitled (tree-ref (root-tree) 1 2))
-        (image-cork (tree-ref (root-tree) 1 3)))
-    (regression-test-group
-      "embedded-propose on unicode filename" "embedded-propose-unicode"
-      embedded-propose-4th (file-under-path "$TEXMACS_PATH/tests")
-      (test "cork encoding" image-cork "学生：张佳.png")
-      (test "ascii"  image-ascii "64_1.png")
-      (test "extension only" image-untitled "64_1_中文文件名-image-4.png"))))
+        (image-cork (tree-ref (root-tree) 1 3))
+        (expected (file-under-path "$TEXMACS_PATH/tests"))
+       ) ;
+    (check (embedded-propose-4th image-cork) => (expected "学生：张佳.png"))
+    (check (embedded-propose-4th image-ascii) => (expected "64_1.png"))
+    (check (embedded-propose-4th image-untitled)
+      =>
+      (expected "64_1_中文文件名-image-4.png")
+    ) ;check
+  ) ;let
+) ;define
 
 (define (test-embedded-suffix)
-  (regression-test-group
-   "embedded edit, test tree with cork" "embedded-edit"
-   embedded-suffix :none
-   (test "cork encoding" '(image (tuple (raw-data "dummy") "<#672A><#547D><#540D><#7ED8><#56FE>.svg") "100pt" "80pt" "" "")
-        "svg")
-   (test "ascii" '(image (tuple (raw-data "dummy") "filename.png") "100pt" "80pt" "" "")
-        "png")
-   (test "extension only" '(image (tuple (raw-data "dummy") "png") "100pt" "80pt" "" "")
-        "png")))
+  (check (embedded-suffix '(image (tuple (raw-data "dummy")
+                                    "<#672A><#547D><#540D><#7ED8><#56FE>.svg")
+                             "100pt"
+                             "80pt"
+                             ""
+                             "")
+         ) ;embedded-suffix
+    =>
+    "svg"
+  ) ;check
+  (check (embedded-suffix '(image (tuple (raw-data "dummy") "filename.png")
+                             "100pt"
+                             "80pt"
+                             ""
+                             "")
+         ) ;embedded-suffix
+    =>
+    "png"
+  ) ;check
+  (check (embedded-suffix '(image (tuple (raw-data "dummy") "png")
+                             "100pt"
+                             "80pt"
+                             ""
+                             ""))
+    =>
+    "png"
+  ) ;check
+) ;define
 
 (tm-define (test_64_1)
-  (let ((n (+ (test-ascii-filename)
-              (test-cjk-filename)
-              (test-embedded-suffix))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 64_1: ok\n")))
+  (test-ascii-filename)
+  (test-cjk-filename)
+  (test-embedded-suffix)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/tests/9_1.scm
+++ b/TeXmacs/tests/9_1.scm
@@ -1,29 +1,27 @@
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
 (define (test-no-title)
   (load-buffer "$TEXMACS_PATH/tests/tm/9_1_无标题.tm")
-  (regression-test-group
-   "get-metadata" "result"
-   get-metadata :none
-   (test "no title" "title" "9_1_无标题.tm")))
+  (check (get-metadata "title") => "9_1_无标题.tm")
+) ;define
 
 (define (test-title)
   (load-buffer "$TEXMACS_PATH/tests/tm/9_1_with_title.tm")
-  (regression-test-group
-   "get-metadata" "result"
-   get-metadata :none
-   (test "with title" "title" "标题")))
+  (check (get-metadata "title") => "标题")
+) ;define
 
 (define (test-metadata)
   (load-buffer "$TEXMACS_PATH/tests/tm/9_1_with_metadata.tm")
-  (regression-test-group
-   "get-metadata" "result"
-   get-metadata :none
-   (test "get author" "author" "作者")
-   (test "get subject" "subject" "主题")
-   (test "get title" "title" "标题")))
+  (check (get-metadata "author") => "作者")
+  (check (get-metadata "subject") => "主题")
+  (check (get-metadata "title") => "标题")
+) ;define
 
 (tm-define (test_9_1)
-  (let ((n (+ (test-no-title)
-              (test-title)
-              (test-metadata))))
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 9_1: ok\n")))
+  (test-no-title)
+  (test-title)
+  (test-metadata)
+  (check-report)
+) ;tm-define

--- a/devel/1119.md
+++ b/devel/1119.md
@@ -1,0 +1,41 @@
+# [1119] 将所有用 regression-test-group 的测试改用 (liii check)
+
+## 2026/06/26
+
+将以下测试文件由 `regression-test-group` 改为 `(liii check)`：
+
+- `TeXmacs/plugins/cite/progs/contrib/cite/cite-sort-test.scm`
+- `TeXmacs/plugins/html/progs/convert/mathml/mathtm-test.scm`
+- `TeXmacs/progs/kernel/regexp/regexp-test.scm`
+- `TeXmacs/progs/kernel/gui/menu-test.scm`
+- `TeXmacs/progs/kernel/old-gui/old-gui-test.scm`
+- `TeXmacs/progs/language/minimal-test.scm`
+- `TeXmacs/progs/moebius/cork-test.scm`
+- `TeXmacs/progs/network/url-test.scm`
+- `TeXmacs/progs/prog/scheme-tools-test.scm`
+- `TeXmacs/progs/generic/generic-test.scm`
+- `TeXmacs/progs/convert/tools/environment-test.scm`
+- `TeXmacs/progs/convert/tools/tmlength-test.scm`
+- `TeXmacs/progs/graphics/graphics-group-test.scm`
+- `TeXmacs/progs/lolly/data-test.scm`
+- `TeXmacs/progs/dynamic/session-edit-test.scm`
+- `TeXmacs/tests/9_1.scm`
+- `TeXmacs/tests/15_3_1.scm`
+- `TeXmacs/tests/15_3_2.scm`
+- `TeXmacs/tests/15_3_3.scm`
+- `TeXmacs/tests/15_3_5.scm`
+- `TeXmacs/tests/15_3_7.scm`
+- `TeXmacs/tests/12_1.scm`
+- `TeXmacs/tests/64_1.scm`
+- `TeXmacs/tests/11_4.scm`
+
+### 转换约定
+
+- `(import (liii check))` + `(check-set-mode! 'report-failed)`
+- 每个 `(test "desc" input expected)` 改写为 `(check (result-cmd input) => expected)`
+- `(test-fails "desc" input expected)` 转为对 `(not (equal? ...))` 的 `check` 断言
+- 入口 `regtest-*`/`test_*` 移除计数返回值与 `Total: N tests.` 输出，统一在末尾调用 `(check-report)`
+
+## 1 相关文档
+
+- [1120] tm-files-test 改用 (liii check)：第一个完成的同类迁移，本文档复用其约定。


### PR DESCRIPTION
## Summary
- 将 24 个测试文件中的 `regression-test-group` 替换为 `(liii check)`，沿用 [1120] tm-files-test 的迁移约定
- `(import (liii check))` + `(check-set-mode! 'report-failed)`；`(test ...)` 改写为 `(check ... => ...)`；`(test-fails ...)` 改写为对 `(not (equal? ...))` 的 `check` 断言
- 入口函数移除计数与 `Total: N tests.` 输出，统一在末尾调用 `(check-report)`
- 覆盖 `TeXmacs/tests/*.scm`、`TeXmacs/progs/**/*-test.scm`、`TeXmacs/plugins/**/*-test.scm`；`regression-test-group` 宏定义保留在 `debug.scm`

## Test plan
- [ ] `gf fmt --changed-since=main` 已通过（23 文件格式化完成）
- [ ] ci-debian13 由 `TeXmacs/tests/*.scm` 路径过滤触发
- [ ] `xmake run --group=scheme_tests` 通过
- [ ] `xmake run --group=tests` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)