### PR TITLE
[1113] releasedbg 模式自动启用 enable_tests

### DIFF
--- a/.github/workflows/ci-debian13.yml
+++ b/.github/workflows/ci-debian13.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: config lolly
         if: steps.filter.outputs.lolly == 'true'
-        run: xmake config -vD --policies=build.ccache -m releasedbg --yes --enable_tests=true
+        run: xmake config -vD --policies=build.ccache -m releasedbg --yes
       - name: build lolly
         if: steps.filter.outputs.lolly == 'true'
         run: xmake build --yes -vD liblolly

--- a/.github/workflows/ci-debian13.yml
+++ b/.github/workflows/ci-debian13.yml
@@ -106,9 +106,8 @@ jobs:
               - 'TeXmacs/tests/*.scm'
               - '3rdparty/**'
 
-      - name: config lolly
-        if: steps.filter.outputs.lolly == 'true'
-        run: xmake config -vD --policies=build.ccache -m releasedbg --yes
+      - name: config
+        run: xmake config -vD --policies=build.ccache -o tmp/build -m releasedbg --yes
       - name: build lolly
         if: steps.filter.outputs.lolly == 'true'
         run: xmake build --yes -vD liblolly
@@ -116,9 +115,6 @@ jobs:
         if: steps.filter.outputs.lolly == 'true'
         run: xmake test "lolly_tests/*"
 
-      - name: config
-        if: steps.filter.outputs.lolly_src == 'true' || steps.filter.outputs.mogan == 'true'
-        run: xmake config -vD --policies=build.ccache -o tmp/build -m releasedbg --yes
       - name: build
         if: steps.filter.outputs.lolly_src == 'true' || steps.filter.outputs.mogan == 'true'
         run: xmake build --yes -vD stem && xmake build --yes -vD --group=tests

--- a/.github/workflows/ci-macos-arm64.yml
+++ b/.github/workflows/ci-macos-arm64.yml
@@ -123,9 +123,8 @@ jobs:
             ${{ env.XMAKE_GLOBALDIR }}/.xmake/packages
           key: xrepo-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('xmake/vars.lua', 'lolly/xmake.lua') }}
 
-      - name: config lolly
-        if: steps.filter.outputs.lolly == 'true'
-        run: xmake config --policies=build.ccache -m releasedbg --yes
+      - name: config
+        run: xmake config --policies=build.ccache -o ${{ runner.workspace }}/build -m releasedbg --yes
       - name: build lolly
         if: steps.filter.outputs.lolly == 'true'
         run: xmake build --yes -vD liblolly
@@ -133,9 +132,6 @@ jobs:
         if: steps.filter.outputs.lolly == 'true'
         run: xmake test "lolly_tests/*"
 
-      - name: config
-        if: steps.filter.outputs.lolly_src == 'true' || steps.filter.outputs.mogan == 'true'
-        run: xmake config --policies=build.ccache -o ${{ runner.workspace }}/build -m releasedbg --yes
       - name: build
         if: steps.filter.outputs.lolly_src == 'true' || steps.filter.outputs.mogan == 'true'
         run: xmake build --yes -vD stem && xmake build --yes -vD --group=tests

--- a/.github/workflows/ci-macos-arm64.yml
+++ b/.github/workflows/ci-macos-arm64.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: config lolly
         if: steps.filter.outputs.lolly == 'true'
-        run: xmake config --policies=build.ccache -m releasedbg --yes --enable_tests=true
+        run: xmake config --policies=build.ccache -m releasedbg --yes
       - name: build lolly
         if: steps.filter.outputs.lolly == 'true'
         run: xmake build --yes -vD liblolly

--- a/.github/workflows/ci-xmake-windows.yml
+++ b/.github/workflows/ci-xmake-windows.yml
@@ -109,8 +109,7 @@ jobs:
           path: |
             ${{ github.workspace }}/build/.build_cache
           key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('xmake/vars.lua', 'lolly/xmake.lua') }}
-      - name: config lolly
-        if: steps.filter.outputs.lolly == 'true'
+      - name: config
         run: xmake config --policies=build.ccache --yes -vD -m releasedbg --plat=windows
       - name: build lolly
         if: steps.filter.outputs.lolly == 'true'
@@ -118,9 +117,7 @@ jobs:
       - name: test lolly
         if: steps.filter.outputs.lolly == 'true'
         run: xmake test "lolly_tests/*"
-      - name: config
-        if: steps.filter.outputs.lolly_src == 'true' || steps.filter.outputs.mogan == 'true'
-        run: xmake config --policies=build.ccache --yes -vD -m releasedbg --plat=windows
+
       - name: build stem
         if: steps.filter.outputs.lolly_src == 'true' || steps.filter.outputs.mogan == 'true'
         run: xmake build --yes -vD stem

--- a/.github/workflows/ci-xmake-windows.yml
+++ b/.github/workflows/ci-xmake-windows.yml
@@ -111,7 +111,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('xmake/vars.lua', 'lolly/xmake.lua') }}
       - name: config lolly
         if: steps.filter.outputs.lolly == 'true'
-        run: xmake config --policies=build.ccache --yes -vD -m releasedbg --plat=windows --enable_tests=true
+        run: xmake config --policies=build.ccache --yes -vD -m releasedbg --plat=windows
       - name: build lolly
         if: steps.filter.outputs.lolly == 'true'
         run: xmake build --yes -vD liblolly

--- a/devel/1113.md
+++ b/devel/1113.md
@@ -189,4 +189,23 @@ xmake b moebius_tests
 - 同步删除 3 个 CI 中冗余的 `--enable_tests=true`。
 - 验证:releasedbg(无 flag)拉入 `liii-doctest`/`nanobench`;release 不拉。
 
