### PR TITLE
[2014] 修复切换 tab 触发整条标签栏重建的性能问题

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,26 @@ private slots:
 
 `cleanup()` 会在每条用例结束后执行，即使断言失败也会兜底隐藏窗口。
 
+### GUI 集成测试
+
+排查 GUI 专属代码路径（如 tab 切换、菜单重建）时，headless 模式无法复现。
+`TeXmacs/tests/*.scm`（`add_target_integration_test`）支持在真实 GUI 进程里跑：
+
+```bash
+xmake b stem
+MOGAN_TEST_GUI=1 xmake r <test名>
+```
+
+- `MOGAN_TEST_GUI=1`：去掉 `-headless`，在真实 GUI 跑，调试日志直接进终端；
+  且不自动 `(quit-TeXmacs)`，由测试脚本自己延迟退出。
+- 不带该环境变量则保持默认 headless + 自动 quit 行为，对其他测试无影响。
+
+测试脚本（`TeXmacs/tests/<name>.scm`，入口 `(test_<name>)`）用 `exec-delayed-at`
+串异步链驱动 GUI（不要用同步 sleep，会阻塞 Qt 事件循环），链尾自己
+`(quit-TeXmacs)`。夹具放 `TeXmacs/tests/tmu/`，运行时复制到 `/tmp` 避免
+save/编辑污染检入副本。配合 `#ifdef LIII_DEBUG` 的临时日志定位根因
+（参考 `TeXmacs/tests/2014.scm`）。
+
 ## 构建命令
 
 主项目构建：`xmake b stem`

--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -57,3 +57,25 @@
     ) ;let*
   ) ;for
 ) ;tm-menu
+
+;; tab 栏内容的稳定签名：view-url + 显示标题（含修改标记）序列。
+;; 用于 get_menu_widget 的 which==4 缓存判等——menu-expand 后的 xmenu 含每次
+;; 新建的 lambda，无法用 equal 比较，故用此签名判定 tab 栏是否真的变化。
+;; 切 tab 时签名不变 => 跳过重建；增删/改名/保存(*) => 签名变 => 重建。
+
+(define (tabpage-entry-signature view)
+  (let* ((buf (view->buffer view))
+         (title (buffer-get-title buf))
+         (title* (if (== title "") (url->system (url-tail buf)) title))
+         (is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab"))
+         (title* (if is-startup? (if (community-stem?) "Mogan STEM" "Liii STEM") title*))
+         (mod? (buffer-modified? buf))
+         (tab-title (string-append title* (if mod? " *" "")))
+        ) ;
+    (string-append (object->string view) "\n" tab-title)
+  ) ;let*
+) ;define
+
+(tm-define (tabpage-menu-signature)
+  (apply string-append (map tabpage-entry-signature (tabpage-list #t)))
+) ;tm-define

--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -43,7 +43,6 @@
            (mod? (buffer-modified? buf))
            (tab-title (string-append title* (if mod? " *" "")))
            (doc-path (if is-startup? "" (utf8->cork (url->system buf))))
-           (active? (== (current-view) view))
           ) ;
       (tab-page (eval view)
        ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path)))
@@ -51,7 +50,9 @@
        ) ;
        ;; #t stansd for focus
        ((balloon "" "Close") (safely-kill-tabpage-by-url view-win view buf))
-       (eval active?)
+       ;; active 不进展开树（否则切 tab 让展开树变化、缓存失效、整条重建），
+       ;; 改由 Qt 端 updateActiveTab 维护。这里恒为 #f。
+       (eval #f)
       ) ;tab-page
     ) ;let*
   ) ;for

--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -31,18 +31,31 @@
   ) ;let*
 ) ;tm-define
 
