### PR TITLE
[1124] glue_drd/glue_file 迁到 standalone 编译单元

### DIFF
--- a/devel/1124.md
+++ b/devel/1124.md
@@ -134,3 +134,22 @@ xmake b stem                   # 必须通过
 ```
 
 分支已创建（`da/1124/lua`），直接 `git push`。
+
+## 后续批次（本分支 `da/1124/2lua`）
+
+第一波（PR #3837）已合入，把 rule 框架 + glue_lolly 样板落地。
+本批继续把剩余 glue 一个一个迁到 standalone 模式，**一个 lua 一个 commit**。
+
+约定：
+- 每个 glue 配一个 `glue_<name>_extra.hpp`，持有该 glue 需要的穿插函数、
+  `using` 引入、辅助类型/宏（参考 `glue_l2_extra.hpp`）。
+- 对应 `init_glue_*.hpp` 加 `void initialize_glue_<name> ();` 前向声明。
+- `init_glue_*.cpp` 删 `#include "glue_<name>.cpp"`，改为 include 对应
+  `_extra.hpp`（如果穿插函数还在用）。
+
+### 进度
+
+- [x] glue_lolly（样板，PR #3837）
+- [ ] glue_drd
+- [ ] glue_file
+- [ ] （后续按需追加）

--- a/devel/1124.md
+++ b/devel/1124.md
@@ -150,6 +150,6 @@ xmake b stem                   # 必须通过
 ### 进度
 
 - [x] glue_lolly（样板，PR #3837）
-- [ ] glue_drd
-- [ ] glue_file
+- [x] glue_drd
+- [x] glue_file
 - [ ] （后续按需追加）

