### PR TITLE
[2017] 修复 Debian/macOS CD 失败：升级 xmake 到 v3.0.x

### DIFF
--- a/.github/workflows/cd-debian13.yml
+++ b/.github/workflows/cd-debian13.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: v2.9.6
+          xmake-version: v3.0.7
 
       - name: Update Xrepo
         run: xrepo update-repo

--- a/.github/workflows/cd_on_macos_arm64.yml
+++ b/.github/workflows/cd_on_macos_arm64.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: v2.9.3
+          xmake-version: v3.0.4
           actions-cache-folder: '.xmake-cache'
       - name: xmake repo --update
         run: xmake repo --update

--- a/devel/2017.md
+++ b/devel/2017.md
@@ -1,0 +1,47 @@
+# [2017] 修复 Debian / macOS CD 因 xmake 版本过旧而失败
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `.github/workflows/cd-debian13.yml` - `xmake-version: v2.9.6` → `v3.0.7`（对齐 `ci-debian13.yml`）
+- `.github/workflows/cd_on_macos_arm64.yml` - `xmake-version: v2.9.3` → `v3.0.4`（对齐 `ci-macos-arm64.yml`）
+
+## 3 如何测试
+
+无法本地复刻 GitHub runner 环境，通过手动触发 CD 验证：
+
+```bash
+# 用 workflow_dispatch 手动触发（无需打 tag），在 Actions 页面观察：
+# - Debian：Build 步骤不再报
+#     fatal error: QWKCore/windowagentbase.h: No such file or directory
+#   与 gcc.lua:319 attempt to concatenate a nil value
+# - macOS：Config and build goldfish 步骤不再报
+#     cannot copy file ... to /tm_configure.hpp, Read-only file system
+```
+
+旁证：同平台同 `xmake.lua` 的 `ci-debian13.yml`(v3.0.7) 与 `ci-macos-arm64.yml`(v3.0.4) 持续通过。
+
+## 4 What
+1. 把 `cd-debian13.yml` 的 `xmake-version` 从 `v2.9.6` 升到 `v3.0.7`。
+2. 把 `cd_on_macos_arm64.yml` 的 `xmake-version` 从 `v2.9.3` 升到 `v3.0.4`。
+
+## 5 Why
+三个 CD 中 Windows 成功、Debian 与 macOS 失败，两者失败现象不同但根因相同：**buildir 在 `on_load` 阶段被解析成了文件系统根目录 `/`**。
+- macOS：`$(builddir)/tm_configure.hpp` → `/tm_configure.hpp`，根目录只读，`cp` 失败。
+- Debian：`QWKCore` 头文件被复制到 `$(buildir)/include/QWKCore/`，而 include 路径 `$(builddir)/include` → `/include`，编译 `widgetwindowagent.h` 时找不到 `QWKCore/windowagentbase.h`；其后的 `gcc.lua:319 attempt to concatenate a nil value` 是该编译失败的次生错误。
+
+源头是 `xmake.lua:208` / `xmake.lua:404` 这段脆弱的 buildir 推导：
+```lua
+local buildir = path.directory(path.directory(path.directory(target:targetdir())))
+```
+注释自述 "compatible with xmake v3.0.4+"——它假设 `target:targetdir()` 默认结构是 `<buildir>/<plat>/<arch>/<mode>`（4 段），往上剥 3 层回到 buildir。该假设仅在 v3.0.x 成立（本地 v3.0.6 实测 `targetdir=build/linux/x86_64/release`，剥 3 层=`build`，正确）。v2.9.x 的默认 targetdir 结构层数不同，剥过头变空串，buildir 退化为 `/`。
+
+关键证据：所有 CI 与 Windows CD 都用 v3.0.x 且通过，唯独两个失败 CD 用 v2.9.x。CI 在同平台、同 `xmake.lua` 下通过，证明 **`xmake.lua` 代码本身在 v3.0.x 上正确**，问题纯粹是版本不一致。因此把两个 CD 的版本对齐到对应 CI 已验证通过的版本即可，不改 `xmake.lua`（改动反而引入回归风险）。
+
+## 6 How
+仅修改两个 workflow 的 `xmake-version` 字段，各自对齐到同平台 CI 使用的版本：
+- `cd-debian13.yml` ← `ci-debian13.yml`(v3.0.7)
+- `cd_on_macos_arm64.yml` ← `ci-macos-arm64.yml`(v3.0.4)
+
+其余 step（container、apt 依赖、env、build/package/release）保持不变。`xmake.lua` 不改动。


### PR DESCRIPTION
## 背景

三个 CD（Windows / Debian / macOS）中 Windows 成功，Debian 与 macOS 失败。两者报错现象不同但根因相同：**buildir 在 `on_load` 阶段被解析成了文件系统根目录 `/`**。

- macOS：`cannot copy file ... to /tm_configure.hpp, Read-only file system`
- Debian：`fatal error: QWKCore/windowagentbase.h: No such file or directory`（编译命令里出现 `-I/include`）

## 根因

`xmake.lua:208/404` 的 buildir 推导（往上剥 3 层 targetdir）假设 `target:targetdir()` 默认结构为 4 段 `<buildir>/<plat>/<arch>/<mode>`，注释自述 \"compatible with xmake v3.0.4+\"。该假设仅在 v3.0.x 成立；v2.9.x 的 targetdir 结构不同，剥过头变空串，buildir 退化为 `/`。

关键证据：

| Workflow | xmake 版本 | 结果 |
|---|---|---|
| ci-debian13 | v3.0.7 | ✅ |
| ci-macos-arm64 | v3.0.4 | ✅ |
| cd_research_on_windows | v3.0.4 | ✅ |
| **cd-debian13** | **v2.9.6** | ❌ |
| **cd_on_macos_arm64** | **v2.9.3** | ❌ |

所有 CI 在同平台、同 `xmake.lua` 下通过，证明代码本身在 v3.0.x 正确，问题纯为版本不一致。

## 改动

仅改两个 workflow 的 `xmake-version` 字段，对齐到同平台 CI：
- `cd-debian13.yml`：`v2.9.6` → `v3.0.7`
- `cd_on_macos_arm64.yml`：`v2.9.3` → `v3.0.4`

不改 `xmake.lua`（CI 已证明它在 v3.0.x 上正确）。

## 验证

合入后用 `workflow_dispatch` 手动触发两个 CD（无需打 tag）：
- Debian `Build` 不再报 `QWKCore/windowagentbase.h` 缺失
- macOS `Config and build goldfish` 不再报 `/tm_configure.hpp` 只读

详见 \`devel/2017.md\`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)