-更新时间：2026/06/27
+## CI 合并为单个无条件 config
+
+### What
+3 个 CI(`ci-debian13`、`ci-macos-arm64`、`ci-xmake-windows`)原来有两条 config
+(`config lolly` + `config`),合并为单个**无条件**运行的 `config`。
+
+### Why
+releasedbg 已自动启用 enable_tests,lolly 与 mogan 两条路径的 config 命令参数一致,
+不再需要分两个 config。config 无条件运行也避免了"paths-filter 漏判导致 build 阶段
+找不到配置"的风险。build/test 阶段仍按 paths-filter 分支(lolly-only 时不构建 stem)。
+
+### How
+- 删除 `config lolly` 步骤。
+- 将原 `config` 的 `if` 条件去掉,变为无条件;命令沿用 mogan 路径的写法
+  (debian13/macos 带 `-o <build目录>`,windows 用默认目录)。
+- lolly 的 build/test 命令保持不变:它们复用 config 设定的 build 目录
+  (mogan 路径的 `xmake build stem` 本就如此工作)。
+- 注意:lolly-only 路径的 build 目录从"默认"变为与 mogan 一致的 `-o` 目录,功能等价。
+
+更新时间：2026/06/27(补充合并 config)

--- a/devel/1113.md
+++ b/devel/1113.md
@@ -154,3 +154,39 @@ xmake b moebius_tests
 ```
 
 整理时间：2026/06/26
+
+## 后续清理：移除 tm_search_backwards
+
+### What
+删除 `lolly/Data/String/cork.{hpp,cpp}` 中未被任何代码调用的 `tm_search_backwards`。
+
+### Why
+全仓搜索仅有声明与定义,无任何调用方,属于迁移到 lolly 后遗留的死代码
+(main 上 `aa354063f` 的任务文档第 125-130 行也记录了它的死循环 bug)。
+保留 `tm_search_forwards`(有调用方)。
+
+### 改动
+- `lolly/Data/String/cork.hpp`: 删除声明及其 docblock。
+- `lolly/Data/String/cork.cpp`: 删除实现。
+
+## releasedbg 模式自动启用 enable_tests
+
+### What
+让 lolly 在 `-m releasedbg` 下自动启用测试,无需 CI 显式传 `--enable_tests=true`。
+
+### Why
+此前 3 个 CI(`ci-debian13`、`ci-xmake-windows`、`ci-macos-arm64`)的 lolly config 步骤
+都要手写 `--enable_tests=true`,而 mogan config 步骤又不带该 flag——
+两条路径 config 命令不一致。releasedbg 本就是带符号的优化构建(CI/开发主用模式),
+默认开测试合理,统一默认值后 config 命令可以一致。
+
+### How
+- 不用 `set_default(is_mode(...))`:option 的 default 求值早于 mode 确定,
+  实测 `is_mode("releasedbg")` 在该点恒返回 false。
+- 改为在两处使用点(`add_requires` 段、`lolly_test_dynamic_library` 等 target 段)
+  把 `has_config("enable_tests")` 改成 `has_config("enable_tests") or is_mode("releasedbg")`。
+  这两处在文件作用域求值,mode 已确定。
+- 同步删除 3 个 CI 中冗余的 `--enable_tests=true`。
+- 验证:releasedbg(无 flag)拉入 `liii-doctest`/`nanobench`;release 不拉。
+
+更新时间：2026/06/27

--- a/lolly/xmake.lua
+++ b/lolly/xmake.lua
@@ -52,11 +52,13 @@ option("posix_thread")
 option_end()
 
 option("enable_tests")
+    set_default(false)
     set_description([[
 Enable tests or not
     - false (default)
     - true
-]])
+    - releasedbg mode: enabled automatically
+    ]])
 option_end()
 
 
@@ -66,7 +68,7 @@ local JEMALLOC_VERSION = "5.3.0"
 
 tbox_configs = {hash=true, ["force-utf8"]=true, charset=true}
 add_requires("tbox", {system=false, configs=tbox_configs})
-if has_config("enable_tests") then
+if has_config("enable_tests") or is_mode("releasedbg") then
     add_requires("liii-doctest", {system=false})
     add_requires("nanobench", {system=false})
 end
@@ -279,7 +281,7 @@ function add_bench_target(filepath)
     end
 end
 
-if has_config("enable_tests") then
+if has_config("enable_tests") or is_mode("releasedbg") then
     target("lolly_example_dynamic_library") do
         set_kind ("shared")
         set_languages("c++17")


### PR DESCRIPTION
## Summary
- lolly 在 `-m releasedbg` 下默认开启测试，CI 不再需要显式传 `--enable_tests=true`。
- 删除 `ci-debian13`、`ci-macos-arm64`、`ci-xmake-windows` 中冗余的 `--enable_tests=true`，使 lolly / mogan 两条路径的 config 命令一致。

## Why
此前 3 个 CI 的 lolly config 步骤要手写 `--enable_tests=true`，而 mogan config 步骤又不带该 flag——两条路径 config 命令不一致。releasedbg 是带符号的优化构建（CI/开发主用模式），默认开测试合理。

## How
- 不用 `set_default(is_mode(...))`：option 的 default 求值早于 mode 确定，实测 `is_mode("releasedbg")` 在该点恒返回 false。
- 改为在两处使用点（`add_requires` 段、`lolly_test_dynamic_library` 等 target 段）把 `has_config("enable_tests")` 改成 `has_config("enable_tests") or is_mode("releasedbg")`。这两处在文件作用域求值，mode 已确定。
- 同步删除 3 个 CI 中冗余的 `--enable_tests=true`。

## Test plan
- [x] 本地验证：releasedbg（无 flag）拉入 `liii-doctest`/`nanobench`；release 不拉
- [ ] CI 通过