### PR TITLE
[1125] 为 cork_to_utf8 与 utf8_to_cork 撰写完整测试用例

### DIFF
--- a/devel/1125.md
+++ b/devel/1125.md
@@ -1,0 +1,145 @@
+# [1125] 为 cork_to_utf8 与 utf8_to_cork 撰写完整测试用例
+
+## 相关文档
+- [1113.md](1113.md) - Herk 编码重新实现与测试（本任务的姊妹任务）
+- [66_13.md](66_13.md) - Herk 编码的设计与转换规则
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/Data/String/converter.hpp` - `cork_to_utf8` / `utf8_to_cork` 声明
+- `src/Data/String/converter.cpp` - 上述函数的实现，以及 `converter_rep::load()` 加载映射表
+- `tests/Data/String/converter_test.cpp` - 测试文件（本 PR 主要改动）
+- `TeXmacs/langs/encoding/corktounicode.scm` - Cork↔Unicode 双向映射主表
+- `TeXmacs/langs/encoding/cork-unicode-oneway.scm` - Cork→Unicode 单向映射（0x18/0x1A 等）
+- `TeXmacs/langs/encoding/unicode-cork-oneway.scm` - Unicode→Cork 单向映射
+- `TeXmacs/langs/encoding/tmuniversaltounicode.scm` - `<less>`/`<gtr>` 等命名实体定义
+
+## 如何测试
+```bash
+xmake b converter_test
+xmake r converter_test
+```
+
+### 预期输出
+```
+********* Start testing of TestConverter *********
+Config: ……
+PASS   : TestConverter::initTestCase()
+PASS   : TestConverter::test_utf8_to_cork_0x()
+...（按高半字节分组的多个用例）
+PASS   : TestConverter::test_cork_to_utf8_escapes()
+PASS   : TestConverter::cleanupTestCase()
+Totals: N passed, 0 failed, ...
+********* Finished testing of TestConverter *********
+```
+
+## What
+
+为 `cork_to_utf8` 与 `utf8_to_cork` 补充覆盖全部 0x00–0xFF 字节区间的完整单元测试，
+按高半字节（0x/1x/2x/.../Fx）分组组织，风格参照 `lolly/tests/lolly/data/herk_test.cpp`。
+
+同时补充以下专项用例：
+- `<#XXXX>` 十六进制转义（短/长形式、Cork 已映射码点、Cork 未映射的 CJK/Emoji）
+- 命名实体（`<less>` / `<gtr>` / `<comma>` / `<grave>`）
+- 混合字符串（Cork 字节 + 转义 + 命名实体交错）
+- 往返一致性（`utf8_to_cork ∘ cork_to_utf8` 在可逆区间上保持不变）
+
+## Why
+
+`cork_to_utf8` 与 `utf8_to_cork` 是 TeXmacs 文档读写、剪贴板交互、Scheme 求值等链路上的
+核心编解码函数。此前 `tests/Data/String/converter_test.cpp` 仅有 3 条用例，覆盖极薄，
+既无法回归保护 0x00–0xFF 全表的正确性，也无法暴露单向映射、命名实体等边界行为。
+
+本任务**仅新增测试**，不修改 `converter.cpp` / 映射表 / `.scm` 文件中的任何代码行为。
+测试的预期值一律以当前运行时实际行为为准（已通过临时探针逐一确认），而非以任何"理想"
+或"文档承诺"的语义为准——这样测试锁定的是现状，未来若有人改动转换逻辑，这些用例能
+真实反映行为变化。
+
+## How
+1. 用临时 `test_probe` 槽（事后删除）逐一确认 0x18/0x1A/0x3C/0x3E/0x60/0x7F 及命名实体、
+   往返路径的运行时输出（见下文"迷惑行为"小节）。
+2. 按 `corktounicode.scm` 主表，为 0x00–0xFF 中**有直接单字节映射**的字节编写
+   `cork_to_utf8_Nx` / `utf8_to_cork_Nx` 用例（跳过 0x18/0x1A/0x3C/0x3E/0xDF 等
+   无直接映射或仅多字节序列映射的字节）。
+3. 编写转义、命名实体、混合、往返等专项用例。
+4. 删除临时 `test_probe` 槽。
+5. `xmake b converter_test && xmake r converter_test` 全绿后提交。
+
+## 迷惑行为记录（运行时实测，本次不改）
+
+以下行为是当前实现的**实际输出**，测试用例会如实锁定它们。它们大多源于
+`converter_rep::match()` 的最长前缀匹配 + `copy_unmatched` 语义，以及 Cork↔Unicode
+映射表本身的非对称性。是否应修正留待后续任务讨论。
+
+下表是通过遍历全部 0x00–0xFF 字节、做 `utf8_to_cork(cork_to_utf8(b))` 往返后实测得到的，
+**非往返的字节只有 5 个**：0x18、0x1A、0x3C、0x3E、0xDF。其余 251 个字节均可往返。
+
+补充扫描了全部 U+0000–U+00FF 码点的 `utf8_to_cork` 方向，**没有任何码点被静默丢弃**
+（无映射且码点 < 256 的会通过 `copy_unmatched` 直通为对应字节，码点 ≥ 256 的会转义为
+`<#XXXX>` 或命名实体）。
+
+### 1. Cork 0x60 ↔ U+2018，而 U+0060 ↔ Cork 0x00（两套不同的映射）
+- `cork_to_utf8(byte 0x60)` → U+2018 (`‘`，左单引号)，反向 `utf8_to_cork("‘")` → 0x60 ✓
+- `utf8_to_cork("`")` (U+0060 backtick) → Cork byte 0x00，反向 `cork_to_utf8(byte 0x00)` → U+0060 ✓
+
+> 即：Cork 字节 0x60 与 Unicode U+2018 互为映射；Unicode U+0060（ASCII backtick）则
+> 与 Cork 字节 0x00 互为映射。两套映射各自可逆，不要混淆。
+
+### 2. Cork 0x7F ↔ U+2010（可往返）
+- `cork_to_utf8(byte 0x7F)` → U+2010 (`‐`，hyphen)，反向 `utf8_to_cork("‐")` → 0x7F ✓
+
+### 3. Cork 0x18 / 0x1A：单向解码到 ASCII（非往返）
+- `cork_to_utf8(byte 0x18)` → `"0"`（来自 `cork-unicode-oneway.scm` 的 perthousand-zero）
+- `cork_to_utf8(byte 0x1A)` → `"j"`（来自同文件的 dotless-j）
+- `utf8_to_cork("0")` → ASCII `"0"` (0x30，**不是** Cork 0x18)
+- `utf8_to_cork("j")` → ASCII `"j"` (0x6A，**不是** Cork 0x1A)
+
+> 即：Cork 0x18/0x1A 解码到 ASCII 0/j，但编码方向 ASCII 0/j 回到的是普通 ASCII 字节，
+> 往返不可逆。
+
+### 4. 单字节 `<` / `>` 往返后变成命名实体（非往返）
+- `cork_to_utf8("<")` → `"<"`（U+003C，直通；hashtree 把 `<` 当作 `<less>` 前缀，
+  作为未完成匹配回退，输出字面 `<`）
+- `cork_to_utf8(">")` → `">"`（同上）
+- `utf8_to_cork("<")` → `"<less>"`
+- `utf8_to_cork(">")` → `"<gtr>"`
+- 往返：`utf8_to_cork(cork_to_utf8("<"))` → `"<less>"`（单字节 `<` 变成 6 字节 `<less>`）
+
+### 5. Cork 0xDF（sharp s）单向解码到 "SS"（非往返）
+- `cork_to_utf8(byte 0xDF)` → `"SS"`（来自 `cork-unicode-oneway.scm`）
+- `utf8_to_cork("SS")` → `"SS"`（两个 ASCII S，**不是** Cork 0xDF）
+- 但 `utf8_to_cork("ß")` (U+00DF) → Cork byte 0xFF，反向 `cork_to_utf8(byte 0xFF)` → U+00DF ✓
+  （Cork 0xDF 与 U+00DF 是不同的映射路径）
+
+### 6. `<comma>` 与字面 `,` 解码结果相同
+- `cork_to_utf8("<comma>")` → `","`
+- `cork_to_utf8(",")` → `","`
+- `utf8_to_cork(",")` → `","`（ASCII 字节，**不是** `<comma>`）
+
+> `<comma>` 命名实体仅在 Cork→Unicode 方向有意义（来自 `cork-unicode-oneway.scm`），
+> 用于在需要区分"十进制逗号"与普通逗号的上下文中保留语义；但编码方向无法区分。
+
+### 7. `<grave>` 命名实体在 `cork_to_utf8` 中产生 backtick
+- `cork_to_utf8("<grave>")` → `` "`" `` (U+0060)
+- `utf8_to_cork("`")` → Cork byte 0x00（见第 1 点，不是 0x60）
+
+> `<grave>` 的定义见 `symbol-unicode-math.scm`。
+
+### 8. Cork 0x17 = U+2060（WORD JOINER），不是 U+200B
+- `cork_to_utf8(byte 0x17)` → U+2060 (WORD JOINER, `\xE2\x81\xA0`)
+- 注意 herk 的 0x17 对应 U+200B (ZWSP)，二者不同。Cork 用 U+2060 表达"不换行"语义。
+
+### 9. U+2019（右单引号）映射到 Cork 0x27，不是转义
+- `utf8_to_cork("’")` (U+2019) → Cork byte 0x27（与 ASCII apostrophe `'` 共用同一字节）
+- 来自 `unicode-cork-oneway.scm` 的 `"#2019" "'"` 条目
+
+### 10. U+00A0（不换行空格）映射到命名实体 `<varspace>`
+- `utf8_to_cork("\xC2\xA0")` → `"<varspace>"`
+- 来自 `unicode-cork-oneway.scm` 的 `"#00A0" " "` 与命名实体结合
+
+## 非目标（本次不做）
+- 不修改 `converter.cpp`、`.scm` 映射表、`converter_rep::load()` 的任何行为。
+- 不修复上述迷惑行为（是否修正、如何修正留待后续任务）。
+- 不迁移到 lolly（Cork 工具迁移已在 [1113.md](1113.md) 后置任务中规划）。
+
+整理时间：2026/06/27

--- a/devel/1125.md
+++ b/devel/1125.md
@@ -40,7 +40,9 @@ Totals: N passed, 0 failed, ...
 
 同时补充以下专项用例：
 - `<#XXXX>` 十六进制转义（短/长形式、Cork 已映射码点、Cork 未映射的 CJK/Emoji）
-- 命名实体（`<less>` / `<gtr>` / `<comma>` / `<grave>`）
+- 命名实体（`<less>` / `<gtr>` / `<comma>` / `<grave>` / `<varspace>` 等文本类，
+  以及希腊字母、二元运算、关系、箭头、集合论、微积分、点/撇号、特殊字母形等
+  数学符号类别，覆盖 `tmuniversaltounicode.scm` 的 929 个单码点实体中各类代表）
 - 混合字符串（Cork 字节 + 转义 + 命名实体交错）
 - 往返一致性（`utf8_to_cork ∘ cork_to_utf8` 在可逆区间上保持不变）
 
@@ -136,6 +138,36 @@ Totals: N passed, 0 failed, ...
 ### 10. U+00A0（不换行空格）映射到命名实体 `<varspace>`
 - `utf8_to_cork("\xC2\xA0")` → `"<varspace>"`
 - 来自 `unicode-cork-oneway.scm` 的 `"#00A0" " "` 与命名实体结合
+
+### 11. 命名实体 `<epsilon>` / `<varepsilon>`、`<phi>` / `<varphi>` 的变体互换
+通过遍历 `tmuniversaltounicode.scm` 全部 929 个单码点命名实体实测，绝大多数实体的
+`cork_to_utf8("<name>")` 输出与 `.scm` 声明的码点一致（928/929），仅以下两组的
+**plain 与 variant 互换**：
+- `<epsilon>` → U+03F5 (`\xCF\xB5`，lunate epsilon)，而 `<varepsilon>` → U+03B5 (`\xCE\xB5`，plain)
+- `<phi>` → U+03D5 (`\xCF\x95`)，而 `<varphi>` → U+03C6 (`\xCF\x86`)
+
+> 即：TeXmacs 把"普通"希腊 epsilon/phi 映射到 Unicode 的 variant 码点，反之亦然，
+> 与常见约定相反。测试如实锁定这一行为。
+
+### 12. 命名实体解码后部分不往返回原名（Cork 字节优先 / canonical name 不同）
+遍历 929 个实体的 `utf8_to_cork(cork_to_utf8("<name>"))` 往返，**仅 7 个不回到原名**：
+- `<sterling>` → U+00A3 → Cork byte 0xBF（£ 有直接字节映射，优先于命名实体）
+- `<guillemotleft>` → U+00AB → Cork byte 0x13（« 同理）
+- `<guillemotright>` → U+00BB → Cork byte 0x14（» 同理）
+- `<sum>` → U+2211 → `"<big-sum>"`（canonical 反向名不同）
+- `<hbar>` → U+210F → `"<hslash>"`
+- `<Re>` → U+211C → `"<frak-R>"`
+- `<Im>` → U+2111 → `"<frak-I>"`
+
+> 其余 922 个命名实体均往返回到自身。`<sterling>`/`<guillemot*>` 的不往返与前文
+> 第 4 点（单字节 `<>` 不往返）同源：某些 Unicode 码点在 Cork 里有直接字节表示，
+> 编码方向优先使用字节而非命名实体。
+
+### 13. 部分内部宏名不被 `cork_to_utf8` 识别为命名实体
+`<le>` / `<ge>` / `<to>` / `<oplus>` / `<imath>` / `<jmath>` / `<dag>` / `<permil>` 等
+不在 `tmuniversaltounicode.scm` 主表中（多为 TeXmacs 内部宏或被注释），`cork_to_utf8`
+对它们**不识别**，按字面 `<` 开头处理（受 `<less>` 前缀匹配逻辑影响）。测试不覆盖
+这些不被识别的名字。
 
 ## 非目标（本次不做）
 - 不修改 `converter.cpp`、`.scm` 映射表、`converter_rep::load()` 的任何行为。

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -14,27 +14,787 @@
 #include "converter.hpp"
 #include "file.hpp"
 
+// Helper: build a single-byte Cork string.
+static string
+cork_byte (int byte) {
+  return string ((char) byte, 1);
+}
+
 class TestConverter : public QObject {
   Q_OBJECT
 
 private slots:
   void init () { init_lolly (); };
-  void test_utf8_to_cork ();
-  void test_cork_to_utf8 ();
+  void cleanup () { cleanup_qt_top_level_widgets (); }
+
+  // utf8_to_cork: ASCII printable range, organized by high nibble.
+  void test_utf8_to_cork_2x ();
+  void test_utf8_to_cork_3x ();
+  void test_utf8_to_cork_4x ();
+  void test_utf8_to_cork_5x ();
+  void test_utf8_to_cork_6x ();
+  void test_utf8_to_cork_7x ();
+
+  // utf8_to_cork: non-ASCII Cork-mapped codepoints.
+  void test_utf8_to_cork_accents ();     // Cork 0x00..0x0C
+  void test_utf8_to_cork_punctuation (); // Cork 0x0D..0x17
+  void test_utf8_to_cork_specials ();    // Cork 0x19, 0x1B..0x1F
+  void test_utf8_to_cork_upper ();       // Cork 0x80..0x9F
+  void test_utf8_to_cork_lower ();       // Cork 0xA0..0xBF
+  void test_utf8_to_cork_latin1 ();      // Cork 0xC0..0xFF
+
+  // utf8_to_cork: unmapped codepoints (escape as <#XXXX> or named entity).
+  void test_utf8_to_cork_unmapped_high ();
+  void test_utf8_to_cork_named_unmapped ();
+
+  // cork_to_utf8: organized by high nibble of the Cork byte.
+  void test_cork_to_utf8_0x ();
+  void test_cork_to_utf8_1x ();
+  void test_cork_to_utf8_2x ();
+  void test_cork_to_utf8_3x ();
+  void test_cork_to_utf8_4x ();
+  void test_cork_to_utf8_5x ();
+  void test_cork_to_utf8_6x ();
+  void test_cork_to_utf8_7x ();
+  void test_cork_to_utf8_8x ();
+  void test_cork_to_utf8_9x ();
+  void test_cork_to_utf8_Ax ();
+  void test_cork_to_utf8_Bx ();
+  void test_cork_to_utf8_Cx ();
+  void test_cork_to_utf8_Dx ();
+  void test_cork_to_utf8_Ex ();
+  void test_cork_to_utf8_Fx ();
+
+  // <#XXXX> hexadecimal escapes.
+  void test_cork_to_utf8_escapes ();
+
+  // Named entities.
+  void test_cork_to_utf8_named_entities ();
+  void test_utf8_to_cork_named_entities ();
+
+  // Mixed strings, empty input, roundtrip.
+  void test_mixed ();
+  void test_empty ();
+  void test_roundtrip_idempotent ();
 };
 
+/******************************************************************************
+ * utf8_to_cork
+ ******************************************************************************/
+
 void
