### PR TITLE
[1132] 修复打开文档时 autobackup 误把其他 buffer 标脏

### DIFF
--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -39,8 +39,12 @@
          (is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab"))
          (title* (if is-startup? (if (community-stem?) "Mogan STEM" "Liii STEM") title*))
          (mod? (buffer-modified? buf))
+         (result (string-append title* (if mod? " *" "")))
         ) ;
-    (string-append title* (if mod? " *" ""))
+    ;; [1132] 临时调试: 观察切 tab 时 buffer-modified? 的返回值
+    (display* "[1132] tabpage-display-title buf=" buf
+              " title=" title* " mod?=" mod? " result=" result "\n")
+    result
   ) ;let*
 ) ;define
 

--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -39,12 +39,8 @@
          (is-startup? (== (utf8->cork (url->system buf)) "tmfs://startup-tab"))
          (title* (if is-startup? (if (community-stem?) "Mogan STEM" "Liii STEM") title*))
          (mod? (buffer-modified? buf))
-         (result (string-append title* (if mod? " *" "")))
         ) ;
-    ;; [1132] 临时调试: 观察切 tab 时 buffer-modified? 的返回值
-    (display* "[1132] tabpage-display-title buf=" buf
-              " title=" title* " mod?=" mod? " result=" result "\n")
-    result
+    (string-append title* (if mod? " *" ""))
   ) ;let*
 ) ;define
 
@@ -63,16 +59,7 @@
           ) ;
       (tab-page (eval view)
        ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path)))
-        ;; [1132] 临时调试: 记录点击切换前所有 buffer 的 mod? 状态
-        (display* "[1132] before window-set-view target=" buf "\n")
-        (for-each (lambda (b)
-                    (display* "[1132]   pre-switch  buf=" b " mod?=" (buffer-modified? b) "\n"))
-                  (buffer-list))
         (window-set-view view-win view #t)
-        (display* "[1132] after  window-set-view target=" buf "\n")
-        (for-each (lambda (b)
-                    (display* "[1132]   post-switch buf=" b " mod?=" (buffer-modified? b) "\n"))
-                  (buffer-list))
        ) ;
        ;; #t stansd for focus
        ((balloon "" "Close") (safely-kill-tabpage-by-url view-win view buf))

--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -63,7 +63,16 @@
           ) ;
       (tab-page (eval view)
        ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path)))
+        ;; [1132] 临时调试: 记录点击切换前所有 buffer 的 mod? 状态
+        (display* "[1132] before window-set-view target=" buf "\n")
+        (for-each (lambda (b)
+                    (display* "[1132]   pre-switch  buf=" b " mod?=" (buffer-modified? b) "\n"))
+                  (buffer-list))
         (window-set-view view-win view #t)
+        (display* "[1132] after  window-set-view target=" buf "\n")
+        (for-each (lambda (b)
+                    (display* "[1132]   post-switch buf=" b " mod?=" (buffer-modified? b) "\n"))
+                  (buffer-list))
        ) ;
        ;; #t stansd for focus
        ((balloon "" "Close") (safely-kill-tabpage-by-url view-win view buf))

