### PR TITLE
[2014] GUI 复现脚本扩展至切/增/删/排序四种动作

### DIFF
--- a/TeXmacs/tests/2014.scm
+++ b/TeXmacs/tests/2014.scm
@@ -1,17 +1,23 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : 2014.scm
-;; DESCRIPTION : GUI 复现：切换 tab 时观察 menu 缓存是否命中
+;; DESCRIPTION : GUI 复现：切换/新建/关闭/拖拽 tab 时观察 menu 缓存命中与重建
 ;; COPYRIGHT   : (C) 2026 Mogan STEM
 ;;
 ;; PURPOSE
-;;   排查"切 tab 仍触发 SLOT_TAB_PAGES 整条重建"。配合 get_menu_widget 里
-;;   which==4 的 [tabpage] menu cache HIT/MISS 日志，在真实 GUI 里切换两个
-;;   文档，看每次切换是 HIT（不重建）还是 MISS（重建）。
+;;   排查"切 tab / 增删 / 排序 tab 触发 SLOT_TAB_PAGES 整条重建"。配合
+;;   get_menu_widget 里 which==4 的 [tabpage] menu cache HIT/MISS 日志与
+;;   QTMTabPageContainer 的 [tabpage] rebuild/active 计数日志，在真实 GUI 里
+;;   驱动四种动作，看每次是 HIT（不重建）还是 MISS（重建）。
+;;
+;;   覆盖动作：
+;;     1. 切换 active（switch-to-view-index）—— 应只 active、零 rebuild。
+;;     2. 点 + 新建（new-document）—— 增 tab，签名变 → 1 次 rebuild。
+;;     3. 关闭一个 tab（safely-kill-tabpage）—— 减 tab，签名变 → 1 次 rebuild。
+;;     4. 拖拽排序（move-buffer-to-index）—— 集合不变、仅顺序变，签名按
+;;        tabpage-list 顺序拼接 → 顺序变也算签名变 → 1 次 rebuild（但指针复用）。
 ;;
 ;;   夹具从 $TEXMACS_PATH/tests/tmu 复制到 /tmp，避免 save/编辑污染检入副本。
-;;   带 stem-doc-id 以排除 auto-backup 标脏干扰（见 1106）。
-;;
 ;;   用 exec-delayed-at 串异步链，不阻塞 Qt 事件循环；链尾自己 quit。
 ;;
 ;; USAGE
@@ -21,6 +27,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (texmacs tests 2014))
+
+(import (only (srfi srfi-1) list-index))
 
 (define (tmp-name name)
   (string->url (string-append "/tmp/" name))
@@ -34,7 +42,24 @@
   ) ;let
 ) ;define
 
+;; 步骤间隔：给 Qt 事件循环 + typeset 足够时间，避免异步事件叠加。
+
 (define step-delay-ms 4000)