+;; tab 显示标题（含修改标记 *）。菜单与签名共用，避免逻辑重复。
+
+(define (tabpage-display-title buf)
+  (let* ((title (buffer-get-title buf))
+         (title* (if (== title "") (url->system (url-tail buf)) title))
+         (is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab"))
+         (title* (if is-startup? (if (community-stem?) "Mogan STEM" "Liii STEM") title*))
+         (mod? (buffer-modified? buf))
+        ) ;
+    (string-append title* (if mod? " *" ""))
+  ) ;let*
+) ;define
+
+(define (tabpage-doc-path buf)
+  (let ((is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab")))
+    (if is-startup? "" (utf8->cork (url->system buf)))
+  ) ;let
+) ;define
+
 (tm-menu (texmacs-tab-pages)
   (for (view (tabpage-list #t))
     (let* ((buf (view->buffer view))
            (view-win (view->window-of-tabpage view))
-           (title (buffer-get-title buf))
-           (title* (if (== title "") (url->system (url-tail buf)) title))
-           (is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab"))
-           ;; 特殊处理启动标签页标题
-           (title* (if is-startup? (if (community-stem?) "Mogan STEM" "Liii STEM") title*))
-           (mod? (buffer-modified? buf))
-           (tab-title (string-append title* (if mod? " *" "")))
-           (doc-path (if is-startup? "" (utf8->cork (url->system buf))))
+           (tab-title (tabpage-display-title buf))
+           (doc-path (tabpage-doc-path buf))
           ) ;
       (tab-page (eval view)
        ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path)))
@@ -58,22 +71,15 @@
   ) ;for
 ) ;tm-menu
 
-;; tab 栏内容的稳定签名：view-url + 显示标题（含修改标记）序列。
-;; 用于 get_menu_widget 的 which==4 缓存判等——menu-expand 后的 xmenu 含每次
-;; 新建的 lambda，无法用 equal 比较，故用此签名判定 tab 栏是否真的变化。
-;; 切 tab 时签名不变 => 跳过重建；增删/改名/保存(*) => 签名变 => 重建。
+;; tab 栏稳定签名：view-url + 显示标题序列（不含 lambda/command）。
+;; get_menu_widget 对 which==4 用它判等——menu-expand 后的 xmenu 含每次新建的
+;; lambda，equal 无法比较；切 tab 时签名不变 => 跳过重建。
 
 (define (tabpage-entry-signature view)
-  (let* ((buf (view->buffer view))
-         (title (buffer-get-title buf))
-         (title* (if (== title "") (url->system (url-tail buf)) title))
-         (is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab"))
-         (title* (if is-startup? (if (community-stem?) "Mogan STEM" "Liii STEM") title*))
-         (mod? (buffer-modified? buf))
-         (tab-title (string-append title* (if mod? " *" "")))
-        ) ;
-    (string-append (object->string view) "\n" tab-title)
-  ) ;let*
+  (string-append (object->string view)
+    "\n"
+    (tabpage-display-title (view->buffer view))
+  ) ;string-append
 ) ;define
 
 (tm-define (tabpage-menu-signature)

--- a/TeXmacs/tests/2014.scm
+++ b/TeXmacs/tests/2014.scm
@@ -1,0 +1,91 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 2014.scm
+;; DESCRIPTION : GUI 复现：切换 tab 时观察 menu 缓存是否命中
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   排查"切 tab 仍触发 SLOT_TAB_PAGES 整条重建"。配合 get_menu_widget 里
+;;   which==4 的 [tabpage] menu cache HIT/MISS 日志，在真实 GUI 里切换两个
+;;   文档，看每次切换是 HIT（不重建）还是 MISS（重建）。
+;;
+;;   夹具从 $TEXMACS_PATH/tests/tmu 复制到 /tmp，避免 save/编辑污染检入副本。
+;;   带 stem-doc-id 以排除 auto-backup 标脏干扰（见 1106）。
+;;
+;;   用 exec-delayed-at 串异步链，不阻塞 Qt 事件循环；链尾自己 quit。
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 2014
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs tests 2014))
+
+(define (tmp-name name)
+  (string->url (string-append "/tmp/" name))
+) ;define
+
+(define (refresh-fixture name)
+  (let ((src (string->url (string-append "$TEXMACS_PATH/tests/tmu/" name))))
+    (when (url-exists? src)
+      (system-copy src (tmp-name name))
+    ) ;when
+  ) ;let
+) ;define
+
+(define step-delay-ms 4000)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[2014-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_2014)
+  (refresh-fixture "2014_a.tmu")
+  (refresh-fixture "2014_b.tmu")
+  (let* ((path-a (tmp-name "2014_a.tmu")) (path-b (tmp-name "2014_b.tmu")))
+    (let ((steps (list (cons "load a" (lambda () (load-buffer path-a)))
+                   (cons "load b" (lambda () (load-buffer path-b)))
+                 ) ;list
+          ) ;steps
+         ) ;
+      ;; 在两个 tab 间来回切 5 轮。
+      (let loop
+        ((i 0) (acc steps))
+        (if (>= i 5)
+          (set! steps
+            (append acc (list (cons "done; quitting" (lambda () (quit-TeXmacs)))))
+          ) ;set!
+          (loop (+ i 1)
+            (append acc
+              (list (cons (string-append "round " (number->string i) ": -> a")
+                      (lambda () (switch-to-view-index 1))
+                    ) ;cons
+                (cons (string-append "round " (number->string i) ": -> b")
+                  (lambda () (switch-to-view-index 2))
+                ) ;cons
+              ) ;list
+            ) ;append
+          ) ;loop
+        ) ;if
+      ) ;let
+      (display "[2014-step] starting delayed chain\n")
+      (run-chain steps)
+    ) ;let
+  ) ;let*
+) ;tm-define

--- a/TeXmacs/tests/tmu/2014_a.tmu
+++ b/TeXmacs/tests/tmu/2014_a.tmu
@@ -1,0 +1,15 @@
+<TMU|<tuple|1.1.0|2026.2.6>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  2014_a
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|2014AAAA-0000-0000-0000-000000000001>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tmu/2014_b.tmu
+++ b/TeXmacs/tests/tmu/2014_b.tmu
@@ -1,0 +1,15 @@
+<TMU|<tuple|1.1.0|2026.2.6>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  2014_b
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|2014BBBB-0000-0000-0000-000000000002>
+  </collection>
+</initial>

--- a/devel/2014.md
+++ b/devel/2014.md
@@ -104,7 +104,24 @@ view-url + 显示标题（含修改标记）序列，**不含 lambda/command**�
 （`deleteLater`）；之后按 startup/chat 约定重排。任何场景都不全量重建。
 `removeAllTabPages` 仅保留给析构。
 
+> **复用路径须释放本次 carrier 的 widget**：`QTMTabPageAction` 的 dtor 不会删
+> `m_widget`（这正是它存在的意义——区别于 QWidgetAction，见 hpp 注释）。所以
+> 复用分支里 carrier 本次新建的 `srcTab` 没人接管，须显式 `delete srcTab;`，
+> 否则每次签名变化的重建（增删/改名/保存）都把全套新 carrier widget 泄漏一遍。
+> 与"未命中时 `delete carrier->m_widget;`"对齐。
+
 ### 7.4 验证
 
 GUI 复现：切 tab 时 `signature HIT`（不重建）+ `SLOT_FILE`（更新 active）；
 增删 tab 时正常重建。切 tab 零重建。单元测试覆盖切 active/加/删/重排四种 diff 路径。
+
+### 7.5 review 修复
+
+1. **`replaceTabPages` 复用路径泄漏**（`QTMTabPage.cpp`）：复用旧 tab 时，
+   carrier 本次新建的 `srcTab` 未被接管也未释放。补 `delete srcTab;`（见 7.3 注释）。
+2. **xmake 集成测试重复定义**（`xmake.lua`）：`add_target_integration_test` 在
+   `xmake.lua` 与 `xmake/tests.lua` 各定义一遍，且 `xmake.lua` 里还多一个遍历
+   `TeXmacs/tests/*.scm` 的循环——每个集成测试 target 被定义两次，靠"后定义覆盖"
+   才让 `MOGAN_TEST_GUI` 生效，脆弱。删除 `xmake.lua` 里的旧定义与旧循环，只保留
+   `tests.lua` 版本（带 `MOGAN_TEST_GUI` 的超集）。`includes` 在调用前加载，顺序正确。
+   `MOGAN_TEST_GUI` 未设时行为与旧版完全一致（`-headless` + 自动 quit）。

--- a/devel/2014.md
+++ b/devel/2014.md
@@ -2,89 +2,94 @@
 
 ## 现象
 
-切换 tab 时性能差：2 个 tab 来回切换体感像 n²（"切一次顶多次重建"）。tab 越多越卡。
+切换 tab 性能差：2 个 tab 来回切体感像 n²。tab 越多越卡。
 
-## 根因
+## 根因（三层叠加，逐层用 GUI 复现 + 日志定位）
 
-切换 tab 的完整链路（逐段代码确认）：
+切 tab 的链路：点 tab → `window_set_view` → `attach_view` → `editor->resume()`
+→ `apply_changes` → `update_menus` → `menu_icons(4)` → `get_menu_widget(which=4)`
+→ `set_tab_pages` → Qt `SLOT_TAB_PAGES` → `replaceTabPages`。
 
-1. 点 tab → `window_set_view`（`src/Texmacs/Data/new_view.cpp:626`）
-2. → `attach_view` → `editor->resume()` → `apply_changes` → `update_menus`
-   （`src/Edit/Interface/edit_interface.cpp:835`）
-3. `update_menus` **无条件**调用 `menu_icons(4, "(horizontal (link texmacs-tab-pages))")`
-4. `menu_icons(4)` → `get_menu_widget(which=4, ...)`（`src/Texmacs/Window/tm_window.cpp:402`）
-5. `get_menu_widget` 本有缓存：展开后的 menu 树没变就 `return false` 跳过重建。
-6. **但** tab 菜单把 `(eval active?)` 嵌进每个 `tab-page`
-   （`TeXmacs/progs/texmacs/menus/tabpage-menu.scm`），`active?` 依赖
-   `(current-view)`，切换 tab 时翻转 → 整个展开树变化 → 缓存失效 → 走
-   `make_menu_widget` 重建所有 tab widget。
-7. → `set_tab_pages` → Qt `SLOT_TAB_PAGES` → `tabPageContainer->replaceTabPages()`
-   （`src/Plugins/Qt/qt_tm_widget.cpp`）
-8. `replaceTabPages`（`src/Plugins/Qt/QTMTabPage.cpp`）原实现 = `removeAllTabPages()`
-   （`deleteLater` 每个 tab）+ `extractTabPages()`（重新 new）+ `arrangeTabPages()`。
+有三层独立的问题，任何一层都能独立导致重建：
 
-两个问题叠加：
-- **active 高亮不该进 menu 展开树**：它让"切选中态"变成"展开树变化 → 缓存失效 → 重建"。
-- **`replaceTabPages` 的设计本身有问题**：即便只是增/删一个 tab，它也把整条 tab bar
-  拆掉重建（删掉全部 N 个、new 全部 N 个），而不是只增减差异的那一个。
+### 层 1：active 高亮进了 menu 展开树
+
+`tabpage-menu.scm` 原 `(eval active?)`（依赖 `current-view`）作为 `tab-page`
+第 4 参数。切 tab 时 active 翻转 → 整棵展开树变化。**必要修复**，但不充分。
+
+### 层 2（真正的大头）：menu 缓存因 lambda 永久失效
+
+`get_menu_widget`（`tm_window.cpp`）用展开后的 `xmenu` 对象做 cache key 判等
+（`menu_cache->contains(xmenu)` / `menu_current[which] == xmenu`）。但
+`menu-expand` 把每个 tab 的点击命令展开成 `#<lambda ()>`（`delay-command` 每次新建
+闭包），scheme `equal?` 对两个不同 lambda 返回 false → **xmenu 每次都不同 →
+cache 永远 contains=false → 每次都 `make_menu_widget` 重新构造整棵 menu 树**。
+
+GUI 复现确认：切 tab 时 `cache contains` 恒为 false，`menu cache MISS` 每次触发，
+`update_menus` 单次 283ms。这是切 tab 卡的真正大头。
+
+### 层 3：`replaceTabPages` 即便只增删一个也全量重建
+
+原 `replaceTabPages` = `removeAllTabPages`（deleteLater 全部）+ `extractTabPages`
+（重新 new 全部）。即使 N→N+1 也重建全部 N+1 个重 widget。
 
 ## How
 
-### 1. active 态移出 menu 展开树
+### 1. active 移出展开树
 
-- `tabpage-menu.scm`：`tab-page` 第 4 参数由 `(eval active?)` 改为 `(eval #f)`。
-  - 不能用裸 `#f`：`gui-make-tab-page`（`menu-define.scm`）对 `tab-page` 每个参数调
-    `gui-make`，裸 `#f` 会被拒（`invalid menu item`）。`(eval #f)` 经 `gui-make-eval`
-    展开后恒为 `#f`，且不依赖 `current-view` → 展开树在切 tab 时不变 → 缓存命中。
-- active 高亮改由 Qt 端单独维护：`QTMTabPageContainer::updateActiveTab(currentView)`，
-  仅遍历现有 tab 调 `setChecked`，不重建 widget。`setChecked` 本就存在。
-- 触发点：`qt_tm_widget.cpp` 的 `SLOT_FILE`。`window_set_view` 在 `set_current_view`
-  之后调 `set_window_url` 触发 `SLOT_FILE`，此时 current view 已是新视图。在 `SLOT_FILE`
-  末尾调 `updateActiveTab`。`SLOT_TAB_PAGES`（首次建/增删）后也兜底调一次。
+`tabpage-menu.scm`：`tab-page` 第 4 参数 `(eval active?)` → `(eval #f)`
+（不能用裸 `#f`，`gui-make-tab-page` 对每个参数调 `gui-make`，裸 `#f` 被拒）。
+active 高亮改由 `QTMTabPageContainer::updateActiveTab(currentView)` 维护（仅遍历
+`setChecked`，`setChecked` 本就存在）。触发点：`qt_tm_widget.cpp` 的 `SLOT_FILE`
+（`window_set_view` 切 view 后触发）末尾调 `updateActiveTab`；`SLOT_TAB_PAGES`
+后兜底调一次。
 
-### 2. `replaceTabPages` 改为真正的增量 diff（不再全量重建）
+### 2. 稳定签名短路 menu 缓存（修层 2，关键修复）
 
-当前 `replaceTabPages` 无脑 `removeAllTabPages` + `extractTabPages`，即使只增删一个
-tab 也重建全部。改为按 view-url 做集合 diff：
+`get_menu_widget` 对 `which==4` 增加签名判等：新增
+`tabpage-menu-signature`（`tabpage-menu.scm`）返回 tab 栏的稳定签名
+（view-url + 显示标题含修改标记的序列，**不含 lambda/command**）。
+`tm_window.cpp` 用成员 `tab_menu_signature` 存上次签名，相同则 `return false`
+跳过重建（保持上次 widget）。切 tab 时签名不变 → 不重建；增删/改名/保存(*) →
+签名变 → 正常重建。
 
-- 复用：新旧都有的 url → 复用现有 `QTMTabPage*`，`setParent(this)`，同步标题。
-- 新增：新列表里有、旧的没有的 url → 从对应 carrier 摄取 `QTMTabPage`，`setParent(this)`。
-- 移除：旧列表里有、新列表没有的 url → `deleteLater`。
-- 之后按 startup/chat 约定重排（沿用 `extractTabPages` 的逻辑）。
+### 3. `replaceTabPages` 增量 diff（修层 3）
 
-这样**任何场景都不全量重建**：
-- 切 tab（active 变化）：展开树不变 → `get_menu_widget` 缓存命中，`SLOT_TAB_PAGES`
-  根本不被触发。
-- 加 tab：N→N+1 → 复用 N 个、摄取 1 个。
-- 删 tab：N→N-1 → 复用 N-1 个、deleteLater 1 个。
-- 首次：0→N → 摄取 N 个。
+按 view-url 做集合 diff：复用已有（同步标题）、摄取新增（`setParent(this)`）、
+`deleteLater` 移除多余；之后按 startup/chat 约定重排。任何场景都不全量重建。
+死代码 `extractTabPages` 删除，`removeAllTabPages` 仅保留给析构。
 
-`removeAllTabPages` 仅保留给析构用，`replaceTabPages` 不再调用它。
+### 可观测钩子（测试用）
 
-### 3. 可观测钩子（测试用）
-
-`QTMTabPageContainer` 加 `#ifdef LIII_DEBUG` 的计数器，统计"从 carrier 摄取新 tab 的
-次数"和"deleteLater 移除的次数"（active 切换另有 `updateActiveTab` 计数）。release
-下编译期剔除。
+`QTMTabPageContainer` 加 `#ifdef LIII_DEBUG` 的 `debug_added_count`/
+`debug_removed_count`/`debug_active_count`，release 下编译期剔除。
 
 ## 测试
 
-新增 `tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp`，容器层验证：
-- 切 active（`updateActiveTab`）不摄取/移除任何 widget。
-- 加一个 tab：只摄取 1 个、复用其余。
-- 删一个 tab：只 deleteLater 1 个、复用其余。
-- 重排（顺序变、集合不变）：不摄取、不移除。
-- 不同规模下，每次 diff 只动差异项。
+### GUI 自动化复现（定位用）
 
-## 如何运行
+`TeXmacs/tests/2014.scm` + 夹具 `2014_a.tmu`/`2014_b.tmu`：GUI 模式下加载两个
+文档、切换 5 轮。配合 `get_menu_widget` 的签名/缓存日志观察切 tab 是否重建。
 
-```bash
-xmake b qt_tabpage_rebuild_test && xmake r qt_tabpage_rebuild_test
+```
+MOGAN_TEST_GUI=1 xmake r 2014   # 需先 xmake b stem
+```
+
+`MOGAN_TEST_GUI=1` 机制（`xmake/tests.lua`，同步自 1106 分支）：在真实 GUI 进程
+跑（无 `-headless`），驱动 GUI 专属代码路径，调试日志进终端；不自动 quit。
+
+### 单元测试
+
+`tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp`：切 active 不重建、加 tab 仅 +1、
+删 tab 仅移除多余、重排不重建。
+
+```
+xmake b qt_tabpage_rebuild_test && xmake r qt_tabpage_rebuild_test   # 6 passed
 xmake r qt_tab_page_test qt_chat_tab_widget_test qt_tm_widget_add_tab_test  # 回归
 xmake b stem
 ```
 
-## 范围说明
+## 验证结果
 
-只针对 tab 菜单栏。其他菜单栏（icons/notification/tools）走同样的"展开树变就重建"
-机制，但展开树依赖相对稳定的状态，不会像 tab 的 `(eval active?)` 那样每次刷新都变。
+GUI 复现：切 tab 时 `signature HIT`（不重建）+ `SLOT_FILE`（更新 active）；
+增删 tab 时正常重建。切 tab 零重建。

--- a/devel/2014.md
+++ b/devel/2014.md
@@ -1,95 +1,90 @@
 # [2014] 修复切换 tab 触发整条标签栏重建的性能问题
 
-## 现象
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1106.md](1106.md) - GUI 自动化复现 + 调试日志定位根因的方法论（本任务沿用）
 
-切换 tab 性能差：2 个 tab 来回切体感像 n²。tab 越多越卡。
+## 2 任务相关的代码文件
+- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm` - tab 菜单定义、新增稳定签名
+- `src/Texmacs/Window/tm_window.cpp` - `get_menu_widget` 签名短路
+- `src/Texmacs/tm_window.hpp` - `tab_menu_signature` 成员
+- `src/Plugins/Qt/QTMTabPage.cpp` / `.hpp` - `replaceTabPages` 增量 diff、`updateActiveTab`
+- `src/Plugins/Qt/qt_tm_widget.cpp` - `SLOT_FILE`/`SLOT_TAB_PAGES` 触发 active 同步
+- `xmake/tests.lua` - `MOGAN_TEST_GUI` GUI 集成测试支持
+- `TeXmacs/tests/2014.scm` + `tmu/2014_{a,b}.tmu` - GUI 复现脚本与夹具
+- `tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp` - 增量重建单元测试
 
-## 根因（三层叠加，逐层用 GUI 复现 + 日志定位）
+## 3 如何测试
 
-切 tab 的链路：点 tab → `window_set_view` → `attach_view` → `editor->resume()`
-→ `apply_changes` → `update_menus` → `menu_icons(4)` → `get_menu_widget(which=4)`
-→ `set_tab_pages` → Qt `SLOT_TAB_PAGES` → `replaceTabPages`。
-
-有三层独立的问题，任何一层都能独立导致重建：
-
-### 层 1：active 高亮进了 menu 展开树
-
-`tabpage-menu.scm` 原 `(eval active?)`（依赖 `current-view`）作为 `tab-page`
-第 4 参数。切 tab 时 active 翻转 → 整棵展开树变化。**必要修复**，但不充分。
-
-### 层 2（真正的大头）：menu 缓存因 lambda 永久失效
-
-`get_menu_widget`（`tm_window.cpp`）用展开后的 `xmenu` 对象做 cache key 判等
-（`menu_cache->contains(xmenu)` / `menu_current[which] == xmenu`）。但
-`menu-expand` 把每个 tab 的点击命令展开成 `#<lambda ()>`（`delay-command` 每次新建
-闭包），scheme `equal?` 对两个不同 lambda 返回 false → **xmenu 每次都不同 →
-cache 永远 contains=false → 每次都 `make_menu_widget` 重新构造整棵 menu 树**。
-
-GUI 复现确认：切 tab 时 `cache contains` 恒为 false，`menu cache MISS` 每次触发，
-`update_menus` 单次 283ms。这是切 tab 卡的真正大头。
-
-### 层 3：`replaceTabPages` 即便只增删一个也全量重建
-
-原 `replaceTabPages` = `removeAllTabPages`（deleteLater 全部）+ `extractTabPages`
-（重新 new 全部）。即使 N→N+1 也重建全部 N+1 个重 widget。
-
-## How
-
-### 1. active 移出展开树
-
-`tabpage-menu.scm`：`tab-page` 第 4 参数 `(eval active?)` → `(eval #f)`
-（不能用裸 `#f`，`gui-make-tab-page` 对每个参数调 `gui-make`，裸 `#f` 被拒）。
-active 高亮改由 `QTMTabPageContainer::updateActiveTab(currentView)` 维护（仅遍历
-`setChecked`，`setChecked` 本就存在）。触发点：`qt_tm_widget.cpp` 的 `SLOT_FILE`
-（`window_set_view` 切 view 后触发）末尾调 `updateActiveTab`；`SLOT_TAB_PAGES`
-后兜底调一次。
-
-### 2. 稳定签名短路 menu 缓存（修层 2，关键修复）
-
-`get_menu_widget` 对 `which==4` 增加签名判等：新增
-`tabpage-menu-signature`（`tabpage-menu.scm`）返回 tab 栏的稳定签名
-（view-url + 显示标题含修改标记的序列，**不含 lambda/command**）。
-`tm_window.cpp` 用成员 `tab_menu_signature` 存上次签名，相同则 `return false`
-跳过重建（保持上次 widget）。切 tab 时签名不变 → 不重建；增删/改名/保存(*) →
-签名变 → 正常重建。
-
-### 3. `replaceTabPages` 增量 diff（修层 3）
-
-按 view-url 做集合 diff：复用已有（同步标题）、摄取新增（`setParent(this)`）、
-`deleteLater` 移除多余；之后按 startup/chat 约定重排。任何场景都不全量重建。
-死代码 `extractTabPages` 删除，`removeAllTabPages` 仅保留给析构。
-
-### 可观测钩子（测试用）
-
-`QTMTabPageContainer` 加 `#ifdef LIII_DEBUG` 的 `debug_added_count`/
-`debug_removed_count`/`debug_active_count`，release 下编译期剔除。
-
-## 测试
-
-### GUI 自动化复现（定位用）
-
-`TeXmacs/tests/2014.scm` + 夹具 `2014_a.tmu`/`2014_b.tmu`：GUI 模式下加载两个
-文档、切换 5 轮。配合 `get_menu_widget` 的签名/缓存日志观察切 tab 是否重建。
-
-```
-MOGAN_TEST_GUI=1 xmake r 2014   # 需先 xmake b stem
-```
-
-`MOGAN_TEST_GUI=1` 机制（`xmake/tests.lua`，同步自 1106 分支）：在真实 GUI 进程
-跑（无 `-headless`），驱动 GUI 专属代码路径，调试日志进终端；不自动 quit。
-
-### 单元测试
-
-`tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp`：切 active 不重建、加 tab 仅 +1、
-删 tab 仅移除多余、重排不重建。
-
-```
-xmake b qt_tabpage_rebuild_test && xmake r qt_tabpage_rebuild_test   # 6 passed
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b qt_tabpage_rebuild_test && xmake r qt_tabpage_rebuild_test
 xmake r qt_tab_page_test qt_chat_tab_widget_test qt_tm_widget_add_tab_test  # 回归
-xmake b stem
 ```
 
-## 验证结果
+### 3.2 非确定性测试（GUI 复现）
+```bash
+xmake b stem
+MOGAN_TEST_GUI=1 xmake r 2014   # 真实 GUI 切 tab，观察是否重建
+```
+切 tab 时不应再触发整条重建（签名命中）；增删 tab 时正常重建。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main     # 格式化改动的 .scm/.cpp
+xmake b stem                     # 主程序编译
+xmake r qt_tabpage_rebuild_test  # 单元测试
+```
+
+## 5 What
+
+1. tab 菜单的 active 高亮移出 menu 展开树，改由 Qt 端 `updateActiveTab` 维护
+2. `get_menu_widget` 对 tab 栏（which==4）用稳定签名短路，绕开含 lambda 的 xmenu
+3. `replaceTabPages` 改为按 view-url 增量 diff（复用/摄取/移除），删除死代码 `extractTabPages`
+4. 新增 `MOGAN_TEST_GUI=1` GUI 集成测试机制与 2014 复现脚本
+
+## 6 Why
+
+切换 tab 性能差，2 个 tab 来回切体感像 n²，tab 越多越卡。用 GUI 复现 + 调试日志
+逐层定位，根因是三层独立问题叠加：
+
+1. **active 进展开树**：`(eval active?)` 依赖 `current-view`，切 tab 让展开树变化。
+2. **menu 缓存因 lambda 永久失效**（真正的大头）：`menu-expand` 把每个 tab 的点击
+   命令展开成 `#<lambda ()>`，每次新建闭包；scheme `equal?` 对两个不同 lambda 返回
+   false，于是 cache key 每次不同 → 永远 MISS → 每次都 `make_menu_widget` 重建整棵
+   menu 树（`update_menus` 单次观测到 283ms）。
+3. **`replaceTabPages` 全量重建**：即使只增删一个 tab 也 `removeAllTabPages` +
+   `extractTabPages` 重建全部 N 个重 widget。
+
+仅修第 1 层不够——GUI 复现显示切 tab 仍 100% 触发 `SLOT_TAB_PAGES`，根因在第 2 层。
+
+## 7 How
+
+### 7.1 active 移出展开树
+
+`tab-page` 第 4 参数 `(eval active?)` → `(eval #f)`（不能用裸 `#f`：
+`gui-make-tab-page` 对每个参数调 `gui-make`，裸 `#f` 被拒）。active 高亮改由
+`QTMTabPageContainer::updateActiveTab(currentView)` 维护——仅遍历现有 tab 调
+`setChecked`（该方法本就存在）。触发点：`SLOT_FILE`（`window_set_view` 切 view 后
+由 `set_window_url` 触发）末尾；`SLOT_TAB_PAGES` 后兜底一次。
+
+### 7.2 稳定签名短路 menu 缓存（关键）
+
+新增 `tabpage-menu-signature`（scheme）：返回 tab 栏的稳定签名 = 每个 tab 的
+view-url + 显示标题（含修改标记）序列，**不含 lambda/command**。`get_menu_widget`
+对 which==4 用成员 `tab_menu_signature` 存上次签名，相同则 `return false` 跳过
+重建（保持上次 widget）。切 tab 时签名不变 → 不重建；增删/改名/保存(*) → 签名变 →
+正常重建。
+
+### 7.3 `replaceTabPages` 增量 diff
+
+按 view-url 做集合 diff：现有 tab 按 url 建 `QHash` 索引；遍历新 carrier 列表，
+命中则复用（同步标题）、未命中则摄取（`setParent(this)`）；索引中剩余的为移除项
+（`deleteLater`）；之后按 startup/chat 约定重排。任何场景都不全量重建。
+`removeAllTabPages` 仅保留给析构。
+
+### 7.4 验证
 
 GUI 复现：切 tab 时 `signature HIT`（不重建）+ `SLOT_FILE`（更新 active）；
-增删 tab 时正常重建。切 tab 零重建。
+增删 tab 时正常重建。切 tab 零重建。单元测试覆盖切 active/加/删/重排四种 diff 路径。

--- a/devel/2014.md
+++ b/devel/2014.md
@@ -1,0 +1,90 @@
+# [2014] 修复切换 tab 触发整条标签栏重建的性能问题
+
+## 现象
+
+切换 tab 时性能差：2 个 tab 来回切换体感像 n²（"切一次顶多次重建"）。tab 越多越卡。
+
+## 根因
+
+切换 tab 的完整链路（逐段代码确认）：
+
+1. 点 tab → `window_set_view`（`src/Texmacs/Data/new_view.cpp:626`）
+2. → `attach_view` → `editor->resume()` → `apply_changes` → `update_menus`
+   （`src/Edit/Interface/edit_interface.cpp:835`）
+3. `update_menus` **无条件**调用 `menu_icons(4, "(horizontal (link texmacs-tab-pages))")`
+4. `menu_icons(4)` → `get_menu_widget(which=4, ...)`（`src/Texmacs/Window/tm_window.cpp:402`）
+5. `get_menu_widget` 本有缓存：展开后的 menu 树没变就 `return false` 跳过重建。
+6. **但** tab 菜单把 `(eval active?)` 嵌进每个 `tab-page`
+   （`TeXmacs/progs/texmacs/menus/tabpage-menu.scm`），`active?` 依赖
+   `(current-view)`，切换 tab 时翻转 → 整个展开树变化 → 缓存失效 → 走
+   `make_menu_widget` 重建所有 tab widget。
+7. → `set_tab_pages` → Qt `SLOT_TAB_PAGES` → `tabPageContainer->replaceTabPages()`
+   （`src/Plugins/Qt/qt_tm_widget.cpp`）
+8. `replaceTabPages`（`src/Plugins/Qt/QTMTabPage.cpp`）原实现 = `removeAllTabPages()`
+   （`deleteLater` 每个 tab）+ `extractTabPages()`（重新 new）+ `arrangeTabPages()`。
+
+两个问题叠加：
+- **active 高亮不该进 menu 展开树**：它让"切选中态"变成"展开树变化 → 缓存失效 → 重建"。
+- **`replaceTabPages` 的设计本身有问题**：即便只是增/删一个 tab，它也把整条 tab bar
+  拆掉重建（删掉全部 N 个、new 全部 N 个），而不是只增减差异的那一个。
+
+## How
+
+### 1. active 态移出 menu 展开树
+
+- `tabpage-menu.scm`：`tab-page` 第 4 参数由 `(eval active?)` 改为 `(eval #f)`。
+  - 不能用裸 `#f`：`gui-make-tab-page`（`menu-define.scm`）对 `tab-page` 每个参数调
+    `gui-make`，裸 `#f` 会被拒（`invalid menu item`）。`(eval #f)` 经 `gui-make-eval`
+    展开后恒为 `#f`，且不依赖 `current-view` → 展开树在切 tab 时不变 → 缓存命中。
+- active 高亮改由 Qt 端单独维护：`QTMTabPageContainer::updateActiveTab(currentView)`，
+  仅遍历现有 tab 调 `setChecked`，不重建 widget。`setChecked` 本就存在。
+- 触发点：`qt_tm_widget.cpp` 的 `SLOT_FILE`。`window_set_view` 在 `set_current_view`
+  之后调 `set_window_url` 触发 `SLOT_FILE`，此时 current view 已是新视图。在 `SLOT_FILE`
+  末尾调 `updateActiveTab`。`SLOT_TAB_PAGES`（首次建/增删）后也兜底调一次。
+
+### 2. `replaceTabPages` 改为真正的增量 diff（不再全量重建）
+
+当前 `replaceTabPages` 无脑 `removeAllTabPages` + `extractTabPages`，即使只增删一个
+tab 也重建全部。改为按 view-url 做集合 diff：
+
+- 复用：新旧都有的 url → 复用现有 `QTMTabPage*`，`setParent(this)`，同步标题。
+- 新增：新列表里有、旧的没有的 url → 从对应 carrier 摄取 `QTMTabPage`，`setParent(this)`。
+- 移除：旧列表里有、新列表没有的 url → `deleteLater`。
+- 之后按 startup/chat 约定重排（沿用 `extractTabPages` 的逻辑）。
+
+这样**任何场景都不全量重建**：
+- 切 tab（active 变化）：展开树不变 → `get_menu_widget` 缓存命中，`SLOT_TAB_PAGES`
+  根本不被触发。
+- 加 tab：N→N+1 → 复用 N 个、摄取 1 个。
+- 删 tab：N→N-1 → 复用 N-1 个、deleteLater 1 个。
+- 首次：0→N → 摄取 N 个。
+
+`removeAllTabPages` 仅保留给析构用，`replaceTabPages` 不再调用它。
+
+### 3. 可观测钩子（测试用）
+
+`QTMTabPageContainer` 加 `#ifdef LIII_DEBUG` 的计数器，统计"从 carrier 摄取新 tab 的
+次数"和"deleteLater 移除的次数"（active 切换另有 `updateActiveTab` 计数）。release
+下编译期剔除。
+
+## 测试
+
+新增 `tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp`，容器层验证：
+- 切 active（`updateActiveTab`）不摄取/移除任何 widget。
+- 加一个 tab：只摄取 1 个、复用其余。
+- 删一个 tab：只 deleteLater 1 个、复用其余。
+- 重排（顺序变、集合不变）：不摄取、不移除。
+- 不同规模下，每次 diff 只动差异项。
+
+## 如何运行
+
+```bash
+xmake b qt_tabpage_rebuild_test && xmake r qt_tabpage_rebuild_test
+xmake r qt_tab_page_test qt_chat_tab_widget_test qt_tm_widget_add_tab_test  # 回归
+xmake b stem
+```
+
+## 范围说明
+
+只针对 tab 菜单栏。其他菜单栏（icons/notification/tools）走同样的"展开树变就重建"
+机制，但展开树依赖相对稳定的状态，不会像 tab 的 `(eval active?)` 那样每次刷新都变。

--- a/devel/2014.md
+++ b/devel/2014.md
@@ -29,6 +29,26 @@ MOGAN_TEST_GUI=1 xmake r 2014   # 真实 GUI 切 tab，观察是否重建
 ```
 切 tab 时不应再触发整条重建（签名命中）；增删 tab 时正常重建。
 
+### 3.3 调试观察（LIII_DEBUG 下）
+
+debug 构建里 `QTMTabPageContainer` 带运行时计数打印，终端实时可见：
+
+- `[tabpage] rebuild tabs=N added=M removed=K` —— 每次 tab 栏重建（增删/首次）。
+  这是增量 diff：`added`/`removed` 只累计真正变动的 tab 数，不会每次跳到总数。
+- `[tabpage] active #X added=M removed=K` —— 每次切 active（不重建）。
+
+**判断修复是否生效**：切 tab 时只看到 `active #` 递增、`added`/`removed` 锁住不动、
+**没有 `rebuild` 行** → 切 tab 零重建。若切 tab 仍出现 `rebuild`，说明签名短路失效。
+
+计数器本身（`debug_added_count`/`debug_removed_count`/`debug_active_count`）与
+`debug_findTab(url)` 仅 `#ifdef LIII_DEBUG` 存在，release 编译期剔除、零开销。
+
+### 3.4 "不全量重建"的硬保证
+
+单元测试 `test_reusedByPointerIdentity` 用指针身份断言：增删后未动 tab 的
+`QTMTabPage*` 地址不变。全量重建必然换新指针，故指针相等是最直接的证据——
+不是靠"计数器恰好凑对"，而是对象身份层面证明复用。
+
 ## 4 如何提交
 
 ```bash

--- a/gf_fmt.json
+++ b/gf_fmt.json
@@ -2,7 +2,7 @@
   "cpp": {
     "suffix": ["hpp", "cpp", "h", "c", "cc", "cxx"],
     "path": ["tests", "src", "moebius", "lolly"],
-    "binary-linux": ["/usr/bin/clang-format", "/usr/bin/clang-format-19"],
+    "binary-linux": ["/usr/bin/clang-format-19", "/usr/bin/clang-format"],
     "binary-macos": ["/opt/homebrew/opt/llvm@19/bin/clang-format", "/usr/local/opt/llvm@19/bin/clang-format"],
     "exclude": [
       {"path": "build", "reason": "构建产物目录（含各子模块下的 build），无需格式化"}

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -544,6 +544,16 @@ QTMTabPageContainer::updateActiveTab (const url& currentView) {
   }
 }
 
+#ifdef LIII_DEBUG
+QTMTabPage*
+QTMTabPageContainer::debug_findTab (const url& viewUrl) const {
+  string key= as_string (viewUrl);
+  for (int i= 0; i < m_tabPageList.size (); ++i)
+    if (as_string (m_tabPageList[i]->m_viewUrl) == key) return m_tabPageList[i];
+  return nullptr;
+}
+#endif
+
 void
 QTMTabPageContainer::removeAllTabPages () {
   for (int i= 0; i < m_tabPageList.size (); ++i) {

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -17,7 +17,9 @@
 #include "tm_window.hpp"
 #include <QCursor>
 #include <QEvent>
+#include <QHash>
 #include <QIcon>
+#include <QList>
 #include <QSize>
 
 // Base tab widths
@@ -455,10 +457,83 @@ QTMTabPageContainer::~QTMTabPageContainer () { removeAllTabPages (); }
 
 void
 QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
-  removeAllTabPages ();    // remove  old tabs
-  extractTabPages (p_src); // extract new tabs
+  // 增量 diff：按 view-url 复用已有 tab、摄取新增、移除多余，不全量重建。
+  if (!p_src) return;
+
+  // 现有 tab 按 url 索引，便于复用与移除判定。
+  QHash<QString, QTMTabPage*> existing;
+  for (QTMTabPage* tab : m_tabPageList)
+    existing.insert (to_qstring (as_string (tab->m_viewUrl)), tab);
+
+  QList<QTMTabPage*> next;
+  for (int i= 0; i < p_src->size (); ++i) {
+    QTMTabPageAction* carrier= qobject_cast<QTMTabPageAction*> ((*p_src)[i]);
+    ASSERT (carrier, "QTMTabPageAction expected")
+    QTMTabPage* srcTab= qobject_cast<QTMTabPage*> (carrier->m_widget);
+    if (!srcTab) {
+      delete carrier->m_widget;
+      continue;
+    }
+    QString key= to_qstring (as_string (srcTab->m_viewUrl));
+    auto    it = existing.find (key);
+    if (it != existing.end ()) {
+      // 复用：已有同 url 的 tab，同步标题即可（active 由 updateActiveTab
+      // 维护）。
+      QTMTabPage* tab= it.value ();
+      existing.erase (it);
+      tab->setText (srcTab->text ());
+      next.append (tab);
+    }
+    else {
+      // 新增：从 carrier 摄取 srcTab，接管其所有权。
+      srcTab->setParent (this);
+      next.append (srcTab);
+#ifdef LIII_DEBUG
+      debug_added_count++;
+#endif
+    }
+    // carrier 由其父 widget（QTMTabPageBar）经 schedule_destruction 统一销毁，
+    // 与原 extractTabPages 的约定一致，这里不手动 delete。
+  }
+
+  // existing 中剩下的 url 不在新列表里 => 已被移除，deleteLater。
+  for (auto it= existing.begin (); it != existing.end (); ++it) {
+    it.value ()->setParent (nullptr);
+    it.value ()->deleteLater ();
+#ifdef LIII_DEBUG
+    debug_removed_count++;
+#endif
+  }
+
+  m_tabPageList= next;
+  // startup/chat 标签固定置顶，与原 extractTabPages 的顺序约定保持一致。
+  int startupIndex= startup_tab_index (m_tabPageList);
+  if (startupIndex > 0) {
+    QTMTabPage* startupTab= m_tabPageList.takeAt (startupIndex);
+    m_tabPageList.prepend (startupTab);
+  }
+  int chatIndex= chat_tab_index (m_tabPageList);
+  if (chatIndex > 1) {
+    QTMTabPage* chatTab= m_tabPageList.takeAt (chatIndex);
+    m_tabPageList.insert (1, chatTab);
+  }
+  else if (chatIndex == 0 && m_tabPageList.size () > 1) {
+    QTMTabPage* chatTab= m_tabPageList.takeAt (chatIndex);
+    m_tabPageList.insert (1, chatTab);
+  }
 
   arrangeTabPages ();
+}
+
+void
+QTMTabPageContainer::updateActiveTab (const url& currentView) {
+#ifdef LIII_DEBUG
+  debug_active_count++;
+#endif
+  for (int i= 0; i < m_tabPageList.size (); ++i) {
+    QTMTabPage* tab= m_tabPageList[i];
+    tab->setChecked (as_string (tab->m_viewUrl) == as_string (currentView));
+  }
 }
 
 void

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -523,12 +523,20 @@ QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
   }
 
   arrangeTabPages ();
+#ifdef LIII_DEBUG
+  cout << "[tabpage] rebuild tabs=" << m_tabPageList.size ()
+       << " added=" << debug_added_count << " removed=" << debug_removed_count
+       << LF;
+#endif
 }
 
 void
 QTMTabPageContainer::updateActiveTab (const url& currentView) {
 #ifdef LIII_DEBUG
   debug_active_count++;
+  cout << "[tabpage] active #" << debug_active_count
+       << " added=" << debug_added_count << " removed=" << debug_removed_count
+       << LF;
 #endif
   for (int i= 0; i < m_tabPageList.size (); ++i) {
     QTMTabPage* tab= m_tabPageList[i];

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -493,7 +493,7 @@ QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
 #endif
     }
     // carrier 由其父 widget（QTMTabPageBar）经 schedule_destruction 统一销毁，
-    // 与原 extractTabPages 的约定一致，这里不手动 delete。
+    // 这里不手动 delete。
   }
 
   // existing 中剩下的 url 不在新列表里 => 已被移除，deleteLater。
@@ -506,7 +506,7 @@ QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
   }
 
   m_tabPageList= next;
-  // startup/chat 标签固定置顶，与原 extractTabPages 的顺序约定保持一致。
+  // startup/chat 标签固定置顶。
   int startupIndex= startup_tab_index (m_tabPageList);
   if (startupIndex > 0) {
     QTMTabPage* startupTab= m_tabPageList.takeAt (startupIndex);
@@ -544,46 +544,6 @@ QTMTabPageContainer::removeAllTabPages () {
     m_tabPageList[i]->deleteLater ();
   }
   m_tabPageList.clear ();
-}
-
-void
-QTMTabPageContainer::extractTabPages (QList<QAction*>* p_src) {
-  if (!p_src) return;
-  for (int i= 0; i < p_src->size (); ++i) {
-    // see the definition of QTMTabPageAction why we're using it
-    QTMTabPageAction* carrier= qobject_cast<QTMTabPageAction*> ((*p_src)[i]);
-    ASSERT (carrier, "QTMTabPageAction expected")
-
-    QTMTabPage* tab= qobject_cast<QTMTabPage*> (carrier->m_widget);
-    if (tab) {
-      tab->setParent (this);
-      m_tabPageList.append (tab);
-    }
-    else {
-      delete carrier->m_widget; // we don't use it so we should delete it
-    }
-
-    // We don't need to manually delete carrier, because it(p_src) is a QAction,
-    // which will be deleted by the parent widget (QTMTabPageBar) when it
-    // is destroyed (by shedule_destruction).
-  }
-
-  int startupIndex= startup_tab_index (m_tabPageList);
-  if (startupIndex > 0) {
-    QTMTabPage* startupTab= m_tabPageList.takeAt (startupIndex);
-    m_tabPageList.prepend (startupTab);
-  }
-
-  int chatIndex= chat_tab_index (m_tabPageList);
-  if (chatIndex > 1) {
-    QTMTabPage* chatTab= m_tabPageList.takeAt (chatIndex);
-    m_tabPageList.insert (1, chatTab);
-  }
-  else if (chatIndex == 0 && m_tabPageList.size () > 1) {
-    // Chat tab should be after startup tab, not before
-    QTMTabPage* chatTab= m_tabPageList.takeAt (chatIndex);
-    m_tabPageList.insert (1, chatTab);
-  }
 }
 
 void

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -483,6 +483,10 @@ QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
       existing.erase (it);
       tab->setText (srcTab->text ());
       next.append (tab);
+      // srcTab 是本次 carrier 新建的 widget，未被接管。QTMTabPageAction 的
+      // dtor 不会删 m_widget（见 hpp 注释），此处须手动释放，否则每次重建都
+      // 把全套新 carrier widget 泄漏一遍。
+      delete srcTab;
     }
     else {
       // 新增：从 carrier 摄取 srcTab，接管其所有权。

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -106,6 +106,9 @@ public:
   int debug_added_count  = 0;
   int debug_removed_count= 0;
   int debug_active_count = 0;
+  // 测试用：按 view-url 取现有 tab 指针，用于断言增量 diff 复用了同一对象
+  // （而非全量重建换新指针）。找不到返回 nullptr。
+  QTMTabPage* debug_findTab (const url& viewUrl) const;
 #endif
 
   inline void setRowHeight (int p_height) { m_rowHeight= p_height; }

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -121,7 +121,6 @@ signals:
 
 private:
   void removeAllTabPages ();
-  void extractTabPages (QList<QAction*>* p_src);
   void adjustHeight (int p_rowCount);
   void onAddTabClicked ();
 

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -100,10 +100,21 @@ public:
   explicit QTMTabPageContainer (QWidget* p_parent);
   ~QTMTabPageContainer ();
 
+#ifdef LIII_DEBUG
+  // 测试用：每次 replaceTabPages 从 carrier 摄取 / deleteLater 移除的 tab 数，
+  // 以及 updateActiveTab 命中次数。release 下编译期剔除。
+  int debug_added_count  = 0;
+  int debug_removed_count= 0;
+  int debug_active_count = 0;
+#endif
+
   inline void setRowHeight (int p_height) { m_rowHeight= p_height; }
-  void        replaceTabPages (QList<QAction*>* p_src);
-  void        arrangeTabPages ();
-  void        setHitTestVisibleForTabPages (QWK::WidgetWindowAgent* agent);
+  // 按 view-url 做增量 diff：复用已有 tab、摄取新增、移除多余，不全量重建。
+  void replaceTabPages (QList<QAction*>* p_src);
+  // 按 currentView 切换 active 高亮，仅遍历 setChecked，不重建 widget。
+  void updateActiveTab (const url& currentView);
+  void arrangeTabPages ();
+  void setHitTestVisibleForTabPages (QWK::WidgetWindowAgent* agent);
 
 signals:
   void addTabRequested ();

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1750,6 +1750,13 @@ qt_tm_widget_rep::send (slot s, blackbox val) {
     sync_chat_tab_mode ();
     sync_chat_sidebar_mode ();
     set_central_widget_updates_frozen (false);
+    // SLOT_FILE 由 window_set_view 在切 view 后触发：轻量同步 active 高亮，
+    // 避免重建 tab bar。
+    if (tabPageContainer) {
+      url currentView= get_current_view_safe ();
+      if (!is_none (currentView))
+        tabPageContainer->updateActiveTab (currentView);
+    }
   } break;
   case SLOT_POSITION: {
     check_type<coord2> (val, s);
@@ -2017,6 +2024,10 @@ qt_tm_widget_rep::write (slot s, blackbox index, widget w) {
         if (windowAgent) {
           tabPageContainer->setHitTestVisibleForTabPages (windowAgent);
         }
+        // 增删 tab 后同步一次 active（active 不再由展开树携带）。
+        url currentView= get_current_view_safe ();
+        if (!is_none (currentView))
+          tabPageContainer->updateActiveTab (currentView);
       }
     }
     break;

--- a/src/Texmacs/Window/tm_window.cpp
+++ b/src/Texmacs/Window/tm_window.cpp
@@ -408,32 +408,27 @@ tm_window_rep::get_menu_widget (int which, string menu, widget& w) {
   }
   object xmenu= call ("menu-expand", eval ("'" * menu));
   the_drd     = old_drd;
-  // if (which == 10) cout << "xmenu= " << xmenu << "\n";
-  // cout << "xmenu= " << xmenu << "\n";
+  // tab 栏（which==4）：xmenu 含每次新建的 lambda，无法用 equal 比较，故用
+  // 稳定签名判等。签名不变（如切 tab）=> 跳过重建，保持上次 widget。
+  if (which == 4) {
+    string sig= as_string (call ("tabpage-menu-signature"));
+    if (sig == tab_menu_signature) return false;
+    tab_menu_signature= sig;
+  }
   if (menu_cache->contains (xmenu)) {
-    // if (menu_current[which] == xmenu) cout << "Same " << menu << "\n";
-    // if (which == 10) cout << which << " -> cached? " << (menu_current[which]
-    // == xmenu) << LF; cout << which << " -> cached? " << (menu_current[which]
-    // == xmenu) << LF;
     if (menu_current[which] == xmenu) return false;
     if (which < 10) {
       menu_current (which)= xmenu;
-      // cout << "Cached " << menu << "\n";
-      w= menu_cache[xmenu];
+      w                   = menu_cache[xmenu];
       return true;
     }
   }
-  // if (which == 10) cout << which << " -> compute" << LF;
-  // cout << which << " -> compute" << LF;
   menu_current (which)= xmenu;
-  // cout << "Compute " << menu << "\n";
-  object umenu= eval ("'" * menu);
+  object umenu        = eval ("'" * menu);
   if (which == 10 || which == 11) w= make_menu_widget (umenu, 400, 1000);
   else w= make_menu_widget (umenu);
   if (menu_caching)
     if (which >= 10 || as_bool (call ("cache-menu?", xmenu))) {
-      // if (which == 10) cout << which << " -> cached" << LF;
-      // cout << which << " -> cached" << LF;
       menu_cache (xmenu)= w;
     }
   return true;

--- a/src/Texmacs/tm_window.hpp
+++ b/src/Texmacs/tm_window.hpp
@@ -30,9 +30,10 @@ public:
 protected:
   hashmap<int, object>    menu_current;
   hashmap<object, widget> menu_cache;
-  string*                 text_ptr;  // where the interactive string is returned
-  command                 call_back; // called when typing finished
-  string                  cur_title; // current window title
+  string  tab_menu_signature; // 上次 tab 栏签名，绕开 xmenu 的 lambda
+  string* text_ptr;           // where the interactive string is returned
+  command call_back;          // called when typing finished
+  string  cur_title;          // current window title
 
 public:
   tm_window_rep (widget wid2, tree geom);

--- a/tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp
+++ b/tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp
@@ -1,0 +1,147 @@
+/******************************************************************************
+ * MODULE     : qt_tabpage_rebuild_test.cpp
+ * DESCRIPTION: 验证 tab 增删/切换不触发整条标签栏重建的性能回归测试
+ * 计数器仅在 LIII_DEBUG 下存在，release 构建相应断言被编译期跳过。
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ ******************************************************************************/
+
+#include "Qt/QTMTabPage.hpp"
+#include "Qt/qt_utilities.hpp"
+#include "base.hpp"
+#include <QAction>
+#include <QApplication>
+#include <QList>
+#include <QtTest/QtTest>
+
+namespace {
+// 构造 carrier 列表：每个 url 一个 QTMTabPage，包成 QTMTabPageAction，
+// 模拟 SLOT_TAB_PAGES 喂给 replaceTabPages 的输入。
+QList<QAction*>*
+makeCarrierList (const QList<QString>& urls) {
+  auto* list= new QList<QAction*> ();
+  for (const auto& u : urls) {
+    auto* title   = new QAction (u);
+    auto* closeBtn= new QAction ("Close");
+    auto* tab= new QTMTabPage (url (from_qstring (u)), title, closeBtn, false);
+    list->append (new QTMTabPageAction (tab));
+  }
+  return list;
+}
+} // namespace
+
+class TestQTMTabPageRebuild : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+  void cleanup () { cleanup_qt_top_level_widgets (); }
+
+  // 仅切换 active => updateActiveTab 不摄取/移除任何 widget。
+  void test_activeSwitchDoesNotRebuild () {
+    QWidget             host;
+    QTMTabPageContainer container (&host);
+    container.setRowHeight (32);
+    host.resize (800, 40);
+    host.show ();
+    QVERIFY (QTest::qWaitForWindowExposed (&host));
+
+    QList<QAction*>* tabs= makeCarrierList ({"tmfs://view/1", "tmfs://view/2"});
+    container.replaceTabPages (tabs);
+
+#ifdef LIII_DEBUG
+    int added0  = container.debug_added_count;
+    int removed0= container.debug_removed_count;
+    int active0 = container.debug_active_count;
+#else
+    QSKIP ("计数器仅在 LIII_DEBUG 构建可用");
+#endif
+
+    // 来回切 active 10 次：这正是性能问题的原始场景。
+    for (int i= 0; i < 5; ++i) {
+      container.updateActiveTab (url ("tmfs://view/2"));
+      container.updateActiveTab (url ("tmfs://view/1"));
+    }
+
+#ifdef LIII_DEBUG
+    QCOMPARE (container.debug_added_count, added0);        // 未摄取
+    QCOMPARE (container.debug_removed_count, removed0);    // 未移除
+    QCOMPARE (container.debug_active_count - active0, 10); // 轻量命中 10 次
+#endif
+  }
+
+  // 加一个 tab => 仅摄取 1 个、复用其余。
+  void test_addTabIsIncremental () {
+    QWidget             host;
+    QTMTabPageContainer container (&host);
+    container.setRowHeight (32);
+    host.resize (800, 40);
+    host.show ();
+    QVERIFY (QTest::qWaitForWindowExposed (&host));
+
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/1", "tmfs://view/2"}));
+#ifdef LIII_DEBUG
+    QCOMPARE (container.debug_added_count, 2); // 首次全部摄取
+    QCOMPARE (container.debug_removed_count, 0);
+#else
+    QSKIP ("计数器仅在 LIII_DEBUG 构建可用");
+#endif
+
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/1", "tmfs://view/2", "tmfs://view/3"}));
+#ifdef LIII_DEBUG
+    QCOMPARE (container.debug_added_count, 3);   // 仅 +1
+    QCOMPARE (container.debug_removed_count, 0); // 未移除
+#endif
+  }
+
+  // 删一个 tab => 仅 deleteLater 1 个、复用其余。
+  void test_removeTabIsIncremental () {
+    QWidget             host;
+    QTMTabPageContainer container (&host);
+    container.setRowHeight (32);
+    host.resize (800, 40);
+    host.show ();
+    QVERIFY (QTest::qWaitForWindowExposed (&host));
+
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/1", "tmfs://view/2", "tmfs://view/3"}));
+
+    container.replaceTabPages (makeCarrierList ({"tmfs://view/1"}));
+#ifdef LIII_DEBUG
+    QCOMPARE (container.debug_removed_count, 2); // 仅移除多余的两个
+    QCOMPARE (container.debug_added_count, 3);   // 首次摄取的不变，无新增
+#else
+    QSKIP ("计数器仅在 LIII_DEBUG 构建可用");
+#endif
+  }
+
+  // 集合不变、仅顺序变化 => 不摄取、不移除。
+  void test_reorderDoesNotRebuild () {
+    QWidget             host;
+    QTMTabPageContainer container (&host);
+    container.setRowHeight (32);
+    host.resize (800, 40);
+    host.show ();
+    QVERIFY (QTest::qWaitForWindowExposed (&host));
+
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/1", "tmfs://view/2", "tmfs://view/3"}));
+#ifdef LIII_DEBUG
+    int added0  = container.debug_added_count;
+    int removed0= container.debug_removed_count;
+#else
+    QSKIP ("计数器仅在 LIII_DEBUG 构建可用");
+#endif
+
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/3", "tmfs://view/1", "tmfs://view/2"}));
+#ifdef LIII_DEBUG
+    QCOMPARE (container.debug_added_count, added0);
+    QCOMPARE (container.debug_removed_count, removed0);
+#endif
+  }
+};
+
+QTEST_MAIN (TestQTMTabPageRebuild)
+#include "qt_tabpage_rebuild_test.moc"

--- a/tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp
+++ b/tests/Plugins/Qt/qt_tabpage_rebuild_test.cpp
@@ -141,6 +141,38 @@ private slots:
     QCOMPARE (container.debug_removed_count, removed0);
 #endif
   }
+
+  // 增删后未动 tab 的指针身份不变 => 证明是复用而非全量重建。
+  // 全量重建必然换新指针，故指针相等是最直接的"不全量重建"证据。
+  void test_reusedByPointerIdentity () {
+    QWidget             host;
+    QTMTabPageContainer container (&host);
+    container.setRowHeight (32);
+    host.resize (800, 40);
+    host.show ();
+    QVERIFY (QTest::qWaitForWindowExposed (&host));
+
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/1", "tmfs://view/2", "tmfs://view/3"}));
+#ifndef LIII_DEBUG
+    QSKIP ("计数器仅在 LIII_DEBUG 构建可用");
+#else
+    QTMTabPage* tab1= container.debug_findTab (url ("tmfs://view/1"));
+    QTMTabPage* tab2= container.debug_findTab (url ("tmfs://view/2"));
+    QVERIFY (tab1 != nullptr);
+    QVERIFY (tab2 != nullptr);
+
+    // 删掉 view/3，再加回 view/4；view/1、view/2 应保持同一对象。
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/1", "tmfs://view/2"}));
+    container.replaceTabPages (
+        makeCarrierList ({"tmfs://view/4", "tmfs://view/1", "tmfs://view/2"}));
+    QCOMPARE (container.debug_findTab (url ("tmfs://view/1")), tab1);
+    QCOMPARE (container.debug_findTab (url ("tmfs://view/2")), tab2);
+    QVERIFY (container.debug_findTab (url ("tmfs://view/3")) == nullptr);
+    QVERIFY (container.debug_findTab (url ("tmfs://view/4")) != nullptr);
+#endif
+  }
 };
 
 QTEST_MAIN (TestQTMTabPageRebuild)

--- a/xmake.lua
+++ b/xmake.lua
@@ -1039,47 +1039,6 @@ target("stem") do
     end)
 end
 
-function add_target_integration_test(filepath, INSTALL_DIR, RUN_ENVS)
-    local testname = path.basename(filepath)
-    target(testname) do
-        set_enabled(not is_plat("wasm"))
-        set_kind("phony")
-        set_group("integration_tests")
-        add_deps("stem")
-        on_run(function (target)
-            name = target:name()
-            test_name = "(test_"..name..")"
-            print("------------------------------------------------------")
-            print("Executing: " .. test_name)
-            params = {
-                "-headless",
-                "-d",
-                "-b", path.join("TeXmacs","tests",name..".scm"),
-                "-x", "(catch #t (lambda () " .. test_name .. " (quit-TeXmacs)) (lambda args (display \"Error: \") (display args) (newline) (exit 1)))"
-            }
-            if is_plat("macosx", "linux") then
-                binary = target:deps()["stem"]:targetfile()
-            elseif is_plat("mingw", "windows") then
-                binary = path.join(INSTALL_DIR,"bin", stem_binary_windows)
-            else
-                print("Unsupported plat $(plat)")
-            end
-            cmd = binary
-            if is_plat("macosx", "linux") then
-                os.execv(cmd, params, {envs=RUN_ENVS})
-            else
-                os.execv(cmd, params)
-            end
-        end)
-    end
-end
-
--- Integration tests
-RUN_ENVS = {TEXMACS_PATH=path.join(os.projectdir(), "TeXmacs")}
-for _, filepath in ipairs(os.files("TeXmacs/tests/*.scm")) do
-    add_target_integration_test(filepath, INSTALL_DIR, RUN_ENVS)
-end
-
 target("stem_packager") do
     set_enabled(is_plat("macosx") and is_mode("release"))
     set_kind("phony")

--- a/xmake/tests.lua
+++ b/xmake/tests.lua
@@ -138,29 +138,29 @@ function add_target_integration_test(filepath, INSTALL_DIR, RUN_ENVS)
         add_runenvs("TEXMACS_PATH", path.join(os.projectdir(), "TeXmacs"))
         INSTALL_DIR = INSTALL_DIR or os.projectdir()
         on_run(function (target)
-            name = target:name()
-            test_name = "(test_"..name..")"
+            local name = target:name()
+            local test_name = "(test_"..name..")"
             print("------------------------------------------------------")
-            print("Executing: " .. test_name)
-            params = {
-                "-headless",
-                "-d",
-                "-b", path.join("TeXmacs","tests",name..".scm"),
-                "-x", "(catch #t (lambda () " .. test_name .. " (quit-TeXmacs)) (lambda args (display \"Error: \") (display args) (newline) (exit 1)))"
-            }
+            -- MOGAN_TEST_GUI=1: 真实 GUI 进程跑（无 -headless），驱动 GUI 专属
+            -- 路径，调试日志进终端；不自动 quit，由测试脚本自己延迟退出。
+            local gui_mode = os.getenv("MOGAN_TEST_GUI") == "1"
+            print(("Executing: %s (mode: %s)"):format(test_name, gui_mode and "GUI" or "headless"))
+            local scm = path.join("TeXmacs","tests",name..".scm")
+            -- GUI 模式不追加 (quit-TeXmacs)，让测试可串异步链后自退。
+            local quit = gui_mode and "" or " (quit-TeXmacs)"
+            local expr = ("(catch #t (lambda () %s%s) (lambda args (display \"Error: \") (display args) (newline) (exit 1)))"):format(test_name, quit)
+            local params = gui_mode and {"-d", "-b", scm, "-x", expr}
+                                      or {"-headless", "-d", "-b", scm, "-x", expr}
+            local binary
             if is_plat("macosx", "linux") then
                 binary = target:deps()["stem"]:targetfile()
             elseif is_plat("mingw", "windows") then
                 binary = path.join(INSTALL_DIR, "build", "packages", "stem", "data", "bin", "MoganSTEM.exe")
             else
                 print("Unsupported plat $(plat)")
+                return
             end
-            cmd = binary
-            if is_plat("macosx", "linux") then
-                os.execv(cmd, params, {envs=RUN_ENVS})
-            else
-                os.execv(cmd, params)
-            end
+            os.execv(binary, params, is_plat("macosx", "linux") and {envs=RUN_ENVS} or nil)
         end)
     end
 end 


### PR DESCRIPTION
## 背景

切换 tab 性能差，2 个 tab 来回切体感像 n²，tab 越多越卡。用 GUI 复现 + 调试日志逐层定位，根因是三层独立问题叠加。

## 根因

1. **active 进展开树**：`(eval active?)` 依赖 `current-view`，切 tab 让展开树变化。
2. **menu 缓存因 lambda 永久失效**（真正的大头）：`menu-expand` 把每个 tab 的点击命令展开成 `#<lambda ()>`，每次新建闭包；scheme `equal?` 对两个不同 lambda 返回 false，于是 cache key 每次不同 → 永远 MISS → 每次都 `make_menu_widget` 重建整棵 menu 树（`update_menus` 单次观测到 283ms）。
3. **`replaceTabPages` 全量重建**：即使只增删一个 tab 也重建全部 N 个重 widget。

## 修复

- active 移出展开树（`(eval #f)`），由 `updateActiveTab(currentView)` 单独维护（`SLOT_FILE` 触发）
- `get_menu_widget` 对 tab 栏（which==4）用稳定签名短路，绕开含 lambda 的 xmenu（关键修复）
- `replaceTabPages` 改为按 view-url 增量 diff，删除死代码 `extractTabPages`

## 测试

- `qt_tabpage_rebuild_test`：切 active/加/删/重排四种 diff 路径（6 passed）
- GUI 复现 `MOGAN_TEST_GUI=1 xmake r 2014`：切 tab 零重建（签名 HIT），增删正常重建
- 回归 `qt_tab_page_test` / `qt_chat_tab_widget_test` / `qt_tm_widget_add_tab_test` 全过

附带：`MOGAN_TEST_GUI=1` GUI 集成测试机制（同步自 1106 并精简），CLAUDE.md 补充用法。

详见 `devel/2014.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)