--- a/TeXmacs/progs/utils/plugins/plugin-eval.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-eval.scm
@@ -209,7 +209,7 @@
               ((== status 0)
                (with author
                  0
-                 (when (!= lan "scheme")
+                 (when (and (!= lan "scheme") (!= lan "autosave"))
                    (set! author (new-author))
                    (start-slave author)
                  ) ;when
@@ -349,7 +349,10 @@
     (pending-ref lan ses)
     (with author
       0
-      (when (!= lan "scheme")
+      ;; "autosave" 是单向喂 payload（回调为 noop），不需要 author 归因；
+      ;; 跳过 start-slave 以免往当前编辑器推 PATCH_BIRTH marker，
+      ;; 把无关 buffer 误标为已修改（见 devel/1132.md）。
+      (when (and (!= lan "scheme") (!= lan "autosave"))
         (set! author (new-author))
         (start-slave author)
       ) ;when

--- a/devel/1132.md
+++ b/devel/1132.md
@@ -1,32 +1,53 @@
-# 1132 切换 tab 后已保存文档被误标为已修改
+# 1132 打开文档后 autobackup 误把其他 buffer 标脏
 
 ## 现象
 
-启动 mogan,打开两个 `.tmu` 文档(例如 A、B),分别保存。
-此时两个文档都应是「已保存」状态。但实际表现:
+启动 mogan,打开两个 `.tmu` 文档(例如 A、B),分别保存。两个文档
+此时都应是「已保存」状态。但实际表现:
 
 - 打开第二个文档(B)之后,第一个文档(A)的 tab 上出现 `*`(已修改)。
 - 在 A、B 之间切换 tab,A 和 B 都会被标上 `*`。
-- **关闭 autobackup 偏好后,问题消失** —— 强烈指向自动备份相关的 Scheme 代码。
+- **关闭 autobackup 偏好后,问题消失** —— 强烈指向自动备份相关代码。
 
-## 关键函数
+更简单的复现路径:**不需要切换 tab,打开第二个文档就足以让第一个
+已保存的文档变脏**。先开 A,再开 B,A 的 tab 上立刻出现 `*`。
 
-标题里的 `*` 来自 Scheme 函数 `tabpage-display-title`
-(`TeXmacs/progs/texmacs/menus/tabpage-menu.scm:36`):
+## 脏化判定链(理解「脏」是怎么定义的)
+
+tab 上的 `*` 由 Scheme 函数 `tabpage-display-title`
+(`TeXmacs/progs/texmacs/menus/tabpage-menu.scm:36`)算出:
 
 ```scheme
-(define (tabpage-display-title buf)
-  (let* (...
-         (mod? (buffer-modified? buf)))
-    (string-append title* (if mod? " *" ""))))
+(mod? (buffer-modified? buf))
+(string-append title* (if mod? " *" ""))
 ```
 
-`buffer-modified?` 是 glue 函数 → C++ `buffer_modified`
-(`src/Texmacs/Data/new_buffer.cpp:409`) → `tm_buffer_rep::needs_to_be_saved`
-(`new_buffer.cpp:71`) → 遍历该 buffer 的所有 view 的 editor `need_save()`。
+`buffer-modified?` 是 glue,往下落到 C++:
+
+```
+buffer_modified          (new_buffer.cpp:409)
+  -> tm_buffer_rep::needs_to_be_saved  (new_buffer.cpp:71)
+     -> 遍历该 buffer 的所有 view: ed->need_save()
+        -> edit_modify_rep::need_save  (edit_modify.cpp:415)
+           -> arch->conform_save ()
+              -> last_save == corrected_depth ()
+```
+
+也就是说:
+
+- `conform_save()` 返回 true ⟺ `last_save == corrected_depth()`
+  ⟺ buffer 不脏、不显示 `*`。
+- 让 `conform_save()` 失败的途径只有两种:
+  1. **`corrected_depth()` 变化**(有 modification 推入编辑栈,
+     `depth` 偏移)。
+  2. **`last_save` 被置 `-1`**(`require_save()` 被调用 → 永远不等于
+     任何 depth)。
+
+`require_save()` 由 `pretend_buffer_modified`(new_buffer.cpp:423)
+对每个 view 调用,对应 Scheme 的 `buffer-pretend-modified`。
 
 注意:`needs_to_be_saved`(决定 `*`)与 `needs_to_be_autosaved`
-(决定是否需要自动备份)是**两条独立的状态**。前者是「相对上次正式
+(决定是否需要自动备份)是**两条独立状态**。前者是「相对上次正式
 保存的修改」,后者是「相对上次 autosave 的修改」。所以 autobackup
 开关理论上不应影响 `*` —— 但实际影响了,这就是 bug 的核心矛盾。
 
@@ -35,17 +56,14 @@
 ### 1. 确认 `*` 标记确实由 `buffer-modified?` 驱动
 
 在 `tabpage-display-title` 里加 `display*` 日志,打印 `buf` /
-`title*` / `mod?` / `result`。
-
-观察:`mod?=#t` 时标题确实带 `*`,`mod?=#f` 时不带。确认标题反映
-的就是 `buffer-modified?` 的返回值。
+`title*` / `mod?` / `result`。观察:`mod?=#t` 时标题确实带 `*`,
+`mod?=#f` 时不带。标题只是**反映** `buffer-modified?` 的返回值。
 
 ### 2. 确认 `window-set-view`(切 tab 的 Scheme 入口)本身不脏化
 
 在 `tabpage-menu.scm:66` 的 `(window-set-view view-win view #t)`
-前后,遍历 `(buffer-list)` 打印每个 buffer 的 `mod?`。
+前后遍历 `(buffer-list)`,打印每个 buffer 的 `mod?`。观察:
 
-观察:
 - `pre-switch` 与 `post-switch` 阶段,所有 buffer `mod?=#f`。
 - 但紧接着的下一次 `tabpage-display-title` 里,目标之外的其他 buffer
   已经 `mod?=#t`。
@@ -53,73 +71,127 @@
 **结论**:`window-set-view` 的同步路径不脏化任何 buffer。脏化发生在
 它返回之后、下一次标题刷新之前的某个**异步/延迟回调**里。
 
-### 3. 更简单的复现路径
+顺带确认:`load-buffer-open`(`tm-files.scm:1058`)只在「打开文档」
+时被调用(经 `load-buffer-load`),**切换 tab 不走这条路径**。切换
+tab 走的是 C++ `window-set-view` → `set_current_view`,纯切 view。
 
-不需要切换 tab,**打开第二个文档**就足以让第一个已保存的文档变脏:
+### 3. `tabpage-display-title` 调用链(已确认无辜)
 
-> 先打开 黑板识别.tmu,再打开 你好.tmu。
-> 打开 你好.tmu 之后,黑板识别.tmu 的 tab 上就出现 `*`。
-
-### 4. `tabpage-display-title` 调用链(已确认无辜)
-
-`grep` 出 `tabpage-display-title` 只有两个调用点,都在
-`tabpage-menu.scm`:
+`tabpage-display-title` 只有两个调用点,都在 `tabpage-menu.scm`:
 
 - line 61: `(tab-title (tabpage-display-title buf))` —— 在
   `texmacs-tab-pages` 菜单的 `for` 循环里给每个 view 算标题。
 - line 94: `(tabpage-display-title (view->buffer view))` —— 在
   `tabpage-entry-signature` 里(tab 栏判等签名)。
 
-两者都**只读** `buffer-modified?`,不会写 buffer。
-`tabpage-entry-signature` 由 C++ `tm_window_rep::get_menu_widget`
-(`src/Texmacs/Window/tm_window.cpp:414`,which==4 时)在重建 tab
-菜单前调用,用于跳过未变化的重建。
+两者都**只读** `buffer-modified?`。`tabpage-entry-signature` 由
+C++ `tm_window_rep::get_menu_widget`(`tm_window.cpp:414`,
+which==4 时)在重建 tab 菜单前调用,用于跳过未变化的重建。
 
-即:`tabpage-display-title` 这条链只是**反映** buffer 已脏,不是
-脏化的元凶。
+即:这条链只是**反映** buffer 已脏,不是脏化的元凶。
 
-### 5. 嫌疑函数(待验证)
+### 4. 排除几条嫌疑路径
 
-`auto-backup-ensure-buffer-doc-id!` (`tm-files.scm:817`):
+**嫌疑 a:`auto-backup-ensure-buffer-doc-id!` 写 `init-env`**
 
-- 名字带 `!`,会在缺失 doc-id 时调 `(init_env "stem-doc-id" doc-id)`
-  写入 buffer 的 init-env —— `init_env` 会修改文档树,从而可能
-  dirty 化 buffer。
-- 但 `grep` 确认 Scheme 层只有 6 处调用它(save-buffer-save、
-  new-document、new-document*、save-buffer-as、auto-backup-trig、
-  save-all-buffers),没有「遍历 buffer-list 对所有 buffer 绑 doc-id」
-  的地方。
-- 已在该函数内加 `display*` 日志(enter/exit/init_env 写入点)，
-  待运行确认是否在切换 tab / 打开新文档路径上对非当前 buffer 跑过。
+`auto-backup-ensure-buffer-doc-id!`(`tm-files.scm:817`)在 doc-id
+缺失时调 `(init-env "stem-doc-id" doc-id)`,而 `init-env` 会改文档树,
+是潜在的脏源。但:
 
-`buffer-pretend-modified` 的调用点也列了 6 处(part-tmfs、bib-local、
-tm-server ×2、tm-files ×2),都不像切换钩子。
+- doc-id 已存在(合法)时走 then 分支直接返回,**不写**。
+- `grep` 确认 Scheme 层调用点有限,没有「遍历 buffer-list 对所有
+  buffer 绑 doc-id」的地方。
 
-## 已加的调试日志(本分支)
+实测日志显示 doc-id 存在时该函数不写,排除了「打开 B 时对 A 也写
+init-env」的可能。
 
-- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`
-  - `tabpage-display-title`: 打印 buf/title*/mod?/result
-  - `texmacs-tab-pages` 菜单点击处: window-set-view 前后遍历
-    `(buffer-list)` 打印每个 buffer 的 mod?
-- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`
-  - `auto-backup-ensure-buffer-doc-id!`: enter/exit/init_env 写入点日志
+**嫌疑 b:`buffer-pretend-modified`**
 
-## 下一步
+`grep` 列出 6 处调用(part-tmfs、bib-local、tm-server ×2、
+tm-files ×2),都不在「打开文档 / 切 tab」路径上。排除。
 
-- 运行带日志的构建,确认「打开第二文档」时
-  `auto-backup-ensure-buffer-doc-id!` 是否对第一个文档跑过、以及
-  `init_env` 写入后 buffer 是否变脏。
-- 若否,排查 `window-set-view` / 打开 buffer 之后 `(:idle N)` 触发的
-  延迟任务里,有哪些会遍历 buffer 并写入文档
-  (`tm-view.scm` 有多处 `delayed` / `idle`)。
-- 范围限定:本次只排查 Scheme 层。
+**嫌疑 c:`save-buffer-save` 的 `if` 分支反了**
 
-## 根因(已定位)
+`save-buffer-save`(`tm-files.scm:370`)有:
+
+```scheme
+(if (buffer-save name)
+    (begin (buffer-pretend-modified name) ...)   ;; 保存失败标脏
+    (begin ... "Saved" ...))
+```
+
+读 C++ `buffer_save`(`new_buffer.cpp:660`):返回值 `r=true` 表示
+**导出失败**、`r=false` 表示成功(还调 `pretend_buffer_saved` 清状态)。
+所以 `if` 语义正确:失败标脏、成功显示 Saved。排除。
+
+**嫌疑 d:`with-buffer` 切 focus 的副作用**
+
+`with-buffer` 宏(`cursor.scm:333`)用 `(buffer-focus new #f)` 切
+current-buffer。怀疑切走/切回时脏化。但追踪 C++:
+
+```
+buffer-focus -> focus_on_buffer (new_view.cpp:827)
+             -> set_current_view (new_view.cpp:134)
+```
+
+`set_current_view` 只改 `the_view` 指针、更新 `the_drd`、记
+`last_visit`,**不推编辑栈,不改 `last_save`**。排除。
+
+### 5. 定位 autobackup 异步链路
+
+`load-buffer-open`(`tm-files.scm:1085`)末尾调:
+
+```scheme
+(auto-backup-opened-buffer! name)
+```
+
+后者(`tm-files.scm:928`):
+
+```scheme
+(auto-backup-ensure-buffer-doc-id! name)
+(delayed (:pause 100) (auto-backup-trig name "on-open"))
+```
+
+`(:pause 100)` 正好匹配第 2 步观察到的「脏化发生在 window-set-view
+之后的异步回调里」。展开 `auto-backup-trig` → `silent-feed*` →
+
+`silent-feed` → `plugin-feed`,在 `lan != "scheme"` 时调
+`(new-author)` + `(start-slave author)`。
+
+### 6. 锁定 `start-slave` 为脏源
+
+`start-slave` → `edit_modify_rep::start_slave` → C++
+`archiver_rep::start_slave`(`archiver.cpp:291`):
+
+```cpp
+patch q (a, false);                // PATCH_BIRTH, birth=false 占位 patch
+current = patch (q, current);      // 推入「当前编辑器」的编辑栈
+```
+
+**这就是脏化动作**:往当前编辑器推 patch,让 `corrected_depth()`
+偏离 `last_save`。
+
+而 `plugin-feed` / `start-slave` 作用在**当时的 current view 编辑器**
+上,不是 payload 对应的 `name`。on-open delayed(100ms)fire 时,
+用户可能已切到别的 tab,current 已不是 `name`。于是 marker 被推到
+了「此刻恰好是 current」的 buffer 的编辑栈 —— 这就是「打开 B 后 A
+变 `*`」的真相。
+
+`corrected_depth()`(`archiver.cpp:652`)虽有「忽略栈顶 birth=false
+marker」的修正,但只覆盖 marker 在栈顶的情形;marker 一旦不在栈顶
+(后续有别的 modification 推上来、或 marker 推到了本不该收它的
+buffer),修正就失配,`conform_save()` 返回 false。
+
+**关闭 autobackup 即消失**:`auto-backup-enabled?` 为假时,
+`auto-backup-trig` 的 `when` 整个跳过,不进 `silent-feed*` /
+`start-slave`。
+
+## 根因
 
 **`silent-feed*` 链路里的 `start-slave` 误把作者切换 marker 推到了
 当时的 current buffer,而不是 payload 真正对应的目标 buffer。**
 
-调用链(全部在 Scheme 层发起,但末端落点是 C++ 编辑器):
+完整调用链(全部在 Scheme 层发起,但末端落点是 C++ 编辑器):
 
 ```
 load-buffer-open (tm-files.scm:1085)
@@ -142,53 +214,66 @@ load-buffer-open (tm-files.scm:1085)
 1. **`(delayed (:pause 100) ...)` 在 100ms 后异步 fire**,此时用户
    可能已切到别的 tab,`(current-buffer)` 已不是 `name`。
 2. **`silent-feed*` 链路对「当前编辑器」操作**,而不是对 `name` 对应
-   的编辑器。`plugin-feed`(plugin-eval.scm:347)在 `lan != "scheme"`
+   的编辑器。`plugin-feed`(`plugin-eval.scm:347`)在 `lan != "scheme"`
    时调 `(new-author)` + `(start-slave author)`,后者作用在
    **current view 的编辑器**上。
-3. **`start_slave` 往编辑栈推 patch**(archiver.cpp:291,
-   `current= patch (q, current)`),让该编辑器的 `corrected_depth()`
-   偏离 `last_save`。
+3. **`start_slave` 往编辑栈推 patch**(`archiver.cpp:291`),
+   让该编辑器的 `corrected_depth()` 偏离 `last_save`。
 4. 于是「打开 B 后,A 的 tab 上出现 `*`」—— 因为 B 的 on-open delayed
    在 A 是 current 时 fire,把 marker 推到了 A 的编辑栈。
-5. **关闭 autobackup 即消失**:`auto-backup-enabled?` 为假时,
-   `auto-backup-trig` 的 `when` 整个跳过,不进 `silent-feed*` /
-   `start-slave`。
 
-`corrected_depth()`(archiver.cpp:652)虽有「忽略栈顶 birth=false
-marker」的修正,但只覆盖 marker 在栈顶的情形;一旦 marker 不在栈顶
-(后续有别的 modification 推上来、或 marker 推到了本不该收它的
-buffer),修正就失配,`conform_save()` 返回 false。
+## 修复方案(已落地)
 
-## 修复方向(待选)
+采用「方向 B」的变体:**用 `lan` 判断,让 `autosave` 跳过
+`start-slave`**。
 
-- **A. 让 autobackup 的 `silent-feed*` 作用在目标 buffer 的编辑器上,
-  而不是 current**。即在 `auto-backup-trig` 里用 `(with-buffer u ...)`
-  包住 `silent-feed*`,保证 `start-slave` 推到 `u` 的编辑栈。但 `u`
-  本来就可能是刚保存过的,推 marker 反而会让 `u` 自己变脏 —— 不对。
-- **B. 让 autobackup 路径完全不走 `start-slave`**。`silent-feed*` 是
-  给交互式 plugin 用的(需要 author 标记来归因输出),autosave 只是
-  单向喂 payload 给子进程,不需要 author。可以为 `silent-feed*` 加
-  一个「跳过 start-slave」的开关,或 autosave 走更轻量的通道。
-- **C. 在 `auto-backup-trig` 触发前后,保存/恢复 current 编辑器的
-  archiver 状态**(脏度阈值),让 marker 不影响 `conform_save()`。
-- **D. 修 `corrected_depth()`,让它对栈中任意位置的 birth=false marker
-  都做修正**(而非只看栈顶)。改 C++,影响面更广,谨慎。
+autobackup 是单向喂 payload(回调为 `(lambda (r) (noop))`),不需要
+author 归因。`silent-feed*` / `plugin-feed` 的 author 机制是为交互式
+plugin(要区分不同 author 的输出)准备的,autosave 借用它属于语义
+错配。
 
-推荐先评估 **B**:autosave 不应触发 author/slave 机制,这是语义上
-最干净的修法。
+改动集中在 `TeXmacs/progs/utils/plugins/plugin-eval.scm`,两处
+`(when (!= lan "scheme") ...)` 都加上 `(!= lan "autosave")`:
+
+- `plugin-feed`(入队时)。
+- `plugin-do`(status==0 首次启动连接时)—— 否则 autosave 子进程
+  首次启动时仍会从这条路径补一次 `start-slave`。
+
+最终:
+
+```scheme
+(when (and (!= lan "scheme") (!= lan "autosave"))
+  (set! author (new-author))
+  (start-slave author))
+```
+
+交互式 plugin(scripts-edit、calc-edit 等走其它 `lan`)不受影响。
+
+### 被否决的备选方案
+
+- **A. 让 `silent-feed*` 作用在目标 buffer 的编辑器上**:在
+  `auto-backup-trig` 里用 `(with-buffer u ...)` 包住。但 `u` 本来
+  可能是刚保存过的,推 marker 反而会让 `u` 自己变脏。不对。
+- **C. 在 `auto-backup-trig` 前后保存/恢复 archiver 状态**:治标,
+  且把 archiver 内部状态暴露给 Scheme,耦合差。
+- **D. 改 `corrected_depth()` 让它对栈中任意位置的 birth=false marker
+  都做修正**:改 C++,影响面更广,且不解决「marker 推到错误 buffer」
+  的根因。
 
 ## 涉及文件
 
-- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`
-- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`
-- `TeXmacs/progs/texmacs/texmacs/tm-server.scm`
-- `TeXmacs/progs/texmacs/texmacs/tm-view.scm`
-- `TeXmacs/progs/utils/plugins/plugin-eval.scm`(`silent-feed*` /
-  `plugin-feed` / `start-slave` 链路)
-- `src/Data/History/archiver.cpp`(`start_slave` /
-  `corrected_depth` / `conform_save`,仅理解末端落点,不改)
-- `src/Edit/Modify/edit_modify.cpp`(`start_slave` 转发)
-- `src/Texmacs/Data/new_buffer.cpp`(`buffer_modified` /
-  `needs_to_be_saved`,仅理解状态来源,不改)
-- `src/Texmacs/Window/tm_window.cpp`(`tabpage-menu-signature` 调用点,
-  仅理解刷新链路,不改)
+- `TeXmacs/progs/utils/plugins/plugin-eval.scm` —— **改动**:
+  `plugin-feed` / `plugin-do` 两处 `when` 加 `(!= lan "autosave")`。
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` —— 排查时的调用链
+  落点(`load-buffer-open` / `auto-backup-opened-buffer!` /
+  `auto-backup-trig` / `auto-backup-ensure-buffer-doc-id!`),不改。
+- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm` —— 标题计算与切 tab
+  入口,排查时埋过日志(已清除),不改。
+- `TeXmacs/progs/utils/library/cursor.scm` —— `with-buffer` 宏定义,
+  排查时验证过切 focus 不脏化,不改。
+- `src/Data/History/archiver.cpp` —— `start_slave` /
+  `corrected_depth` / `conform_save` / `require_save`,仅理解末端
+  落点与判定语义,不改。
+- `src/Texmacs/Data/new_buffer.cpp` / `new_view.cpp` ——
+  `buffer_modified` / `needs_to_be_saved` / `focus_on_buffer` /
+  `set_current_view`,仅理解状态来源与切 view 是否脏化,不改。

--- a/devel/1132.md
+++ b/devel/1132.md
@@ -114,13 +114,81 @@ tm-server ×2、tm-files ×2),都不像切换钩子。
   (`tm-view.scm` 有多处 `delayed` / `idle`)。
 - 范围限定:本次只排查 Scheme 层。
 
+## 根因(已定位)
+
+**`silent-feed*` 链路里的 `start-slave` 误把作者切换 marker 推到了
+当时的 current buffer,而不是 payload 真正对应的目标 buffer。**
+
+调用链(全部在 Scheme 层发起,但末端落点是 C++ 编辑器):
+
+```
+load-buffer-open (tm-files.scm:1085)
+  -> auto-backup-opened-buffer! (tm-files.scm:928)
+     -> (delayed (:pause 100) (auto-backup-trig name "on-open"))
+        -> auto-backup-trig (tm-files.scm:902)
+           -> silent-feed* "autosave" ... (tm-files.scm:906)
+              -> silent-feed (plugin-eval.scm:492)
+                 -> plugin-feed (plugin-eval.scm:347)
+                    -> (start-slave author) (plugin-eval.scm:354)
+                       -> edit_modify_rep::start_slave
+                          -> archiver_rep::start_slave (archiver.cpp:291)
+                             -> current= patch (q, current);
+                                ;; 推 PATCH_BIRTH birth=false 占位 patch
+                                ;; 到「当前编辑器」的编辑栈
+```
+
+关键点:
+
+1. **`(delayed (:pause 100) ...)` 在 100ms 后异步 fire**,此时用户
+   可能已切到别的 tab,`(current-buffer)` 已不是 `name`。
+2. **`silent-feed*` 链路对「当前编辑器」操作**,而不是对 `name` 对应
+   的编辑器。`plugin-feed`(plugin-eval.scm:347)在 `lan != "scheme"`
+   时调 `(new-author)` + `(start-slave author)`,后者作用在
+   **current view 的编辑器**上。
+3. **`start_slave` 往编辑栈推 patch**(archiver.cpp:291,
+   `current= patch (q, current)`),让该编辑器的 `corrected_depth()`
+   偏离 `last_save`。
+4. 于是「打开 B 后,A 的 tab 上出现 `*`」—— 因为 B 的 on-open delayed
+   在 A 是 current 时 fire,把 marker 推到了 A 的编辑栈。
+5. **关闭 autobackup 即消失**:`auto-backup-enabled?` 为假时,
+   `auto-backup-trig` 的 `when` 整个跳过,不进 `silent-feed*` /
+   `start-slave`。
+
+`corrected_depth()`(archiver.cpp:652)虽有「忽略栈顶 birth=false
+marker」的修正,但只覆盖 marker 在栈顶的情形;一旦 marker 不在栈顶
+(后续有别的 modification 推上来、或 marker 推到了本不该收它的
+buffer),修正就失配,`conform_save()` 返回 false。
+
+## 修复方向(待选)
+
+- **A. 让 autobackup 的 `silent-feed*` 作用在目标 buffer 的编辑器上,
+  而不是 current**。即在 `auto-backup-trig` 里用 `(with-buffer u ...)`
+  包住 `silent-feed*`,保证 `start-slave` 推到 `u` 的编辑栈。但 `u`
+  本来就可能是刚保存过的,推 marker 反而会让 `u` 自己变脏 —— 不对。
+- **B. 让 autobackup 路径完全不走 `start-slave`**。`silent-feed*` 是
+  给交互式 plugin 用的(需要 author 标记来归因输出),autosave 只是
+  单向喂 payload 给子进程,不需要 author。可以为 `silent-feed*` 加
+  一个「跳过 start-slave」的开关,或 autosave 走更轻量的通道。
+- **C. 在 `auto-backup-trig` 触发前后,保存/恢复 current 编辑器的
+  archiver 状态**(脏度阈值),让 marker 不影响 `conform_save()`。
+- **D. 修 `corrected_depth()`,让它对栈中任意位置的 birth=false marker
+  都做修正**(而非只看栈顶)。改 C++,影响面更广,谨慎。
+
+推荐先评估 **B**:autosave 不应触发 author/slave 机制,这是语义上
+最干净的修法。
+
 ## 涉及文件
 
 - `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`
 - `TeXmacs/progs/texmacs/texmacs/tm-files.scm`
 - `TeXmacs/progs/texmacs/texmacs/tm-server.scm`
 - `TeXmacs/progs/texmacs/texmacs/tm-view.scm`
+- `TeXmacs/progs/utils/plugins/plugin-eval.scm`(`silent-feed*` /
+  `plugin-feed` / `start-slave` 链路)
+- `src/Data/History/archiver.cpp`(`start_slave` /
+  `corrected_depth` / `conform_save`,仅理解末端落点,不改)
+- `src/Edit/Modify/edit_modify.cpp`(`start_slave` 转发)
 - `src/Texmacs/Data/new_buffer.cpp`(`buffer_modified` /
-  `needs_to_be_saved`,仅用于理解状态来源,不改)
+  `needs_to_be_saved`,仅理解状态来源,不改)
 - `src/Texmacs/Window/tm_window.cpp`(`tabpage-menu-signature` 调用点,
   仅理解刷新链路,不改)

--- a/devel/1132.md
+++ b/devel/1132.md
@@ -1,0 +1,126 @@
+# 1132 切换 tab 后已保存文档被误标为已修改
+
+## 现象
+
+启动 mogan,打开两个 `.tmu` 文档(例如 A、B),分别保存。
+此时两个文档都应是「已保存」状态。但实际表现:
+
+- 打开第二个文档(B)之后,第一个文档(A)的 tab 上出现 `*`(已修改)。
+- 在 A、B 之间切换 tab,A 和 B 都会被标上 `*`。
+- **关闭 autobackup 偏好后,问题消失** —— 强烈指向自动备份相关的 Scheme 代码。
+
+## 关键函数
+
+标题里的 `*` 来自 Scheme 函数 `tabpage-display-title`
+(`TeXmacs/progs/texmacs/menus/tabpage-menu.scm:36`):
+
+```scheme
+(define (tabpage-display-title buf)
+  (let* (...
+         (mod? (buffer-modified? buf)))
+    (string-append title* (if mod? " *" ""))))
+```
+
+`buffer-modified?` 是 glue 函数 → C++ `buffer_modified`
+(`src/Texmacs/Data/new_buffer.cpp:409`) → `tm_buffer_rep::needs_to_be_saved`
+(`new_buffer.cpp:71`) → 遍历该 buffer 的所有 view 的 editor `need_save()`。
+
+注意:`needs_to_be_saved`(决定 `*`)与 `needs_to_be_autosaved`
+(决定是否需要自动备份)是**两条独立的状态**。前者是「相对上次正式
+保存的修改」,后者是「相对上次 autosave 的修改」。所以 autobackup
+开关理论上不应影响 `*` —— 但实际影响了,这就是 bug 的核心矛盾。
+
+## 排查过程
+
+### 1. 确认 `*` 标记确实由 `buffer-modified?` 驱动
+
+在 `tabpage-display-title` 里加 `display*` 日志,打印 `buf` /
+`title*` / `mod?` / `result`。
+
+观察:`mod?=#t` 时标题确实带 `*`,`mod?=#f` 时不带。确认标题反映
+的就是 `buffer-modified?` 的返回值。
+
+### 2. 确认 `window-set-view`(切 tab 的 Scheme 入口)本身不脏化
+
+在 `tabpage-menu.scm:66` 的 `(window-set-view view-win view #t)`
+前后,遍历 `(buffer-list)` 打印每个 buffer 的 `mod?`。
+
+观察:
+- `pre-switch` 与 `post-switch` 阶段,所有 buffer `mod?=#f`。
+- 但紧接着的下一次 `tabpage-display-title` 里,目标之外的其他 buffer
+  已经 `mod?=#t`。
+
+**结论**:`window-set-view` 的同步路径不脏化任何 buffer。脏化发生在
+它返回之后、下一次标题刷新之前的某个**异步/延迟回调**里。
+
+### 3. 更简单的复现路径
+
+不需要切换 tab,**打开第二个文档**就足以让第一个已保存的文档变脏:
+
+> 先打开 黑板识别.tmu,再打开 你好.tmu。
+> 打开 你好.tmu 之后,黑板识别.tmu 的 tab 上就出现 `*`。
+
+### 4. `tabpage-display-title` 调用链(已确认无辜)
+
+`grep` 出 `tabpage-display-title` 只有两个调用点,都在
+`tabpage-menu.scm`:
+
+- line 61: `(tab-title (tabpage-display-title buf))` —— 在
+  `texmacs-tab-pages` 菜单的 `for` 循环里给每个 view 算标题。
+- line 94: `(tabpage-display-title (view->buffer view))` —— 在
+  `tabpage-entry-signature` 里(tab 栏判等签名)。
+
+两者都**只读** `buffer-modified?`,不会写 buffer。
+`tabpage-entry-signature` 由 C++ `tm_window_rep::get_menu_widget`
+(`src/Texmacs/Window/tm_window.cpp:414`,which==4 时)在重建 tab
+菜单前调用,用于跳过未变化的重建。
+
+即:`tabpage-display-title` 这条链只是**反映** buffer 已脏,不是
+脏化的元凶。
+
+### 5. 嫌疑函数(待验证)
+
+`auto-backup-ensure-buffer-doc-id!` (`tm-files.scm:817`):
+
+- 名字带 `!`,会在缺失 doc-id 时调 `(init_env "stem-doc-id" doc-id)`
+  写入 buffer 的 init-env —— `init_env` 会修改文档树,从而可能
+  dirty 化 buffer。
+- 但 `grep` 确认 Scheme 层只有 6 处调用它(save-buffer-save、
+  new-document、new-document*、save-buffer-as、auto-backup-trig、
+  save-all-buffers),没有「遍历 buffer-list 对所有 buffer 绑 doc-id」
+  的地方。
+- 已在该函数内加 `display*` 日志(enter/exit/init_env 写入点)，
+  待运行确认是否在切换 tab / 打开新文档路径上对非当前 buffer 跑过。
+
+`buffer-pretend-modified` 的调用点也列了 6 处(part-tmfs、bib-local、
+tm-server ×2、tm-files ×2),都不像切换钩子。
+
+## 已加的调试日志(本分支)
+
+- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`
+  - `tabpage-display-title`: 打印 buf/title*/mod?/result
+  - `texmacs-tab-pages` 菜单点击处: window-set-view 前后遍历
+    `(buffer-list)` 打印每个 buffer 的 mod?
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`
+  - `auto-backup-ensure-buffer-doc-id!`: enter/exit/init_env 写入点日志
+
+## 下一步
+
+- 运行带日志的构建,确认「打开第二文档」时
+  `auto-backup-ensure-buffer-doc-id!` 是否对第一个文档跑过、以及
+  `init_env` 写入后 buffer 是否变脏。
+- 若否,排查 `window-set-view` / 打开 buffer 之后 `(:idle N)` 触发的
+  延迟任务里,有哪些会遍历 buffer 并写入文档
+  (`tm-view.scm` 有多处 `delayed` / `idle`)。
+- 范围限定:本次只排查 Scheme 层。
+
+## 涉及文件
+
+- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`
+- `TeXmacs/progs/texmacs/texmacs/tm-server.scm`
+- `TeXmacs/progs/texmacs/texmacs/tm-view.scm`
+- `src/Texmacs/Data/new_buffer.cpp`(`buffer_modified` /
+  `needs_to_be_saved`,仅用于理解状态来源,不改)
+- `src/Texmacs/Window/tm_window.cpp`(`tabpage-menu-signature` 调用点,
+  仅理解刷新链路,不改)


### PR DESCRIPTION
## 问题

打开第二个文档后,第一个已保存文档的 tab 上出现 `*`(已修改标记);在两个文档间切换 tab,两边都会被标 `*`。关闭 autobackup 偏好后问题消失。

## 根因

`load-buffer-open` 在打开文档后会异步触发 autobackup:

```
load-buffer-open
  -> auto-backup-opened-buffer!
     -> (delayed (:pause 100) (auto-backup-trig name "on-open"))
        -> silent-feed* "autosave" ...
           -> plugin-feed
              -> (start-slave author)
                 -> archiver_rep::start_slave
                    -> current = patch (q, current)
                       ;; 往「当前编辑器」的编辑栈推 PATCH_BIRTH birth=false marker
```

`(delayed (:pause 100) ...)` 异步 fire 时,用户可能已切到别的 tab,`(current-buffer)` 已不是 `name`。而 `plugin-feed` / `plugin-do` 里的 `(start-slave author)` 作用在**当前编辑器**上(不是 payload 对应的 `name`),于是 marker 被推到了「此刻恰好是 current」的那个 buffer 的编辑栈,让它偏离 `last_save`,`conform_save()` 失败,tab 显示 `*`。

`corrected_depth()` 的「忽略栈顶 birth=false marker」修正只覆盖 marker 在栈顶的情形,治标不治本。

## 修复

autobackup 是单向喂 payload(回调为 `(lambda (r) (noop))`),不需要 author 归因。让 `lan="autosave"` 和 `lan="scheme"` 一样跳过 `new-author` / `start-slave`,避免往当前编辑器推 marker。改动两处(`TeXmacs/progs/utils/plugins/plugin-eval.scm`):

- `plugin-feed` 入队的 `(when (!= lan "scheme") ...)`
- `plugin-do` 首次启动连接 (status==0) 的 `(when (!= lan "scheme") ...)`

都改成 `(when (and (!= lan "scheme") (!= lan "autosave")) ...)`。

交互式 plugin (scripts-edit、calc-edit 等) 走的是其它 `lan`,不受影响。

详见 `devel/1132.md`。

## 测试计划

- [ ] 开启 autobackup,打开 A.tmu、B.tmu,确认两边 tab 都不带 `*`
- [ ] 在 A、B 间切换 tab,确认 tab 不被误标 `*`
- [ ] 真正编辑 A 后保存,确认 `*` 行为正常(编辑后出现、保存后消失)
- [ ] 确认 autobackup 仍正常触发(云备份有记录)