### PR TITLE
[3689] 修复 LaTeX 导出时 algo-state 未正确映射为 \State 的问题

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
@@ -432,6 +432,7 @@
   (dueto (textup (textbf (!append "(" 1 ") "))))
   (op 1)
   (todo (!group (!append (color "red!75!black") "[To do: " 1 "]")))
+  (algostate (!group "\\State " 1))
   (tmoutput 1)
   (tmerrput (!append (color "red!50!black") 1))
   (tmtiming (!append (hfill) (footnotesize) (color "black!50") 1 (par)))

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-texmacs-drd.scm
@@ -311,6 +311,7 @@
   dueto
   op
   todo
+  algostate
   tmdate
   tmoutput
   tmerrput

--- a/TeXmacs/tests/203_34.scm
+++ b/TeXmacs/tests/203_34.scm
@@ -1,0 +1,28 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 203_34.scm
+;; DESCRIPTION : Test LaTeX export of algo-state macro to standard \State command
+;; COPYRIGHT   : (C) 2026
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/plugins/latex/progs/init-latex.scm")
+
+(define (snippet->latex snippet opts)
+  (serialize-latex (texmacs->latex snippet opts)))
+
+(tm-define (test_203_34)
+  (with result (snippet->latex '(algo-state "x = 0") '())
+    (display* ";;; algo-state: " result "\n")
+    (check (string-contains? result "\\State") => #t)
+    (check (string-contains? result "\\algostate") => #f)))
+
+(check-report)

--- a/devel/203_34.md
+++ b/devel/203_34.md
@@ -1,0 +1,28 @@
+# [203_34] 导出的 .tex 使用了 \algostate，但 Overleaf 缺少定义该命令的宏包
+
+## 相关文档
+- [env-pseudo-code.ts](file:///d:/vscode/mogan/TeXmacs/packages/environment/env-pseudo-code.ts) - 伪代码环境定义
+
+## 任务相关的代码文件
+- [latex-define.scm](file:///d:/vscode/mogan/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm) - LaTeX 宏翻译映射表
+- [203_34.scm](file:///d:/vscode/mogan/TeXmacs/tests/203_34.scm) - 集成测试文件
+
+## 如何测试
+```bash
+xmake b 203_34
+xmake r 203_34
+```
+
+## 2026/06/26 修复 LaTeX 导出时 algo-state 映射缺失问题
+
+### What
+在导出为 LaTeX 格式时，将内部表示 `<algo-state|body>` 映射转换为 LaTeX 标准的 `\State {body}`。
+
+### Why
+之前没有配置映射关系，默认的转换器会将 `algo-state` 去掉连字符转换成 `\algostate`。而 standard LaTeX 的 `algpseudocode` / `algorithmic` 宏包只定义了 `\State`。用户在 LaTeX 工具中编译会报错 `undefined control sequence \algostate`。
+
+### How
+在 `latex-define.scm` 的一元宏表 `smart-table latex-texmacs-macro` 中新增映射：
+```scheme
+(algo-state (!group "\\State " 1))
+```


### PR DESCRIPTION
fix: 修复 LaTeX 导出时 algo-state 未正确映射为 \State 的问题 。Closes #3689