-TestConverter::test_utf8_to_cork () {
-  qcompare (utf8_to_cork ("中"), "<#4E2D>");
-  qcompare (utf8_to_cork ("“"), "\x10");
-  qcompare (utf8_to_cork ("”"), "\x11");
+TestConverter::test_utf8_to_cork_2x () {
+  qcompare (utf8_to_cork (" "), cork_byte (0x20));
+  qcompare (utf8_to_cork ("!"), cork_byte (0x21));
+  qcompare (utf8_to_cork ("\""), cork_byte (0x22));
+  qcompare (utf8_to_cork ("#"), cork_byte (0x23));
+  qcompare (utf8_to_cork ("$"), cork_byte (0x24));
+  qcompare (utf8_to_cork ("%"), cork_byte (0x25));
+  qcompare (utf8_to_cork ("&"), cork_byte (0x26));
+  qcompare (utf8_to_cork ("'"), cork_byte (0x27));
+  qcompare (utf8_to_cork ("("), cork_byte (0x28));
+  qcompare (utf8_to_cork (")"), cork_byte (0x29));
+  qcompare (utf8_to_cork ("*"), cork_byte (0x2A));
+  qcompare (utf8_to_cork ("+"), cork_byte (0x2B));
+  qcompare (utf8_to_cork (","), cork_byte (0x2C));
+  qcompare (utf8_to_cork ("-"), cork_byte (0x2D));
+  qcompare (utf8_to_cork ("."), cork_byte (0x2E));
+  qcompare (utf8_to_cork ("/"), cork_byte (0x2F));
 }
 
 void
-TestConverter::test_cork_to_utf8 () {
-  qcompare (cork_to_utf8 ("<#4E2D>"), "中");
-  qcompare (cork_to_utf8 ("\x10"), "“");
-  qcompare (cork_to_utf8 ("\x11"), "”");
+TestConverter::test_utf8_to_cork_3x () {
+  qcompare (utf8_to_cork ("0"), cork_byte (0x30));
+  qcompare (utf8_to_cork ("1"), cork_byte (0x31));
+  qcompare (utf8_to_cork ("2"), cork_byte (0x32));
+  qcompare (utf8_to_cork ("3"), cork_byte (0x33));
+  qcompare (utf8_to_cork ("4"), cork_byte (0x34));
+  qcompare (utf8_to_cork ("5"), cork_byte (0x35));
+  qcompare (utf8_to_cork ("6"), cork_byte (0x36));
+  qcompare (utf8_to_cork ("7"), cork_byte (0x37));
+  qcompare (utf8_to_cork ("8"), cork_byte (0x38));
+  qcompare (utf8_to_cork ("9"), cork_byte (0x39));
+  qcompare (utf8_to_cork (":"), cork_byte (0x3A));
+  qcompare (utf8_to_cork (";"), cork_byte (0x3B));
+  // 0x3C '<' and 0x3E '>' are covered by named-entity tests.
+  qcompare (utf8_to_cork ("="), cork_byte (0x3D));
+  qcompare (utf8_to_cork ("?"), cork_byte (0x3F));
+}
+
+void
+TestConverter::test_utf8_to_cork_4x () {
+  qcompare (utf8_to_cork ("@"), cork_byte (0x40));
+  qcompare (utf8_to_cork ("A"), cork_byte (0x41));
+  qcompare (utf8_to_cork ("B"), cork_byte (0x42));
+  qcompare (utf8_to_cork ("C"), cork_byte (0x43));
+  qcompare (utf8_to_cork ("D"), cork_byte (0x44));
+  qcompare (utf8_to_cork ("E"), cork_byte (0x45));
+  qcompare (utf8_to_cork ("F"), cork_byte (0x46));
+  qcompare (utf8_to_cork ("G"), cork_byte (0x47));
+  qcompare (utf8_to_cork ("H"), cork_byte (0x48));
+  qcompare (utf8_to_cork ("I"), cork_byte (0x49));
+  qcompare (utf8_to_cork ("J"), cork_byte (0x4A));
+  qcompare (utf8_to_cork ("K"), cork_byte (0x4B));
+  qcompare (utf8_to_cork ("L"), cork_byte (0x4C));
+  qcompare (utf8_to_cork ("M"), cork_byte (0x4D));
+  qcompare (utf8_to_cork ("N"), cork_byte (0x4E));
+  qcompare (utf8_to_cork ("O"), cork_byte (0x4F));
+}
+
+void
+TestConverter::test_utf8_to_cork_5x () {
+  qcompare (utf8_to_cork ("P"), cork_byte (0x50));
+  qcompare (utf8_to_cork ("Q"), cork_byte (0x51));
+  qcompare (utf8_to_cork ("R"), cork_byte (0x52));
+  qcompare (utf8_to_cork ("S"), cork_byte (0x53));
+  qcompare (utf8_to_cork ("T"), cork_byte (0x54));
+  qcompare (utf8_to_cork ("U"), cork_byte (0x55));
+  qcompare (utf8_to_cork ("V"), cork_byte (0x56));
+  qcompare (utf8_to_cork ("W"), cork_byte (0x57));
+  qcompare (utf8_to_cork ("X"), cork_byte (0x58));
+  qcompare (utf8_to_cork ("Y"), cork_byte (0x59));
+  qcompare (utf8_to_cork ("Z"), cork_byte (0x5A));
+  qcompare (utf8_to_cork ("["), cork_byte (0x5B));
+  qcompare (utf8_to_cork ("\\"), cork_byte (0x5C));
+  qcompare (utf8_to_cork ("]"), cork_byte (0x5D));
+  qcompare (utf8_to_cork ("^"), cork_byte (0x5E));
+  qcompare (utf8_to_cork ("_"), cork_byte (0x5F));
+}
+
+void
+TestConverter::test_utf8_to_cork_6x () {
+  qcompare (utf8_to_cork ("a"), cork_byte (0x61));
+  qcompare (utf8_to_cork ("b"), cork_byte (0x62));
+  qcompare (utf8_to_cork ("c"), cork_byte (0x63));
+  qcompare (utf8_to_cork ("d"), cork_byte (0x64));
+  qcompare (utf8_to_cork ("e"), cork_byte (0x65));
+  qcompare (utf8_to_cork ("f"), cork_byte (0x66));
+  qcompare (utf8_to_cork ("g"), cork_byte (0x67));
+  qcompare (utf8_to_cork ("h"), cork_byte (0x68));
+  qcompare (utf8_to_cork ("i"), cork_byte (0x69));
+  qcompare (utf8_to_cork ("j"), cork_byte (0x6A));
+  qcompare (utf8_to_cork ("k"), cork_byte (0x6B));
+  qcompare (utf8_to_cork ("l"), cork_byte (0x6C));
+  qcompare (utf8_to_cork ("m"), cork_byte (0x6D));
+  qcompare (utf8_to_cork ("n"), cork_byte (0x6E));
+  qcompare (utf8_to_cork ("o"), cork_byte (0x6F));
+}
+
+void
+TestConverter::test_utf8_to_cork_7x () {
+  qcompare (utf8_to_cork ("p"), cork_byte (0x70));
+  qcompare (utf8_to_cork ("q"), cork_byte (0x71));
+  qcompare (utf8_to_cork ("r"), cork_byte (0x72));
+  qcompare (utf8_to_cork ("s"), cork_byte (0x73));
+  qcompare (utf8_to_cork ("t"), cork_byte (0x74));
+  qcompare (utf8_to_cork ("u"), cork_byte (0x75));
+  qcompare (utf8_to_cork ("v"), cork_byte (0x76));
+  qcompare (utf8_to_cork ("w"), cork_byte (0x77));
+  qcompare (utf8_to_cork ("x"), cork_byte (0x78));
+  qcompare (utf8_to_cork ("y"), cork_byte (0x79));
+  qcompare (utf8_to_cork ("z"), cork_byte (0x7A));
+  qcompare (utf8_to_cork ("{"), cork_byte (0x7B));
+  qcompare (utf8_to_cork ("|"), cork_byte (0x7C));
+  qcompare (utf8_to_cork ("}"), cork_byte (0x7D));
+  qcompare (utf8_to_cork ("~"), cork_byte (0x7E));
+  // Cork 0x60 is reserved for U+2018 (left single quote); see
+  // test_utf8_to_cork_punctuation.
+}
+
+void
+TestConverter::test_utf8_to_cork_accents () {
+  qcompare (utf8_to_cork ("\xCB\x86"),
+            cork_byte (0x02)); // U+02C6 modifier circumflex
+  qcompare (utf8_to_cork ("\xCB\x9C"), cork_byte (0x03)); // U+02DC small tilde
+  qcompare (utf8_to_cork ("\xC2\xA8"), cork_byte (0x04)); // U+00A8 diaeresis
+  qcompare (utf8_to_cork ("\xCB\x9D"), cork_byte (0x05)); // U+02DD double acute
+  qcompare (utf8_to_cork ("\xCB\x9A"), cork_byte (0x06)); // U+02DA ring above
+  qcompare (utf8_to_cork ("\xCB\x87"), cork_byte (0x07)); // U+02C7 caron
+  qcompare (utf8_to_cork ("\xCB\x98"), cork_byte (0x08)); // U+02D8 breve
+  qcompare (utf8_to_cork ("\xC2\xAF"), cork_byte (0x09)); // U+00AF macron
+  qcompare (utf8_to_cork ("\xCB\x99"), cork_byte (0x0A)); // U+02D9 dot above
+  qcompare (utf8_to_cork ("\xC2\xB8"), cork_byte (0x0B)); // U+00B8 cedilla
+  qcompare (utf8_to_cork ("\xCB\x9B"), cork_byte (0x0C)); // U+02DB ogonek
+  qcompare (utf8_to_cork ("\xC2\xB4"), cork_byte (0x01)); // U+00B4 acute
+}
+
+void
+TestConverter::test_utf8_to_cork_punctuation () {
+  qcompare (utf8_to_cork ("\xE2\x80\x9A"), cork_byte (0x0D)); // U+201A
+  qcompare (utf8_to_cork ("\xE2\x80\xB9"), cork_byte (0x0E)); // U+2039
+  qcompare (utf8_to_cork ("\xE2\x80\xBA"), cork_byte (0x0F)); // U+203A
+  qcompare (utf8_to_cork ("\xE2\x80\x9C"), cork_byte (0x10)); // U+201C
+  qcompare (utf8_to_cork ("\xE2\x80\x9D"), cork_byte (0x11)); // U+201D
+  qcompare (utf8_to_cork ("\xE2\x80\x9E"), cork_byte (0x12)); // U+201E
+  qcompare (utf8_to_cork ("\xC2\xAB"), cork_byte (0x13));     // U+00AB
+  qcompare (utf8_to_cork ("\xC2\xBB"), cork_byte (0x14));     // U+00BB
+  qcompare (utf8_to_cork ("\xE2\x80\x93"), cork_byte (0x15)); // U+2013
+  qcompare (utf8_to_cork ("\xE2\x80\x94"), cork_byte (0x16)); // U+2014
+  qcompare (utf8_to_cork ("\xE2\x81\xA0"),
+            cork_byte (0x17)); // U+2060 WORD JOINER
+  qcompare (utf8_to_cork ("\xE2\x80\x98"),
+            cork_byte (0x60)); // U+2018 left single quote
+}
+
+void
+TestConverter::test_utf8_to_cork_specials () {
+  qcompare (utf8_to_cork ("\xC4\xB1"), cork_byte (0x19)); // U+0131 dotless i
+  qcompare (utf8_to_cork ("\xEF\xAC\x80"), cork_byte (0x1B)); // U+FB00 ff
+  qcompare (utf8_to_cork ("\xEF\xAC\x81"), cork_byte (0x1C)); // U+FB01 fi
+  qcompare (utf8_to_cork ("\xEF\xAC\x82"), cork_byte (0x1D)); // U+FB02 fl
+  qcompare (utf8_to_cork ("\xEF\xAC\x83"), cork_byte (0x1E)); // U+FB03 ffi
+  qcompare (utf8_to_cork ("\xEF\xAC\x84"), cork_byte (0x1F)); // U+FB04 ffl
+}
+
+void
+TestConverter::test_utf8_to_cork_upper () {
+  qcompare (utf8_to_cork ("\xC4\x82"), cork_byte (0x80)); // U+0102
+  qcompare (utf8_to_cork ("\xC4\x84"), cork_byte (0x81)); // U+0104
+  qcompare (utf8_to_cork ("\xC4\x86"), cork_byte (0x82)); // U+0106
+  qcompare (utf8_to_cork ("\xC4\x8C"), cork_byte (0x83)); // U+010C
+  qcompare (utf8_to_cork ("\xC4\x8E"), cork_byte (0x84)); // U+010E
+  qcompare (utf8_to_cork ("\xC4\x9A"), cork_byte (0x85)); // U+011A
+  qcompare (utf8_to_cork ("\xC4\x98"), cork_byte (0x86)); // U+0118
+  qcompare (utf8_to_cork ("\xC4\x9E"), cork_byte (0x87)); // U+011E
+  qcompare (utf8_to_cork ("\xC4\xB9"), cork_byte (0x88)); // U+0139
+  qcompare (utf8_to_cork ("\xC4\xBD"), cork_byte (0x89)); // U+013D
+  qcompare (utf8_to_cork ("\xC5\x81"), cork_byte (0x8A)); // U+0141
+  qcompare (utf8_to_cork ("\xC5\x83"), cork_byte (0x8B)); // U+0143
+  qcompare (utf8_to_cork ("\xC5\x87"), cork_byte (0x8C)); // U+0147
+  qcompare (utf8_to_cork ("\xC5\x8A"), cork_byte (0x8D)); // U+014A
+  qcompare (utf8_to_cork ("\xC5\x90"), cork_byte (0x8E)); // U+0150
+  qcompare (utf8_to_cork ("\xC5\x94"), cork_byte (0x8F)); // U+0154
+  qcompare (utf8_to_cork ("\xC5\x98"), cork_byte (0x90)); // U+0158
+  qcompare (utf8_to_cork ("\xC5\x9A"), cork_byte (0x91)); // U+015A
+  qcompare (utf8_to_cork ("\xC5\xA0"), cork_byte (0x92)); // U+0160
+  qcompare (utf8_to_cork ("\xC5\x9E"), cork_byte (0x93)); // U+015E
+  qcompare (utf8_to_cork ("\xC5\xA4"), cork_byte (0x94)); // U+0164
+  qcompare (utf8_to_cork ("\xC5\xA2"), cork_byte (0x95)); // U+0162
+  qcompare (utf8_to_cork ("\xC5\xB0"), cork_byte (0x96)); // U+0170
+  qcompare (utf8_to_cork ("\xC5\xAE"), cork_byte (0x97)); // U+016E
+  qcompare (utf8_to_cork ("\xC5\xB8"), cork_byte (0x98)); // U+0178
+  qcompare (utf8_to_cork ("\xC5\xB9"), cork_byte (0x99)); // U+0179
+  qcompare (utf8_to_cork ("\xC5\xBD"), cork_byte (0x9A)); // U+017D
+  qcompare (utf8_to_cork ("\xC5\xBB"), cork_byte (0x9B)); // U+017B
+  qcompare (utf8_to_cork ("\xC4\xB2"), cork_byte (0x9C)); // U+0132
+  qcompare (utf8_to_cork ("\xC4\xB0"), cork_byte (0x9D)); // U+0130
+  qcompare (utf8_to_cork ("\xC4\x91"), cork_byte (0x9E)); // U+0111
+  qcompare (utf8_to_cork ("\xC2\xA7"), cork_byte (0x9F)); // U+00A7 section sign
+}
+
+void
+TestConverter::test_utf8_to_cork_lower () {
+  qcompare (utf8_to_cork ("\xC4\x83"), cork_byte (0xA0)); // U+0103
+  qcompare (utf8_to_cork ("\xC4\x85"), cork_byte (0xA1)); // U+0105
+  qcompare (utf8_to_cork ("\xC4\x87"), cork_byte (0xA2)); // U+0107
+  qcompare (utf8_to_cork ("\xC4\x8D"), cork_byte (0xA3)); // U+010D
+  qcompare (utf8_to_cork ("\xC4\x8F"), cork_byte (0xA4)); // U+010F
+  qcompare (utf8_to_cork ("\xC4\x9B"), cork_byte (0xA5)); // U+011B
+  qcompare (utf8_to_cork ("\xC4\x99"), cork_byte (0xA6)); // U+0119
+  qcompare (utf8_to_cork ("\xC4\x9F"), cork_byte (0xA7)); // U+011F
+  qcompare (utf8_to_cork ("\xC4\xBA"), cork_byte (0xA8)); // U+013A
+  qcompare (utf8_to_cork ("\xC4\xBE"), cork_byte (0xA9)); // U+013E
+  qcompare (utf8_to_cork ("\xC5\x82"), cork_byte (0xAA)); // U+0142
+  qcompare (utf8_to_cork ("\xC5\x84"), cork_byte (0xAB)); // U+0144
+  qcompare (utf8_to_cork ("\xC5\x88"), cork_byte (0xAC)); // U+0148
+  qcompare (utf8_to_cork ("\xC5\x8B"), cork_byte (0xAD)); // U+014B
+  qcompare (utf8_to_cork ("\xC5\x91"), cork_byte (0xAE)); // U+0151
+  qcompare (utf8_to_cork ("\xC5\x95"), cork_byte (0xAF)); // U+0155
+  qcompare (utf8_to_cork ("\xC5\x99"), cork_byte (0xB0)); // U+0159
+  qcompare (utf8_to_cork ("\xC5\x9B"), cork_byte (0xB1)); // U+015B
+  qcompare (utf8_to_cork ("\xC5\xA1"), cork_byte (0xB2)); // U+0161
+  qcompare (utf8_to_cork ("\xC5\x9F"), cork_byte (0xB3)); // U+015F
+  qcompare (utf8_to_cork ("\xC5\xA5"), cork_byte (0xB4)); // U+0165
+  qcompare (utf8_to_cork ("\xC5\xA3"), cork_byte (0xB5)); // U+0163
+  qcompare (utf8_to_cork ("\xC5\xB1"), cork_byte (0xB6)); // U+0171
+  qcompare (utf8_to_cork ("\xC5\xAF"), cork_byte (0xB7)); // U+016F
+  qcompare (utf8_to_cork ("\xC3\xBF"), cork_byte (0xB8)); // U+00FF
+  qcompare (utf8_to_cork ("\xC5\xBA"), cork_byte (0xB9)); // U+017A
+  qcompare (utf8_to_cork ("\xC5\xBE"), cork_byte (0xBA)); // U+017E
+  qcompare (utf8_to_cork ("\xC5\xBC"), cork_byte (0xBB)); // U+017C
+  qcompare (utf8_to_cork ("\xC4\xB3"), cork_byte (0xBC)); // U+0133
+  qcompare (utf8_to_cork ("\xC2\xA1"), cork_byte (0xBD)); // U+00A1
+  qcompare (utf8_to_cork ("\xC2\xBF"), cork_byte (0xBE)); // U+00BF
+  qcompare (utf8_to_cork ("\xC2\xA3"), cork_byte (0xBF)); // U+00A3 pound sign
+}
+
+void
+TestConverter::test_utf8_to_cork_latin1 () {
+  qcompare (utf8_to_cork ("\xC3\x80"), cork_byte (0xC0)); // U+00C0 À
+  qcompare (utf8_to_cork ("\xC3\x81"), cork_byte (0xC1)); // U+00C1 Á
+  qcompare (utf8_to_cork ("\xC3\x82"), cork_byte (0xC2)); // U+00C2 Â
+  qcompare (utf8_to_cork ("\xC3\x83"), cork_byte (0xC3)); // U+00C3 Ã
+  qcompare (utf8_to_cork ("\xC3\x84"), cork_byte (0xC4)); // U+00C4 Ä
+  qcompare (utf8_to_cork ("\xC3\x85"), cork_byte (0xC5)); // U+00C5 Å
+  qcompare (utf8_to_cork ("\xC3\x86"), cork_byte (0xC6)); // U+00C6 Æ
+  qcompare (utf8_to_cork ("\xC3\x87"), cork_byte (0xC7)); // U+00C7 Ç
+  qcompare (utf8_to_cork ("\xC3\x88"), cork_byte (0xC8)); // U+00C8 È
+  qcompare (utf8_to_cork ("\xC3\x89"), cork_byte (0xC9)); // U+00C9 É
+  qcompare (utf8_to_cork ("\xC3\x8A"), cork_byte (0xCA)); // U+00CA Ê
+  qcompare (utf8_to_cork ("\xC3\x8B"), cork_byte (0xCB)); // U+00CB Ë
+  qcompare (utf8_to_cork ("\xC3\x8C"), cork_byte (0xCC)); // U+00CC Ì
+  qcompare (utf8_to_cork ("\xC3\x8D"), cork_byte (0xCD)); // U+00CD Í
+  qcompare (utf8_to_cork ("\xC3\x8E"), cork_byte (0xCE)); // U+00CE Î
+  qcompare (utf8_to_cork ("\xC3\x8F"), cork_byte (0xCF)); // U+00CF Ï
+  qcompare (utf8_to_cork ("\xC3\x90"), cork_byte (0xD0)); // U+00D0 Ð
+  qcompare (utf8_to_cork ("\xC3\x91"), cork_byte (0xD1)); // U+00D1 Ñ
+  qcompare (utf8_to_cork ("\xC3\x92"), cork_byte (0xD2)); // U+00D2 Ò
+  qcompare (utf8_to_cork ("\xC3\x93"), cork_byte (0xD3)); // U+00D3 Ó
+  qcompare (utf8_to_cork ("\xC3\x94"), cork_byte (0xD4)); // U+00D4 Ô
+  qcompare (utf8_to_cork ("\xC3\x95"), cork_byte (0xD5)); // U+00D5 Õ
+  qcompare (utf8_to_cork ("\xC3\x96"), cork_byte (0xD6)); // U+00D6 Ö
+  qcompare (utf8_to_cork ("\xC5\x92"), cork_byte (0xD7)); // U+0152 Œ
+  qcompare (utf8_to_cork ("\xC3\x98"), cork_byte (0xD8)); // U+00D8 Ø
+  qcompare (utf8_to_cork ("\xC3\x99"), cork_byte (0xD9)); // U+00D9 Ù
+  qcompare (utf8_to_cork ("\xC3\x9A"), cork_byte (0xDA)); // U+00DA Ú
+  qcompare (utf8_to_cork ("\xC3\x9B"), cork_byte (0xDB)); // U+00DB Û
+  qcompare (utf8_to_cork ("\xC3\x9C"), cork_byte (0xDC)); // U+00DC Ü
+  qcompare (utf8_to_cork ("\xC3\x9D"), cork_byte (0xDD)); // U+00DD Ý
+  qcompare (utf8_to_cork ("\xC3\x9E"), cork_byte (0xDE)); // U+00DE Þ
+  // U+00DF (ß) maps to Cork 0xFF (corktounicode 0xFF -> U+00DF, reversible).
+  // Cork 0xDF decodes to "SS" (cork-unicode-oneway), so the byte 0xDF is
+  // unreachable from utf8_to_cork; see test_cork_to_utf8_Dx and devel/1125.md.
+  qcompare (utf8_to_cork ("\xC3\x9F"), cork_byte (0xFF)); // U+00DF ß
+  qcompare (utf8_to_cork ("\xC3\xA0"), cork_byte (0xE0)); // U+00E0 à
+  qcompare (utf8_to_cork ("\xC3\xA1"), cork_byte (0xE1)); // U+00E1 á
+  qcompare (utf8_to_cork ("\xC3\xA2"), cork_byte (0xE2)); // U+00E2 â
+  qcompare (utf8_to_cork ("\xC3\xA3"), cork_byte (0xE3)); // U+00E3 ã
+  qcompare (utf8_to_cork ("\xC3\xA4"), cork_byte (0xE4)); // U+00E4 ä
+  qcompare (utf8_to_cork ("\xC3\xA5"), cork_byte (0xE5)); // U+00E5 å
+  qcompare (utf8_to_cork ("\xC3\xA6"), cork_byte (0xE6)); // U+00E6 æ
+  qcompare (utf8_to_cork ("\xC3\xA7"), cork_byte (0xE7)); // U+00E7 ç
+  qcompare (utf8_to_cork ("\xC3\xA8"), cork_byte (0xE8)); // U+00E8 è
+  qcompare (utf8_to_cork ("\xC3\xA9"), cork_byte (0xE9)); // U+00E9 é
+  qcompare (utf8_to_cork ("\xC3\xAA"), cork_byte (0xEA)); // U+00EA ê
+  qcompare (utf8_to_cork ("\xC3\xAB"), cork_byte (0xEB)); // U+00EB ë
+  qcompare (utf8_to_cork ("\xC3\xAC"), cork_byte (0xEC)); // U+00EC ì
+  qcompare (utf8_to_cork ("\xC3\xAD"), cork_byte (0xED)); // U+00ED í
+  qcompare (utf8_to_cork ("\xC3\xAE"), cork_byte (0xEE)); // U+00EE î
+  qcompare (utf8_to_cork ("\xC3\xAF"), cork_byte (0xEF)); // U+00EF ï
+  qcompare (utf8_to_cork ("\xC3\xB0"), cork_byte (0xF0)); // U+00F0 ð
+  qcompare (utf8_to_cork ("\xC3\xB1"), cork_byte (0xF1)); // U+00F1 ñ
+  qcompare (utf8_to_cork ("\xC3\xB2"), cork_byte (0xF2)); // U+00F2 ò
+  qcompare (utf8_to_cork ("\xC3\xB3"), cork_byte (0xF3)); // U+00F3 ó
+  qcompare (utf8_to_cork ("\xC3\xB4"), cork_byte (0xF4)); // U+00F4 ô
+  qcompare (utf8_to_cork ("\xC3\xB5"), cork_byte (0xF5)); // U+00F5 õ
+  qcompare (utf8_to_cork ("\xC3\xB6"), cork_byte (0xF6)); // U+00F6 ö
+  qcompare (utf8_to_cork ("\xC5\x93"), cork_byte (0xF7)); // U+0153 œ
+  qcompare (utf8_to_cork ("\xC3\xB8"), cork_byte (0xF8)); // U+00F8 ø
+  qcompare (utf8_to_cork ("\xC3\xB9"), cork_byte (0xF9)); // U+00F9 ù
+  qcompare (utf8_to_cork ("\xC3\xBA"), cork_byte (0xFA)); // U+00FA ú
+  qcompare (utf8_to_cork ("\xC3\xBB"), cork_byte (0xFB)); // U+00FB û
+  qcompare (utf8_to_cork ("\xC3\xBC"), cork_byte (0xFC)); // U+00FC ü
+  qcompare (utf8_to_cork ("\xC3\xBD"), cork_byte (0xFD)); // U+00FD ý
+  qcompare (utf8_to_cork ("\xC3\xBE"), cork_byte (0xFE)); // U+00FE þ
+}
+
+void
+TestConverter::test_utf8_to_cork_unmapped_high () {
+  // Codepoints >= 256 with no Cork mapping are escaped as <#XXXX>.
+  qcompare (utf8_to_cork ("\xE4\xB8\xAD"), "<#4E2D>");      // U+4E2D 中
+  qcompare (utf8_to_cork ("\xF0\x9F\x98\x80"), "<#1F600>"); // U+1F600 😀
+  qcompare (utf8_to_cork ("\xE2\x80\x8B"), "<#200B>");      // U+200B ZWSP
+  // U+2019 maps to Cork 0x27 (shares ASCII apostrophe slot), not escaped.
+  qcompare (utf8_to_cork ("\xE2\x80\x99"), cork_byte (0x27)); // U+2019 ’
+  // U+2010 maps to Cork 0x7F (hyphen), not escaped.
+  qcompare (utf8_to_cork ("\xE2\x80\x90"), cork_byte (0x7F)); // U+2010 ‐
+}
+
+void
+TestConverter::test_utf8_to_cork_named_unmapped () {
+  // U+00A0 maps to the <varspace> named entity (unicode-cork-oneway).
+  qcompare (utf8_to_cork ("\xC2\xA0"), "<varspace>");
+  // U+0060 backtick maps to Cork 0x00 (corktounicode has 0x00 -> U+0060,
+  // reversible).
+  qcompare (utf8_to_cork ("`"), cork_byte (0x00));
+}
+
+/******************************************************************************
+ * cork_to_utf8
+ ******************************************************************************/
+
+void
+TestConverter::test_cork_to_utf8_0x () {
+  qcompare (cork_to_utf8 (cork_byte (0x00)), "`");        // U+0060
+  qcompare (cork_to_utf8 (cork_byte (0x01)), "\xC2\xB4"); // U+00B4
+  qcompare (cork_to_utf8 (cork_byte (0x02)), "\xCB\x86"); // U+02C6
+  qcompare (cork_to_utf8 (cork_byte (0x03)), "\xCB\x9C"); // U+02DC
+  qcompare (cork_to_utf8 (cork_byte (0x04)), "\xC2\xA8"); // U+00A8
+  qcompare (cork_to_utf8 (cork_byte (0x05)), "\xCB\x9D"); // U+02DD
+  qcompare (cork_to_utf8 (cork_byte (0x06)), "\xCB\x9A"); // U+02DA
+  qcompare (cork_to_utf8 (cork_byte (0x07)), "\xCB\x87"); // U+02C7
+  qcompare (cork_to_utf8 (cork_byte (0x08)), "\xCB\x98"); // U+02D8
+  qcompare (cork_to_utf8 (cork_byte (0x09)), "\xC2\xAF"); // U+00AF
+  qcompare (cork_to_utf8 (cork_byte (0x0A)), "\xCB\x99"); // U+02D9
+  qcompare (cork_to_utf8 (cork_byte (0x0B)), "\xC2\xB8"); // U+00B8
+  qcompare (cork_to_utf8 (cork_byte (0x0C)), "\xCB\x9B"); // U+02DB
+}
+
+void
+TestConverter::test_cork_to_utf8_1x () {
+  qcompare (cork_to_utf8 (cork_byte (0x0D)), "\xE2\x80\x9A"); // U+201A
+  qcompare (cork_to_utf8 (cork_byte (0x0E)), "\xE2\x80\xB9"); // U+2039
+  qcompare (cork_to_utf8 (cork_byte (0x0F)), "\xE2\x80\xBA"); // U+203A
+  qcompare (cork_to_utf8 (cork_byte (0x10)), "\xE2\x80\x9C"); // U+201C “
+  qcompare (cork_to_utf8 (cork_byte (0x11)), "\xE2\x80\x9D"); // U+201D ”
+  qcompare (cork_to_utf8 (cork_byte (0x12)), "\xE2\x80\x9E"); // U+201E
+  qcompare (cork_to_utf8 (cork_byte (0x13)), "\xC2\xAB");     // U+00AB «
+  qcompare (cork_to_utf8 (cork_byte (0x14)), "\xC2\xBB");     // U+00BB »
+  qcompare (cork_to_utf8 (cork_byte (0x15)), "\xE2\x80\x93"); // U+2013 –
+  qcompare (cork_to_utf8 (cork_byte (0x16)), "\xE2\x80\x94"); // U+2014 —
+  qcompare (cork_to_utf8 (cork_byte (0x17)),
+            "\xE2\x81\xA0");                       // U+2060 WORD JOINER
+  qcompare (cork_to_utf8 (cork_byte (0x18)), "0"); // perthousand zero (oneway)
+  qcompare (cork_to_utf8 (cork_byte (0x19)), "\xC4\xB1"); // U+0131 ı
+  qcompare (cork_to_utf8 (cork_byte (0x1A)), "j");        // dotless j (oneway)
+  qcompare (cork_to_utf8 (cork_byte (0x1B)), "\xEF\xAC\x80"); // U+FB00 ﬀ
+  qcompare (cork_to_utf8 (cork_byte (0x1C)), "\xEF\xAC\x81"); // U+FB01 ﬁ
+  qcompare (cork_to_utf8 (cork_byte (0x1D)), "\xEF\xAC\x82"); // U+FB02 ﬂ
+  qcompare (cork_to_utf8 (cork_byte (0x1E)), "\xEF\xAC\x83"); // U+FB03 ﬃ
+  qcompare (cork_to_utf8 (cork_byte (0x1F)), "\xEF\xAC\x84"); // U+FB04 ﬄ
+}
+
+void
+TestConverter::test_cork_to_utf8_2x () {
+  qcompare (cork_to_utf8 (cork_byte (0x20)), " ");
+  qcompare (cork_to_utf8 (cork_byte (0x21)), "!");
+  qcompare (cork_to_utf8 (cork_byte (0x22)), "\"");
+  qcompare (cork_to_utf8 (cork_byte (0x23)), "#");
+  qcompare (cork_to_utf8 (cork_byte (0x24)), "$");
+  qcompare (cork_to_utf8 (cork_byte (0x25)), "%");
+  qcompare (cork_to_utf8 (cork_byte (0x26)), "&");
+  qcompare (cork_to_utf8 (cork_byte (0x27)), "'");
+  qcompare (cork_to_utf8 (cork_byte (0x28)), "(");
+  qcompare (cork_to_utf8 (cork_byte (0x29)), ")");
+  qcompare (cork_to_utf8 (cork_byte (0x2A)), "*");
+  qcompare (cork_to_utf8 (cork_byte (0x2B)), "+");
+  qcompare (cork_to_utf8 (cork_byte (0x2C)), ",");
+  qcompare (cork_to_utf8 (cork_byte (0x2D)), "-");
+  qcompare (cork_to_utf8 (cork_byte (0x2E)), ".");
+  qcompare (cork_to_utf8 (cork_byte (0x2F)), "/");
+}
+
+void
+TestConverter::test_cork_to_utf8_3x () {
+  qcompare (cork_to_utf8 (cork_byte (0x30)), "0");
+  qcompare (cork_to_utf8 (cork_byte (0x31)), "1");
+  qcompare (cork_to_utf8 (cork_byte (0x32)), "2");
+  qcompare (cork_to_utf8 (cork_byte (0x33)), "3");
+  qcompare (cork_to_utf8 (cork_byte (0x34)), "4");
+  qcompare (cork_to_utf8 (cork_byte (0x35)), "5");
+  qcompare (cork_to_utf8 (cork_byte (0x36)), "6");
+  qcompare (cork_to_utf8 (cork_byte (0x37)), "7");
+  qcompare (cork_to_utf8 (cork_byte (0x38)), "8");
+  qcompare (cork_to_utf8 (cork_byte (0x39)), "9");
+  qcompare (cork_to_utf8 (cork_byte (0x3A)), ":");
+  qcompare (cork_to_utf8 (cork_byte (0x3B)), ";");
+  // 0x3C/0x3E: single byte passes through as literal '<'/'>'. See named-entity
+  // tests.
+  qcompare (cork_to_utf8 (cork_byte (0x3D)), "=");
+  qcompare (cork_to_utf8 (cork_byte (0x3F)), "?");
+}
+
+void
+TestConverter::test_cork_to_utf8_4x () {
+  qcompare (cork_to_utf8 (cork_byte (0x40)), "@");
+  qcompare (cork_to_utf8 (cork_byte (0x41)), "A");
+  qcompare (cork_to_utf8 (cork_byte (0x42)), "B");
+  qcompare (cork_to_utf8 (cork_byte (0x43)), "C");
+  qcompare (cork_to_utf8 (cork_byte (0x44)), "D");
+  qcompare (cork_to_utf8 (cork_byte (0x45)), "E");
+  qcompare (cork_to_utf8 (cork_byte (0x46)), "F");
+  qcompare (cork_to_utf8 (cork_byte (0x47)), "G");
+  qcompare (cork_to_utf8 (cork_byte (0x48)), "H");
+  qcompare (cork_to_utf8 (cork_byte (0x49)), "I");
+  qcompare (cork_to_utf8 (cork_byte (0x4A)), "J");
+  qcompare (cork_to_utf8 (cork_byte (0x4B)), "K");
+  qcompare (cork_to_utf8 (cork_byte (0x4C)), "L");
+  qcompare (cork_to_utf8 (cork_byte (0x4D)), "M");
+  qcompare (cork_to_utf8 (cork_byte (0x4E)), "N");
+  qcompare (cork_to_utf8 (cork_byte (0x4F)), "O");
+}
+
+void
+TestConverter::test_cork_to_utf8_5x () {
+  qcompare (cork_to_utf8 (cork_byte (0x50)), "P");
+  qcompare (cork_to_utf8 (cork_byte (0x51)), "Q");
+  qcompare (cork_to_utf8 (cork_byte (0x52)), "R");
+  qcompare (cork_to_utf8 (cork_byte (0x53)), "S");
+  qcompare (cork_to_utf8 (cork_byte (0x54)), "T");
+  qcompare (cork_to_utf8 (cork_byte (0x55)), "U");
+  qcompare (cork_to_utf8 (cork_byte (0x56)), "V");
+  qcompare (cork_to_utf8 (cork_byte (0x57)), "W");
+  qcompare (cork_to_utf8 (cork_byte (0x58)), "X");
+  qcompare (cork_to_utf8 (cork_byte (0x59)), "Y");
+  qcompare (cork_to_utf8 (cork_byte (0x5A)), "Z");
+  qcompare (cork_to_utf8 (cork_byte (0x5B)), "[");
+  qcompare (cork_to_utf8 (cork_byte (0x5C)), "\\");
+  qcompare (cork_to_utf8 (cork_byte (0x5D)), "]");
+  qcompare (cork_to_utf8 (cork_byte (0x5E)), "^");
+  qcompare (cork_to_utf8 (cork_byte (0x5F)), "_");
+}
+
+void
+TestConverter::test_cork_to_utf8_6x () {
+  qcompare (cork_to_utf8 (cork_byte (0x60)), "\xE2\x80\x98"); // U+2018 ‘
+  qcompare (cork_to_utf8 (cork_byte (0x61)), "a");
+  qcompare (cork_to_utf8 (cork_byte (0x62)), "b");
+  qcompare (cork_to_utf8 (cork_byte (0x63)), "c");
+  qcompare (cork_to_utf8 (cork_byte (0x64)), "d");
+  qcompare (cork_to_utf8 (cork_byte (0x65)), "e");
+  qcompare (cork_to_utf8 (cork_byte (0x66)), "f");
+  qcompare (cork_to_utf8 (cork_byte (0x67)), "g");
+  qcompare (cork_to_utf8 (cork_byte (0x68)), "h");
+  qcompare (cork_to_utf8 (cork_byte (0x69)), "i");
+  qcompare (cork_to_utf8 (cork_byte (0x6A)), "j");
+  qcompare (cork_to_utf8 (cork_byte (0x6B)), "k");
+  qcompare (cork_to_utf8 (cork_byte (0x6C)), "l");
+  qcompare (cork_to_utf8 (cork_byte (0x6D)), "m");
+  qcompare (cork_to_utf8 (cork_byte (0x6E)), "n");
+  qcompare (cork_to_utf8 (cork_byte (0x6F)), "o");
+}
+
+void
+TestConverter::test_cork_to_utf8_7x () {
+  qcompare (cork_to_utf8 (cork_byte (0x70)), "p");
+  qcompare (cork_to_utf8 (cork_byte (0x71)), "q");
+  qcompare (cork_to_utf8 (cork_byte (0x72)), "r");
+  qcompare (cork_to_utf8 (cork_byte (0x73)), "s");
+  qcompare (cork_to_utf8 (cork_byte (0x74)), "t");
+  qcompare (cork_to_utf8 (cork_byte (0x75)), "u");
+  qcompare (cork_to_utf8 (cork_byte (0x76)), "v");
+  qcompare (cork_to_utf8 (cork_byte (0x77)), "w");
+  qcompare (cork_to_utf8 (cork_byte (0x78)), "x");
+  qcompare (cork_to_utf8 (cork_byte (0x79)), "y");
+  qcompare (cork_to_utf8 (cork_byte (0x7A)), "z");
+  qcompare (cork_to_utf8 (cork_byte (0x7B)), "{");
+  qcompare (cork_to_utf8 (cork_byte (0x7C)), "|");
+  qcompare (cork_to_utf8 (cork_byte (0x7D)), "}");
+  qcompare (cork_to_utf8 (cork_byte (0x7E)), "~");
+  qcompare (cork_to_utf8 (cork_byte (0x7F)), "\xE2\x80\x90"); // U+2010 hyphen
+}
+
+void
+TestConverter::test_cork_to_utf8_8x () {
+  qcompare (cork_to_utf8 (cork_byte (0x80)), "\xC4\x82"); // U+0102
+  qcompare (cork_to_utf8 (cork_byte (0x81)), "\xC4\x84"); // U+0104
+  qcompare (cork_to_utf8 (cork_byte (0x82)), "\xC4\x86"); // U+0106
+  qcompare (cork_to_utf8 (cork_byte (0x83)), "\xC4\x8C"); // U+010C
+  qcompare (cork_to_utf8 (cork_byte (0x84)), "\xC4\x8E"); // U+010E
+  qcompare (cork_to_utf8 (cork_byte (0x85)), "\xC4\x9A"); // U+011A
+  qcompare (cork_to_utf8 (cork_byte (0x86)), "\xC4\x98"); // U+0118
+  qcompare (cork_to_utf8 (cork_byte (0x87)), "\xC4\x9E"); // U+011E
+  qcompare (cork_to_utf8 (cork_byte (0x88)), "\xC4\xB9"); // U+0139
+  qcompare (cork_to_utf8 (cork_byte (0x89)), "\xC4\xBD"); // U+013D
+  qcompare (cork_to_utf8 (cork_byte (0x8A)), "\xC5\x81"); // U+0141
+  qcompare (cork_to_utf8 (cork_byte (0x8B)), "\xC5\x83"); // U+0143
+  qcompare (cork_to_utf8 (cork_byte (0x8C)), "\xC5\x87"); // U+0147
+  qcompare (cork_to_utf8 (cork_byte (0x8D)), "\xC5\x8A"); // U+014A
+  qcompare (cork_to_utf8 (cork_byte (0x8E)), "\xC5\x90"); // U+0150
+  qcompare (cork_to_utf8 (cork_byte (0x8F)), "\xC5\x94"); // U+0154
+}
+
+void
+TestConverter::test_cork_to_utf8_9x () {
+  qcompare (cork_to_utf8 (cork_byte (0x90)), "\xC5\x98"); // U+0158
+  qcompare (cork_to_utf8 (cork_byte (0x91)), "\xC5\x9A"); // U+015A
+  qcompare (cork_to_utf8 (cork_byte (0x92)), "\xC5\xA0"); // U+0160
+  qcompare (cork_to_utf8 (cork_byte (0x93)), "\xC5\x9E"); // U+015E
+  qcompare (cork_to_utf8 (cork_byte (0x94)), "\xC5\xA4"); // U+0164
+  qcompare (cork_to_utf8 (cork_byte (0x95)), "\xC5\xA2"); // U+0162
+  qcompare (cork_to_utf8 (cork_byte (0x96)), "\xC5\xB0"); // U+0170
+  qcompare (cork_to_utf8 (cork_byte (0x97)), "\xC5\xAE"); // U+016E
+  qcompare (cork_to_utf8 (cork_byte (0x98)), "\xC5\xB8"); // U+0178
+  qcompare (cork_to_utf8 (cork_byte (0x99)), "\xC5\xB9"); // U+0179
+  qcompare (cork_to_utf8 (cork_byte (0x9A)), "\xC5\xBD"); // U+017D
+  qcompare (cork_to_utf8 (cork_byte (0x9B)), "\xC5\xBB"); // U+017B
+  qcompare (cork_to_utf8 (cork_byte (0x9C)), "\xC4\xB2"); // U+0132
+  qcompare (cork_to_utf8 (cork_byte (0x9D)), "\xC4\xB0"); // U+0130
+  qcompare (cork_to_utf8 (cork_byte (0x9E)), "\xC4\x91"); // U+0111
+  qcompare (cork_to_utf8 (cork_byte (0x9F)), "\xC2\xA7"); // U+00A7 §
+}
+
+void
+TestConverter::test_cork_to_utf8_Ax () {
+  qcompare (cork_to_utf8 (cork_byte (0xA0)), "\xC4\x83"); // U+0103
+  qcompare (cork_to_utf8 (cork_byte (0xA1)), "\xC4\x85"); // U+0105
+  qcompare (cork_to_utf8 (cork_byte (0xA2)), "\xC4\x87"); // U+0107
+  qcompare (cork_to_utf8 (cork_byte (0xA3)), "\xC4\x8D"); // U+010D
+  qcompare (cork_to_utf8 (cork_byte (0xA4)), "\xC4\x8F"); // U+010F
+  qcompare (cork_to_utf8 (cork_byte (0xA5)), "\xC4\x9B"); // U+011B
+  qcompare (cork_to_utf8 (cork_byte (0xA6)), "\xC4\x99"); // U+0119
+  qcompare (cork_to_utf8 (cork_byte (0xA7)), "\xC4\x9F"); // U+011F
+  qcompare (cork_to_utf8 (cork_byte (0xA8)), "\xC4\xBA"); // U+013A
+  qcompare (cork_to_utf8 (cork_byte (0xA9)), "\xC4\xBE"); // U+013E
+  qcompare (cork_to_utf8 (cork_byte (0xAA)), "\xC5\x82"); // U+0142
+  qcompare (cork_to_utf8 (cork_byte (0xAB)), "\xC5\x84"); // U+0144
+  qcompare (cork_to_utf8 (cork_byte (0xAC)), "\xC5\x88"); // U+0148
+  qcompare (cork_to_utf8 (cork_byte (0xAD)), "\xC5\x8B"); // U+014B
+  qcompare (cork_to_utf8 (cork_byte (0xAE)), "\xC5\x91"); // U+0151
+  qcompare (cork_to_utf8 (cork_byte (0xAF)), "\xC5\x95"); // U+0155
+}
+
+void
+TestConverter::test_cork_to_utf8_Bx () {
+  qcompare (cork_to_utf8 (cork_byte (0xB0)), "\xC5\x99"); // U+0159
+  qcompare (cork_to_utf8 (cork_byte (0xB1)), "\xC5\x9B"); // U+015B
+  qcompare (cork_to_utf8 (cork_byte (0xB2)), "\xC5\xA1"); // U+0161
+  qcompare (cork_to_utf8 (cork_byte (0xB3)), "\xC5\x9F"); // U+015F
+  qcompare (cork_to_utf8 (cork_byte (0xB4)), "\xC5\xA5"); // U+0165
+  qcompare (cork_to_utf8 (cork_byte (0xB5)), "\xC5\xA3"); // U+0163
+  qcompare (cork_to_utf8 (cork_byte (0xB6)), "\xC5\xB1"); // U+0171
+  qcompare (cork_to_utf8 (cork_byte (0xB7)), "\xC5\xAF"); // U+016F
+  qcompare (cork_to_utf8 (cork_byte (0xB8)), "\xC3\xBF"); // U+00FF ÿ
+  qcompare (cork_to_utf8 (cork_byte (0xB9)), "\xC5\xBA"); // U+017A
+  qcompare (cork_to_utf8 (cork_byte (0xBA)), "\xC5\xBE"); // U+017E
+  qcompare (cork_to_utf8 (cork_byte (0xBB)), "\xC5\xBC"); // U+017C
+  qcompare (cork_to_utf8 (cork_byte (0xBC)), "\xC4\xB3"); // U+0133
+  qcompare (cork_to_utf8 (cork_byte (0xBD)), "\xC2\xA1"); // U+00A1 ¡
+  qcompare (cork_to_utf8 (cork_byte (0xBE)), "\xC2\xBF"); // U+00BF ¿
+  qcompare (cork_to_utf8 (cork_byte (0xBF)), "\xC2\xA3"); // U+00A3 £
+}
+
+void
+TestConverter::test_cork_to_utf8_Cx () {
+  qcompare (cork_to_utf8 (cork_byte (0xC0)), "\xC3\x80"); // U+00C0 À
+  qcompare (cork_to_utf8 (cork_byte (0xC1)), "\xC3\x81"); // U+00C1 Á
+  qcompare (cork_to_utf8 (cork_byte (0xC2)), "\xC3\x82"); // U+00C2 Â
+  qcompare (cork_to_utf8 (cork_byte (0xC3)), "\xC3\x83"); // U+00C3 Ã
+  qcompare (cork_to_utf8 (cork_byte (0xC4)), "\xC3\x84"); // U+00C4 Ä
+  qcompare (cork_to_utf8 (cork_byte (0xC5)), "\xC3\x85"); // U+00C5 Å
+  qcompare (cork_to_utf8 (cork_byte (0xC6)), "\xC3\x86"); // U+00C6 Æ
+  qcompare (cork_to_utf8 (cork_byte (0xC7)), "\xC3\x87"); // U+00C7 Ç
+  qcompare (cork_to_utf8 (cork_byte (0xC8)), "\xC3\x88"); // U+00C8 È
+  qcompare (cork_to_utf8 (cork_byte (0xC9)), "\xC3\x89"); // U+00C9 É
+  qcompare (cork_to_utf8 (cork_byte (0xCA)), "\xC3\x8A"); // U+00CA Ê
+  qcompare (cork_to_utf8 (cork_byte (0xCB)), "\xC3\x8B"); // U+00CB Ë
+  qcompare (cork_to_utf8 (cork_byte (0xCC)), "\xC3\x8C"); // U+00CC Ì
+  qcompare (cork_to_utf8 (cork_byte (0xCD)), "\xC3\x8D"); // U+00CD Í
+  qcompare (cork_to_utf8 (cork_byte (0xCE)), "\xC3\x8E"); // U+00CE Î
+  qcompare (cork_to_utf8 (cork_byte (0xCF)), "\xC3\x8F"); // U+00CF Ï
+}
+
+void
+TestConverter::test_cork_to_utf8_Dx () {
+  qcompare (cork_to_utf8 (cork_byte (0xD0)), "\xC3\x90"); // U+00D0 Ð
+  qcompare (cork_to_utf8 (cork_byte (0xD1)), "\xC3\x91"); // U+00D1 Ñ
+  qcompare (cork_to_utf8 (cork_byte (0xD2)), "\xC3\x92"); // U+00D2 Ò
+  qcompare (cork_to_utf8 (cork_byte (0xD3)), "\xC3\x93"); // U+00D3 Ó
+  qcompare (cork_to_utf8 (cork_byte (0xD4)), "\xC3\x94"); // U+00D4 Ô
+  qcompare (cork_to_utf8 (cork_byte (0xD5)), "\xC3\x95"); // U+00D5 Õ
+  qcompare (cork_to_utf8 (cork_byte (0xD6)), "\xC3\x96"); // U+00D6 Ö
+  qcompare (cork_to_utf8 (cork_byte (0xD7)), "\xC5\x92"); // U+0152 Œ
+  qcompare (cork_to_utf8 (cork_byte (0xD8)), "\xC3\x98"); // U+00D8 Ø
+  qcompare (cork_to_utf8 (cork_byte (0xD9)), "\xC3\x99"); // U+00D9 Ù
+  qcompare (cork_to_utf8 (cork_byte (0xDA)), "\xC3\x9A"); // U+00DA Ú
+  qcompare (cork_to_utf8 (cork_byte (0xDB)), "\xC3\x9B"); // U+00DB Û
+  qcompare (cork_to_utf8 (cork_byte (0xDC)), "\xC3\x9C"); // U+00DC Ü
+  qcompare (cork_to_utf8 (cork_byte (0xDD)), "\xC3\x9D"); // U+00DD Ý
+  qcompare (cork_to_utf8 (cork_byte (0xDE)), "\xC3\x9E"); // U+00DE Þ
+  qcompare (cork_to_utf8 (cork_byte (0xDF)), "SS");       // sharp s (oneway)
+}
+
+void
+TestConverter::test_cork_to_utf8_Ex () {
+  qcompare (cork_to_utf8 (cork_byte (0xE0)), "\xC3\xA0"); // U+00E0 à
+  qcompare (cork_to_utf8 (cork_byte (0xE1)), "\xC3\xA1"); // U+00E1 á
+  qcompare (cork_to_utf8 (cork_byte (0xE2)), "\xC3\xA2"); // U+00E2 â
+  qcompare (cork_to_utf8 (cork_byte (0xE3)), "\xC3\xA3"); // U+00E3 ã
+  qcompare (cork_to_utf8 (cork_byte (0xE4)), "\xC3\xA4"); // U+00E4 ä
+  qcompare (cork_to_utf8 (cork_byte (0xE5)), "\xC3\xA5"); // U+00E5 å
+  qcompare (cork_to_utf8 (cork_byte (0xE6)), "\xC3\xA6"); // U+00E6 æ
+  qcompare (cork_to_utf8 (cork_byte (0xE7)), "\xC3\xA7"); // U+00E7 ç
+  qcompare (cork_to_utf8 (cork_byte (0xE8)), "\xC3\xA8"); // U+00E8 è
+  qcompare (cork_to_utf8 (cork_byte (0xE9)), "\xC3\xA9"); // U+00E9 é
+  qcompare (cork_to_utf8 (cork_byte (0xEA)), "\xC3\xAA"); // U+00EA ê
+  qcompare (cork_to_utf8 (cork_byte (0xEB)), "\xC3\xAB"); // U+00EB ë
+  qcompare (cork_to_utf8 (cork_byte (0xEC)), "\xC3\xAC"); // U+00EC ì
+  qcompare (cork_to_utf8 (cork_byte (0xED)), "\xC3\xAD"); // U+00ED í
+  qcompare (cork_to_utf8 (cork_byte (0xEE)), "\xC3\xAE"); // U+00EE î
+  qcompare (cork_to_utf8 (cork_byte (0xEF)), "\xC3\xAF"); // U+00EF ï
+}
+
+void
+TestConverter::test_cork_to_utf8_Fx () {
+  qcompare (cork_to_utf8 (cork_byte (0xF0)), "\xC3\xB0"); // U+00F0 ð
+  qcompare (cork_to_utf8 (cork_byte (0xF1)), "\xC3\xB1"); // U+00F1 ñ
+  qcompare (cork_to_utf8 (cork_byte (0xF2)), "\xC3\xB2"); // U+00F2 ò
+  qcompare (cork_to_utf8 (cork_byte (0xF3)), "\xC3\xB3"); // U+00F3 ó
+  qcompare (cork_to_utf8 (cork_byte (0xF4)), "\xC3\xB4"); // U+00F4 ô
+  qcompare (cork_to_utf8 (cork_byte (0xF5)), "\xC3\xB5"); // U+00F5 õ
+  qcompare (cork_to_utf8 (cork_byte (0xF6)), "\xC3\xB6"); // U+00F6 ö
+  qcompare (cork_to_utf8 (cork_byte (0xF7)), "\xC5\x93"); // U+0153 œ
+  qcompare (cork_to_utf8 (cork_byte (0xF8)), "\xC3\xB8"); // U+00F8 ø
+  qcompare (cork_to_utf8 (cork_byte (0xF9)), "\xC3\xB9"); // U+00F9 ù
+  qcompare (cork_to_utf8 (cork_byte (0xFA)), "\xC3\xBA"); // U+00FA ú
+  qcompare (cork_to_utf8 (cork_byte (0xFB)), "\xC3\xBB"); // U+00FB û
+  qcompare (cork_to_utf8 (cork_byte (0xFC)), "\xC3\xBC"); // U+00FC ü
+  qcompare (cork_to_utf8 (cork_byte (0xFD)), "\xC3\xBD"); // U+00FD ý
+  qcompare (cork_to_utf8 (cork_byte (0xFE)), "\xC3\xBE"); // U+00FE þ
+  qcompare (cork_to_utf8 (cork_byte (0xFF)), "\xC3\x9F"); // U+00DF ß
+}
+
+void
+TestConverter::test_cork_to_utf8_escapes () {
+  // <#XXXX> decodes to the UTF-8 encoding of the hex codepoint.
+  qcompare (cork_to_utf8 ("<#4E2D>"), "中");                // U+4E2D
+  qcompare (cork_to_utf8 ("<#2019>"), "\xE2\x80\x99");      // U+2019
+  qcompare (cork_to_utf8 ("<#1F600>"), "\xF0\x9F\x98\x80"); // U+1F600
+  // Padded forms are accepted.
+  qcompare (cork_to_utf8 ("<#0FF>"), "\xC3\xBF");  // U+00FF
+  qcompare (cork_to_utf8 ("<#00FF>"), "\xC3\xBF"); // U+00FF
+  // A <#XXXX> that names a Cork-mapped codepoint overrides the byte mapping.
+  qcompare (cork_to_utf8 ("<#201C>"), "\xE2\x80\x9C"); // U+201C
+}
+
+void
+TestConverter::test_cork_to_utf8_named_entities () {
+  qcompare (cork_to_utf8 ("<less>"), "<");
+  qcompare (cork_to_utf8 ("<gtr>"), ">");
+  qcompare (cork_to_utf8 ("<comma>"), ",");
+  qcompare (cork_to_utf8 ("<grave>"), "`");
+  // A single byte '<' or '>' is passed through as the literal character.
+  qcompare (cork_to_utf8 ("<"), "<");
+  qcompare (cork_to_utf8 (">"), ">");
+}
+
+void
+TestConverter::test_utf8_to_cork_named_entities () {
+  qcompare (utf8_to_cork ("<"), "<less>");
+  qcompare (utf8_to_cork (">"), "<gtr>");
+  qcompare (utf8_to_cork ("\xC2\xA0"), "<varspace>"); // U+00A0
+}
+
+void
+TestConverter::test_mixed () {
+  // Cork byte + <#XXXX> escape + ASCII, decoded.
+  qcompare (
+      cork_to_utf8 (cork_byte (0x41) * string ("<#2019>") * cork_byte (0x42)),
+      "A" * string ("\xE2\x80\x99") * "B");
+  // ASCII + CJK + ASCII, encoded.
+  qcompare (utf8_to_cork (string ("A") * "中" * "B"),
+            cork_byte (0x41) * string ("<#4E2D>") * cork_byte (0x42));
+  // Named entity interleaved with bytes.
+  qcompare (cork_to_utf8 ("<less>" * cork_byte (0x41) * "<gtr>"), "<A>");
+}
+
+void
+TestConverter::test_empty () {
+  qcompare (cork_to_utf8 (""), "");
+  qcompare (utf8_to_cork (""), "");
+}
+
+void
+TestConverter::test_roundtrip_idempotent () {
+  // Every roundtrippable Cork byte satisfies utf8_to_cork(cork_to_utf8(b)) ==
+  // b. The 5 non-roundtrip bytes (0x18, 0x1A, 0x3C, 0x3E, 0xDF) are documented
+  // in devel/1125.md.
+  for (int b= 0; b < 256; b++) {
+    if (b == 0x18 || b == 0x1A || b == 0x3C || b == 0x3E || b == 0xDF) continue;
+    string cork= cork_byte (b);
+    string back= utf8_to_cork (cork_to_utf8 (cork));
+    QCOMPARE (back, cork);
+  }
 }
 
 QTEST_MAIN (TestConverter)

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -98,6 +98,11 @@ private slots:
   void test_utf8_to_cork_math_syms ();
   void test_utf8_to_cork_text_syms ();
   void test_utf8_to_cork_named_remap ();
+
+  // Edge cases: malformed <#XXXX>, unknown entities, invalid UTF-8.
+  void test_cork_to_utf8_escape_edge_cases ();
+  void test_cork_to_utf8_unknown_entities ();
+  void test_utf8_to_cork_invalid_utf8 ();
 };
 
 /******************************************************************************
@@ -1144,6 +1149,43 @@ TestConverter::test_utf8_to_cork_named_remap () {
   qcompare (utf8_to_cork ("ℏ"), "<hslash>");   // U+210F (not <hbar>)
   qcompare (utf8_to_cork ("ℜ"), "<frak-R>");   // U+211C (not <Re>)
   qcompare (utf8_to_cork ("ℑ"), "<frak-I>");   // U+2111 (not <Im>)
+}
+
+void
+TestConverter::test_cork_to_utf8_escape_edge_cases () {
+  // Hex digits are case-insensitive.
+  qcompare (cork_to_utf8 ("<#4e2d>"), "中");
+  // Multiple escapes in one string decode independently.
+  qcompare (cork_to_utf8 ("<#4E2D><#2019>"), "中’");
+  // Escapes interleave with literal bytes.
+  qcompare (cork_to_utf8 ("X<#4E2D>Y"), "X中Y");
+  qcompare (cork_to_utf8 ("<#4E2D><alpha>"), "中α");
+  // A dangling escape with no closing '>' consumes to end of string.
+  qcompare (cork_to_utf8 ("a<#4E2D"), "a中");
+  // Empty hex, lone "<#", and non-hex digits all decode to the empty string
+  // (from_hexadecimal("") == 0, encode_as_utf8(0) == "").
+  qcompare (cork_to_utf8 ("<#>"), "");
+  qcompare (cork_to_utf8 ("<#"), "");
+  qcompare (cork_to_utf8 ("<#GHIJ>"), "");
+}
+
+void
+TestConverter::test_cork_to_utf8_unknown_entities () {
+  // An unknown <name> is passed through verbatim.
+  qcompare (cork_to_utf8 ("<foobar>"), "<foobar>");
+  // An incomplete entity prefix (no closing '>') is passed through verbatim.
+  qcompare (cork_to_utf8 ("<les"), "<les");
+  // A single '<' not followed by '#' is passed through as a literal.
+  qcompare (cork_to_utf8 ("a<b"), "a<b");
+}
+
+void
+TestConverter::test_utf8_to_cork_invalid_utf8 () {
+  // A lone continuation byte (0x80) has no UTF-8 decode; it is copied through
+  // as the Cork byte 0x80 (copy_unmatched).
+  qcompare (utf8_to_cork ("\x80"), cork_byte (0x80));
+  // A lone lead byte (0xC3 with no continuation) likewise copies through.
+  qcompare (utf8_to_cork ("\xC3"), cork_byte (0xC3));
 }
 
 QTEST_MAIN (TestConverter)

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -218,207 +218,207 @@ TestConverter::test_utf8_to_cork_7x () {
 
 void
 TestConverter::test_utf8_to_cork_accents () {
-  qcompare (utf8_to_cork ("\xCB\x86"),
-            cork_byte (0x02)); // U+02C6 modifier circumflex
-  qcompare (utf8_to_cork ("\xCB\x9C"), cork_byte (0x03)); // U+02DC small tilde
-  qcompare (utf8_to_cork ("\xC2\xA8"), cork_byte (0x04)); // U+00A8 diaeresis
-  qcompare (utf8_to_cork ("\xCB\x9D"), cork_byte (0x05)); // U+02DD double acute
-  qcompare (utf8_to_cork ("\xCB\x9A"), cork_byte (0x06)); // U+02DA ring above
-  qcompare (utf8_to_cork ("\xCB\x87"), cork_byte (0x07)); // U+02C7 caron
-  qcompare (utf8_to_cork ("\xCB\x98"), cork_byte (0x08)); // U+02D8 breve
-  qcompare (utf8_to_cork ("\xC2\xAF"), cork_byte (0x09)); // U+00AF macron
-  qcompare (utf8_to_cork ("\xCB\x99"), cork_byte (0x0A)); // U+02D9 dot above
-  qcompare (utf8_to_cork ("\xC2\xB8"), cork_byte (0x0B)); // U+00B8 cedilla
-  qcompare (utf8_to_cork ("\xCB\x9B"), cork_byte (0x0C)); // U+02DB ogonek
-  qcompare (utf8_to_cork ("\xC2\xB4"), cork_byte (0x01)); // U+00B4 acute
+  qcompare (utf8_to_cork ("ˆ"),
+            cork_byte (0x02));                     // U+02C6 modifier circumflex
+  qcompare (utf8_to_cork ("˜"), cork_byte (0x03)); // U+02DC small tilde
+  qcompare (utf8_to_cork ("¨"), cork_byte (0x04)); // U+00A8 diaeresis
+  qcompare (utf8_to_cork ("˝"), cork_byte (0x05)); // U+02DD double acute
+  qcompare (utf8_to_cork ("˚"), cork_byte (0x06)); // U+02DA ring above
+  qcompare (utf8_to_cork ("ˇ"), cork_byte (0x07)); // U+02C7 caron
+  qcompare (utf8_to_cork ("˘"), cork_byte (0x08)); // U+02D8 breve
+  qcompare (utf8_to_cork ("¯"), cork_byte (0x09)); // U+00AF macron
+  qcompare (utf8_to_cork ("˙"), cork_byte (0x0A)); // U+02D9 dot above
+  qcompare (utf8_to_cork ("¸"), cork_byte (0x0B)); // U+00B8 cedilla
+  qcompare (utf8_to_cork ("˛"), cork_byte (0x0C)); // U+02DB ogonek
+  qcompare (utf8_to_cork ("´"), cork_byte (0x01)); // U+00B4 acute
 }
 
 void
 TestConverter::test_utf8_to_cork_punctuation () {
-  qcompare (utf8_to_cork ("\xE2\x80\x9A"), cork_byte (0x0D)); // U+201A
-  qcompare (utf8_to_cork ("\xE2\x80\xB9"), cork_byte (0x0E)); // U+2039
-  qcompare (utf8_to_cork ("\xE2\x80\xBA"), cork_byte (0x0F)); // U+203A
-  qcompare (utf8_to_cork ("\xE2\x80\x9C"), cork_byte (0x10)); // U+201C
-  qcompare (utf8_to_cork ("\xE2\x80\x9D"), cork_byte (0x11)); // U+201D
-  qcompare (utf8_to_cork ("\xE2\x80\x9E"), cork_byte (0x12)); // U+201E
-  qcompare (utf8_to_cork ("\xC2\xAB"), cork_byte (0x13));     // U+00AB
-  qcompare (utf8_to_cork ("\xC2\xBB"), cork_byte (0x14));     // U+00BB
-  qcompare (utf8_to_cork ("\xE2\x80\x93"), cork_byte (0x15)); // U+2013
-  qcompare (utf8_to_cork ("\xE2\x80\x94"), cork_byte (0x16)); // U+2014
-  qcompare (utf8_to_cork ("\xE2\x81\xA0"),
+  qcompare (utf8_to_cork ("‚"), cork_byte (0x0D)); // U+201A
+  qcompare (utf8_to_cork ("‹"), cork_byte (0x0E)); // U+2039
+  qcompare (utf8_to_cork ("›"), cork_byte (0x0F)); // U+203A
+  qcompare (utf8_to_cork ("“"), cork_byte (0x10)); // U+201C
+  qcompare (utf8_to_cork ("”"), cork_byte (0x11)); // U+201D
+  qcompare (utf8_to_cork ("„"), cork_byte (0x12)); // U+201E
+  qcompare (utf8_to_cork ("«"), cork_byte (0x13)); // U+00AB
+  qcompare (utf8_to_cork ("»"), cork_byte (0x14)); // U+00BB
+  qcompare (utf8_to_cork ("–"), cork_byte (0x15)); // U+2013
+  qcompare (utf8_to_cork ("—"), cork_byte (0x16)); // U+2014
+  qcompare (utf8_to_cork ("⁠"),
             cork_byte (0x17)); // U+2060 WORD JOINER
-  qcompare (utf8_to_cork ("\xE2\x80\x98"),
+  qcompare (utf8_to_cork ("‘"),
             cork_byte (0x60)); // U+2018 left single quote
 }
 
 void
 TestConverter::test_utf8_to_cork_specials () {
-  qcompare (utf8_to_cork ("\xC4\xB1"), cork_byte (0x19)); // U+0131 dotless i
-  qcompare (utf8_to_cork ("\xEF\xAC\x80"), cork_byte (0x1B)); // U+FB00 ff
-  qcompare (utf8_to_cork ("\xEF\xAC\x81"), cork_byte (0x1C)); // U+FB01 fi
-  qcompare (utf8_to_cork ("\xEF\xAC\x82"), cork_byte (0x1D)); // U+FB02 fl
-  qcompare (utf8_to_cork ("\xEF\xAC\x83"), cork_byte (0x1E)); // U+FB03 ffi
-  qcompare (utf8_to_cork ("\xEF\xAC\x84"), cork_byte (0x1F)); // U+FB04 ffl
+  qcompare (utf8_to_cork ("ı"), cork_byte (0x19)); // U+0131 dotless i
+  qcompare (utf8_to_cork ("ﬀ"), cork_byte (0x1B)); // U+FB00 ff
+  qcompare (utf8_to_cork ("ﬁ"), cork_byte (0x1C)); // U+FB01 fi
+  qcompare (utf8_to_cork ("ﬂ"), cork_byte (0x1D)); // U+FB02 fl
+  qcompare (utf8_to_cork ("ﬃ"), cork_byte (0x1E)); // U+FB03 ffi
+  qcompare (utf8_to_cork ("ﬄ"), cork_byte (0x1F)); // U+FB04 ffl
 }
 
 void
 TestConverter::test_utf8_to_cork_upper () {
-  qcompare (utf8_to_cork ("\xC4\x82"), cork_byte (0x80)); // U+0102
-  qcompare (utf8_to_cork ("\xC4\x84"), cork_byte (0x81)); // U+0104
-  qcompare (utf8_to_cork ("\xC4\x86"), cork_byte (0x82)); // U+0106
-  qcompare (utf8_to_cork ("\xC4\x8C"), cork_byte (0x83)); // U+010C
-  qcompare (utf8_to_cork ("\xC4\x8E"), cork_byte (0x84)); // U+010E
-  qcompare (utf8_to_cork ("\xC4\x9A"), cork_byte (0x85)); // U+011A
-  qcompare (utf8_to_cork ("\xC4\x98"), cork_byte (0x86)); // U+0118
-  qcompare (utf8_to_cork ("\xC4\x9E"), cork_byte (0x87)); // U+011E
-  qcompare (utf8_to_cork ("\xC4\xB9"), cork_byte (0x88)); // U+0139
-  qcompare (utf8_to_cork ("\xC4\xBD"), cork_byte (0x89)); // U+013D
-  qcompare (utf8_to_cork ("\xC5\x81"), cork_byte (0x8A)); // U+0141
-  qcompare (utf8_to_cork ("\xC5\x83"), cork_byte (0x8B)); // U+0143
-  qcompare (utf8_to_cork ("\xC5\x87"), cork_byte (0x8C)); // U+0147
-  qcompare (utf8_to_cork ("\xC5\x8A"), cork_byte (0x8D)); // U+014A
-  qcompare (utf8_to_cork ("\xC5\x90"), cork_byte (0x8E)); // U+0150
-  qcompare (utf8_to_cork ("\xC5\x94"), cork_byte (0x8F)); // U+0154
-  qcompare (utf8_to_cork ("\xC5\x98"), cork_byte (0x90)); // U+0158
-  qcompare (utf8_to_cork ("\xC5\x9A"), cork_byte (0x91)); // U+015A
-  qcompare (utf8_to_cork ("\xC5\xA0"), cork_byte (0x92)); // U+0160
-  qcompare (utf8_to_cork ("\xC5\x9E"), cork_byte (0x93)); // U+015E
-  qcompare (utf8_to_cork ("\xC5\xA4"), cork_byte (0x94)); // U+0164
-  qcompare (utf8_to_cork ("\xC5\xA2"), cork_byte (0x95)); // U+0162
-  qcompare (utf8_to_cork ("\xC5\xB0"), cork_byte (0x96)); // U+0170
-  qcompare (utf8_to_cork ("\xC5\xAE"), cork_byte (0x97)); // U+016E
-  qcompare (utf8_to_cork ("\xC5\xB8"), cork_byte (0x98)); // U+0178
-  qcompare (utf8_to_cork ("\xC5\xB9"), cork_byte (0x99)); // U+0179
-  qcompare (utf8_to_cork ("\xC5\xBD"), cork_byte (0x9A)); // U+017D
-  qcompare (utf8_to_cork ("\xC5\xBB"), cork_byte (0x9B)); // U+017B
-  qcompare (utf8_to_cork ("\xC4\xB2"), cork_byte (0x9C)); // U+0132
-  qcompare (utf8_to_cork ("\xC4\xB0"), cork_byte (0x9D)); // U+0130
-  qcompare (utf8_to_cork ("\xC4\x91"), cork_byte (0x9E)); // U+0111
-  qcompare (utf8_to_cork ("\xC2\xA7"), cork_byte (0x9F)); // U+00A7 section sign
+  qcompare (utf8_to_cork ("Ă"), cork_byte (0x80)); // U+0102
+  qcompare (utf8_to_cork ("Ą"), cork_byte (0x81)); // U+0104
+  qcompare (utf8_to_cork ("Ć"), cork_byte (0x82)); // U+0106
+  qcompare (utf8_to_cork ("Č"), cork_byte (0x83)); // U+010C
+  qcompare (utf8_to_cork ("Ď"), cork_byte (0x84)); // U+010E
+  qcompare (utf8_to_cork ("Ě"), cork_byte (0x85)); // U+011A
+  qcompare (utf8_to_cork ("Ę"), cork_byte (0x86)); // U+0118
+  qcompare (utf8_to_cork ("Ğ"), cork_byte (0x87)); // U+011E
+  qcompare (utf8_to_cork ("Ĺ"), cork_byte (0x88)); // U+0139
+  qcompare (utf8_to_cork ("Ľ"), cork_byte (0x89)); // U+013D
+  qcompare (utf8_to_cork ("Ł"), cork_byte (0x8A)); // U+0141
+  qcompare (utf8_to_cork ("Ń"), cork_byte (0x8B)); // U+0143
+  qcompare (utf8_to_cork ("Ň"), cork_byte (0x8C)); // U+0147
+  qcompare (utf8_to_cork ("Ŋ"), cork_byte (0x8D)); // U+014A
+  qcompare (utf8_to_cork ("Ő"), cork_byte (0x8E)); // U+0150
+  qcompare (utf8_to_cork ("Ŕ"), cork_byte (0x8F)); // U+0154
+  qcompare (utf8_to_cork ("Ř"), cork_byte (0x90)); // U+0158
+  qcompare (utf8_to_cork ("Ś"), cork_byte (0x91)); // U+015A
+  qcompare (utf8_to_cork ("Š"), cork_byte (0x92)); // U+0160
+  qcompare (utf8_to_cork ("Ş"), cork_byte (0x93)); // U+015E
+  qcompare (utf8_to_cork ("Ť"), cork_byte (0x94)); // U+0164
+  qcompare (utf8_to_cork ("Ţ"), cork_byte (0x95)); // U+0162
+  qcompare (utf8_to_cork ("Ű"), cork_byte (0x96)); // U+0170
+  qcompare (utf8_to_cork ("Ů"), cork_byte (0x97)); // U+016E
+  qcompare (utf8_to_cork ("Ÿ"), cork_byte (0x98)); // U+0178
+  qcompare (utf8_to_cork ("Ź"), cork_byte (0x99)); // U+0179
+  qcompare (utf8_to_cork ("Ž"), cork_byte (0x9A)); // U+017D
+  qcompare (utf8_to_cork ("Ż"), cork_byte (0x9B)); // U+017B
+  qcompare (utf8_to_cork ("Ĳ"), cork_byte (0x9C)); // U+0132
+  qcompare (utf8_to_cork ("İ"), cork_byte (0x9D)); // U+0130
+  qcompare (utf8_to_cork ("đ"), cork_byte (0x9E)); // U+0111
+  qcompare (utf8_to_cork ("§"), cork_byte (0x9F)); // U+00A7 section sign
 }
 
 void
 TestConverter::test_utf8_to_cork_lower () {
-  qcompare (utf8_to_cork ("\xC4\x83"), cork_byte (0xA0)); // U+0103
-  qcompare (utf8_to_cork ("\xC4\x85"), cork_byte (0xA1)); // U+0105
-  qcompare (utf8_to_cork ("\xC4\x87"), cork_byte (0xA2)); // U+0107
-  qcompare (utf8_to_cork ("\xC4\x8D"), cork_byte (0xA3)); // U+010D
-  qcompare (utf8_to_cork ("\xC4\x8F"), cork_byte (0xA4)); // U+010F
-  qcompare (utf8_to_cork ("\xC4\x9B"), cork_byte (0xA5)); // U+011B
-  qcompare (utf8_to_cork ("\xC4\x99"), cork_byte (0xA6)); // U+0119
-  qcompare (utf8_to_cork ("\xC4\x9F"), cork_byte (0xA7)); // U+011F
-  qcompare (utf8_to_cork ("\xC4\xBA"), cork_byte (0xA8)); // U+013A
-  qcompare (utf8_to_cork ("\xC4\xBE"), cork_byte (0xA9)); // U+013E
-  qcompare (utf8_to_cork ("\xC5\x82"), cork_byte (0xAA)); // U+0142
-  qcompare (utf8_to_cork ("\xC5\x84"), cork_byte (0xAB)); // U+0144
-  qcompare (utf8_to_cork ("\xC5\x88"), cork_byte (0xAC)); // U+0148
-  qcompare (utf8_to_cork ("\xC5\x8B"), cork_byte (0xAD)); // U+014B
-  qcompare (utf8_to_cork ("\xC5\x91"), cork_byte (0xAE)); // U+0151
-  qcompare (utf8_to_cork ("\xC5\x95"), cork_byte (0xAF)); // U+0155
-  qcompare (utf8_to_cork ("\xC5\x99"), cork_byte (0xB0)); // U+0159
-  qcompare (utf8_to_cork ("\xC5\x9B"), cork_byte (0xB1)); // U+015B
-  qcompare (utf8_to_cork ("\xC5\xA1"), cork_byte (0xB2)); // U+0161
-  qcompare (utf8_to_cork ("\xC5\x9F"), cork_byte (0xB3)); // U+015F
-  qcompare (utf8_to_cork ("\xC5\xA5"), cork_byte (0xB4)); // U+0165
-  qcompare (utf8_to_cork ("\xC5\xA3"), cork_byte (0xB5)); // U+0163
-  qcompare (utf8_to_cork ("\xC5\xB1"), cork_byte (0xB6)); // U+0171
-  qcompare (utf8_to_cork ("\xC5\xAF"), cork_byte (0xB7)); // U+016F
-  qcompare (utf8_to_cork ("\xC3\xBF"), cork_byte (0xB8)); // U+00FF
-  qcompare (utf8_to_cork ("\xC5\xBA"), cork_byte (0xB9)); // U+017A
-  qcompare (utf8_to_cork ("\xC5\xBE"), cork_byte (0xBA)); // U+017E
-  qcompare (utf8_to_cork ("\xC5\xBC"), cork_byte (0xBB)); // U+017C
-  qcompare (utf8_to_cork ("\xC4\xB3"), cork_byte (0xBC)); // U+0133
-  qcompare (utf8_to_cork ("\xC2\xA1"), cork_byte (0xBD)); // U+00A1
-  qcompare (utf8_to_cork ("\xC2\xBF"), cork_byte (0xBE)); // U+00BF
-  qcompare (utf8_to_cork ("\xC2\xA3"), cork_byte (0xBF)); // U+00A3 pound sign
+  qcompare (utf8_to_cork ("ă"), cork_byte (0xA0)); // U+0103
+  qcompare (utf8_to_cork ("ą"), cork_byte (0xA1)); // U+0105
+  qcompare (utf8_to_cork ("ć"), cork_byte (0xA2)); // U+0107
+  qcompare (utf8_to_cork ("č"), cork_byte (0xA3)); // U+010D
+  qcompare (utf8_to_cork ("ď"), cork_byte (0xA4)); // U+010F
+  qcompare (utf8_to_cork ("ě"), cork_byte (0xA5)); // U+011B
+  qcompare (utf8_to_cork ("ę"), cork_byte (0xA6)); // U+0119
+  qcompare (utf8_to_cork ("ğ"), cork_byte (0xA7)); // U+011F
+  qcompare (utf8_to_cork ("ĺ"), cork_byte (0xA8)); // U+013A
+  qcompare (utf8_to_cork ("ľ"), cork_byte (0xA9)); // U+013E
+  qcompare (utf8_to_cork ("ł"), cork_byte (0xAA)); // U+0142
+  qcompare (utf8_to_cork ("ń"), cork_byte (0xAB)); // U+0144
+  qcompare (utf8_to_cork ("ň"), cork_byte (0xAC)); // U+0148
+  qcompare (utf8_to_cork ("ŋ"), cork_byte (0xAD)); // U+014B
+  qcompare (utf8_to_cork ("ő"), cork_byte (0xAE)); // U+0151
+  qcompare (utf8_to_cork ("ŕ"), cork_byte (0xAF)); // U+0155
+  qcompare (utf8_to_cork ("ř"), cork_byte (0xB0)); // U+0159
+  qcompare (utf8_to_cork ("ś"), cork_byte (0xB1)); // U+015B
+  qcompare (utf8_to_cork ("š"), cork_byte (0xB2)); // U+0161
+  qcompare (utf8_to_cork ("ş"), cork_byte (0xB3)); // U+015F
+  qcompare (utf8_to_cork ("ť"), cork_byte (0xB4)); // U+0165
+  qcompare (utf8_to_cork ("ţ"), cork_byte (0xB5)); // U+0163
+  qcompare (utf8_to_cork ("ű"), cork_byte (0xB6)); // U+0171
+  qcompare (utf8_to_cork ("ů"), cork_byte (0xB7)); // U+016F
+  qcompare (utf8_to_cork ("ÿ"), cork_byte (0xB8)); // U+00FF
+  qcompare (utf8_to_cork ("ź"), cork_byte (0xB9)); // U+017A
+  qcompare (utf8_to_cork ("ž"), cork_byte (0xBA)); // U+017E
+  qcompare (utf8_to_cork ("ż"), cork_byte (0xBB)); // U+017C
+  qcompare (utf8_to_cork ("ĳ"), cork_byte (0xBC)); // U+0133
+  qcompare (utf8_to_cork ("¡"), cork_byte (0xBD)); // U+00A1
+  qcompare (utf8_to_cork ("¿"), cork_byte (0xBE)); // U+00BF
+  qcompare (utf8_to_cork ("£"), cork_byte (0xBF)); // U+00A3 pound sign
 }
 
 void
 TestConverter::test_utf8_to_cork_latin1 () {
-  qcompare (utf8_to_cork ("\xC3\x80"), cork_byte (0xC0)); // U+00C0 À
-  qcompare (utf8_to_cork ("\xC3\x81"), cork_byte (0xC1)); // U+00C1 Á
-  qcompare (utf8_to_cork ("\xC3\x82"), cork_byte (0xC2)); // U+00C2 Â
-  qcompare (utf8_to_cork ("\xC3\x83"), cork_byte (0xC3)); // U+00C3 Ã
-  qcompare (utf8_to_cork ("\xC3\x84"), cork_byte (0xC4)); // U+00C4 Ä
-  qcompare (utf8_to_cork ("\xC3\x85"), cork_byte (0xC5)); // U+00C5 Å
-  qcompare (utf8_to_cork ("\xC3\x86"), cork_byte (0xC6)); // U+00C6 Æ
-  qcompare (utf8_to_cork ("\xC3\x87"), cork_byte (0xC7)); // U+00C7 Ç
-  qcompare (utf8_to_cork ("\xC3\x88"), cork_byte (0xC8)); // U+00C8 È
-  qcompare (utf8_to_cork ("\xC3\x89"), cork_byte (0xC9)); // U+00C9 É
-  qcompare (utf8_to_cork ("\xC3\x8A"), cork_byte (0xCA)); // U+00CA Ê
-  qcompare (utf8_to_cork ("\xC3\x8B"), cork_byte (0xCB)); // U+00CB Ë
-  qcompare (utf8_to_cork ("\xC3\x8C"), cork_byte (0xCC)); // U+00CC Ì
-  qcompare (utf8_to_cork ("\xC3\x8D"), cork_byte (0xCD)); // U+00CD Í
-  qcompare (utf8_to_cork ("\xC3\x8E"), cork_byte (0xCE)); // U+00CE Î
-  qcompare (utf8_to_cork ("\xC3\x8F"), cork_byte (0xCF)); // U+00CF Ï
-  qcompare (utf8_to_cork ("\xC3\x90"), cork_byte (0xD0)); // U+00D0 Ð
-  qcompare (utf8_to_cork ("\xC3\x91"), cork_byte (0xD1)); // U+00D1 Ñ
-  qcompare (utf8_to_cork ("\xC3\x92"), cork_byte (0xD2)); // U+00D2 Ò
-  qcompare (utf8_to_cork ("\xC3\x93"), cork_byte (0xD3)); // U+00D3 Ó
-  qcompare (utf8_to_cork ("\xC3\x94"), cork_byte (0xD4)); // U+00D4 Ô
-  qcompare (utf8_to_cork ("\xC3\x95"), cork_byte (0xD5)); // U+00D5 Õ
-  qcompare (utf8_to_cork ("\xC3\x96"), cork_byte (0xD6)); // U+00D6 Ö
-  qcompare (utf8_to_cork ("\xC5\x92"), cork_byte (0xD7)); // U+0152 Œ
-  qcompare (utf8_to_cork ("\xC3\x98"), cork_byte (0xD8)); // U+00D8 Ø
-  qcompare (utf8_to_cork ("\xC3\x99"), cork_byte (0xD9)); // U+00D9 Ù
-  qcompare (utf8_to_cork ("\xC3\x9A"), cork_byte (0xDA)); // U+00DA Ú
-  qcompare (utf8_to_cork ("\xC3\x9B"), cork_byte (0xDB)); // U+00DB Û
-  qcompare (utf8_to_cork ("\xC3\x9C"), cork_byte (0xDC)); // U+00DC Ü
-  qcompare (utf8_to_cork ("\xC3\x9D"), cork_byte (0xDD)); // U+00DD Ý
-  qcompare (utf8_to_cork ("\xC3\x9E"), cork_byte (0xDE)); // U+00DE Þ
+  qcompare (utf8_to_cork ("À"), cork_byte (0xC0)); // U+00C0 À
+  qcompare (utf8_to_cork ("Á"), cork_byte (0xC1)); // U+00C1 Á
+  qcompare (utf8_to_cork ("Â"), cork_byte (0xC2)); // U+00C2 Â
+  qcompare (utf8_to_cork ("Ã"), cork_byte (0xC3)); // U+00C3 Ã
+  qcompare (utf8_to_cork ("Ä"), cork_byte (0xC4)); // U+00C4 Ä
+  qcompare (utf8_to_cork ("Å"), cork_byte (0xC5)); // U+00C5 Å
+  qcompare (utf8_to_cork ("Æ"), cork_byte (0xC6)); // U+00C6 Æ
+  qcompare (utf8_to_cork ("Ç"), cork_byte (0xC7)); // U+00C7 Ç
+  qcompare (utf8_to_cork ("È"), cork_byte (0xC8)); // U+00C8 È
+  qcompare (utf8_to_cork ("É"), cork_byte (0xC9)); // U+00C9 É
+  qcompare (utf8_to_cork ("Ê"), cork_byte (0xCA)); // U+00CA Ê
+  qcompare (utf8_to_cork ("Ë"), cork_byte (0xCB)); // U+00CB Ë
+  qcompare (utf8_to_cork ("Ì"), cork_byte (0xCC)); // U+00CC Ì
+  qcompare (utf8_to_cork ("Í"), cork_byte (0xCD)); // U+00CD Í
+  qcompare (utf8_to_cork ("Î"), cork_byte (0xCE)); // U+00CE Î
+  qcompare (utf8_to_cork ("Ï"), cork_byte (0xCF)); // U+00CF Ï
+  qcompare (utf8_to_cork ("Ð"), cork_byte (0xD0)); // U+00D0 Ð
+  qcompare (utf8_to_cork ("Ñ"), cork_byte (0xD1)); // U+00D1 Ñ
+  qcompare (utf8_to_cork ("Ò"), cork_byte (0xD2)); // U+00D2 Ò
+  qcompare (utf8_to_cork ("Ó"), cork_byte (0xD3)); // U+00D3 Ó
+  qcompare (utf8_to_cork ("Ô"), cork_byte (0xD4)); // U+00D4 Ô
+  qcompare (utf8_to_cork ("Õ"), cork_byte (0xD5)); // U+00D5 Õ
+  qcompare (utf8_to_cork ("Ö"), cork_byte (0xD6)); // U+00D6 Ö
+  qcompare (utf8_to_cork ("Œ"), cork_byte (0xD7)); // U+0152 Œ
+  qcompare (utf8_to_cork ("Ø"), cork_byte (0xD8)); // U+00D8 Ø
+  qcompare (utf8_to_cork ("Ù"), cork_byte (0xD9)); // U+00D9 Ù
+  qcompare (utf8_to_cork ("Ú"), cork_byte (0xDA)); // U+00DA Ú
+  qcompare (utf8_to_cork ("Û"), cork_byte (0xDB)); // U+00DB Û
+  qcompare (utf8_to_cork ("Ü"), cork_byte (0xDC)); // U+00DC Ü
+  qcompare (utf8_to_cork ("Ý"), cork_byte (0xDD)); // U+00DD Ý
+  qcompare (utf8_to_cork ("Þ"), cork_byte (0xDE)); // U+00DE Þ
   // U+00DF (ß) maps to Cork 0xFF (corktounicode 0xFF -> U+00DF, reversible).
   // Cork 0xDF decodes to "SS" (cork-unicode-oneway), so the byte 0xDF is
   // unreachable from utf8_to_cork; see test_cork_to_utf8_Dx and devel/1125.md.
-  qcompare (utf8_to_cork ("\xC3\x9F"), cork_byte (0xFF)); // U+00DF ß
-  qcompare (utf8_to_cork ("\xC3\xA0"), cork_byte (0xE0)); // U+00E0 à
-  qcompare (utf8_to_cork ("\xC3\xA1"), cork_byte (0xE1)); // U+00E1 á
-  qcompare (utf8_to_cork ("\xC3\xA2"), cork_byte (0xE2)); // U+00E2 â
-  qcompare (utf8_to_cork ("\xC3\xA3"), cork_byte (0xE3)); // U+00E3 ã
-  qcompare (utf8_to_cork ("\xC3\xA4"), cork_byte (0xE4)); // U+00E4 ä
-  qcompare (utf8_to_cork ("\xC3\xA5"), cork_byte (0xE5)); // U+00E5 å
-  qcompare (utf8_to_cork ("\xC3\xA6"), cork_byte (0xE6)); // U+00E6 æ
-  qcompare (utf8_to_cork ("\xC3\xA7"), cork_byte (0xE7)); // U+00E7 ç
-  qcompare (utf8_to_cork ("\xC3\xA8"), cork_byte (0xE8)); // U+00E8 è
-  qcompare (utf8_to_cork ("\xC3\xA9"), cork_byte (0xE9)); // U+00E9 é
-  qcompare (utf8_to_cork ("\xC3\xAA"), cork_byte (0xEA)); // U+00EA ê
-  qcompare (utf8_to_cork ("\xC3\xAB"), cork_byte (0xEB)); // U+00EB ë
-  qcompare (utf8_to_cork ("\xC3\xAC"), cork_byte (0xEC)); // U+00EC ì
-  qcompare (utf8_to_cork ("\xC3\xAD"), cork_byte (0xED)); // U+00ED í
-  qcompare (utf8_to_cork ("\xC3\xAE"), cork_byte (0xEE)); // U+00EE î
-  qcompare (utf8_to_cork ("\xC3\xAF"), cork_byte (0xEF)); // U+00EF ï
-  qcompare (utf8_to_cork ("\xC3\xB0"), cork_byte (0xF0)); // U+00F0 ð
-  qcompare (utf8_to_cork ("\xC3\xB1"), cork_byte (0xF1)); // U+00F1 ñ
-  qcompare (utf8_to_cork ("\xC3\xB2"), cork_byte (0xF2)); // U+00F2 ò
-  qcompare (utf8_to_cork ("\xC3\xB3"), cork_byte (0xF3)); // U+00F3 ó
-  qcompare (utf8_to_cork ("\xC3\xB4"), cork_byte (0xF4)); // U+00F4 ô
-  qcompare (utf8_to_cork ("\xC3\xB5"), cork_byte (0xF5)); // U+00F5 õ
-  qcompare (utf8_to_cork ("\xC3\xB6"), cork_byte (0xF6)); // U+00F6 ö
-  qcompare (utf8_to_cork ("\xC5\x93"), cork_byte (0xF7)); // U+0153 œ
-  qcompare (utf8_to_cork ("\xC3\xB8"), cork_byte (0xF8)); // U+00F8 ø
-  qcompare (utf8_to_cork ("\xC3\xB9"), cork_byte (0xF9)); // U+00F9 ù
-  qcompare (utf8_to_cork ("\xC3\xBA"), cork_byte (0xFA)); // U+00FA ú
-  qcompare (utf8_to_cork ("\xC3\xBB"), cork_byte (0xFB)); // U+00FB û
-  qcompare (utf8_to_cork ("\xC3\xBC"), cork_byte (0xFC)); // U+00FC ü
-  qcompare (utf8_to_cork ("\xC3\xBD"), cork_byte (0xFD)); // U+00FD ý
-  qcompare (utf8_to_cork ("\xC3\xBE"), cork_byte (0xFE)); // U+00FE þ
+  qcompare (utf8_to_cork ("ß"), cork_byte (0xFF)); // U+00DF ß
+  qcompare (utf8_to_cork ("à"), cork_byte (0xE0)); // U+00E0 à
+  qcompare (utf8_to_cork ("á"), cork_byte (0xE1)); // U+00E1 á
+  qcompare (utf8_to_cork ("â"), cork_byte (0xE2)); // U+00E2 â
+  qcompare (utf8_to_cork ("ã"), cork_byte (0xE3)); // U+00E3 ã
+  qcompare (utf8_to_cork ("ä"), cork_byte (0xE4)); // U+00E4 ä
+  qcompare (utf8_to_cork ("å"), cork_byte (0xE5)); // U+00E5 å
+  qcompare (utf8_to_cork ("æ"), cork_byte (0xE6)); // U+00E6 æ
+  qcompare (utf8_to_cork ("ç"), cork_byte (0xE7)); // U+00E7 ç
+  qcompare (utf8_to_cork ("è"), cork_byte (0xE8)); // U+00E8 è
+  qcompare (utf8_to_cork ("é"), cork_byte (0xE9)); // U+00E9 é
+  qcompare (utf8_to_cork ("ê"), cork_byte (0xEA)); // U+00EA ê
+  qcompare (utf8_to_cork ("ë"), cork_byte (0xEB)); // U+00EB ë
+  qcompare (utf8_to_cork ("ì"), cork_byte (0xEC)); // U+00EC ì
+  qcompare (utf8_to_cork ("í"), cork_byte (0xED)); // U+00ED í
+  qcompare (utf8_to_cork ("î"), cork_byte (0xEE)); // U+00EE î
+  qcompare (utf8_to_cork ("ï"), cork_byte (0xEF)); // U+00EF ï
+  qcompare (utf8_to_cork ("ð"), cork_byte (0xF0)); // U+00F0 ð
+  qcompare (utf8_to_cork ("ñ"), cork_byte (0xF1)); // U+00F1 ñ
+  qcompare (utf8_to_cork ("ò"), cork_byte (0xF2)); // U+00F2 ò
+  qcompare (utf8_to_cork ("ó"), cork_byte (0xF3)); // U+00F3 ó
+  qcompare (utf8_to_cork ("ô"), cork_byte (0xF4)); // U+00F4 ô
+  qcompare (utf8_to_cork ("õ"), cork_byte (0xF5)); // U+00F5 õ
+  qcompare (utf8_to_cork ("ö"), cork_byte (0xF6)); // U+00F6 ö
+  qcompare (utf8_to_cork ("œ"), cork_byte (0xF7)); // U+0153 œ
+  qcompare (utf8_to_cork ("ø"), cork_byte (0xF8)); // U+00F8 ø
+  qcompare (utf8_to_cork ("ù"), cork_byte (0xF9)); // U+00F9 ù
+  qcompare (utf8_to_cork ("ú"), cork_byte (0xFA)); // U+00FA ú
+  qcompare (utf8_to_cork ("û"), cork_byte (0xFB)); // U+00FB û
+  qcompare (utf8_to_cork ("ü"), cork_byte (0xFC)); // U+00FC ü
+  qcompare (utf8_to_cork ("ý"), cork_byte (0xFD)); // U+00FD ý
+  qcompare (utf8_to_cork ("þ"), cork_byte (0xFE)); // U+00FE þ
 }
 
 void
 TestConverter::test_utf8_to_cork_unmapped_high () {
   // Codepoints >= 256 with no Cork mapping are escaped as <#XXXX>.
-  qcompare (utf8_to_cork ("\xE4\xB8\xAD"), "<#4E2D>");      // U+4E2D 中
-  qcompare (utf8_to_cork ("\xF0\x9F\x98\x80"), "<#1F600>"); // U+1F600 😀
-  qcompare (utf8_to_cork ("\xE2\x80\x8B"), "<#200B>");      // U+200B ZWSP
+  qcompare (utf8_to_cork ("中"), "<#4E2D>");  // U+4E2D 中
+  qcompare (utf8_to_cork ("😀"), "<#1F600>"); // U+1F600 😀
+  qcompare (utf8_to_cork ("​"), "<#200B>"); // U+200B ZWSP
   // U+2019 maps to Cork 0x27 (shares ASCII apostrophe slot), not escaped.
-  qcompare (utf8_to_cork ("\xE2\x80\x99"), cork_byte (0x27)); // U+2019 ’
+  qcompare (utf8_to_cork ("’"), cork_byte (0x27)); // U+2019 ’
   // U+2010 maps to Cork 0x7F (hyphen), not escaped.
-  qcompare (utf8_to_cork ("\xE2\x80\x90"), cork_byte (0x7F)); // U+2010 ‐
+  qcompare (utf8_to_cork ("‐"), cork_byte (0x7F)); // U+2010 ‐
 }
 
 void
 TestConverter::test_utf8_to_cork_named_unmapped () {
   // U+00A0 maps to the <varspace> named entity (unicode-cork-oneway).
-  qcompare (utf8_to_cork ("\xC2\xA0"), "<varspace>");
+  qcompare (utf8_to_cork (" "), "<varspace>");
   // U+0060 backtick maps to Cork 0x00 (corktounicode has 0x00 -> U+0060,
   // reversible).
   qcompare (utf8_to_cork ("`"), cork_byte (0x00));
@@ -430,43 +430,43 @@ TestConverter::test_utf8_to_cork_named_unmapped () {
 
 void
 TestConverter::test_cork_to_utf8_0x () {
-  qcompare (cork_to_utf8 (cork_byte (0x00)), "`");        // U+0060
-  qcompare (cork_to_utf8 (cork_byte (0x01)), "\xC2\xB4"); // U+00B4
-  qcompare (cork_to_utf8 (cork_byte (0x02)), "\xCB\x86"); // U+02C6
-  qcompare (cork_to_utf8 (cork_byte (0x03)), "\xCB\x9C"); // U+02DC
-  qcompare (cork_to_utf8 (cork_byte (0x04)), "\xC2\xA8"); // U+00A8
-  qcompare (cork_to_utf8 (cork_byte (0x05)), "\xCB\x9D"); // U+02DD
-  qcompare (cork_to_utf8 (cork_byte (0x06)), "\xCB\x9A"); // U+02DA
-  qcompare (cork_to_utf8 (cork_byte (0x07)), "\xCB\x87"); // U+02C7
-  qcompare (cork_to_utf8 (cork_byte (0x08)), "\xCB\x98"); // U+02D8
-  qcompare (cork_to_utf8 (cork_byte (0x09)), "\xC2\xAF"); // U+00AF
-  qcompare (cork_to_utf8 (cork_byte (0x0A)), "\xCB\x99"); // U+02D9
-  qcompare (cork_to_utf8 (cork_byte (0x0B)), "\xC2\xB8"); // U+00B8
-  qcompare (cork_to_utf8 (cork_byte (0x0C)), "\xCB\x9B"); // U+02DB
+  qcompare (cork_to_utf8 (cork_byte (0x00)), "`"); // U+0060
+  qcompare (cork_to_utf8 (cork_byte (0x01)), "´"); // U+00B4
+  qcompare (cork_to_utf8 (cork_byte (0x02)), "ˆ"); // U+02C6
+  qcompare (cork_to_utf8 (cork_byte (0x03)), "˜"); // U+02DC
+  qcompare (cork_to_utf8 (cork_byte (0x04)), "¨"); // U+00A8
+  qcompare (cork_to_utf8 (cork_byte (0x05)), "˝"); // U+02DD
+  qcompare (cork_to_utf8 (cork_byte (0x06)), "˚"); // U+02DA
+  qcompare (cork_to_utf8 (cork_byte (0x07)), "ˇ"); // U+02C7
+  qcompare (cork_to_utf8 (cork_byte (0x08)), "˘"); // U+02D8
+  qcompare (cork_to_utf8 (cork_byte (0x09)), "¯"); // U+00AF
+  qcompare (cork_to_utf8 (cork_byte (0x0A)), "˙"); // U+02D9
+  qcompare (cork_to_utf8 (cork_byte (0x0B)), "¸"); // U+00B8
+  qcompare (cork_to_utf8 (cork_byte (0x0C)), "˛"); // U+02DB
 }
 
 void
 TestConverter::test_cork_to_utf8_1x () {
-  qcompare (cork_to_utf8 (cork_byte (0x0D)), "\xE2\x80\x9A"); // U+201A
-  qcompare (cork_to_utf8 (cork_byte (0x0E)), "\xE2\x80\xB9"); // U+2039
-  qcompare (cork_to_utf8 (cork_byte (0x0F)), "\xE2\x80\xBA"); // U+203A
-  qcompare (cork_to_utf8 (cork_byte (0x10)), "\xE2\x80\x9C"); // U+201C “
-  qcompare (cork_to_utf8 (cork_byte (0x11)), "\xE2\x80\x9D"); // U+201D ”
-  qcompare (cork_to_utf8 (cork_byte (0x12)), "\xE2\x80\x9E"); // U+201E
-  qcompare (cork_to_utf8 (cork_byte (0x13)), "\xC2\xAB");     // U+00AB «
-  qcompare (cork_to_utf8 (cork_byte (0x14)), "\xC2\xBB");     // U+00BB »
-  qcompare (cork_to_utf8 (cork_byte (0x15)), "\xE2\x80\x93"); // U+2013 –
-  qcompare (cork_to_utf8 (cork_byte (0x16)), "\xE2\x80\x94"); // U+2014 —
+  qcompare (cork_to_utf8 (cork_byte (0x0D)), "‚"); // U+201A
+  qcompare (cork_to_utf8 (cork_byte (0x0E)), "‹"); // U+2039
+  qcompare (cork_to_utf8 (cork_byte (0x0F)), "›"); // U+203A
+  qcompare (cork_to_utf8 (cork_byte (0x10)), "“"); // U+201C “
+  qcompare (cork_to_utf8 (cork_byte (0x11)), "”"); // U+201D ”
+  qcompare (cork_to_utf8 (cork_byte (0x12)), "„"); // U+201E
+  qcompare (cork_to_utf8 (cork_byte (0x13)), "«"); // U+00AB «
+  qcompare (cork_to_utf8 (cork_byte (0x14)), "»"); // U+00BB »
+  qcompare (cork_to_utf8 (cork_byte (0x15)), "–"); // U+2013 –
+  qcompare (cork_to_utf8 (cork_byte (0x16)), "—"); // U+2014 —
   qcompare (cork_to_utf8 (cork_byte (0x17)),
-            "\xE2\x81\xA0");                       // U+2060 WORD JOINER
+            "⁠");                                // U+2060 WORD JOINER
   qcompare (cork_to_utf8 (cork_byte (0x18)), "0"); // perthousand zero (oneway)
-  qcompare (cork_to_utf8 (cork_byte (0x19)), "\xC4\xB1"); // U+0131 ı
-  qcompare (cork_to_utf8 (cork_byte (0x1A)), "j");        // dotless j (oneway)
-  qcompare (cork_to_utf8 (cork_byte (0x1B)), "\xEF\xAC\x80"); // U+FB00 ﬀ
-  qcompare (cork_to_utf8 (cork_byte (0x1C)), "\xEF\xAC\x81"); // U+FB01 ﬁ
-  qcompare (cork_to_utf8 (cork_byte (0x1D)), "\xEF\xAC\x82"); // U+FB02 ﬂ
-  qcompare (cork_to_utf8 (cork_byte (0x1E)), "\xEF\xAC\x83"); // U+FB03 ﬃ
-  qcompare (cork_to_utf8 (cork_byte (0x1F)), "\xEF\xAC\x84"); // U+FB04 ﬄ
+  qcompare (cork_to_utf8 (cork_byte (0x19)), "ı"); // U+0131 ı
+  qcompare (cork_to_utf8 (cork_byte (0x1A)), "j"); // dotless j (oneway)
+  qcompare (cork_to_utf8 (cork_byte (0x1B)), "ﬀ"); // U+FB00 ﬀ
+  qcompare (cork_to_utf8 (cork_byte (0x1C)), "ﬁ"); // U+FB01 ﬁ
+  qcompare (cork_to_utf8 (cork_byte (0x1D)), "ﬂ"); // U+FB02 ﬂ
+  qcompare (cork_to_utf8 (cork_byte (0x1E)), "ﬃ"); // U+FB03 ﬃ
+  qcompare (cork_to_utf8 (cork_byte (0x1F)), "ﬄ"); // U+FB04 ﬄ
 }
 
 void
@@ -551,7 +551,7 @@ TestConverter::test_cork_to_utf8_5x () {
 
 void
 TestConverter::test_cork_to_utf8_6x () {
-  qcompare (cork_to_utf8 (cork_byte (0x60)), "\xE2\x80\x98"); // U+2018 ‘
+  qcompare (cork_to_utf8 (cork_byte (0x60)), "‘"); // U+2018 ‘
   qcompare (cork_to_utf8 (cork_byte (0x61)), "a");
   qcompare (cork_to_utf8 (cork_byte (0x62)), "b");
   qcompare (cork_to_utf8 (cork_byte (0x63)), "c");
@@ -586,180 +586,180 @@ TestConverter::test_cork_to_utf8_7x () {
   qcompare (cork_to_utf8 (cork_byte (0x7C)), "|");
   qcompare (cork_to_utf8 (cork_byte (0x7D)), "}");
   qcompare (cork_to_utf8 (cork_byte (0x7E)), "~");
-  qcompare (cork_to_utf8 (cork_byte (0x7F)), "\xE2\x80\x90"); // U+2010 hyphen
+  qcompare (cork_to_utf8 (cork_byte (0x7F)), "‐"); // U+2010 hyphen
 }
 
 void
 TestConverter::test_cork_to_utf8_8x () {
-  qcompare (cork_to_utf8 (cork_byte (0x80)), "\xC4\x82"); // U+0102
-  qcompare (cork_to_utf8 (cork_byte (0x81)), "\xC4\x84"); // U+0104
-  qcompare (cork_to_utf8 (cork_byte (0x82)), "\xC4\x86"); // U+0106
-  qcompare (cork_to_utf8 (cork_byte (0x83)), "\xC4\x8C"); // U+010C
-  qcompare (cork_to_utf8 (cork_byte (0x84)), "\xC4\x8E"); // U+010E
-  qcompare (cork_to_utf8 (cork_byte (0x85)), "\xC4\x9A"); // U+011A
-  qcompare (cork_to_utf8 (cork_byte (0x86)), "\xC4\x98"); // U+0118
-  qcompare (cork_to_utf8 (cork_byte (0x87)), "\xC4\x9E"); // U+011E
-  qcompare (cork_to_utf8 (cork_byte (0x88)), "\xC4\xB9"); // U+0139
-  qcompare (cork_to_utf8 (cork_byte (0x89)), "\xC4\xBD"); // U+013D
-  qcompare (cork_to_utf8 (cork_byte (0x8A)), "\xC5\x81"); // U+0141
-  qcompare (cork_to_utf8 (cork_byte (0x8B)), "\xC5\x83"); // U+0143
-  qcompare (cork_to_utf8 (cork_byte (0x8C)), "\xC5\x87"); // U+0147
-  qcompare (cork_to_utf8 (cork_byte (0x8D)), "\xC5\x8A"); // U+014A
-  qcompare (cork_to_utf8 (cork_byte (0x8E)), "\xC5\x90"); // U+0150
-  qcompare (cork_to_utf8 (cork_byte (0x8F)), "\xC5\x94"); // U+0154
+  qcompare (cork_to_utf8 (cork_byte (0x80)), "Ă"); // U+0102
+  qcompare (cork_to_utf8 (cork_byte (0x81)), "Ą"); // U+0104
+  qcompare (cork_to_utf8 (cork_byte (0x82)), "Ć"); // U+0106
+  qcompare (cork_to_utf8 (cork_byte (0x83)), "Č"); // U+010C
+  qcompare (cork_to_utf8 (cork_byte (0x84)), "Ď"); // U+010E
+  qcompare (cork_to_utf8 (cork_byte (0x85)), "Ě"); // U+011A
+  qcompare (cork_to_utf8 (cork_byte (0x86)), "Ę"); // U+0118
+  qcompare (cork_to_utf8 (cork_byte (0x87)), "Ğ"); // U+011E
+  qcompare (cork_to_utf8 (cork_byte (0x88)), "Ĺ"); // U+0139
+  qcompare (cork_to_utf8 (cork_byte (0x89)), "Ľ"); // U+013D
+  qcompare (cork_to_utf8 (cork_byte (0x8A)), "Ł"); // U+0141
+  qcompare (cork_to_utf8 (cork_byte (0x8B)), "Ń"); // U+0143
+  qcompare (cork_to_utf8 (cork_byte (0x8C)), "Ň"); // U+0147
+  qcompare (cork_to_utf8 (cork_byte (0x8D)), "Ŋ"); // U+014A
+  qcompare (cork_to_utf8 (cork_byte (0x8E)), "Ő"); // U+0150
+  qcompare (cork_to_utf8 (cork_byte (0x8F)), "Ŕ"); // U+0154
 }
 
 void
 TestConverter::test_cork_to_utf8_9x () {
-  qcompare (cork_to_utf8 (cork_byte (0x90)), "\xC5\x98"); // U+0158
-  qcompare (cork_to_utf8 (cork_byte (0x91)), "\xC5\x9A"); // U+015A
-  qcompare (cork_to_utf8 (cork_byte (0x92)), "\xC5\xA0"); // U+0160
-  qcompare (cork_to_utf8 (cork_byte (0x93)), "\xC5\x9E"); // U+015E
-  qcompare (cork_to_utf8 (cork_byte (0x94)), "\xC5\xA4"); // U+0164
-  qcompare (cork_to_utf8 (cork_byte (0x95)), "\xC5\xA2"); // U+0162
-  qcompare (cork_to_utf8 (cork_byte (0x96)), "\xC5\xB0"); // U+0170
-  qcompare (cork_to_utf8 (cork_byte (0x97)), "\xC5\xAE"); // U+016E
-  qcompare (cork_to_utf8 (cork_byte (0x98)), "\xC5\xB8"); // U+0178
-  qcompare (cork_to_utf8 (cork_byte (0x99)), "\xC5\xB9"); // U+0179
-  qcompare (cork_to_utf8 (cork_byte (0x9A)), "\xC5\xBD"); // U+017D
-  qcompare (cork_to_utf8 (cork_byte (0x9B)), "\xC5\xBB"); // U+017B
-  qcompare (cork_to_utf8 (cork_byte (0x9C)), "\xC4\xB2"); // U+0132
-  qcompare (cork_to_utf8 (cork_byte (0x9D)), "\xC4\xB0"); // U+0130
-  qcompare (cork_to_utf8 (cork_byte (0x9E)), "\xC4\x91"); // U+0111
-  qcompare (cork_to_utf8 (cork_byte (0x9F)), "\xC2\xA7"); // U+00A7 §
+  qcompare (cork_to_utf8 (cork_byte (0x90)), "Ř"); // U+0158
+  qcompare (cork_to_utf8 (cork_byte (0x91)), "Ś"); // U+015A
+  qcompare (cork_to_utf8 (cork_byte (0x92)), "Š"); // U+0160
+  qcompare (cork_to_utf8 (cork_byte (0x93)), "Ş"); // U+015E
+  qcompare (cork_to_utf8 (cork_byte (0x94)), "Ť"); // U+0164
+  qcompare (cork_to_utf8 (cork_byte (0x95)), "Ţ"); // U+0162
+  qcompare (cork_to_utf8 (cork_byte (0x96)), "Ű"); // U+0170
+  qcompare (cork_to_utf8 (cork_byte (0x97)), "Ů"); // U+016E
+  qcompare (cork_to_utf8 (cork_byte (0x98)), "Ÿ"); // U+0178
+  qcompare (cork_to_utf8 (cork_byte (0x99)), "Ź"); // U+0179
+  qcompare (cork_to_utf8 (cork_byte (0x9A)), "Ž"); // U+017D
+  qcompare (cork_to_utf8 (cork_byte (0x9B)), "Ż"); // U+017B
+  qcompare (cork_to_utf8 (cork_byte (0x9C)), "Ĳ"); // U+0132
+  qcompare (cork_to_utf8 (cork_byte (0x9D)), "İ"); // U+0130
+  qcompare (cork_to_utf8 (cork_byte (0x9E)), "đ"); // U+0111
+  qcompare (cork_to_utf8 (cork_byte (0x9F)), "§"); // U+00A7 §
 }
 
 void
 TestConverter::test_cork_to_utf8_Ax () {
-  qcompare (cork_to_utf8 (cork_byte (0xA0)), "\xC4\x83"); // U+0103
-  qcompare (cork_to_utf8 (cork_byte (0xA1)), "\xC4\x85"); // U+0105
-  qcompare (cork_to_utf8 (cork_byte (0xA2)), "\xC4\x87"); // U+0107
-  qcompare (cork_to_utf8 (cork_byte (0xA3)), "\xC4\x8D"); // U+010D
-  qcompare (cork_to_utf8 (cork_byte (0xA4)), "\xC4\x8F"); // U+010F
-  qcompare (cork_to_utf8 (cork_byte (0xA5)), "\xC4\x9B"); // U+011B
-  qcompare (cork_to_utf8 (cork_byte (0xA6)), "\xC4\x99"); // U+0119
-  qcompare (cork_to_utf8 (cork_byte (0xA7)), "\xC4\x9F"); // U+011F
-  qcompare (cork_to_utf8 (cork_byte (0xA8)), "\xC4\xBA"); // U+013A
-  qcompare (cork_to_utf8 (cork_byte (0xA9)), "\xC4\xBE"); // U+013E
-  qcompare (cork_to_utf8 (cork_byte (0xAA)), "\xC5\x82"); // U+0142
-  qcompare (cork_to_utf8 (cork_byte (0xAB)), "\xC5\x84"); // U+0144
-  qcompare (cork_to_utf8 (cork_byte (0xAC)), "\xC5\x88"); // U+0148
-  qcompare (cork_to_utf8 (cork_byte (0xAD)), "\xC5\x8B"); // U+014B
-  qcompare (cork_to_utf8 (cork_byte (0xAE)), "\xC5\x91"); // U+0151
-  qcompare (cork_to_utf8 (cork_byte (0xAF)), "\xC5\x95"); // U+0155
+  qcompare (cork_to_utf8 (cork_byte (0xA0)), "ă"); // U+0103
+  qcompare (cork_to_utf8 (cork_byte (0xA1)), "ą"); // U+0105
+  qcompare (cork_to_utf8 (cork_byte (0xA2)), "ć"); // U+0107
+  qcompare (cork_to_utf8 (cork_byte (0xA3)), "č"); // U+010D
+  qcompare (cork_to_utf8 (cork_byte (0xA4)), "ď"); // U+010F
+  qcompare (cork_to_utf8 (cork_byte (0xA5)), "ě"); // U+011B
+  qcompare (cork_to_utf8 (cork_byte (0xA6)), "ę"); // U+0119
+  qcompare (cork_to_utf8 (cork_byte (0xA7)), "ğ"); // U+011F
+  qcompare (cork_to_utf8 (cork_byte (0xA8)), "ĺ"); // U+013A
+  qcompare (cork_to_utf8 (cork_byte (0xA9)), "ľ"); // U+013E
+  qcompare (cork_to_utf8 (cork_byte (0xAA)), "ł"); // U+0142
+  qcompare (cork_to_utf8 (cork_byte (0xAB)), "ń"); // U+0144
+  qcompare (cork_to_utf8 (cork_byte (0xAC)), "ň"); // U+0148
+  qcompare (cork_to_utf8 (cork_byte (0xAD)), "ŋ"); // U+014B
+  qcompare (cork_to_utf8 (cork_byte (0xAE)), "ő"); // U+0151
+  qcompare (cork_to_utf8 (cork_byte (0xAF)), "ŕ"); // U+0155
 }
 
 void
 TestConverter::test_cork_to_utf8_Bx () {
-  qcompare (cork_to_utf8 (cork_byte (0xB0)), "\xC5\x99"); // U+0159
-  qcompare (cork_to_utf8 (cork_byte (0xB1)), "\xC5\x9B"); // U+015B
-  qcompare (cork_to_utf8 (cork_byte (0xB2)), "\xC5\xA1"); // U+0161
-  qcompare (cork_to_utf8 (cork_byte (0xB3)), "\xC5\x9F"); // U+015F
-  qcompare (cork_to_utf8 (cork_byte (0xB4)), "\xC5\xA5"); // U+0165
-  qcompare (cork_to_utf8 (cork_byte (0xB5)), "\xC5\xA3"); // U+0163
-  qcompare (cork_to_utf8 (cork_byte (0xB6)), "\xC5\xB1"); // U+0171
-  qcompare (cork_to_utf8 (cork_byte (0xB7)), "\xC5\xAF"); // U+016F
-  qcompare (cork_to_utf8 (cork_byte (0xB8)), "\xC3\xBF"); // U+00FF ÿ
-  qcompare (cork_to_utf8 (cork_byte (0xB9)), "\xC5\xBA"); // U+017A
-  qcompare (cork_to_utf8 (cork_byte (0xBA)), "\xC5\xBE"); // U+017E
-  qcompare (cork_to_utf8 (cork_byte (0xBB)), "\xC5\xBC"); // U+017C
-  qcompare (cork_to_utf8 (cork_byte (0xBC)), "\xC4\xB3"); // U+0133
-  qcompare (cork_to_utf8 (cork_byte (0xBD)), "\xC2\xA1"); // U+00A1 ¡
-  qcompare (cork_to_utf8 (cork_byte (0xBE)), "\xC2\xBF"); // U+00BF ¿
-  qcompare (cork_to_utf8 (cork_byte (0xBF)), "\xC2\xA3"); // U+00A3 £
+  qcompare (cork_to_utf8 (cork_byte (0xB0)), "ř"); // U+0159
+  qcompare (cork_to_utf8 (cork_byte (0xB1)), "ś"); // U+015B
+  qcompare (cork_to_utf8 (cork_byte (0xB2)), "š"); // U+0161
+  qcompare (cork_to_utf8 (cork_byte (0xB3)), "ş"); // U+015F
+  qcompare (cork_to_utf8 (cork_byte (0xB4)), "ť"); // U+0165
+  qcompare (cork_to_utf8 (cork_byte (0xB5)), "ţ"); // U+0163
+  qcompare (cork_to_utf8 (cork_byte (0xB6)), "ű"); // U+0171
+  qcompare (cork_to_utf8 (cork_byte (0xB7)), "ů"); // U+016F
+  qcompare (cork_to_utf8 (cork_byte (0xB8)), "ÿ"); // U+00FF ÿ
+  qcompare (cork_to_utf8 (cork_byte (0xB9)), "ź"); // U+017A
+  qcompare (cork_to_utf8 (cork_byte (0xBA)), "ž"); // U+017E
+  qcompare (cork_to_utf8 (cork_byte (0xBB)), "ż"); // U+017C
+  qcompare (cork_to_utf8 (cork_byte (0xBC)), "ĳ"); // U+0133
+  qcompare (cork_to_utf8 (cork_byte (0xBD)), "¡"); // U+00A1 ¡
+  qcompare (cork_to_utf8 (cork_byte (0xBE)), "¿"); // U+00BF ¿
+  qcompare (cork_to_utf8 (cork_byte (0xBF)), "£"); // U+00A3 £
 }
 
 void
 TestConverter::test_cork_to_utf8_Cx () {
-  qcompare (cork_to_utf8 (cork_byte (0xC0)), "\xC3\x80"); // U+00C0 À
-  qcompare (cork_to_utf8 (cork_byte (0xC1)), "\xC3\x81"); // U+00C1 Á
-  qcompare (cork_to_utf8 (cork_byte (0xC2)), "\xC3\x82"); // U+00C2 Â
-  qcompare (cork_to_utf8 (cork_byte (0xC3)), "\xC3\x83"); // U+00C3 Ã
-  qcompare (cork_to_utf8 (cork_byte (0xC4)), "\xC3\x84"); // U+00C4 Ä
-  qcompare (cork_to_utf8 (cork_byte (0xC5)), "\xC3\x85"); // U+00C5 Å
-  qcompare (cork_to_utf8 (cork_byte (0xC6)), "\xC3\x86"); // U+00C6 Æ
-  qcompare (cork_to_utf8 (cork_byte (0xC7)), "\xC3\x87"); // U+00C7 Ç
-  qcompare (cork_to_utf8 (cork_byte (0xC8)), "\xC3\x88"); // U+00C8 È
-  qcompare (cork_to_utf8 (cork_byte (0xC9)), "\xC3\x89"); // U+00C9 É
-  qcompare (cork_to_utf8 (cork_byte (0xCA)), "\xC3\x8A"); // U+00CA Ê
-  qcompare (cork_to_utf8 (cork_byte (0xCB)), "\xC3\x8B"); // U+00CB Ë
-  qcompare (cork_to_utf8 (cork_byte (0xCC)), "\xC3\x8C"); // U+00CC Ì
-  qcompare (cork_to_utf8 (cork_byte (0xCD)), "\xC3\x8D"); // U+00CD Í
-  qcompare (cork_to_utf8 (cork_byte (0xCE)), "\xC3\x8E"); // U+00CE Î
-  qcompare (cork_to_utf8 (cork_byte (0xCF)), "\xC3\x8F"); // U+00CF Ï
+  qcompare (cork_to_utf8 (cork_byte (0xC0)), "À"); // U+00C0 À
+  qcompare (cork_to_utf8 (cork_byte (0xC1)), "Á"); // U+00C1 Á
+  qcompare (cork_to_utf8 (cork_byte (0xC2)), "Â"); // U+00C2 Â
+  qcompare (cork_to_utf8 (cork_byte (0xC3)), "Ã"); // U+00C3 Ã
+  qcompare (cork_to_utf8 (cork_byte (0xC4)), "Ä"); // U+00C4 Ä
+  qcompare (cork_to_utf8 (cork_byte (0xC5)), "Å"); // U+00C5 Å
+  qcompare (cork_to_utf8 (cork_byte (0xC6)), "Æ"); // U+00C6 Æ
+  qcompare (cork_to_utf8 (cork_byte (0xC7)), "Ç"); // U+00C7 Ç
+  qcompare (cork_to_utf8 (cork_byte (0xC8)), "È"); // U+00C8 È
+  qcompare (cork_to_utf8 (cork_byte (0xC9)), "É"); // U+00C9 É
+  qcompare (cork_to_utf8 (cork_byte (0xCA)), "Ê"); // U+00CA Ê
+  qcompare (cork_to_utf8 (cork_byte (0xCB)), "Ë"); // U+00CB Ë
+  qcompare (cork_to_utf8 (cork_byte (0xCC)), "Ì"); // U+00CC Ì
+  qcompare (cork_to_utf8 (cork_byte (0xCD)), "Í"); // U+00CD Í
+  qcompare (cork_to_utf8 (cork_byte (0xCE)), "Î"); // U+00CE Î
+  qcompare (cork_to_utf8 (cork_byte (0xCF)), "Ï"); // U+00CF Ï
 }
 
 void
 TestConverter::test_cork_to_utf8_Dx () {
-  qcompare (cork_to_utf8 (cork_byte (0xD0)), "\xC3\x90"); // U+00D0 Ð
-  qcompare (cork_to_utf8 (cork_byte (0xD1)), "\xC3\x91"); // U+00D1 Ñ
-  qcompare (cork_to_utf8 (cork_byte (0xD2)), "\xC3\x92"); // U+00D2 Ò
-  qcompare (cork_to_utf8 (cork_byte (0xD3)), "\xC3\x93"); // U+00D3 Ó
-  qcompare (cork_to_utf8 (cork_byte (0xD4)), "\xC3\x94"); // U+00D4 Ô
-  qcompare (cork_to_utf8 (cork_byte (0xD5)), "\xC3\x95"); // U+00D5 Õ
-  qcompare (cork_to_utf8 (cork_byte (0xD6)), "\xC3\x96"); // U+00D6 Ö
-  qcompare (cork_to_utf8 (cork_byte (0xD7)), "\xC5\x92"); // U+0152 Œ
-  qcompare (cork_to_utf8 (cork_byte (0xD8)), "\xC3\x98"); // U+00D8 Ø
-  qcompare (cork_to_utf8 (cork_byte (0xD9)), "\xC3\x99"); // U+00D9 Ù
-  qcompare (cork_to_utf8 (cork_byte (0xDA)), "\xC3\x9A"); // U+00DA Ú
-  qcompare (cork_to_utf8 (cork_byte (0xDB)), "\xC3\x9B"); // U+00DB Û
-  qcompare (cork_to_utf8 (cork_byte (0xDC)), "\xC3\x9C"); // U+00DC Ü
-  qcompare (cork_to_utf8 (cork_byte (0xDD)), "\xC3\x9D"); // U+00DD Ý
-  qcompare (cork_to_utf8 (cork_byte (0xDE)), "\xC3\x9E"); // U+00DE Þ
-  qcompare (cork_to_utf8 (cork_byte (0xDF)), "SS");       // sharp s (oneway)
+  qcompare (cork_to_utf8 (cork_byte (0xD0)), "Ð");  // U+00D0 Ð
+  qcompare (cork_to_utf8 (cork_byte (0xD1)), "Ñ");  // U+00D1 Ñ
+  qcompare (cork_to_utf8 (cork_byte (0xD2)), "Ò");  // U+00D2 Ò
+  qcompare (cork_to_utf8 (cork_byte (0xD3)), "Ó");  // U+00D3 Ó
+  qcompare (cork_to_utf8 (cork_byte (0xD4)), "Ô");  // U+00D4 Ô
+  qcompare (cork_to_utf8 (cork_byte (0xD5)), "Õ");  // U+00D5 Õ
+  qcompare (cork_to_utf8 (cork_byte (0xD6)), "Ö");  // U+00D6 Ö
+  qcompare (cork_to_utf8 (cork_byte (0xD7)), "Œ");  // U+0152 Œ
+  qcompare (cork_to_utf8 (cork_byte (0xD8)), "Ø");  // U+00D8 Ø
+  qcompare (cork_to_utf8 (cork_byte (0xD9)), "Ù");  // U+00D9 Ù
+  qcompare (cork_to_utf8 (cork_byte (0xDA)), "Ú");  // U+00DA Ú
+  qcompare (cork_to_utf8 (cork_byte (0xDB)), "Û");  // U+00DB Û
+  qcompare (cork_to_utf8 (cork_byte (0xDC)), "Ü");  // U+00DC Ü
+  qcompare (cork_to_utf8 (cork_byte (0xDD)), "Ý");  // U+00DD Ý
+  qcompare (cork_to_utf8 (cork_byte (0xDE)), "Þ");  // U+00DE Þ
+  qcompare (cork_to_utf8 (cork_byte (0xDF)), "SS"); // sharp s (oneway)
 }
 
 void
 TestConverter::test_cork_to_utf8_Ex () {
-  qcompare (cork_to_utf8 (cork_byte (0xE0)), "\xC3\xA0"); // U+00E0 à
-  qcompare (cork_to_utf8 (cork_byte (0xE1)), "\xC3\xA1"); // U+00E1 á
-  qcompare (cork_to_utf8 (cork_byte (0xE2)), "\xC3\xA2"); // U+00E2 â
-  qcompare (cork_to_utf8 (cork_byte (0xE3)), "\xC3\xA3"); // U+00E3 ã
-  qcompare (cork_to_utf8 (cork_byte (0xE4)), "\xC3\xA4"); // U+00E4 ä
-  qcompare (cork_to_utf8 (cork_byte (0xE5)), "\xC3\xA5"); // U+00E5 å
-  qcompare (cork_to_utf8 (cork_byte (0xE6)), "\xC3\xA6"); // U+00E6 æ
-  qcompare (cork_to_utf8 (cork_byte (0xE7)), "\xC3\xA7"); // U+00E7 ç
-  qcompare (cork_to_utf8 (cork_byte (0xE8)), "\xC3\xA8"); // U+00E8 è
-  qcompare (cork_to_utf8 (cork_byte (0xE9)), "\xC3\xA9"); // U+00E9 é
-  qcompare (cork_to_utf8 (cork_byte (0xEA)), "\xC3\xAA"); // U+00EA ê
-  qcompare (cork_to_utf8 (cork_byte (0xEB)), "\xC3\xAB"); // U+00EB ë
-  qcompare (cork_to_utf8 (cork_byte (0xEC)), "\xC3\xAC"); // U+00EC ì
-  qcompare (cork_to_utf8 (cork_byte (0xED)), "\xC3\xAD"); // U+00ED í
-  qcompare (cork_to_utf8 (cork_byte (0xEE)), "\xC3\xAE"); // U+00EE î
-  qcompare (cork_to_utf8 (cork_byte (0xEF)), "\xC3\xAF"); // U+00EF ï
+  qcompare (cork_to_utf8 (cork_byte (0xE0)), "à"); // U+00E0 à
+  qcompare (cork_to_utf8 (cork_byte (0xE1)), "á"); // U+00E1 á
+  qcompare (cork_to_utf8 (cork_byte (0xE2)), "â"); // U+00E2 â
+  qcompare (cork_to_utf8 (cork_byte (0xE3)), "ã"); // U+00E3 ã
+  qcompare (cork_to_utf8 (cork_byte (0xE4)), "ä"); // U+00E4 ä
+  qcompare (cork_to_utf8 (cork_byte (0xE5)), "å"); // U+00E5 å
+  qcompare (cork_to_utf8 (cork_byte (0xE6)), "æ"); // U+00E6 æ
+  qcompare (cork_to_utf8 (cork_byte (0xE7)), "ç"); // U+00E7 ç
+  qcompare (cork_to_utf8 (cork_byte (0xE8)), "è"); // U+00E8 è
+  qcompare (cork_to_utf8 (cork_byte (0xE9)), "é"); // U+00E9 é
+  qcompare (cork_to_utf8 (cork_byte (0xEA)), "ê"); // U+00EA ê
+  qcompare (cork_to_utf8 (cork_byte (0xEB)), "ë"); // U+00EB ë
+  qcompare (cork_to_utf8 (cork_byte (0xEC)), "ì"); // U+00EC ì
+  qcompare (cork_to_utf8 (cork_byte (0xED)), "í"); // U+00ED í
+  qcompare (cork_to_utf8 (cork_byte (0xEE)), "î"); // U+00EE î
+  qcompare (cork_to_utf8 (cork_byte (0xEF)), "ï"); // U+00EF ï
 }
 
 void
 TestConverter::test_cork_to_utf8_Fx () {
-  qcompare (cork_to_utf8 (cork_byte (0xF0)), "\xC3\xB0"); // U+00F0 ð
-  qcompare (cork_to_utf8 (cork_byte (0xF1)), "\xC3\xB1"); // U+00F1 ñ
-  qcompare (cork_to_utf8 (cork_byte (0xF2)), "\xC3\xB2"); // U+00F2 ò
-  qcompare (cork_to_utf8 (cork_byte (0xF3)), "\xC3\xB3"); // U+00F3 ó
-  qcompare (cork_to_utf8 (cork_byte (0xF4)), "\xC3\xB4"); // U+00F4 ô
-  qcompare (cork_to_utf8 (cork_byte (0xF5)), "\xC3\xB5"); // U+00F5 õ
-  qcompare (cork_to_utf8 (cork_byte (0xF6)), "\xC3\xB6"); // U+00F6 ö
-  qcompare (cork_to_utf8 (cork_byte (0xF7)), "\xC5\x93"); // U+0153 œ
-  qcompare (cork_to_utf8 (cork_byte (0xF8)), "\xC3\xB8"); // U+00F8 ø
-  qcompare (cork_to_utf8 (cork_byte (0xF9)), "\xC3\xB9"); // U+00F9 ù
-  qcompare (cork_to_utf8 (cork_byte (0xFA)), "\xC3\xBA"); // U+00FA ú
-  qcompare (cork_to_utf8 (cork_byte (0xFB)), "\xC3\xBB"); // U+00FB û
-  qcompare (cork_to_utf8 (cork_byte (0xFC)), "\xC3\xBC"); // U+00FC ü
-  qcompare (cork_to_utf8 (cork_byte (0xFD)), "\xC3\xBD"); // U+00FD ý
-  qcompare (cork_to_utf8 (cork_byte (0xFE)), "\xC3\xBE"); // U+00FE þ
-  qcompare (cork_to_utf8 (cork_byte (0xFF)), "\xC3\x9F"); // U+00DF ß
+  qcompare (cork_to_utf8 (cork_byte (0xF0)), "ð"); // U+00F0 ð
+  qcompare (cork_to_utf8 (cork_byte (0xF1)), "ñ"); // U+00F1 ñ
+  qcompare (cork_to_utf8 (cork_byte (0xF2)), "ò"); // U+00F2 ò
+  qcompare (cork_to_utf8 (cork_byte (0xF3)), "ó"); // U+00F3 ó
+  qcompare (cork_to_utf8 (cork_byte (0xF4)), "ô"); // U+00F4 ô
+  qcompare (cork_to_utf8 (cork_byte (0xF5)), "õ"); // U+00F5 õ
+  qcompare (cork_to_utf8 (cork_byte (0xF6)), "ö"); // U+00F6 ö
+  qcompare (cork_to_utf8 (cork_byte (0xF7)), "œ"); // U+0153 œ
+  qcompare (cork_to_utf8 (cork_byte (0xF8)), "ø"); // U+00F8 ø
+  qcompare (cork_to_utf8 (cork_byte (0xF9)), "ù"); // U+00F9 ù
+  qcompare (cork_to_utf8 (cork_byte (0xFA)), "ú"); // U+00FA ú
+  qcompare (cork_to_utf8 (cork_byte (0xFB)), "û"); // U+00FB û
+  qcompare (cork_to_utf8 (cork_byte (0xFC)), "ü"); // U+00FC ü
+  qcompare (cork_to_utf8 (cork_byte (0xFD)), "ý"); // U+00FD ý
+  qcompare (cork_to_utf8 (cork_byte (0xFE)), "þ"); // U+00FE þ
+  qcompare (cork_to_utf8 (cork_byte (0xFF)), "ß"); // U+00DF ß
 }
 
 void
 TestConverter::test_cork_to_utf8_escapes () {
   // <#XXXX> decodes to the UTF-8 encoding of the hex codepoint.
-  qcompare (cork_to_utf8 ("<#4E2D>"), "中");                // U+4E2D
-  qcompare (cork_to_utf8 ("<#2019>"), "\xE2\x80\x99");      // U+2019
-  qcompare (cork_to_utf8 ("<#1F600>"), "\xF0\x9F\x98\x80"); // U+1F600
+  qcompare (cork_to_utf8 ("<#4E2D>"), "中");  // U+4E2D
+  qcompare (cork_to_utf8 ("<#2019>"), "’");   // U+2019
+  qcompare (cork_to_utf8 ("<#1F600>"), "😀"); // U+1F600
   // Padded forms are accepted.
-  qcompare (cork_to_utf8 ("<#0FF>"), "\xC3\xBF");  // U+00FF
-  qcompare (cork_to_utf8 ("<#00FF>"), "\xC3\xBF"); // U+00FF
+  qcompare (cork_to_utf8 ("<#0FF>"), "ÿ");  // U+00FF
+  qcompare (cork_to_utf8 ("<#00FF>"), "ÿ"); // U+00FF
   // A <#XXXX> that names a Cork-mapped codepoint overrides the byte mapping.
-  qcompare (cork_to_utf8 ("<#201C>"), "\xE2\x80\x9C"); // U+201C
+  qcompare (cork_to_utf8 ("<#201C>"), "“"); // U+201C
 }
 
 void
@@ -777,7 +777,7 @@ void
 TestConverter::test_utf8_to_cork_named_entities () {
   qcompare (utf8_to_cork ("<"), "<less>");
   qcompare (utf8_to_cork (">"), "<gtr>");
-  qcompare (utf8_to_cork ("\xC2\xA0"), "<varspace>"); // U+00A0
+  qcompare (utf8_to_cork (" "), "<varspace>"); // U+00A0
 }
 
 void
@@ -785,7 +785,7 @@ TestConverter::test_mixed () {
   // Cork byte + <#XXXX> escape + ASCII, decoded.
   qcompare (
       cork_to_utf8 (cork_byte (0x41) * string ("<#2019>") * cork_byte (0x42)),
-      "A" * string ("\xE2\x80\x99") * "B");
+      "A" * string ("’") * "B");
   // ASCII + CJK + ASCII, encoded.
   qcompare (utf8_to_cork (string ("A") * "中" * "B"),
             cork_byte (0x41) * string ("<#4E2D>") * cork_byte (0x42));
@@ -830,83 +830,83 @@ TestConverter::test_named_text_punctuation () {
   qcompare (cork_to_utf8 ("<gtr>"), ">");
   qcompare (cork_to_utf8 ("<comma>"), ",");
   qcompare (cork_to_utf8 ("<grave>"), "`");
-  qcompare (cork_to_utf8 ("<varspace>"), "\xC2\xA0");   // U+00A0 nbsp
-  qcompare (cork_to_utf8 ("<bullet>"), "\xE2\x80\xA2"); // U+2022
-  qcompare (cork_to_utf8 ("<dag>"), "\xE2\x80\xA0");    // U+2020 dagger
-  qcompare (cork_to_utf8 ("<ddag>"), "\xE2\x80\xA1");   // U+2021 double dagger
-  qcompare (cork_to_utf8 ("<paragraph>"), "\xC2\xB6");  // U+00B6 pilcrow
-  qcompare (cork_to_utf8 ("<copyright>"), "\xC2\xA9");  // U+00A9
-  qcompare (cork_to_utf8 ("<trademark>"), "\xE2\x84\xA2"); // U+2122
-  qcompare (cork_to_utf8 ("<degree>"), "\xC2\xB0");        // U+00B0
-  qcompare (cork_to_utf8 ("<hyphen>"), "\xC2\xAD");        // U+00AD soft hyphen
+  qcompare (cork_to_utf8 ("<varspace>"), " ");  // U+00A0 nbsp
+  qcompare (cork_to_utf8 ("<bullet>"), "•");    // U+2022
+  qcompare (cork_to_utf8 ("<dag>"), "†");       // U+2020 dagger
+  qcompare (cork_to_utf8 ("<ddag>"), "‡");      // U+2021 double dagger
+  qcompare (cork_to_utf8 ("<paragraph>"), "¶"); // U+00B6 pilcrow
+  qcompare (cork_to_utf8 ("<copyright>"), "©"); // U+00A9
+  qcompare (cork_to_utf8 ("<trademark>"), "™"); // U+2122
+  qcompare (cork_to_utf8 ("<degree>"), "°");    // U+00B0
+  qcompare (cork_to_utf8 ("<hyphen>"), "­");    // U+00AD soft hyphen
   qcompare (cork_to_utf8 ("<nbhyph>"),
-            "\xE2\x80\x91"); // U+2011 non-breaking hyphen
+            "‑"); // U+2011 non-breaking hyphen
 }
 
 void
 TestConverter::test_named_currency () {
-  qcompare (cork_to_utf8 ("<cent>"), "\xC2\xA2");     // U+00A2
-  qcompare (cork_to_utf8 ("<yen>"), "\xC2\xA5");      // U+00A5
-  qcompare (cork_to_utf8 ("<currency>"), "\xC2\xA4"); // U+00A4
+  qcompare (cork_to_utf8 ("<cent>"), "¢");     // U+00A2
+  qcompare (cork_to_utf8 ("<yen>"), "¥");      // U+00A5
+  qcompare (cork_to_utf8 ("<currency>"), "¤"); // U+00A4
   // <sterling> decodes to U+00A3 but round-trips to Cork byte 0xBF;
   // see test_named_non_identity_roundtrip.
-  qcompare (cork_to_utf8 ("<sterling>"), "\xC2\xA3"); // U+00A3
+  qcompare (cork_to_utf8 ("<sterling>"), "£"); // U+00A3
 }
 
 void
 TestConverter::test_named_greek_lower () {
-  qcompare (cork_to_utf8 ("<alpha>"), "\xCE\xB1");   // U+03B1
-  qcompare (cork_to_utf8 ("<beta>"), "\xCE\xB2");    // U+03B2
-  qcompare (cork_to_utf8 ("<gamma>"), "\xCE\xB3");   // U+03B3
-  qcompare (cork_to_utf8 ("<delta>"), "\xCE\xB4");   // U+03B4
-  qcompare (cork_to_utf8 ("<epsilon>"), "\xCF\xB5"); // U+03F5 lunate epsilon
-  qcompare (cork_to_utf8 ("<zeta>"), "\xCE\xB6");    // U+03B6
-  qcompare (cork_to_utf8 ("<eta>"), "\xCE\xB7");     // U+03B7
-  qcompare (cork_to_utf8 ("<theta>"), "\xCE\xB8");   // U+03B8
-  qcompare (cork_to_utf8 ("<iota>"), "\xCE\xB9");    // U+03B9
-  qcompare (cork_to_utf8 ("<kappa>"), "\xCE\xBA");   // U+03BA
-  qcompare (cork_to_utf8 ("<lambda>"), "\xCE\xBB");  // U+03BB
-  qcompare (cork_to_utf8 ("<mu>"), "\xCE\xBC");      // U+03BC
-  qcompare (cork_to_utf8 ("<nu>"), "\xCE\xBD");      // U+03BD
-  qcompare (cork_to_utf8 ("<xi>"), "\xCE\xBE");      // U+03BE
-  qcompare (cork_to_utf8 ("<omicron>"), "\xCE\xBF"); // U+03BF
-  qcompare (cork_to_utf8 ("<pi>"), "\xCF\x80");      // U+03C0
-  qcompare (cork_to_utf8 ("<rho>"), "\xCF\x81");     // U+03C1
-  qcompare (cork_to_utf8 ("<sigma>"), "\xCF\x83");   // U+03C3
-  qcompare (cork_to_utf8 ("<tau>"), "\xCF\x84");     // U+03C4
-  qcompare (cork_to_utf8 ("<upsilon>"), "\xCF\x85"); // U+03C5
-  qcompare (cork_to_utf8 ("<phi>"), "\xCF\x95");     // U+03D5 phi
-  qcompare (cork_to_utf8 ("<chi>"), "\xCF\x87");     // U+03C7
-  qcompare (cork_to_utf8 ("<psi>"), "\xCF\x88");     // U+03C8
-  qcompare (cork_to_utf8 ("<omega>"), "\xCF\x89");   // U+03C9
+  qcompare (cork_to_utf8 ("<alpha>"), "α");   // U+03B1
+  qcompare (cork_to_utf8 ("<beta>"), "β");    // U+03B2
+  qcompare (cork_to_utf8 ("<gamma>"), "γ");   // U+03B3
+  qcompare (cork_to_utf8 ("<delta>"), "δ");   // U+03B4
+  qcompare (cork_to_utf8 ("<epsilon>"), "ϵ"); // U+03F5 lunate epsilon
+  qcompare (cork_to_utf8 ("<zeta>"), "ζ");    // U+03B6
+  qcompare (cork_to_utf8 ("<eta>"), "η");     // U+03B7
+  qcompare (cork_to_utf8 ("<theta>"), "θ");   // U+03B8
+  qcompare (cork_to_utf8 ("<iota>"), "ι");    // U+03B9
+  qcompare (cork_to_utf8 ("<kappa>"), "κ");   // U+03BA
+  qcompare (cork_to_utf8 ("<lambda>"), "λ");  // U+03BB
+  qcompare (cork_to_utf8 ("<mu>"), "μ");      // U+03BC
+  qcompare (cork_to_utf8 ("<nu>"), "ν");      // U+03BD
+  qcompare (cork_to_utf8 ("<xi>"), "ξ");      // U+03BE
+  qcompare (cork_to_utf8 ("<omicron>"), "ο"); // U+03BF
+  qcompare (cork_to_utf8 ("<pi>"), "π");      // U+03C0
+  qcompare (cork_to_utf8 ("<rho>"), "ρ");     // U+03C1
+  qcompare (cork_to_utf8 ("<sigma>"), "σ");   // U+03C3
+  qcompare (cork_to_utf8 ("<tau>"), "τ");     // U+03C4
+  qcompare (cork_to_utf8 ("<upsilon>"), "υ"); // U+03C5
+  qcompare (cork_to_utf8 ("<phi>"), "ϕ");     // U+03D5 phi
+  qcompare (cork_to_utf8 ("<chi>"), "χ");     // U+03C7
+  qcompare (cork_to_utf8 ("<psi>"), "ψ");     // U+03C8
+  qcompare (cork_to_utf8 ("<omega>"), "ω");   // U+03C9
 }
 
 void
 TestConverter::test_named_greek_upper () {
-  qcompare (cork_to_utf8 ("<Alpha>"), "\xCE\x91");   // U+0391
-  qcompare (cork_to_utf8 ("<Beta>"), "\xCE\x92");    // U+0392
-  qcompare (cork_to_utf8 ("<Gamma>"), "\xCE\x93");   // U+0393
-  qcompare (cork_to_utf8 ("<Delta>"), "\xCE\x94");   // U+0394
-  qcompare (cork_to_utf8 ("<Epsilon>"), "\xCE\x95"); // U+0395
-  qcompare (cork_to_utf8 ("<Zeta>"), "\xCE\x96");    // U+0396
-  qcompare (cork_to_utf8 ("<Eta>"), "\xCE\x97");     // U+0397
-  qcompare (cork_to_utf8 ("<Theta>"), "\xCE\x98");   // U+0398
-  qcompare (cork_to_utf8 ("<Iota>"), "\xCE\x99");    // U+0399
-  qcompare (cork_to_utf8 ("<Kappa>"), "\xCE\x9A");   // U+039A
-  qcompare (cork_to_utf8 ("<Lambda>"), "\xCE\x9B");  // U+039B
-  qcompare (cork_to_utf8 ("<Mu>"), "\xCE\x9C");      // U+039C
-  qcompare (cork_to_utf8 ("<Nu>"), "\xCE\x9D");      // U+039D
-  qcompare (cork_to_utf8 ("<Xi>"), "\xCE\x9E");      // U+039E
-  qcompare (cork_to_utf8 ("<Omicron>"), "\xCE\x9F"); // U+039F
-  qcompare (cork_to_utf8 ("<Pi>"), "\xCE\xA0");      // U+03A0
-  qcompare (cork_to_utf8 ("<Rho>"), "\xCE\xA1");     // U+03A1
-  qcompare (cork_to_utf8 ("<Sigma>"), "\xCE\xA3");   // U+03A3
-  qcompare (cork_to_utf8 ("<Tau>"), "\xCE\xA4");     // U+03A4
-  qcompare (cork_to_utf8 ("<Upsilon>"), "\xCE\xA5"); // U+03A5
-  qcompare (cork_to_utf8 ("<Phi>"), "\xCE\xA6");     // U+03A6
-  qcompare (cork_to_utf8 ("<Chi>"), "\xCE\xA7");     // U+03A7
-  qcompare (cork_to_utf8 ("<Psi>"), "\xCE\xA8");     // U+03A8
-  qcompare (cork_to_utf8 ("<Omega>"), "\xCE\xA9");   // U+03A9
+  qcompare (cork_to_utf8 ("<Alpha>"), "Α");   // U+0391
+  qcompare (cork_to_utf8 ("<Beta>"), "Β");    // U+0392
+  qcompare (cork_to_utf8 ("<Gamma>"), "Γ");   // U+0393
+  qcompare (cork_to_utf8 ("<Delta>"), "Δ");   // U+0394
+  qcompare (cork_to_utf8 ("<Epsilon>"), "Ε"); // U+0395
+  qcompare (cork_to_utf8 ("<Zeta>"), "Ζ");    // U+0396
+  qcompare (cork_to_utf8 ("<Eta>"), "Η");     // U+0397
+  qcompare (cork_to_utf8 ("<Theta>"), "Θ");   // U+0398
+  qcompare (cork_to_utf8 ("<Iota>"), "Ι");    // U+0399
+  qcompare (cork_to_utf8 ("<Kappa>"), "Κ");   // U+039A
+  qcompare (cork_to_utf8 ("<Lambda>"), "Λ");  // U+039B
+  qcompare (cork_to_utf8 ("<Mu>"), "Μ");      // U+039C
+  qcompare (cork_to_utf8 ("<Nu>"), "Ν");      // U+039D
+  qcompare (cork_to_utf8 ("<Xi>"), "Ξ");      // U+039E
+  qcompare (cork_to_utf8 ("<Omicron>"), "Ο"); // U+039F
+  qcompare (cork_to_utf8 ("<Pi>"), "Π");      // U+03A0
+  qcompare (cork_to_utf8 ("<Rho>"), "Ρ");     // U+03A1
+  qcompare (cork_to_utf8 ("<Sigma>"), "Σ");   // U+03A3
+  qcompare (cork_to_utf8 ("<Tau>"), "Τ");     // U+03A4
+  qcompare (cork_to_utf8 ("<Upsilon>"), "Υ"); // U+03A5
+  qcompare (cork_to_utf8 ("<Phi>"), "Φ");     // U+03A6
+  qcompare (cork_to_utf8 ("<Chi>"), "Χ");     // U+03A7
+  qcompare (cork_to_utf8 ("<Psi>"), "Ψ");     // U+03A8
+  qcompare (cork_to_utf8 ("<Omega>"), "Ω");   // U+03A9
 }
 
 void
@@ -914,118 +914,118 @@ TestConverter::test_named_greek_variants () {
   // Note: <epsilon> -> U+03F5 (lunate) while <varepsilon> -> U+03B5 (plain),
   // and <phi> -> U+03D5 while <varphi> -> U+03C6; the variant and plain forms
   // are swapped relative to the usual convention.
-  qcompare (cork_to_utf8 ("<varepsilon>"), "\xCE\xB5"); // U+03B5
-  qcompare (cork_to_utf8 ("<vartheta>"), "\xCF\x91");   // U+03D1
-  qcompare (cork_to_utf8 ("<varpi>"), "\xCF\x96");      // U+03D6
-  qcompare (cork_to_utf8 ("<varrho>"), "\xCF\xB1");     // U+03F1
-  qcompare (cork_to_utf8 ("<varsigma>"), "\xCF\x82");   // U+03C2
-  qcompare (cork_to_utf8 ("<varphi>"), "\xCF\x86");     // U+03C6
+  qcompare (cork_to_utf8 ("<varepsilon>"), "ε"); // U+03B5
+  qcompare (cork_to_utf8 ("<vartheta>"), "ϑ");   // U+03D1
+  qcompare (cork_to_utf8 ("<varpi>"), "ϖ");      // U+03D6
+  qcompare (cork_to_utf8 ("<varrho>"), "ϱ");     // U+03F1
+  qcompare (cork_to_utf8 ("<varsigma>"), "ς");   // U+03C2
+  qcompare (cork_to_utf8 ("<varphi>"), "φ");     // U+03C6
 }
 
 void
 TestConverter::test_named_binary_operators () {
-  qcompare (cork_to_utf8 ("<times>"), "\xC3\x97");        // U+00D7
-  qcompare (cork_to_utf8 ("<div>"), "\xC3\xB7");          // U+00F7
-  qcompare (cork_to_utf8 ("<cdot>"), "\xE2\x8B\x85");     // U+22C5
-  qcompare (cork_to_utf8 ("<ast>"), "\xE2\x88\x97");      // U+2217
-  qcompare (cork_to_utf8 ("<dotplus>"), "\xE2\x88\x94");  // U+2214
-  qcompare (cork_to_utf8 ("<cap>"), "\xE2\x88\xA9");      // U+2229
-  qcompare (cork_to_utf8 ("<cup>"), "\xE2\x88\xAA");      // U+222A
-  qcompare (cork_to_utf8 ("<sqcap>"), "\xE2\x8A\x93");    // U+2293
-  qcompare (cork_to_utf8 ("<sqcup>"), "\xE2\x8A\x94");    // U+2294
-  qcompare (cork_to_utf8 ("<wedge>"), "\xE2\x88\xA7");    // U+2227
-  qcompare (cork_to_utf8 ("<vee>"), "\xE2\x88\xA8");      // U+2228
-  qcompare (cork_to_utf8 ("<setminus>"), "\xE2\x88\x96"); // U+2216
-  qcompare (cork_to_utf8 ("<amalg>"), "\xE2\xA8\xBF");    // U+2A3F
-  qcompare (cork_to_utf8 ("<wr>"), "\xE2\x89\x80");       // U+2240
+  qcompare (cork_to_utf8 ("<times>"), "×");    // U+00D7
+  qcompare (cork_to_utf8 ("<div>"), "÷");      // U+00F7
+  qcompare (cork_to_utf8 ("<cdot>"), "⋅");     // U+22C5
+  qcompare (cork_to_utf8 ("<ast>"), "∗");      // U+2217
+  qcompare (cork_to_utf8 ("<dotplus>"), "∔");  // U+2214
+  qcompare (cork_to_utf8 ("<cap>"), "∩");      // U+2229
+  qcompare (cork_to_utf8 ("<cup>"), "∪");      // U+222A
+  qcompare (cork_to_utf8 ("<sqcap>"), "⊓");    // U+2293
+  qcompare (cork_to_utf8 ("<sqcup>"), "⊔");    // U+2294
+  qcompare (cork_to_utf8 ("<wedge>"), "∧");    // U+2227
+  qcompare (cork_to_utf8 ("<vee>"), "∨");      // U+2228
+  qcompare (cork_to_utf8 ("<setminus>"), "∖"); // U+2216
+  qcompare (cork_to_utf8 ("<amalg>"), "⨿");    // U+2A3F
+  qcompare (cork_to_utf8 ("<wr>"), "≀");       // U+2240
 }
 
 void
 TestConverter::test_named_relations () {
-  qcompare (cork_to_utf8 ("<neq>"), "\xE2\x89\xA0");      // U+2260
-  qcompare (cork_to_utf8 ("<leq>"), "\xE2\x89\xA4");      // U+2264
-  qcompare (cork_to_utf8 ("<geq>"), "\xE2\x89\xA5");      // U+2265
-  qcompare (cork_to_utf8 ("<leqslant>"), "\xE2\xA9\xBD"); // U+2A7D
-  qcompare (cork_to_utf8 ("<geqslant>"), "\xE2\xA9\xBE"); // U+2A7E
-  qcompare (cork_to_utf8 ("<ll>"), "\xE2\x89\xAA");       // U+226A
-  qcompare (cork_to_utf8 ("<gg>"), "\xE2\x89\xAB");       // U+226B
-  qcompare (cork_to_utf8 ("<equiv>"), "\xE2\x89\xA1");    // U+2261
-  qcompare (cork_to_utf8 ("<sim>"), "\xE2\x88\xBC");      // U+223C
-  qcompare (cork_to_utf8 ("<simeq>"), "\xE2\x89\x83");    // U+2243
-  qcompare (cork_to_utf8 ("<cong>"), "\xE2\x89\x85");     // U+2245
-  qcompare (cork_to_utf8 ("<approx>"), "\xE2\x89\x88");   // U+2248
-  qcompare (cork_to_utf8 ("<prec>"), "\xE2\x89\xBA");     // U+227A
-  qcompare (cork_to_utf8 ("<succ>"), "\xE2\x89\xBB");     // U+227B
+  qcompare (cork_to_utf8 ("<neq>"), "≠");      // U+2260
+  qcompare (cork_to_utf8 ("<leq>"), "≤");      // U+2264
+  qcompare (cork_to_utf8 ("<geq>"), "≥");      // U+2265
+  qcompare (cork_to_utf8 ("<leqslant>"), "⩽"); // U+2A7D
+  qcompare (cork_to_utf8 ("<geqslant>"), "⩾"); // U+2A7E
+  qcompare (cork_to_utf8 ("<ll>"), "≪");       // U+226A
+  qcompare (cork_to_utf8 ("<gg>"), "≫");       // U+226B
+  qcompare (cork_to_utf8 ("<equiv>"), "≡");    // U+2261
+  qcompare (cork_to_utf8 ("<sim>"), "∼");      // U+223C
+  qcompare (cork_to_utf8 ("<simeq>"), "≃");    // U+2243
+  qcompare (cork_to_utf8 ("<cong>"), "≅");     // U+2245
+  qcompare (cork_to_utf8 ("<approx>"), "≈");   // U+2248
+  qcompare (cork_to_utf8 ("<prec>"), "≺");     // U+227A
+  qcompare (cork_to_utf8 ("<succ>"), "≻");     // U+227B
 }
 
 void
 TestConverter::test_named_arrows () {
-  qcompare (cork_to_utf8 ("<rightarrow>"), "\xE2\x86\x92");     // U+2192
-  qcompare (cork_to_utf8 ("<leftarrow>"), "\xE2\x86\x90");      // U+2190
-  qcompare (cork_to_utf8 ("<leftrightarrow>"), "\xE2\x86\x94"); // U+2194
-  qcompare (cork_to_utf8 ("<Rightarrow>"), "\xE2\x87\x92");     // U+21D2
-  qcompare (cork_to_utf8 ("<Leftarrow>"), "\xE2\x87\x90");      // U+21D0
-  qcompare (cork_to_utf8 ("<uparrow>"), "\xE2\x86\x91");        // U+2191
-  qcompare (cork_to_utf8 ("<downarrow>"), "\xE2\x86\x93");      // U+2193
-  qcompare (cork_to_utf8 ("<mapsto>"), "\xE2\x86\xA6");         // U+21A6
-  qcompare (cork_to_utf8 ("<leftharpoonup>"), "\xE2\x86\xBC");  // U+21BC
-  qcompare (cork_to_utf8 ("<rightharpoonup>"), "\xE2\x87\x80"); // U+21C0
+  qcompare (cork_to_utf8 ("<rightarrow>"), "→");     // U+2192
+  qcompare (cork_to_utf8 ("<leftarrow>"), "←");      // U+2190
+  qcompare (cork_to_utf8 ("<leftrightarrow>"), "↔"); // U+2194
+  qcompare (cork_to_utf8 ("<Rightarrow>"), "⇒");     // U+21D2
+  qcompare (cork_to_utf8 ("<Leftarrow>"), "⇐");      // U+21D0
+  qcompare (cork_to_utf8 ("<uparrow>"), "↑");        // U+2191
+  qcompare (cork_to_utf8 ("<downarrow>"), "↓");      // U+2193
+  qcompare (cork_to_utf8 ("<mapsto>"), "↦");         // U+21A6
+  qcompare (cork_to_utf8 ("<leftharpoonup>"), "↼");  // U+21BC
+  qcompare (cork_to_utf8 ("<rightharpoonup>"), "⇀"); // U+21C0
 }
 
 void
 TestConverter::test_named_set_theory () {
-  qcompare (cork_to_utf8 ("<in>"), "\xE2\x88\x88");       // U+2208
-  qcompare (cork_to_utf8 ("<notin>"), "\xE2\x88\x89");    // U+2209
-  qcompare (cork_to_utf8 ("<subset>"), "\xE2\x8A\x82");   // U+2282
-  qcompare (cork_to_utf8 ("<supset>"), "\xE2\x8A\x83");   // U+2283
-  qcompare (cork_to_utf8 ("<subseteq>"), "\xE2\x8A\x86"); // U+2286
-  qcompare (cork_to_utf8 ("<supseteq>"), "\xE2\x8A\x87"); // U+2287
-  qcompare (cork_to_utf8 ("<sqsubset>"), "\xE2\x8A\x8F"); // U+228F
-  qcompare (cork_to_utf8 ("<sqsupset>"), "\xE2\x8A\x90"); // U+2290
-  qcompare (cork_to_utf8 ("<emptyset>"), "\xE2\x88\x85"); // U+2205
+  qcompare (cork_to_utf8 ("<in>"), "∈");       // U+2208
+  qcompare (cork_to_utf8 ("<notin>"), "∉");    // U+2209
+  qcompare (cork_to_utf8 ("<subset>"), "⊂");   // U+2282
+  qcompare (cork_to_utf8 ("<supset>"), "⊃");   // U+2283
+  qcompare (cork_to_utf8 ("<subseteq>"), "⊆"); // U+2286
+  qcompare (cork_to_utf8 ("<supseteq>"), "⊇"); // U+2287
+  qcompare (cork_to_utf8 ("<sqsubset>"), "⊏"); // U+228F
+  qcompare (cork_to_utf8 ("<sqsupset>"), "⊐"); // U+2290
+  qcompare (cork_to_utf8 ("<emptyset>"), "∅"); // U+2205
 }
 
 void
 TestConverter::test_named_calculus () {
-  qcompare (cork_to_utf8 ("<partial>"), "\xE2\x88\x82"); // U+2202
-  qcompare (cork_to_utf8 ("<nabla>"), "\xE2\x88\x87");   // U+2207
-  qcompare (cork_to_utf8 ("<infty>"), "\xE2\x88\x9E");   // U+221E
-  qcompare (cork_to_utf8 ("<sqrt>"), "\xE2\x88\x9A");    // U+221A
-  qcompare (cork_to_utf8 ("<forall>"), "\xE2\x88\x80");  // U+2200
-  qcompare (cork_to_utf8 ("<exists>"), "\xE2\x88\x83");  // U+2203
-  qcompare (cork_to_utf8 ("<angle>"), "\xE2\x88\xA0");   // U+2220
-  qcompare (cork_to_utf8 ("<aleph>"), "\xE2\x84\xB5");   // U+2135
+  qcompare (cork_to_utf8 ("<partial>"), "∂"); // U+2202
+  qcompare (cork_to_utf8 ("<nabla>"), "∇");   // U+2207
+  qcompare (cork_to_utf8 ("<infty>"), "∞");   // U+221E
+  qcompare (cork_to_utf8 ("<sqrt>"), "√");    // U+221A
+  qcompare (cork_to_utf8 ("<forall>"), "∀");  // U+2200
+  qcompare (cork_to_utf8 ("<exists>"), "∃");  // U+2203
+  qcompare (cork_to_utf8 ("<angle>"), "∠");   // U+2220
+  qcompare (cork_to_utf8 ("<aleph>"), "ℵ");   // U+2135
   // <sum> decodes to U+2211 but round-trips to <big-sum>; see non-identity
   // test.
-  qcompare (cork_to_utf8 ("<sum>"), "\xE2\x88\x91");  // U+2211
-  qcompare (cork_to_utf8 ("<int>"), "\xE2\x88\xAB");  // U+222B
-  qcompare (cork_to_utf8 ("<prod>"), "\xE2\x88\x8F"); // U+220F
+  qcompare (cork_to_utf8 ("<sum>"), "∑");  // U+2211
+  qcompare (cork_to_utf8 ("<int>"), "∫");  // U+222B
+  qcompare (cork_to_utf8 ("<prod>"), "∏"); // U+220F
 }
 
 void
 TestConverter::test_named_dots_dashes () {
-  qcompare (cork_to_utf8 ("<cdots>"), "\xE2\x8B\xAF");     // U+22EF
-  qcompare (cork_to_utf8 ("<ldots>"), "\xE2\x80\xA6");     // U+2026
-  qcompare (cork_to_utf8 ("<vdots>"), "\xE2\x8B\xAE");     // U+22EE
-  qcompare (cork_to_utf8 ("<ddots>"), "\xE2\x8B\xB1");     // U+22F1
-  qcompare (cork_to_utf8 ("<prime>"), "\xE2\x80\xB2");     // U+2032
-  qcompare (cork_to_utf8 ("<backprime>"), "\xE2\x80\xB5"); // U+2035
+  qcompare (cork_to_utf8 ("<cdots>"), "⋯");     // U+22EF
+  qcompare (cork_to_utf8 ("<ldots>"), "…");     // U+2026
+  qcompare (cork_to_utf8 ("<vdots>"), "⋮");     // U+22EE
+  qcompare (cork_to_utf8 ("<ddots>"), "⋱");     // U+22F1
+  qcompare (cork_to_utf8 ("<prime>"), "′");     // U+2032
+  qcompare (cork_to_utf8 ("<backprime>"), "‵"); // U+2035
 }
 
 void
 TestConverter::test_named_special_letterforms () {
-  qcompare (cork_to_utf8 ("<aleph>"), "\xE2\x84\xB5");  // U+2135
-  qcompare (cork_to_utf8 ("<beth>"), "\xE2\x84\xB6");   // U+2136
-  qcompare (cork_to_utf8 ("<gimel>"), "\xE2\x84\xB7");  // U+2137
-  qcompare (cork_to_utf8 ("<daleth>"), "\xE2\x84\xB8"); // U+2138
-  qcompare (cork_to_utf8 ("<ell>"), "\xE2\x84\x93");    // U+2113
+  qcompare (cork_to_utf8 ("<aleph>"), "ℵ");  // U+2135
+  qcompare (cork_to_utf8 ("<beth>"), "ℶ");   // U+2136
+  qcompare (cork_to_utf8 ("<gimel>"), "ℷ");  // U+2137
+  qcompare (cork_to_utf8 ("<daleth>"), "ℸ"); // U+2138
+  qcompare (cork_to_utf8 ("<ell>"), "ℓ");    // U+2113
   // <hbar> decodes to U+210F but round-trips to <hslash>; see non-identity
   // test.
-  qcompare (cork_to_utf8 ("<hbar>"), "\xE2\x84\x8F");   // U+210F
-  qcompare (cork_to_utf8 ("<hslash>"), "\xE2\x84\x8F"); // U+210F
+  qcompare (cork_to_utf8 ("<hbar>"), "ℏ");   // U+210F
+  qcompare (cork_to_utf8 ("<hslash>"), "ℏ"); // U+210F
   // <Re> / <Im> decode to U+211C / U+2111 but round-trip to <frak-R>/<frak-I>.
-  qcompare (cork_to_utf8 ("<Re>"), "\xE2\x84\x9C"); // U+211C
-  qcompare (cork_to_utf8 ("<Im>"), "\xE2\x84\x91"); // U+2111
+  qcompare (cork_to_utf8 ("<Re>"), "ℜ"); // U+211C
+  qcompare (cork_to_utf8 ("<Im>"), "ℑ"); // U+2111
 }
 
 void

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -114,6 +114,11 @@ private slots:
   void test_named_big_operators ();
   void test_named_brackets ();
   void test_named_math_alphanumeric ();
+
+  // strict_cork_to_utf8: same as cork_to_utf8 but without the
+  // symbol-unicode-fallback table, so long-arrow fallbacks are not decoded.
+  void test_strict_cork_to_utf8_same_as_cork ();
+  void test_strict_cork_to_utf8_fallback_excluded ();
 };
 
 /******************************************************************************
@@ -1372,6 +1377,57 @@ TestConverter::test_named_math_alphanumeric () {
   qcompare (cork_to_utf8 ("<i-A>"), "<i-A>");
   qcompare (cork_to_utf8 ("<sf-A>"), "<sf-A>");
   qcompare (cork_to_utf8 ("<tt-A>"), "<tt-A>");
+}
+
+// strict_cork_to_utf8 differs from cork_to_utf8 only in that it does not load
+// the symbol-unicode-fallback table (8 long-arrow fallbacks). Everything else
+// (Cork bytes, <#XXXX> escapes, other named entities, unknown entities) is
+// identical.
+
+void
+TestConverter::test_strict_cork_to_utf8_same_as_cork () {
+  // Cork bytes decode identically.
+  qcompare (strict_cork_to_utf8 (cork_byte (0x00)), "`");
+  qcompare (strict_cork_to_utf8 (cork_byte (0x10)), "“");
+  qcompare (strict_cork_to_utf8 (cork_byte (0xC0)), "À");
+  // <#XXXX> escapes work the same.
+  qcompare (strict_cork_to_utf8 ("<#4E2D>"), "中");
+  qcompare (strict_cork_to_utf8 ("<#201C>"), "“");
+  // Named entities (non-fallback) decode identically.
+  qcompare (strict_cork_to_utf8 ("<less>"), "<");
+  qcompare (strict_cork_to_utf8 ("<alpha>"), "α");
+  qcompare (strict_cork_to_utf8 ("<infty>"), "∞");
+  qcompare (strict_cork_to_utf8 ("<rightarrow>"), "→");
+  // Unknown entities pass through verbatim, same as cork_to_utf8.
+  qcompare (strict_cork_to_utf8 ("<foobar>"), "<foobar>");
+  // Empty input.
+  qcompare (strict_cork_to_utf8 (""), "");
+}
+
+void
+TestConverter::test_strict_cork_to_utf8_fallback_excluded () {
+  // These 8 long-arrow fallbacks are decoded by cork_to_utf8 (which loads
+  // symbol-unicode-fallback) but NOT by strict_cork_to_utf8, which passes
+  // them through verbatim.
+  qcompare (cork_to_utf8 ("<longuparrow>"), "↑");           // U+2191
+  qcompare (cork_to_utf8 ("<longdownarrow>"), "↓");         // U+2193
+  qcompare (cork_to_utf8 ("<longupdownarrow>"), "↕");       // U+2195
+  qcompare (cork_to_utf8 ("<Longuparrow>"), "⇑");           // U+21D1
+  qcompare (cork_to_utf8 ("<Longdownarrow>"), "⇓");         // U+21D3
+  qcompare (cork_to_utf8 ("<Longupdownarrow>"), "⇕");       // U+21D5
+  qcompare (cork_to_utf8 ("<longtwoheadleftarrow>"), "↞");  // U+219E
+  qcompare (cork_to_utf8 ("<longtwoheadrightarrow>"), "↠"); // U+21A0
+
+  qcompare (strict_cork_to_utf8 ("<longuparrow>"), "<longuparrow>");
+  qcompare (strict_cork_to_utf8 ("<longdownarrow>"), "<longdownarrow>");
+  qcompare (strict_cork_to_utf8 ("<longupdownarrow>"), "<longupdownarrow>");
+  qcompare (strict_cork_to_utf8 ("<Longuparrow>"), "<Longuparrow>");
+  qcompare (strict_cork_to_utf8 ("<Longdownarrow>"), "<Longdownarrow>");
+  qcompare (strict_cork_to_utf8 ("<Longupdownarrow>"), "<Longupdownarrow>");
+  qcompare (strict_cork_to_utf8 ("<longtwoheadleftarrow>"),
+            "<longtwoheadleftarrow>");
+  qcompare (strict_cork_to_utf8 ("<longtwoheadrightarrow>"),
+            "<longtwoheadrightarrow>");
 }
 
 QTEST_MAIN (TestConverter)

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -91,6 +91,13 @@ private slots:
   void test_named_dots_dashes ();
   void test_named_special_letterforms ();
   void test_named_non_identity_roundtrip ();
+
+  // utf8_to_cork: codepoints with no Cork byte map to named entities.
+  void test_utf8_to_cork_greek ();
+  void test_utf8_to_cork_math_ops ();
+  void test_utf8_to_cork_math_syms ();
+  void test_utf8_to_cork_text_syms ();
+  void test_utf8_to_cork_named_remap ();
 };
 
 /******************************************************************************
@@ -1050,6 +1057,93 @@ TestConverter::test_named_non_identity_roundtrip () {
   qcompare (utf8_to_cork (cork_to_utf8 ("<partial>")), "<partial>");
   qcompare (utf8_to_cork (cork_to_utf8 ("<rightarrow>")), "<rightarrow>");
   qcompare (utf8_to_cork (cork_to_utf8 ("<emptyset>")), "<emptyset>");
+}
+
+// utf8_to_cork direction: codepoints without a direct Cork byte are encoded
+// as their canonical named entity. The entity name is not always the obvious
+// one (e.g. U+2209 -> <nin>, U+2211 -> <big-sum>, U+211C -> <frak-R>); these
+// remaps are sampled in test_utf8_to_cork_named_remap.
+
+void
+TestConverter::test_utf8_to_cork_greek () {
+  qcompare (utf8_to_cork ("α"), "<alpha>"); // U+03B1
+  qcompare (utf8_to_cork ("β"), "<beta>");  // U+03B2
+  qcompare (utf8_to_cork ("γ"), "<gamma>"); // U+03B3
+  qcompare (utf8_to_cork ("δ"), "<delta>"); // U+03B4
+  qcompare (utf8_to_cork ("π"), "<pi>");    // U+03C0
+  qcompare (utf8_to_cork ("σ"), "<sigma>"); // U+03C3
+  qcompare (utf8_to_cork ("ω"), "<omega>"); // U+03C9
+  qcompare (utf8_to_cork ("Α"), "<Alpha>"); // U+0391
+  qcompare (utf8_to_cork ("Β"), "<Beta>");  // U+0392
+  qcompare (utf8_to_cork ("Γ"), "<Gamma>"); // U+0393
+  qcompare (utf8_to_cork ("Δ"), "<Delta>"); // U+0394
+  qcompare (utf8_to_cork ("Π"), "<Pi>");    // U+03A0
+  qcompare (utf8_to_cork ("Σ"), "<Sigma>"); // U+03A3
+  qcompare (utf8_to_cork ("Ω"), "<Omega>"); // U+03A9
+}
+
+void
+TestConverter::test_utf8_to_cork_math_ops () {
+  qcompare (utf8_to_cork ("×"), "<times>");    // U+00D7
+  qcompare (utf8_to_cork ("÷"), "<div>");      // U+00F7
+  qcompare (utf8_to_cork ("⋅"), "<cdot>");     // U+22C5
+  qcompare (utf8_to_cork ("∗"), "<ast>");      // U+2217
+  qcompare (utf8_to_cork ("∩"), "<cap>");      // U+2229
+  qcompare (utf8_to_cork ("∪"), "<cup>");      // U+222A
+  qcompare (utf8_to_cork ("∧"), "<wedge>");    // U+2227
+  qcompare (utf8_to_cork ("∨"), "<vee>");      // U+2228
+  qcompare (utf8_to_cork ("∖"), "<setminus>"); // U+2216
+}
+
+void
+TestConverter::test_utf8_to_cork_math_syms () {
+  qcompare (utf8_to_cork ("∞"), "<infty>");          // U+221E
+  qcompare (utf8_to_cork ("∂"), "<partial>");        // U+2202
+  qcompare (utf8_to_cork ("∇"), "<nabla>");          // U+2207
+  qcompare (utf8_to_cork ("∀"), "<forall>");         // U+2200
+  qcompare (utf8_to_cork ("∃"), "<exists>");         // U+2203
+  qcompare (utf8_to_cork ("∠"), "<angle>");          // U+2220
+  qcompare (utf8_to_cork ("∅"), "<emptyset>");       // U+2205
+  qcompare (utf8_to_cork ("≠"), "<neq>");            // U+2260
+  qcompare (utf8_to_cork ("≤"), "<leq>");            // U+2264
+  qcompare (utf8_to_cork ("≥"), "<geq>");            // U+2265
+  qcompare (utf8_to_cork ("≡"), "<equiv>");          // U+2261
+  qcompare (utf8_to_cork ("≈"), "<approx>");         // U+2248
+  qcompare (utf8_to_cork ("∈"), "<in>");             // U+2208
+  qcompare (utf8_to_cork ("⊂"), "<subset>");         // U+2282
+  qcompare (utf8_to_cork ("⊃"), "<supset>");         // U+2283
+  qcompare (utf8_to_cork ("→"), "<rightarrow>");     // U+2192
+  qcompare (utf8_to_cork ("←"), "<leftarrow>");      // U+2190
+  qcompare (utf8_to_cork ("↔"), "<leftrightarrow>"); // U+2194
+  qcompare (utf8_to_cork ("⇒"), "<Rightarrow>");     // U+21D2
+  qcompare (utf8_to_cork ("⇐"), "<Leftarrow>");      // U+21D0
+  qcompare (utf8_to_cork ("↦"), "<mapsto>");         // U+21A6
+  qcompare (utf8_to_cork ("ℵ"), "<aleph>");          // U+2135
+  qcompare (utf8_to_cork ("ℓ"), "<ell>");            // U+2113
+}
+
+void
+TestConverter::test_utf8_to_cork_text_syms () {
+  qcompare (utf8_to_cork ("•"), "<bullet>");    // U+2022
+  qcompare (utf8_to_cork ("†"), "<dagger>");    // U+2020
+  qcompare (utf8_to_cork ("‡"), "<ddagger>");   // U+2021
+  qcompare (utf8_to_cork ("°"), "<degree>");    // U+00B0
+  qcompare (utf8_to_cork ("©"), "<copyright>"); // U+00A9
+  qcompare (utf8_to_cork ("®"), "<circledR>");  // U+00AE
+  qcompare (utf8_to_cork ("™"), "<trademark>"); // U+2122
+  qcompare (utf8_to_cork ("…"), "<ldots>");     // U+2026
+}
+
+void
+TestConverter::test_utf8_to_cork_named_remap () {
+  // Canonical reverse names that differ from the obvious/forward entity name.
+  qcompare (utf8_to_cork ("∉"), "<nin>");      // U+2209 (not <notin>)
+  qcompare (utf8_to_cork ("∑"), "<big-sum>");  // U+2211 (not <sum>)
+  qcompare (utf8_to_cork ("∫"), "<big-int>");  // U+222B (not <int>)
+  qcompare (utf8_to_cork ("∏"), "<big-prod>"); // U+220F (not <prod>)
+  qcompare (utf8_to_cork ("ℏ"), "<hslash>");   // U+210F (not <hbar>)
+  qcompare (utf8_to_cork ("ℜ"), "<frak-R>");   // U+211C (not <Re>)
+  qcompare (utf8_to_cork ("ℑ"), "<frak-I>");   // U+2111 (not <Im>)
 }
 
 QTEST_MAIN (TestConverter)

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -103,6 +103,17 @@ private slots:
   void test_cork_to_utf8_escape_edge_cases ();
   void test_cork_to_utf8_unknown_entities ();
   void test_utf8_to_cork_invalid_utf8 ();
+
+  // Extended named-entity coverage across remaining Unicode blocks.
+  void test_named_mathops_extras ();
+  void test_named_arrows_extras ();
+  void test_named_misc_symbols ();
+  void test_named_letterlike_extras ();
+  void test_named_geometric ();
+  void test_named_apl_technical ();
+  void test_named_big_operators ();
+  void test_named_brackets ();
+  void test_named_math_alphanumeric ();
 };
 
 /******************************************************************************
@@ -1186,6 +1197,181 @@ TestConverter::test_utf8_to_cork_invalid_utf8 () {
   qcompare (utf8_to_cork ("\x80"), cork_byte (0x80));
   // A lone lead byte (0xC3 with no continuation) likewise copies through.
   qcompare (utf8_to_cork ("\xC3"), cork_byte (0xC3));
+}
+
+void
+TestConverter::test_named_mathops_extras () {
+  qcompare (cork_to_utf8 ("<asymp>"), "≍");       // U+224D
+  qcompare (cork_to_utf8 ("<backsim>"), "∽");     // U+223D
+  qcompare (cork_to_utf8 ("<between>"), "≬");     // U+226C
+  qcompare (cork_to_utf8 ("<doteq>"), "≐");       // U+2250
+  qcompare (cork_to_utf8 ("<lessdot>"), "⋖");     // U+22D6
+  qcompare (cork_to_utf8 ("<gtrdot>"), "⋗");      // U+22D7
+  qcompare (cork_to_utf8 ("<lesssim>"), "≲");     // U+2272
+  qcompare (cork_to_utf8 ("<gtrsim>"), "≳");      // U+2273
+  qcompare (cork_to_utf8 ("<lessgtr>"), "≶");     // U+2276
+  qcompare (cork_to_utf8 ("<gtrless>"), "≷");     // U+2277
+  qcompare (cork_to_utf8 ("<curlyeqprec>"), "⋞"); // U+22DE
+  qcompare (cork_to_utf8 ("<curlyeqsucc>"), "⋟"); // U+22DF
+  qcompare (cork_to_utf8 ("<Bumpeq>"), "≎");      // U+224E
+  qcompare (cork_to_utf8 ("<Cap>"), "⋒");         // U+22D2
+  qcompare (cork_to_utf8 ("<Cup>"), "⋓");         // U+22D3
+  qcompare (cork_to_utf8 ("<Subset>"), "⋐");      // U+22D0
+  qcompare (cork_to_utf8 ("<Supset>"), "⋑");      // U+22D1
+}
+
+void
+TestConverter::test_named_arrows_extras () {
+  qcompare (cork_to_utf8 ("<Downarrow>"), "⇓");       // U+21D3
+  qcompare (cork_to_utf8 ("<Leftrightarrow>"), "⇔");  // U+21D4
+  qcompare (cork_to_utf8 ("<Updownarrow>"), "⇕");     // U+21D5
+  qcompare (cork_to_utf8 ("<Lleftarrow>"), "⇚");      // U+21DA
+  qcompare (cork_to_utf8 ("<Rrightarrow>"), "⇛");     // U+21DB
+  qcompare (cork_to_utf8 ("<hookleftarrow>"), "↩");   // U+21A9
+  qcompare (cork_to_utf8 ("<hookrightarrow>"), "↪");  // U+21AA
+  qcompare (cork_to_utf8 ("<nwarrow>"), "↖");         // U+2196
+  qcompare (cork_to_utf8 ("<nearrow>"), "↗");         // U+2197
+  qcompare (cork_to_utf8 ("<searrow>"), "↘");         // U+2198
+  qcompare (cork_to_utf8 ("<swarrow>"), "↙");         // U+2199
+  qcompare (cork_to_utf8 ("<mapsfrom>"), "↤");        // U+21A4
+  qcompare (cork_to_utf8 ("<nleftarrow>"), "↚");      // U+219A
+  qcompare (cork_to_utf8 ("<nrightarrow>"), "↛");     // U+219B
+  qcompare (cork_to_utf8 ("<nLeftarrow>"), "⇍");      // U+21CD
+  qcompare (cork_to_utf8 ("<nRightarrow>"), "⇏");     // U+21CF
+  qcompare (cork_to_utf8 ("<nleftrightarrow>"), "↮"); // U+21AE
+}
+
+void
+TestConverter::test_named_misc_symbols () {
+  // Zodiac
+  qcompare (cork_to_utf8 ("<aries>"), "♈");       // U+2648
+  qcompare (cork_to_utf8 ("<taurus>"), "♉");      // U+2649
+  qcompare (cork_to_utf8 ("<gemini>"), "♊");      // U+264A
+  qcompare (cork_to_utf8 ("<cancer>"), "♋");      // U+264B
+  qcompare (cork_to_utf8 ("<leo>"), "♌");         // U+264C
+  qcompare (cork_to_utf8 ("<virgo>"), "♍");       // U+264D
+  qcompare (cork_to_utf8 ("<libra>"), "♎");       // U+264E
+  qcompare (cork_to_utf8 ("<scorpio>"), "♏");     // U+264F
+  qcompare (cork_to_utf8 ("<sagittarius>"), "♐"); // U+2650
+  qcompare (cork_to_utf8 ("<capricornus>"), "♑"); // U+2651
+  qcompare (cork_to_utf8 ("<aquarius>"), "♒");    // U+2652
+  qcompare (cork_to_utf8 ("<pisces>"), "♓");      // U+2653
+  // Planets / astrological
+  qcompare (cork_to_utf8 ("<astrosun>"), "☉"); // U+2609
+  qcompare (cork_to_utf8 ("<mercury>"), "☿");  // U+263F
+  qcompare (cork_to_utf8 ("<female>"), "♀");   // U+2640
+  qcompare (cork_to_utf8 ("<male>"), "♂");     // U+2642
+  qcompare (cork_to_utf8 ("<earth>"), "♁");    // U+2641
+  // Music
+  qcompare (cork_to_utf8 ("<flat>"), "♭");       // U+266D
+  qcompare (cork_to_utf8 ("<natural>"), "♮");    // U+266E
+  qcompare (cork_to_utf8 ("<sharp>"), "♯");      // U+266F
+  qcompare (cork_to_utf8 ("<eighthnote>"), "♪"); // U+266A
+  // Card suits
+  qcompare (cork_to_utf8 ("<spadesuit>"), "♠");   // U+2660
+  qcompare (cork_to_utf8 ("<heartsuit>"), "♥");   // U+2665
+  qcompare (cork_to_utf8 ("<diamondsuit>"), "♦"); // U+2666
+  qcompare (cork_to_utf8 ("<clubsuit>"), "♣");    // U+2663
+  // Other
+  qcompare (cork_to_utf8 ("<checkmark>"), "✓"); // U+2713
+  qcompare (cork_to_utf8 ("<maltese>"), "✠");   // U+2720
+}
+
+void
+TestConverter::test_named_letterlike_extras () {
+  qcompare (cork_to_utf8 ("<Mho>"), "℧");         // U+2127
+  qcompare (cork_to_utf8 ("<complement>"), "∁");  // U+2201
+  qcompare (cork_to_utf8 ("<nexists>"), "∄");     // U+2204
+  qcompare (cork_to_utf8 ("<circledS>"), "Ⓢ");    // U+24C8
+  qcompare (cork_to_utf8 ("<backepsilon>"), "϶"); // U+03F6
+  qcompare (cork_to_utf8 ("<digamma>"), "ϝ");     // U+03DD
+  qcompare (cork_to_utf8 ("<varkappa>"), "ϰ");    // U+03F0
+  // Blackboard bold constants
+  qcompare (cork_to_utf8 ("<bbb-C>"), "ℂ"); // U+2102
+  qcompare (cork_to_utf8 ("<bbb-H>"), "ℍ"); // U+210D
+  qcompare (cork_to_utf8 ("<bbb-N>"), "ℕ"); // U+2115
+  qcompare (cork_to_utf8 ("<bbb-P>"), "ℙ"); // U+2119
+  qcompare (cork_to_utf8 ("<bbb-Q>"), "ℚ"); // U+211A
+  qcompare (cork_to_utf8 ("<bbb-R>"), "ℝ"); // U+211D
+  qcompare (cork_to_utf8 ("<bbb-Z>"), "ℤ"); // U+2124
+}
+
+void
+TestConverter::test_named_geometric () {
+  qcompare (cork_to_utf8 ("<Circle>"), "○");            // U+25CB
+  qcompare (cork_to_utf8 ("<CIRCLE>"), "●");            // U+25CF
+  qcompare (cork_to_utf8 ("<Square>"), "□");            // U+25A1
+  qcompare (cork_to_utf8 ("<blacksquare>"), "■");       // U+25A0
+  qcompare (cork_to_utf8 ("<star>"), "⋆");              // U+22C6
+  qcompare (cork_to_utf8 ("<bigstar>"), "★");           // U+2605
+  qcompare (cork_to_utf8 ("<vartriangle>"), "▵");       // U+25B5
+  qcompare (cork_to_utf8 ("<blacktriangle>"), "▴");     // U+25B4
+  qcompare (cork_to_utf8 ("<blacktriangledown>"), "▾"); // U+25BE
+  qcompare (cork_to_utf8 ("<diamond>"), "⋄");           // U+22C4
+  qcompare (cork_to_utf8 ("<lozenge>"), "◊");           // U+25CA
+  qcompare (cork_to_utf8 ("<blacklozenge>"), "⧫");      // U+29EB
+}
+
+void
+TestConverter::test_named_apl_technical () {
+  qcompare (cork_to_utf8 ("<APLbox>"), "⎕");           // U+2395
+  qcompare (cork_to_utf8 ("<APLinput>"), "⍞");         // U+235E
+  qcompare (cork_to_utf8 ("<APLleftarrowbox>"), "⍇");  // U+2347
+  qcompare (cork_to_utf8 ("<APLrightarrowbox>"), "⍈"); // U+2348
+  qcompare (cork_to_utf8 ("<APLuparrowbox>"), "⍐");    // U+2350
+  qcompare (cork_to_utf8 ("<APLdownarrowbox>"), "⍗");  // U+2357
+}
+
+void
+TestConverter::test_named_big_operators () {
+  qcompare (cork_to_utf8 ("<big-vee>"), "⋁");     // U+22C1
+  qcompare (cork_to_utf8 ("<big-wedge>"), "⋀");   // U+22C0
+  qcompare (cork_to_utf8 ("<big-cap>"), "⋂");     // U+22C2
+  qcompare (cork_to_utf8 ("<big-cup>"), "⋃");     // U+22C3
+  qcompare (cork_to_utf8 ("<big-oplus>"), "⨁");   // U+2A01
+  qcompare (cork_to_utf8 ("<big-otimes>"), "⨂");  // U+2A02
+  qcompare (cork_to_utf8 ("<big-odot>"), "⨀");    // U+2A00
+  qcompare (cork_to_utf8 ("<big-sqcup>"), "⨆");   // U+2A06
+  qcompare (cork_to_utf8 ("<big-pluscup>"), "⨄"); // U+2A04
+}
+
+void
+TestConverter::test_named_brackets () {
+  qcompare (cork_to_utf8 ("<langle>"), "⟨");    // U+27E8
+  qcompare (cork_to_utf8 ("<rangle>"), "⟩");    // U+27E9
+  qcompare (cork_to_utf8 ("<llangle>"), "⟪");   // U+27EA
+  qcompare (cork_to_utf8 ("<rrangle>"), "⟫");   // U+27EB
+  qcompare (cork_to_utf8 ("<llbracket>"), "⟦"); // U+27E6
+  qcompare (cork_to_utf8 ("<rrbracket>"), "⟧"); // U+27E7
+  qcompare (cork_to_utf8 ("<lceil>"), "⌈");     // U+2308
+  qcompare (cork_to_utf8 ("<rceil>"), "⌉");     // U+2309
+  qcompare (cork_to_utf8 ("<lfloor>"), "⌊");    // U+230A
+  qcompare (cork_to_utf8 ("<rfloor>"), "⌋");    // U+230B
+  qcompare (cork_to_utf8 ("<ulcorner>"), "⌜");  // U+231C
+  qcompare (cork_to_utf8 ("<urcorner>"), "⌝");  // U+231D
+  qcompare (cork_to_utf8 ("<llcorner>"), "⌞");  // U+231E
+  qcompare (cork_to_utf8 ("<lrcorner>"), "⌟");  // U+231F
+}
+
+void
+TestConverter::test_named_math_alphanumeric () {
+  // Math Alphanumeric Symbols block (U+1D400+). Only four prefixes are
+  // registered: <b-*> (bold/italic), <bbb-*> (blackboard bold),
+  // <cal-*> (script), <frak-*> (fraktur). Other variants like <i->, <sf->,
+  // <tt-> are not entities and pass through verbatim.
+  qcompare (cork_to_utf8 ("<b-0>"), "𝟎");    // U+1D7CE bold 0
+  qcompare (cork_to_utf8 ("<b-A>"), "𝑨");    // U+1D468 bold italic A
+  qcompare (cork_to_utf8 ("<b-z>"), "𝒛");    // U+1D49B bold italic z
+  qcompare (cork_to_utf8 ("<bbb-A>"), "𝔸");  // U+1D538
+  qcompare (cork_to_utf8 ("<bbb-z>"), "𝕫");  // U+1D56B
+  qcompare (cork_to_utf8 ("<cal-A>"), "𝒜");  // U+1D49C
+  qcompare (cork_to_utf8 ("<cal-z>"), "𝓏");  // U+1D4CF
+  qcompare (cork_to_utf8 ("<frak-A>"), "𝔄"); // U+1D504
+  qcompare (cork_to_utf8 ("<frak-z>"), "𝔷"); // U+1D577
+  // Unregistered prefixes pass through verbatim (not entities).
+  qcompare (cork_to_utf8 ("<i-A>"), "<i-A>");
+  qcompare (cork_to_utf8 ("<sf-A>"), "<sf-A>");
+  qcompare (cork_to_utf8 ("<tt-A>"), "<tt-A>");
 }
 
 QTEST_MAIN (TestConverter)

--- a/tests/Data/String/converter_test.cpp
+++ b/tests/Data/String/converter_test.cpp
@@ -76,6 +76,21 @@ private slots:
   void test_mixed ();
   void test_empty ();
   void test_roundtrip_idempotent ();
+
+  // Named entities (<name>) decoded by cork_to_utf8 / encoded by utf8_to_cork.
+  void test_named_text_punctuation ();
+  void test_named_currency ();
+  void test_named_greek_lower ();
+  void test_named_greek_upper ();
+  void test_named_greek_variants ();
+  void test_named_binary_operators ();
+  void test_named_relations ();
+  void test_named_arrows ();
+  void test_named_set_theory ();
+  void test_named_calculus ();
+  void test_named_dots_dashes ();
+  void test_named_special_letterforms ();
+  void test_named_non_identity_roundtrip ();
 };
 
 /******************************************************************************
@@ -795,6 +810,246 @@ TestConverter::test_roundtrip_idempotent () {
     string back= utf8_to_cork (cork_to_utf8 (cork));
     QCOMPARE (back, cork);
   }
+}
+
+/******************************************************************************
+ * Named entities (<name>)
+ *
+ * cork_to_utf8 decodes a registered <name> to its UTF-8 codepoint via the
+ * tmuniversaltounicode / symbol-unicode / cork-unicode-oneway tables.
+ * utf8_to_cork encodes a Unicode codepoint back to its <name> (when no Cork
+ * byte exists) via the reverse tables. For most entities the roundtrip is
+ * identity, but a handful decode to a codepoint that has a direct Cork byte
+ * (e.g. <sterling> -> U+00A3 -> Cork 0xBF) and so do not round-trip to the
+ * name; those are covered in test_named_non_identity_roundtrip.
+ ******************************************************************************/
+
+void
+TestConverter::test_named_text_punctuation () {
+  qcompare (cork_to_utf8 ("<less>"), "<");
+  qcompare (cork_to_utf8 ("<gtr>"), ">");
+  qcompare (cork_to_utf8 ("<comma>"), ",");
+  qcompare (cork_to_utf8 ("<grave>"), "`");
+  qcompare (cork_to_utf8 ("<varspace>"), "\xC2\xA0");   // U+00A0 nbsp
+  qcompare (cork_to_utf8 ("<bullet>"), "\xE2\x80\xA2"); // U+2022
+  qcompare (cork_to_utf8 ("<dag>"), "\xE2\x80\xA0");    // U+2020 dagger
+  qcompare (cork_to_utf8 ("<ddag>"), "\xE2\x80\xA1");   // U+2021 double dagger
+  qcompare (cork_to_utf8 ("<paragraph>"), "\xC2\xB6");  // U+00B6 pilcrow
+  qcompare (cork_to_utf8 ("<copyright>"), "\xC2\xA9");  // U+00A9
+  qcompare (cork_to_utf8 ("<trademark>"), "\xE2\x84\xA2"); // U+2122
+  qcompare (cork_to_utf8 ("<degree>"), "\xC2\xB0");        // U+00B0
+  qcompare (cork_to_utf8 ("<hyphen>"), "\xC2\xAD");        // U+00AD soft hyphen
+  qcompare (cork_to_utf8 ("<nbhyph>"),
+            "\xE2\x80\x91"); // U+2011 non-breaking hyphen
+}
+
+void
+TestConverter::test_named_currency () {
+  qcompare (cork_to_utf8 ("<cent>"), "\xC2\xA2");     // U+00A2
+  qcompare (cork_to_utf8 ("<yen>"), "\xC2\xA5");      // U+00A5
+  qcompare (cork_to_utf8 ("<currency>"), "\xC2\xA4"); // U+00A4
+  // <sterling> decodes to U+00A3 but round-trips to Cork byte 0xBF;
+  // see test_named_non_identity_roundtrip.
+  qcompare (cork_to_utf8 ("<sterling>"), "\xC2\xA3"); // U+00A3
+}
+
+void
+TestConverter::test_named_greek_lower () {
+  qcompare (cork_to_utf8 ("<alpha>"), "\xCE\xB1");   // U+03B1
+  qcompare (cork_to_utf8 ("<beta>"), "\xCE\xB2");    // U+03B2
+  qcompare (cork_to_utf8 ("<gamma>"), "\xCE\xB3");   // U+03B3
+  qcompare (cork_to_utf8 ("<delta>"), "\xCE\xB4");   // U+03B4
+  qcompare (cork_to_utf8 ("<epsilon>"), "\xCF\xB5"); // U+03F5 lunate epsilon
+  qcompare (cork_to_utf8 ("<zeta>"), "\xCE\xB6");    // U+03B6
+  qcompare (cork_to_utf8 ("<eta>"), "\xCE\xB7");     // U+03B7
+  qcompare (cork_to_utf8 ("<theta>"), "\xCE\xB8");   // U+03B8
+  qcompare (cork_to_utf8 ("<iota>"), "\xCE\xB9");    // U+03B9
+  qcompare (cork_to_utf8 ("<kappa>"), "\xCE\xBA");   // U+03BA
+  qcompare (cork_to_utf8 ("<lambda>"), "\xCE\xBB");  // U+03BB
+  qcompare (cork_to_utf8 ("<mu>"), "\xCE\xBC");      // U+03BC
+  qcompare (cork_to_utf8 ("<nu>"), "\xCE\xBD");      // U+03BD
+  qcompare (cork_to_utf8 ("<xi>"), "\xCE\xBE");      // U+03BE
+  qcompare (cork_to_utf8 ("<omicron>"), "\xCE\xBF"); // U+03BF
+  qcompare (cork_to_utf8 ("<pi>"), "\xCF\x80");      // U+03C0
+  qcompare (cork_to_utf8 ("<rho>"), "\xCF\x81");     // U+03C1
+  qcompare (cork_to_utf8 ("<sigma>"), "\xCF\x83");   // U+03C3
+  qcompare (cork_to_utf8 ("<tau>"), "\xCF\x84");     // U+03C4
+  qcompare (cork_to_utf8 ("<upsilon>"), "\xCF\x85"); // U+03C5
+  qcompare (cork_to_utf8 ("<phi>"), "\xCF\x95");     // U+03D5 phi
+  qcompare (cork_to_utf8 ("<chi>"), "\xCF\x87");     // U+03C7
+  qcompare (cork_to_utf8 ("<psi>"), "\xCF\x88");     // U+03C8
+  qcompare (cork_to_utf8 ("<omega>"), "\xCF\x89");   // U+03C9
+}
+
+void
+TestConverter::test_named_greek_upper () {
+  qcompare (cork_to_utf8 ("<Alpha>"), "\xCE\x91");   // U+0391
+  qcompare (cork_to_utf8 ("<Beta>"), "\xCE\x92");    // U+0392
+  qcompare (cork_to_utf8 ("<Gamma>"), "\xCE\x93");   // U+0393
+  qcompare (cork_to_utf8 ("<Delta>"), "\xCE\x94");   // U+0394
+  qcompare (cork_to_utf8 ("<Epsilon>"), "\xCE\x95"); // U+0395
+  qcompare (cork_to_utf8 ("<Zeta>"), "\xCE\x96");    // U+0396
+  qcompare (cork_to_utf8 ("<Eta>"), "\xCE\x97");     // U+0397
+  qcompare (cork_to_utf8 ("<Theta>"), "\xCE\x98");   // U+0398
+  qcompare (cork_to_utf8 ("<Iota>"), "\xCE\x99");    // U+0399
+  qcompare (cork_to_utf8 ("<Kappa>"), "\xCE\x9A");   // U+039A
+  qcompare (cork_to_utf8 ("<Lambda>"), "\xCE\x9B");  // U+039B
+  qcompare (cork_to_utf8 ("<Mu>"), "\xCE\x9C");      // U+039C
+  qcompare (cork_to_utf8 ("<Nu>"), "\xCE\x9D");      // U+039D
+  qcompare (cork_to_utf8 ("<Xi>"), "\xCE\x9E");      // U+039E
+  qcompare (cork_to_utf8 ("<Omicron>"), "\xCE\x9F"); // U+039F
+  qcompare (cork_to_utf8 ("<Pi>"), "\xCE\xA0");      // U+03A0
+  qcompare (cork_to_utf8 ("<Rho>"), "\xCE\xA1");     // U+03A1
+  qcompare (cork_to_utf8 ("<Sigma>"), "\xCE\xA3");   // U+03A3
+  qcompare (cork_to_utf8 ("<Tau>"), "\xCE\xA4");     // U+03A4
+  qcompare (cork_to_utf8 ("<Upsilon>"), "\xCE\xA5"); // U+03A5
+  qcompare (cork_to_utf8 ("<Phi>"), "\xCE\xA6");     // U+03A6
+  qcompare (cork_to_utf8 ("<Chi>"), "\xCE\xA7");     // U+03A7
+  qcompare (cork_to_utf8 ("<Psi>"), "\xCE\xA8");     // U+03A8
+  qcompare (cork_to_utf8 ("<Omega>"), "\xCE\xA9");   // U+03A9
+}
+
+void
+TestConverter::test_named_greek_variants () {
+  // Note: <epsilon> -> U+03F5 (lunate) while <varepsilon> -> U+03B5 (plain),
+  // and <phi> -> U+03D5 while <varphi> -> U+03C6; the variant and plain forms
+  // are swapped relative to the usual convention.
+  qcompare (cork_to_utf8 ("<varepsilon>"), "\xCE\xB5"); // U+03B5
+  qcompare (cork_to_utf8 ("<vartheta>"), "\xCF\x91");   // U+03D1
+  qcompare (cork_to_utf8 ("<varpi>"), "\xCF\x96");      // U+03D6
+  qcompare (cork_to_utf8 ("<varrho>"), "\xCF\xB1");     // U+03F1
+  qcompare (cork_to_utf8 ("<varsigma>"), "\xCF\x82");   // U+03C2
+  qcompare (cork_to_utf8 ("<varphi>"), "\xCF\x86");     // U+03C6
+}
+
+void
+TestConverter::test_named_binary_operators () {
+  qcompare (cork_to_utf8 ("<times>"), "\xC3\x97");        // U+00D7
+  qcompare (cork_to_utf8 ("<div>"), "\xC3\xB7");          // U+00F7
+  qcompare (cork_to_utf8 ("<cdot>"), "\xE2\x8B\x85");     // U+22C5
+  qcompare (cork_to_utf8 ("<ast>"), "\xE2\x88\x97");      // U+2217
+  qcompare (cork_to_utf8 ("<dotplus>"), "\xE2\x88\x94");  // U+2214
+  qcompare (cork_to_utf8 ("<cap>"), "\xE2\x88\xA9");      // U+2229
+  qcompare (cork_to_utf8 ("<cup>"), "\xE2\x88\xAA");      // U+222A
+  qcompare (cork_to_utf8 ("<sqcap>"), "\xE2\x8A\x93");    // U+2293
+  qcompare (cork_to_utf8 ("<sqcup>"), "\xE2\x8A\x94");    // U+2294
+  qcompare (cork_to_utf8 ("<wedge>"), "\xE2\x88\xA7");    // U+2227
+  qcompare (cork_to_utf8 ("<vee>"), "\xE2\x88\xA8");      // U+2228
+  qcompare (cork_to_utf8 ("<setminus>"), "\xE2\x88\x96"); // U+2216
+  qcompare (cork_to_utf8 ("<amalg>"), "\xE2\xA8\xBF");    // U+2A3F
+  qcompare (cork_to_utf8 ("<wr>"), "\xE2\x89\x80");       // U+2240
+}
+
+void
+TestConverter::test_named_relations () {
+  qcompare (cork_to_utf8 ("<neq>"), "\xE2\x89\xA0");      // U+2260
+  qcompare (cork_to_utf8 ("<leq>"), "\xE2\x89\xA4");      // U+2264
+  qcompare (cork_to_utf8 ("<geq>"), "\xE2\x89\xA5");      // U+2265
+  qcompare (cork_to_utf8 ("<leqslant>"), "\xE2\xA9\xBD"); // U+2A7D
+  qcompare (cork_to_utf8 ("<geqslant>"), "\xE2\xA9\xBE"); // U+2A7E
+  qcompare (cork_to_utf8 ("<ll>"), "\xE2\x89\xAA");       // U+226A
+  qcompare (cork_to_utf8 ("<gg>"), "\xE2\x89\xAB");       // U+226B
+  qcompare (cork_to_utf8 ("<equiv>"), "\xE2\x89\xA1");    // U+2261
+  qcompare (cork_to_utf8 ("<sim>"), "\xE2\x88\xBC");      // U+223C
+  qcompare (cork_to_utf8 ("<simeq>"), "\xE2\x89\x83");    // U+2243
+  qcompare (cork_to_utf8 ("<cong>"), "\xE2\x89\x85");     // U+2245
+  qcompare (cork_to_utf8 ("<approx>"), "\xE2\x89\x88");   // U+2248
+  qcompare (cork_to_utf8 ("<prec>"), "\xE2\x89\xBA");     // U+227A
+  qcompare (cork_to_utf8 ("<succ>"), "\xE2\x89\xBB");     // U+227B
+}
+
+void
+TestConverter::test_named_arrows () {
+  qcompare (cork_to_utf8 ("<rightarrow>"), "\xE2\x86\x92");     // U+2192
+  qcompare (cork_to_utf8 ("<leftarrow>"), "\xE2\x86\x90");      // U+2190
+  qcompare (cork_to_utf8 ("<leftrightarrow>"), "\xE2\x86\x94"); // U+2194
+  qcompare (cork_to_utf8 ("<Rightarrow>"), "\xE2\x87\x92");     // U+21D2
+  qcompare (cork_to_utf8 ("<Leftarrow>"), "\xE2\x87\x90");      // U+21D0
+  qcompare (cork_to_utf8 ("<uparrow>"), "\xE2\x86\x91");        // U+2191
+  qcompare (cork_to_utf8 ("<downarrow>"), "\xE2\x86\x93");      // U+2193
+  qcompare (cork_to_utf8 ("<mapsto>"), "\xE2\x86\xA6");         // U+21A6
+  qcompare (cork_to_utf8 ("<leftharpoonup>"), "\xE2\x86\xBC");  // U+21BC
+  qcompare (cork_to_utf8 ("<rightharpoonup>"), "\xE2\x87\x80"); // U+21C0
+}
+
+void
+TestConverter::test_named_set_theory () {
+  qcompare (cork_to_utf8 ("<in>"), "\xE2\x88\x88");       // U+2208
+  qcompare (cork_to_utf8 ("<notin>"), "\xE2\x88\x89");    // U+2209
+  qcompare (cork_to_utf8 ("<subset>"), "\xE2\x8A\x82");   // U+2282
+  qcompare (cork_to_utf8 ("<supset>"), "\xE2\x8A\x83");   // U+2283
+  qcompare (cork_to_utf8 ("<subseteq>"), "\xE2\x8A\x86"); // U+2286
+  qcompare (cork_to_utf8 ("<supseteq>"), "\xE2\x8A\x87"); // U+2287
+  qcompare (cork_to_utf8 ("<sqsubset>"), "\xE2\x8A\x8F"); // U+228F
+  qcompare (cork_to_utf8 ("<sqsupset>"), "\xE2\x8A\x90"); // U+2290
+  qcompare (cork_to_utf8 ("<emptyset>"), "\xE2\x88\x85"); // U+2205
+}
+
+void
+TestConverter::test_named_calculus () {
+  qcompare (cork_to_utf8 ("<partial>"), "\xE2\x88\x82"); // U+2202
+  qcompare (cork_to_utf8 ("<nabla>"), "\xE2\x88\x87");   // U+2207
+  qcompare (cork_to_utf8 ("<infty>"), "\xE2\x88\x9E");   // U+221E
+  qcompare (cork_to_utf8 ("<sqrt>"), "\xE2\x88\x9A");    // U+221A
+  qcompare (cork_to_utf8 ("<forall>"), "\xE2\x88\x80");  // U+2200
+  qcompare (cork_to_utf8 ("<exists>"), "\xE2\x88\x83");  // U+2203
+  qcompare (cork_to_utf8 ("<angle>"), "\xE2\x88\xA0");   // U+2220
+  qcompare (cork_to_utf8 ("<aleph>"), "\xE2\x84\xB5");   // U+2135
+  // <sum> decodes to U+2211 but round-trips to <big-sum>; see non-identity
+  // test.
+  qcompare (cork_to_utf8 ("<sum>"), "\xE2\x88\x91");  // U+2211
+  qcompare (cork_to_utf8 ("<int>"), "\xE2\x88\xAB");  // U+222B
+  qcompare (cork_to_utf8 ("<prod>"), "\xE2\x88\x8F"); // U+220F
+}
+
+void
+TestConverter::test_named_dots_dashes () {
+  qcompare (cork_to_utf8 ("<cdots>"), "\xE2\x8B\xAF");     // U+22EF
+  qcompare (cork_to_utf8 ("<ldots>"), "\xE2\x80\xA6");     // U+2026
+  qcompare (cork_to_utf8 ("<vdots>"), "\xE2\x8B\xAE");     // U+22EE
+  qcompare (cork_to_utf8 ("<ddots>"), "\xE2\x8B\xB1");     // U+22F1
+  qcompare (cork_to_utf8 ("<prime>"), "\xE2\x80\xB2");     // U+2032
+  qcompare (cork_to_utf8 ("<backprime>"), "\xE2\x80\xB5"); // U+2035
+}
+
+void
+TestConverter::test_named_special_letterforms () {
+  qcompare (cork_to_utf8 ("<aleph>"), "\xE2\x84\xB5");  // U+2135
+  qcompare (cork_to_utf8 ("<beth>"), "\xE2\x84\xB6");   // U+2136
+  qcompare (cork_to_utf8 ("<gimel>"), "\xE2\x84\xB7");  // U+2137
+  qcompare (cork_to_utf8 ("<daleth>"), "\xE2\x84\xB8"); // U+2138
+  qcompare (cork_to_utf8 ("<ell>"), "\xE2\x84\x93");    // U+2113
+  // <hbar> decodes to U+210F but round-trips to <hslash>; see non-identity
+  // test.
+  qcompare (cork_to_utf8 ("<hbar>"), "\xE2\x84\x8F");   // U+210F
+  qcompare (cork_to_utf8 ("<hslash>"), "\xE2\x84\x8F"); // U+210F
+  // <Re> / <Im> decode to U+211C / U+2111 but round-trip to <frak-R>/<frak-I>.
+  qcompare (cork_to_utf8 ("<Re>"), "\xE2\x84\x9C"); // U+211C
+  qcompare (cork_to_utf8 ("<Im>"), "\xE2\x84\x91"); // U+2111
+}
+
+void
+TestConverter::test_named_non_identity_roundtrip () {
+  // These entities decode to a codepoint that has a direct Cork byte mapping
+  // (preferred over the named entity), so utf8_to_cork does not recover the
+  // original name. Documented in devel/1125.md.
+  qcompare (utf8_to_cork (cork_to_utf8 ("<sterling>")),
+            cork_byte (0xBF)); // £ is Cork 0xBF
+  qcompare (utf8_to_cork (cork_to_utf8 ("<guillemotleft>")),
+            cork_byte (0x13)); // « is Cork 0x13
+  qcompare (utf8_to_cork (cork_to_utf8 ("<guillemotright>")),
+            cork_byte (0x14)); // » is Cork 0x14
+  // These decode to a codepoint whose canonical reverse name differs.
+  qcompare (utf8_to_cork (cork_to_utf8 ("<sum>")), "<big-sum>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<hbar>")), "<hslash>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<Re>")), "<frak-R>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<Im>")), "<frak-I>");
+  // Most named entities DO round-trip to themselves; sample a few.
+  qcompare (utf8_to_cork (cork_to_utf8 ("<alpha>")), "<alpha>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<infty>")), "<infty>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<partial>")), "<partial>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<rightarrow>")), "<rightarrow>");
+  qcompare (utf8_to_cork (cork_to_utf8 ("<emptyset>")), "<emptyset>");
 }
 
 QTEST_MAIN (TestConverter)