+
+;; 打印当前 tab 数与 buffer 列表，便于把 [tabpage] 日志和动作对齐。
+
+(define (log-state label)
+  (let ((n (length (tabpage-list #t))))
+    (display "[2014-step] ")
+    (display label)
+    (display "  tabs=")
+    (display n)
+    (newline)
+  ) ;let
+) ;define
+
+;; 串异步链：每步在 exec-delayed-at 触发，步间隔 step-delay-ms。
+;; 每个元素是 (label . action-thunk)。
 
 (define (run-chain steps)
   (let loop
@@ -46,6 +71,7 @@
                            (display label)
                            (newline)
                            (act)
+                           (log-state (string-append "after " label))
                            (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
                          ) ;lambda
           t
@@ -59,31 +85,63 @@
   (refresh-fixture "2014_a.tmu")
   (refresh-fixture "2014_b.tmu")
   (let* ((path-a (tmp-name "2014_a.tmu")) (path-b (tmp-name "2014_b.tmu")))
-    (let ((steps (list (cons "load a" (lambda () (load-buffer path-a)))
-                   (cons "load b" (lambda () (load-buffer path-b)))
-                 ) ;list
+    ;; 动作链：
+    ;;  - 载入 a、b（建 tab）
+    ;;  - 1. 来回切 5 轮（应零 rebuild，全部 menu cache HIT）
+    ;;  - 2. 新建 1 个 tab（+，应 1 次 MISS + 1 次 rebuild，added 仅 +1）
+    ;;  - 3. 关闭当前 tab（应 1 次 MISS + 1 次 rebuild，removed 仅 +1）
+    ;;  - 4. 排序：把当前 buffer 移到首位（应 1 次 MISS + 1 次 rebuild，added/removed 均为 0）
+    ;;  - 结束退出
+    ;;
+    ;; 关闭/排序的可预测性要点：
+    ;;  - new-document 建的是脏 buffer，safely-kill-tabpage 会命中 buffer-modified?
+    ;;    分支弹确认框、卡住异步链。故新建后立即 buffer-pretend-saved 去脏。
+    ;;  - 排序用 move-buffer-to-index 移到 index 0（首位），顺序必变。
+    (let ((steps (append (list (cons "load a" (lambda () (load-buffer path-a)))
+                           (cons "load b" (lambda () (load-buffer path-b)))
+                         ) ;list
+                   ;; 1) 切换 active：5 轮来回切 view 1 / view 2
+                   (let loop
+                     ((i 0) (acc '()))
+                     (if (>= i 5)
+                       (reverse acc)
+                       (loop (+ i 1)
+                         (append (list (cons (string-append "round " (number->string i) ": -> a")
+                                         (lambda () (switch-to-view-index 1))
+                                       ) ;cons
+                                   (cons (string-append "round " (number->string i) ": -> b")
+                                     (lambda () (switch-to-view-index 2))
+                                   ) ;cons
+                                 ) ;list
+                           acc
+                         ) ;append
+                       ) ;loop
+                     ) ;if
+                   ) ;let
+                   ;; 2) 新建 tab（+）并去脏，便于后续安全关闭
+                   (list (cons "new-document (+)" (lambda () (new-document))))
+                   (list (cons "buffer-pretend-saved"
+                           (lambda () (buffer-pretend-saved (current-buffer)))
+                         ) ;cons
+                   ) ;list
+                   ;; 3) 关闭当前 tab（新建的那个，已去脏，不弹框）
+                   (list (cons "safely-kill-tabpage" (lambda () (safely-kill-tabpage))))
+                   ;; 4) 排序：当前 buffer 移到首位（index 0）
+                   (list (cons "move-buffer-to-index (reorder to 0)"
+                           (lambda ()
+                             (let ((buf (current-buffer)))
+                               (when buf
+                                 (move-buffer-to-index buf 0)
+                               ) ;when
+                             ) ;let
+                           ) ;lambda
+                         ) ;cons
+                   ) ;list
+                   ;; 结束
+                   (list (cons "done; quitting" (lambda () (quit-TeXmacs))))
+                 ) ;append
           ) ;steps
          ) ;
-      ;; 在两个 tab 间来回切 5 轮。
-      (let loop
-        ((i 0) (acc steps))
-        (if (>= i 5)
-          (set! steps
-            (append acc (list (cons "done; quitting" (lambda () (quit-TeXmacs)))))
-          ) ;set!
-          (loop (+ i 1)
-            (append acc
-              (list (cons (string-append "round " (number->string i) ": -> a")
-                      (lambda () (switch-to-view-index 1))
-                    ) ;cons
-                (cons (string-append "round " (number->string i) ": -> b")
-                  (lambda () (switch-to-view-index 2))
-                ) ;cons
-              ) ;list
-            ) ;append
-          ) ;loop
-        ) ;if
-      ) ;let
       (display "[2014-step] starting delayed chain\n")
       (run-chain steps)
     ) ;let

--- a/devel/2014.md
+++ b/devel/2014.md
@@ -25,9 +25,23 @@ xmake r qt_tab_page_test qt_chat_tab_widget_test qt_tm_widget_add_tab_test  # �
 ### 3.2 非确定性测试（GUI 复现）
 ```bash
 xmake b stem
-MOGAN_TEST_GUI=1 xmake r 2014   # 真实 GUI 切 tab，观察是否重建
+MOGAN_TEST_GUI=1 xmake r 2014   # 真实 GUI，驱动切/增/删/排序 tab
 ```
-切 tab 时不应再触发整条重建（签名命中）；增删 tab 时正常重建。
+`2014.scm` 用异步链依次驱动四种动作，每种对照 `[tabpage]` 计数日志判读：
+
+- **切换 active**（`switch-to-view-index`）：只应见 `active #` 递增、**零 `rebuild`**。
+- **新建 `+`**（`new-document`）：增 tab，签名变 → 触发 `rebuild`，`added` 只 +1
+  （其余复用）。
+- **关闭**（`safely-kill-tabpage`）：减 tab，签名变 → 触发 `rebuild`，`removed` 只 +1。
+- **拖拽排序**（`move-buffer-to-index`）：实测在脚本驱动下**不触发 `SLOT_TAB_PAGES`**
+  （无 `rebuild` 行，`tabs` 数不变）。即当前实现里排序后 tab 栏不刷新——这本身是
+  理想行为（零重建）。脚本仍保留该步作为回归观测点：若将来排序改为触发刷新，
+  应见 `rebuild` 且 `added`/`removed` 不变（指针复用，不全量重建）。
+
+**判读要点**：`debug_added_count`/`debug_removed_count` 是累计计数（从对象创建起累加，
+不重置）。看每次 `rebuild` 行里这两个值相对上一次是否增长，而非 `rebuild` 行出现的
+次数——TeXmacs 对一次增删可能发多次 `SLOT_TAB_PAGES`，后续若 `added`/`removed` 不变
+即复用。
 
 ### 3.3 调试观察（LIII_DEBUG 下）
 
@@ -125,3 +139,12 @@ GUI 复现：切 tab 时 `signature HIT`（不重建）+ `SLOT_FILE`（更新 ac
    才让 `MOGAN_TEST_GUI` 生效，脆弱。删除 `xmake.lua` 里的旧定义与旧循环，只保留
    `tests.lua` 版本（带 `MOGAN_TEST_GUI` 的超集）。`includes` 在调用前加载，顺序正确。
    `MOGAN_TEST_GUI` 未设时行为与旧版完全一致（`-headless` + 自动 quit）。
+3. **GUI 复现脚本扩展至四种动作**（`TeXmacs/tests/2014.scm`）：原脚本只复现"切 tab"。
+   扩展为切换 active / 新建 `+` / 关闭 / 排序四条异步链，配合 `[tabpage]` 日志逐动作判读。
+   - 关闭可预测性：`new-document` 建的是脏 buffer，`safely-kill-tabpage` 会命中
+     `buffer-modified?` 分支弹确认框、卡住异步链。故新建后立即
+     `buffer-pretend-saved` 去脏，再安全关闭当前 tab。
+   - 排序用 `move-buffer-to-index` 移到首位（顺序必变）。实测在脚本驱动下排序
+     **不触发 `SLOT_TAB_PAGES`**（无 `rebuild` 行，`tabs` 数不变）——即当前
+     实现排序后 tab 栏不刷新，本身是理想行为；脚本保留该步作回归观测点。
+   - 复现结论：切 tab 零重建；新建 `added` 仅 +1、关闭 `removed` 仅 +1（增量非全量）。


### PR DESCRIPTION
原 2014.scm 只复现切 tab。
扩展为切换 active / 新建 + / 关闭 / 排序四条 异步链，配合 [tabpage] 计数日志逐动作判读。
关闭前 buffer-pretend-saved 去脏避免弹确认框卡链；排序用 move-buffer-to-index 移首位。
devel 3.2 写清 四动作预期与累计计数判读要点，7.5 补本次记录。