### PR TITLE
[2018] 移除首次启动自动打开 stem 欢迎文档

### DIFF
--- a/devel/2018.md
+++ b/devel/2018.md
@@ -1,0 +1,17 @@
+# [2018] 移除首次启动自动打开 stem 欢迎文档
+
+## 1 任务相关的代码文件
+- `src/System/Boot/init_texmacs.cpp` - 删除 `load_welcome_doc()` 函数定义及 `TeXmacs_main` 中首次启动时对它的调用。
+- `TeXmacs/progs/doc/help-funcs.scm` - `mogan-welcome` 函数**保留不动**（「帮助」菜单仍可手动打开 stem 文档）。
+- `TeXmacs/progs/doc/help-menu.scm` - Welcome 菜单项**保留不动**。
+
+## 2 What
+1. 移除 `init_texmacs.cpp` 中的 `load_welcome_doc()` 函数（原 596–601 行）。
+2. 移除 `TeXmacs_main` 中首次启动分支 `if (install_status == 1) load_welcome_doc();`（原 902 行）。
+
+## 3 Why
+首次启动改为新的引导交互流程，不再需要在启动时自动弹出 `stem.zh.tmu` / `stem.en.tmu` 欢迎文档。`install_status`（首次安装标记）仍被 `src/Plugins/Qt/qt_tutorial.cpp` 用于首次启动教程逻辑，因此仅删除欢迎文档的自动加载，**不删** `install_status` 本身，也**不删**「帮助」菜单里手动打开的 Welcome 菜单项与 `mogan-welcome` Scheme 函数。
+
+## 4 How
+- `init_texmacs.cpp`：删除 `load_welcome_doc()` 定义及其唯一调用点。
+- 其余（`install_status`、`mogan-welcome`、菜单项、stem 文档文件）保持不变。

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -593,13 +593,6 @@ init_texmacs () {
   // cout << "Initialize -- font_database_load end\n";
 }
 
-void
-load_welcome_doc () {
-  if (DEBUG_STD) debug_boot << "Loading welcome message...\n";
-  string cmd= "(mogan-welcome)";
-  exec_delayed (scheme_cmd (cmd));
-}
-
 /******************************************************************************
  * Load settings and check version
  ******************************************************************************/
@@ -898,8 +891,6 @@ TeXmacs_main (int argc, char** argv) {
     server sv (app_type::RESEARCH);
     string where     = "";
     bool   first_file= true;
-
-    if (install_status == 1) load_welcome_doc ();
 
     ensure_window ();
 


### PR DESCRIPTION
## 背景

首次启动现已改为新的引导交互流程（登录引导弹窗 `StartupLoginDialog` + 聚光灯教程 `FirstLaunchTutorialController`），不再需要在启动时自动弹出 `stem.zh.tmu` / `stem.en.tmu` 欢迎文档。

## 改动

- `src/System/Boot/init_texmacs.cpp`：删除 `load_welcome_doc()` 函数定义，及 `TeXmacs_main` 中首次启动分支 `if (install_status == 1) load_welcome_doc();`。

## 保留不动

- `install_status`：仍被 `src/Plugins/Qt/qt_tutorial.cpp` 的聚光灯教程使用，不可删。
- `mogan-welcome` Scheme 函数（`help-funcs.scm`）与「帮助」菜单的 Welcome 菜单项（`help-menu.scm`）：用户仍可手动从帮助菜单打开 stem 文档。
- stem 文档文件本身。

## 验证

- `gf fmt --changed-since=main` 通过。
- `xmake b stem` 构建成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)