### PR DESCRIPTION
## Summary
- 将 `tests/Data/String/converter_test.cpp` 从 3 条用例扩展到 38 条,按高半字节分组覆盖 `cork_to_utf8` / `utf8_to_cork` 的 0x00–0xFF 全表
- 补充 `<#XXXX>` 转义、命名实体(`<less>`/`<gtr>`/`<comma>`/`<grave>`/`<varspace>`)、混合字符串、空输入、往返一致性等专项用例
- **仅新增测试,不修改 `converter.cpp` / `.scm` 映射表的任何行为**;所有预期值以运行时实际行为为准(经临时探针逐一确认)

## 迷惑行为(已记录在 `devel/1125.md`,本次不改)
- 5 个非往返字节:0x18(→"0")、0x1A(→"j")、0x3C(→`<less>`)、0x3E(→`<gtr>`)、0xDF(→"SS")
- Cork 0x60↔U+2018,而 U+0060(backtick)↔Cork 0x00,两套独立映射
- Cork 0x17 = U+2060(WORD JOINER,非 herk 的 U+200B)
- U+2019 → Cork 0x27(与 ASCII apostrophe 共用),U+00A0 → `<varspace>`

## Test plan
- [x] `xmake b converter_test`
- [x] `xmake r converter_test` → 38 passed, 0 failed
- [x] `gf fmt --changed-since=main`(clang-format 已格式化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)