--- a/src/Scheme/L3/glue_drd.lua
+++ b/src/Scheme/L3/glue_drd.lua
@@ -14,6 +14,13 @@ function main()
     return {
         binding_object = "",
         initializer_name = "initialize_glue_drd",
+        standalone = true,
+        includes = {
+            "object_l1.hpp",
+            "object_l2.hpp",
+            "scheme.hpp",
+            "glue_drd_extra.hpp",
+        },
         glues = {
             {
                 scm_name = "set-access-mode",

--- a/src/Scheme/L3/glue_drd_extra.hpp
+++ b/src/Scheme/L3/glue_drd_extra.hpp
@@ -1,0 +1,16 @@
+/******************************************************************************
+ * MODULE     : glue_drd_extra.hpp
+ * DESCRIPTION: helper declarations used by glue_drd (generated, standalone)
+ *              and by init_glue_l3.cpp. Extracted so glue_drd.cpp can be
+ *              compiled as an independent translation unit.
+ ******************************************************************************/
+
+#ifndef GLUE_DRD_EXTRA_HPP
+#define GLUE_DRD_EXTRA_HPP
+
+#include <moebius/drd/drd_mode.hpp>
+
+using moebius::drd::get_access_mode;
+using moebius::drd::set_access_mode;
+
+#endif

--- a/src/Scheme/L3/glue_file.lua
+++ b/src/Scheme/L3/glue_file.lua
@@ -15,6 +15,15 @@ function main()
         group_name = "glue_file",
         binding_object = "",
         initializer_name = "initialize_glue_file",
+        standalone = true,
+        includes = {
+            "object_l1.hpp",
+            "object_l2.hpp",
+            "scheme.hpp",
+            "file.hpp",
+            "tm_file.hpp",
+            "tm_url.hpp",
+        },
         glues = {
             {
                 scm_name = "string-append-to-file",

--- a/src/Scheme/L3/init_glue_l3.cpp
+++ b/src/Scheme/L3/init_glue_l3.cpp
@@ -37,7 +37,6 @@
 using moebius::data::scm_quote;
 using moebius::data::scm_unquote;
 
-#include "glue_file.cpp"
 #include "glue_url.cpp"
 
 string

--- a/src/Scheme/L3/init_glue_l3.cpp
+++ b/src/Scheme/L3/init_glue_l3.cpp
@@ -33,14 +33,10 @@
 #include "url.hpp"
 
 #include <moebius/data/scheme.hpp>
-#include <moebius/drd/drd_mode.hpp>
 
 using moebius::data::scm_quote;
 using moebius::data::scm_unquote;
-using moebius::drd::get_access_mode;
-using moebius::drd::set_access_mode;
 
-#include "glue_drd.cpp"
 #include "glue_file.cpp"
 #include "glue_url.cpp"
 

--- a/src/Scheme/L3/init_glue_l3.hpp
+++ b/src/Scheme/L3/init_glue_l3.hpp
@@ -13,5 +13,6 @@
 #define INIT_GLUE_L3_HPP
 
 void initialize_glue_l3 ();
+void initialize_glue_drd ();
 
 #endif

--- a/src/Scheme/L3/init_glue_l3.hpp
+++ b/src/Scheme/L3/init_glue_l3.hpp
@@ -14,5 +14,6 @@
 
 void initialize_glue_l3 ();
 void initialize_glue_drd ();
+void initialize_glue_file ();
 
 #endif

--- a/xmake.lua
+++ b/xmake.lua
@@ -175,8 +175,9 @@ function build_glue_on_config()
         local build_glue_path = path.join("src", "Scheme", "Glue")
         local build_glue = import("build_glue", {rootdir = build_glue_path})
         for _, filepath in ipairs(os.filedirs(path.join(scheme_path, "**/glue_*.lua"))) do
-            -- glue_lolly 走 mogan.glue rule，这里跳过避免重复生成
-            if path.filename(filepath) ~= "glue_lolly.lua" then
+            -- 走 mogan.glue rule 的 glue 在这里跳过，避免重复生成
+            local name = path.filename(filepath)
+            if name ~= "glue_lolly.lua" and name ~= "glue_drd.lua" then
                 depend.on_changed(function ()
                     local glue_name = path.basename(filepath)
                     local glue_dir = path.directory(filepath)
@@ -538,6 +539,7 @@ target("libmogan") do
     build_glue_on_config()
     add_rules("mogan.glue")
     add_files("src/Scheme/L2/glue_lolly.lua", {rule = "mogan.glue"})
+    add_files("src/Scheme/L3/glue_drd.lua", {rule = "mogan.glue"})
     set_configvar("QTTEXMACS", 1)
     add_defines("QTTEXMACS")
     set_configvar("QTPIPES", 1)

--- a/xmake.lua
+++ b/xmake.lua
@@ -177,7 +177,7 @@ function build_glue_on_config()
         for _, filepath in ipairs(os.filedirs(path.join(scheme_path, "**/glue_*.lua"))) do
             -- 走 mogan.glue rule 的 glue 在这里跳过，避免重复生成
             local name = path.filename(filepath)
-            if name ~= "glue_lolly.lua" and name ~= "glue_drd.lua" then
+            if name ~= "glue_lolly.lua" and name ~= "glue_drd.lua" and name ~= "glue_file.lua" then
                 depend.on_changed(function ()
                     local glue_name = path.basename(filepath)
                     local glue_dir = path.directory(filepath)
@@ -540,6 +540,7 @@ target("libmogan") do
     add_rules("mogan.glue")
     add_files("src/Scheme/L2/glue_lolly.lua", {rule = "mogan.glue"})
     add_files("src/Scheme/L3/glue_drd.lua", {rule = "mogan.glue"})
+    add_files("src/Scheme/L3/glue_file.lua", {rule = "mogan.glue"})
     set_configvar("QTTEXMACS", 1)
     add_defines("QTTEXMACS")
     set_configvar("QTPIPES", 1)


### PR DESCRIPTION
## Summary

继 PR #3837（rule 框架 + glue_lolly 样板）之后，继续把剩余 glue 一个一个迁到 standalone 编译模式。本批：

- **glue_drd**：`standalone=true` + includes；新增 `glue_drd_extra.hpp` 持 `using moebius::drd::{set,get}_access_mode`；`init_glue_l3.{cpp,hpp}` 去掉 `#include "glue_drd.cpp"` 并加前向声明。
- **glue_file**：`standalone=true` + includes（无穿插函数，不需 `_extra.hpp`）；同上去 `#include "glue_file.cpp"` + 加前向声明。
- `xmake.lua`：两个 glue 都加入 `mogan.glue` rule 的 `add_files`，并从 `build_glue_on_config` 的处理列表里排除。

约定见 `devel/1124.md`：每个 glue 配一个 `glue_<name>_extra.hpp`，对应 `init_glue_*.hpp` 加前向声明。

## Test plan

- [x] `xmake b stem` 通过
- [x] `nm` 看到 `initialize_glue_drd` / `initialize_glue_file` 及对应 `tmg_*` 符号
- [x] `touch glue_drd.lua` / `touch glue_file.lua` 只重生成对应 cpp（增量粒度到单文件）
- [x] `touch build_glue.lua` 触发所有 glue 全部重生成
- [x] `xmake r stem` 启动，日志含 `Initialization done`，scheme 初始化正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)