### PR TITLE
[0653] 为 accent 的结构化变体在焦点工具栏增加选项

### DIFF
--- a/TeXmacs/progs/math/math-edit.scm
+++ b/TeXmacs/progs/math/math-edit.scm
@@ -1432,6 +1432,94 @@
   ) ;let
 ) ;tm-define
 
+(define wide-variant-alist
+  '((tilde "~" "~")
+    (hat "^" "^")
+    (bar "<bar>" "<bar>")
+    (vector "<vect>" "<vect>")
+    (check "<check>" "<check>")
+    (breve "<breve>" "<breve>")
+    (invbreve "<invbreve>" "<invbreve>")
+    (acute "<acute>" "<acute>")
+    (grave "<grave>" "<grave>")
+    (dot "<dot>" "<dot>")
+    (ddot "<ddot>" "<ddot>")
+    (dddot "<dddot>" "<dddot>")
+    (ddddot "<ddddot>" "<ddddot>")
+    (circle "<abovering>" "<abovering>")
+    (overbrace "<wide-overbrace>" "<wide-overbrace*>")
+    (underbrace "<wide-underbrace*>" "<wide-underbrace>")
+    (poverbrace "<wide-poverbrace>" "<wide-poverbrace*>")
+    (punderbrace "<wide-punderbrace*>" "<wide-punderbrace>")
+    (sqoverbrace "<wide-sqoverbrace>" "<wide-sqoverbrace*>")
+    (squnderbrace "<wide-squnderbrace*>" "<wide-squnderbrace>")
+    (rightarrow "<wide-varrightarrow>" "<wide-varrightarrow>")
+    (leftarrow "<wide-varleftarrow>" "<wide-varleftarrow>")
+    (leftrightarrow "<wide-varleftrightarrow>" "<wide-varleftrightarrow>")
+    (wide-bar "<wide-bar>" "<wide-bar>"))
+) ;define
+
+(tm-define (get-accent-variant t)
+  (:require (tree-in? t '(wide wide*)))
+  (when (and (== (tree-arity t) 2) (tree-atomic? (tree-ref t 1)))
+    (with s
+      (tree->string (tree-ref t 1))
+      (let* ((above? (tree-is? t 'wide)) (idx (if above? 1 2)))
+        (let loop
+          ((alist wide-variant-alist))
+          (cond ((null? alist) #f)
+                ((== s (list-ref (car alist) idx)) (caar alist))
+                (else (loop (cdr alist)))
+          ) ;cond
+        ) ;let
+      ) ;let*
+    ) ;with
+  ) ;when
+) ;tm-define
+
+(tm-define (get-accent-variants-list t)
+  (:require (tree-in? t '(wide wide*)))
+  (with v
+    (get-accent-variant t)
+    (cond ((not v) '(tilde))
+          ((in? v '(tilde hat bar vector check breve invbreve))
+           '(tilde hat bar vector check breve invbreve)
+          ) ;
+          ((in? v '(acute grave dot ddot dddot ddddot circle))
+           '(acute grave dot ddot dddot ddddot circle)
+          ) ;
+          ((in? v '(overbrace underbrace
+                     poverbrace
+                     punderbrace
+                     sqoverbrace
+                     squnderbrace))
+           '(overbrace underbrace
+              poverbrace
+              punderbrace
+              sqoverbrace
+              squnderbrace)
+          ) ;
+          ((in? v '(rightarrow leftarrow leftrightarrow wide-bar))
+           '(rightarrow leftarrow leftrightarrow wide-bar)
+          ) ;
+          (else '(tilde))
+    ) ;cond
+  ) ;with
+) ;tm-define
+
+(tm-define (variant-set t v)
+  (:require (tree-in? t '(wide wide*)))
+  (let ((pair (assoc v wide-variant-alist)))
+    (when pair
+      (let* ((above? (tree-is? t 'wide)) (sym (if above? (cadr pair) (caddr pair))))
+        (when (== (tree-arity t) 2)
+          (tree-set t 1 sym)
+        ) ;when
+      ) ;let*
+    ) ;when
+  ) ;let
+) ;tm-define
+
 (tm-define (kbd-paste)
   (:require (in-math?))
   ;; 在数学模式下粘贴

--- a/TeXmacs/progs/math/math-menu.scm
+++ b/TeXmacs/progs/math/math-menu.scm
@@ -1555,9 +1555,75 @@
 ;; Wide accent focus menus
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (focus-tag-name l) (:require (in? l '(wide wide*))) "Wide")
+(tm-define (focus-tag-name l)
+  (:require (in? l
+              '(tilde hat
+                 bar
+                 vector
+                 check
+                 breve
+                 invbreve
+                 acute
+                 grave
+                 dot
+                 ddot
+                 dddot
+                 ddddot
+                 circle
+                 overbrace
+                 underbrace
+                 poverbrace
+                 punderbrace
+                 sqoverbrace
+                 squnderbrace
+                 rightarrow
+                 leftarrow
+                 leftrightarrow
+                 wide-bar)
+            ) ;in?
+  ) ;:require
+  (cond ((== l 'tilde) "Tilda ~")
+        ((== l 'hat) "Hat ^")
+        ((== l 'bar) "Bar ¯")
+        ((== l 'vector) "Vector →")
+        ((== l 'check) "Check ˇ")
+        ((== l 'breve) "Breve ˘")
+        ((== l 'invbreve) "Inverted breve ̑")
+        ((== l 'acute) "Acute ´")
+        ((== l 'grave) "Grave `")
+        ((== l 'dot) "Dot ˙")
+        ((== l 'ddot) "Two dots ¨")
+        ((== l 'dddot) "Three dots ˙˙˙")
+        ((== l 'ddddot) "Four dots ˙˙˙˙")
+        ((== l 'circle) "Circle ˚")
+        ((== l 'overbrace) "Overbrace ⏞")
+        ((== l 'underbrace) "Underbrace ⏟")
+        ((== l 'poverbrace) "Round overbrace")
+        ((== l 'punderbrace) "Round underbrace")
+        ((== l 'sqoverbrace) "Square overbrace")
+        ((== l 'squnderbrace) "Square underbrace")
+        ((== l 'rightarrow) "Right arrow →")
+        ((== l 'leftarrow) "Left arrow ←")
+        ((== l 'leftrightarrow) "Left-right arrow ↔")
+        ((== l 'wide-bar) "Wide bar ￣")
+  ) ;cond
+) ;tm-define
 
-(tm-define (focus-variants-of t) (:require (tree-in? t '(wide wide*))) '(wide))
+(tm-define (focus-tag-name l)
+  (:require (in? l '(wide wide*)))
+  (with t
+    (focus-tree)
+    (if (and t (tree-in? t '(wide wide*)))
+      (with v (get-accent-variant t) (if v (focus-tag-name v) "Wide"))
+      "Wide"
+    ) ;if
+  ) ;with
+) ;tm-define
+
+(tm-define (focus-variants-of t)
+  (:require (tree-in? t '(wide wide*)))
+  (get-accent-variants-list t)
+) ;tm-define
 
 (tm-menu (focus-toggle-menu t)
   (:require (tree-in? t '(wide wide*)))

--- a/TeXmacs/tests/0653.scm
+++ b/TeXmacs/tests/0653.scm
@@ -1,0 +1,46 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0653.scm
+;; DESCRIPTION : Unit tests for accent pseudo-variants and focus tag names
+;; COPYRIGHT   : (C) 2026 Sisyphus
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (tests 653) (:use (math math-menu)))
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(define (test-accent-focus-tag-names)
+  (check (focus-tag-name 'tilde) => "Tilda ~")
+  (check (focus-tag-name 'hat) => "Hat ^")
+  (check (focus-tag-name 'overbrace) => "Overbrace ⏞")
+  (check (focus-tag-name 'rightarrow) => "Right arrow →")
+  (let ((t (tm->tree '(wide "x" "~"))))
+    (check (get-accent-variant t) => 'tilde)
+    (check (get-accent-variants-list t)
+      =>
+      '(tilde hat bar vector check breve invbreve)
+    ) ;check
+    (variant-set t 'hat)
+    (check (tree->string (tree-ref t 1)) => "^")
+    (check (get-accent-variant t) => 'hat)
+  ) ;let
+  (let ((t* (tm->tree '(wide* "x" "~"))))
+    (check (get-accent-variant t*) => 'tilde)
+    (check (get-accent-variants-list t*)
+      =>
+      '(tilde hat bar vector check breve invbreve)
+    ) ;check
+    (variant-set t* 'hat)
+    (check (tree->string (tree-ref t* 1)) => "^")
+    (check (get-accent-variant t*) => 'hat)
+  ) ;let
+) ;define
+
+(tm-define (test_0653) (test-accent-focus-tag-names) (check-report))

--- a/devel/0653.md
+++ b/devel/0653.md
@@ -1,0 +1,46 @@
+# [0653] 为 accent 的结构化变体在焦点工具栏增加选项
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [201_64.md](201_64.md) - 支持 Around 多种括号类型的切换（相似参考）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/math/math-menu.scm`
+- `TeXmacs/tests/0653.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake r 0653
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 进入数学模式，使用快捷键或者插入菜单添加一个 accent（例如输入波浪号 `~` ）。
+2. 观察顶部焦点工具栏：原先显示 `Wide`，现在应该动态显示当前具体的变体名称（例如 `Tilda ~` 或者 `波浪号 ~`）。
+3. 点击当前 accent 选项，下拉菜单应显示同一类别的其他变体（例如 Tilda、Hat、Bar、Vector、Check 等），点击可以切换。
+4. 在中文界面下，下拉菜单和状态指示应正确汉化。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+简要描述任务目标和完成的工作。
+
+1. 实现 `get-accent-variant` 和 `get-accent-variants-list` 辅助函数用于获取当前的 Accent 变体符号和当前的变体分组列表。
+2. 重载 `variant-set` 使得对 `wide`/`wide*` 进行变体设置时能改变当前的 accent 符号。
+3. 实现 `focus-tag-name` 重载，当焦点在 `wide`/`wide*` 时显示具体变体对应的英文/中文说明。
+4. 重载 `focus-variants-of`，使其能够按分组动态列出所有可切换的 Accent 符号，进而自动生成下拉菜单选项。
+
+## 6 Why
+目前 Wide Accent 在顶部工具栏上只显示 `Wide` 且不可点击，用户无法直观看出它是哪种 Accent 或直接利用鼠标点击进行类型切换，给多类型切换造成了操作门槛。引入此特性提升了科学文档编辑的直观度与易用性。
+
+## 7 How
+1. 建立 Accent 与 pseudo-variant（伪变体符号，如 `tilde`、`hat` 等）的关联，并在 `variant-set` 切换时区分 `wide`（上标）与 `wide*`（下标）对应不同的符号字符串。
+2. 在 `focus-tag-name` 中返回带有符号提示的丰富文案（如 `Tilda ~`、`Hat ^` 等）。
+3. 按照键盘循环组（`wide-list-1` 到 `wide-list-5`）对 24 种数学 Accent 进行分类。当焦点在特定 Accent 时，工具栏下拉列表中仅展示同一分类的变体，以提供高内聚且简洁的切换菜单。


### PR DESCRIPTION
# [0653] 为 accent 的结构化变体在焦点工具栏增加选项

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板
- [201_64.md](201_64.md) - 支持 Around 多种括号类型的切换（相似参考）

## 2 任务相关的代码文件
- `TeXmacs/progs/math/math-menu.scm`
- `TeXmacs/tests/0653.scm`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake r 0653
```

### 3.2 非确定性测试（文档验证）
1. 进入数学模式，使用快捷键或者插入菜单添加一个 accent（例如输入波浪号 `~` ）。
2. 观察顶部焦点工具栏：原先显示 `Wide`，现在应该动态显示当前具体的变体名称（例如 `Tilda ~`）。
3. 点击当前 accent 选项，下拉菜单应显示同一类别的其他变体（例如 Tilda、Hat、Bar、Vector、Check 等），点击可以切换。

## 4 如何提交

提交前执行以下最少步骤：

```bash
gf fmt --changed-since=main
```

## 5 What
为数学公式中 Wide Accent 变体提供在焦点工具栏进行切换与名称动态显示的功能。

1. 实现 `get-accent-variant` 和 `get-accent-variants-list` 辅助函数用于获取当前的 Accent 变体符号和当前的变体分组列表。
2. 重载 `variant-set` 使得对 `wide`/`wide*` 进行变体设置时能改变当前的 accent 符号。
3. 实现 `focus-tag-name` 重载，当焦点在 `wide`/`wide*` 时显示具体变体对应的说明。
4. 重载 `focus-variants-of`，使其能够按分组动态列出所有可切换的 Accent 符号，进而自动生成下拉菜单选项。

## 6 Why
目前 Wide Accent 在顶部工具栏上只显示 `Wide` 且不可点击，用户无法直观看出它是哪种 Accent 或直接利用鼠标点击进行类型切换，给多类型切换造成了操作门槛。引入此特性提升了科学文档编辑的直观度与易用性。

## 7 How
1. 建立 Accent 与 pseudo-variant（伪变体符号，如 `tilde`、`hat` 等）的关联，并在 `variant-set` 切换时区分 `wide`（上标）与 `wide*`（下标）对应不同的符号字符串。
2. 在 `focus-tag-name` 中返回带有符号提示的丰富文案（如 `Tilda ~`、`Hat ^` 等）。
3. 按照键盘循环组（`wide-list-1` 到 `wide-list-5`）对 24 种数学 Accent 进行分类。当焦点在特定 Accent 时，工具栏下拉列表中仅展示同一分类的变体，以提供高内聚且简洁的切换菜单。