### PR TITLE
[0808] Julia 会话支持科学绘图

### DIFF
--- a/.github/workflows/ci-julia.yml
+++ b/.github/workflows/ci-julia.yml
@@ -41,7 +41,7 @@ jobs:
           PYTHON: /usr/bin/python3
         run: |
           python3 -c "import sympy; print('sympy', sympy.__version__)"
-          julia -e 'using Pkg; Pkg.add(["Symbolics", "Latexify", "LaTeXStrings", "SymPy"])'
+          julia -e 'using Pkg; Pkg.add(["Symbolics", "Latexify", "LaTeXStrings", "SymPy", "Plots"])'
 
       - name: Run Julia unit tests
         run: |

--- a/TeXmacs/plugins/julia/bin/julia.jl
+++ b/TeXmacs/plugins/julia/bin/julia.jl
@@ -11,6 +11,9 @@
 
 module MoganJulia
 
+# Disable GUI popups for GR backend (Plots.jl)
+ENV["GKSwstype"] = "100"
+
 # Imports
 using REPL
 using Markdown

--- a/TeXmacs/plugins/julia/bin/tmjl/capture.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/capture.jl
@@ -57,7 +57,13 @@ Base.flush(io::TMJuliaStdio) = begin
     if get(io.io, :mogan_stream, "error") == "stdout"
         tm_out(buf * "\n")
     elseif get(io.io, :mogan_stream, "error") == "stderr"
-        tm_err(VERBATIM, buf)
+        # Filter out GKS font warnings to avoid plugin marking session in red
+        lines = split(buf, '\n')
+        filtered_lines = filter(line -> !occursin("GKS: glyph missing from current font", line), lines)
+        filtered_buf = join(filtered_lines, '\n')
+        if filtered_buf != ""
+            tm_err(VERBATIM, filtered_buf)
+        end
     end
 end
 

--- a/TeXmacs/plugins/julia/bin/tmjl/display.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/display.jl
@@ -134,13 +134,13 @@ is_plots_type(t::Type) = begin
     # Fallback to name-based heuristics
     # s = string(t)
     # (occursin("Plots.Plot", s) || s == "Plot") && return true
-    try
-        m = parentmodule(t)
-        m_name = string(Symbol(m))
-        return occursin("Plots", m_name)
-    catch
-        return false
-    end
+    # try
+    #     m = parentmodule(t)
+    #     m_name = string(Symbol(m))
+    #     return occursin("Plots", m_name)
+    # catch
+    #     return false
+    # end
 end
 
 is_plots_object(x) = is_plots_type(typeof(x))

--- a/TeXmacs/plugins/julia/bin/tmjl/display.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/display.jl
@@ -122,7 +122,41 @@ is_symbolic_object(x::Tuple) = any(is_symbolic_object, x)
 is_symbolic_object(x::Set) = any(is_symbolic_object, x)
 is_symbolic_object(x::Dict) = any(is_symbolic_object, keys(x)) || any(is_symbolic_object, values(x))
 
+is_plots_type(t::Type) = begin
+    t isa Union && return false
+    s = string(t)
+    (occursin("Plots.Plot", s) || s == "Plot") && return true
+    try
+        m = parentmodule(t)
+        m_name = string(Symbol(m))
+        return occursin("Plots", m_name)
+    catch
+        return false
+    end
+end
+
+is_plots_object(x) = is_plots_type(typeof(x))
+
 function display(d::InlineDisplay, x)
+    if is_plots_object(x)
+        try
+            tmp_path = tempname() * ".pdf"
+            t = typeof(x)
+            m = parentmodule(t)
+            if isdefined(m, :savefig)
+                m.savefig(x, tmp_path)
+                tm_out("file:", tmp_path)
+                return
+            elseif isdefined(Main, :Plots) && isdefined(Main.Plots, :savefig)
+                Main.Plots.savefig(x, tmp_path)
+                tm_out("file:", tmp_path)
+                return
+            end
+        catch e
+            tm_out("Error rendering Plots: $(e)\n")
+        end
+    end
+
     if is_symbolic_object(x)
         if showable(MIME("text/latex"), x)
             display(d, MIME("text/latex"), x)

--- a/TeXmacs/plugins/julia/bin/tmjl/display.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/display.jl
@@ -124,8 +124,16 @@ is_symbolic_object(x::Dict) = any(is_symbolic_object, keys(x)) || any(is_symboli
 
 is_plots_type(t::Type) = begin
     t isa Union && return false
-    s = string(t)
-    (occursin("Plots.Plot", s) || s == "Plot") && return true
+    # Prefer a precise type check when Plots.jl is loaded in Main
+    if isdefined(Main, :Plots)
+        try
+            return t <: Main.Plots.Plot
+        catch
+        end
+    end
+    # Fallback to name-based heuristics
+    # s = string(t)
+    # (occursin("Plots.Plot", s) || s == "Plot") && return true
     try
         m = parentmodule(t)
         m_name = string(Symbol(m))
@@ -154,6 +162,7 @@ function display(d::InlineDisplay, x)
             end
         catch e
             tm_out("Error rendering Plots: $(e)\n")
+            return
         end
     end
 

--- a/TeXmacs/plugins/julia/bin/tmjl/display.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/display.jl
@@ -131,16 +131,19 @@ is_plots_type(t::Type) = begin
         catch
         end
     end
-    # Fallback to name-based heuristics
-    # s = string(t)
-    # (occursin("Plots.Plot", s) || s == "Plot") && return true
-    # try
-    #     m = parentmodule(t)
-    #     m_name = string(Symbol(m))
-    #     return occursin("Plots", m_name)
-    # catch
-    #     return false
-    # end
+    # Fallback: accept Plot objects whose immediate parent module is literally
+    # named "Plots" and defines a Plot supertype. This covers packages that
+    # internally use Plots.jl (e.g. StatsPlots) or objects created in nested
+    # modules, while avoiding false positives from modules like MockPlots
+    # whose names merely contain "Plots".
+    try
+        m = parentmodule(t)
+        if nameof(m) === :Plots && isdefined(m, :Plot)
+            return t <: m.Plot
+        end
+    catch
+    end
+    return false
 end
 
 is_plots_object(x) = is_plots_type(typeof(x))

--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -27,7 +27,9 @@
 (define (julia-launcher)
   (let* ((boot (string-quote (julia-entry)))
          (cmd  (url->system (find-binary-julia))))
-    (string-append cmd " " boot)))
+    (if (or (os-win32?) (os-mingw?))
+        (string-append cmd " " boot)
+        (string-append "env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH " cmd " " boot))))
 
 (plugin-configure julia
   (:require (has-binary-julia?))

--- a/TeXmacs/plugins/julia/tests/runtests.jl
+++ b/TeXmacs/plugins/julia/tests/runtests.jl
@@ -151,7 +151,9 @@ end
     @testset "5. Plots Objects Recognition (is_plots_object)" begin
         @test !is_plots_object(1)
         @test !is_plots_object("plot")
-        @test is_plots_object(MockPlots.Plot())
+        # MockPlots.Plot is not from a module named Plots, so it must not be recognized
+        @test !is_plots_object(MockPlots.Plot())
+        # Positive case (real Plots.jl object) is covered by testset 17 when Plots is installed
     end
 
     @testset "6. Auto-completion Parsing (do_tab_complete)" begin

--- a/TeXmacs/plugins/julia/tests/runtests.jl
+++ b/TeXmacs/plugins/julia/tests/runtests.jl
@@ -11,10 +11,14 @@
 using Test
 using REPL
 
+# Disable GUI popups and sockets for GR backend (Plots.jl) during tests
+ENV["GKSwstype"] = "100"
+
 # Mock modules/types representing SymPy, Symbolics, SymbolicUtils for test detection
 module MockSymPy struct Sym end end
 module MockSymbolics struct Num end end
 module MockSymbolicUtils struct Basic end end
+module MockPlots struct Plot end end
 
 # Mock global variables and refs expected by included files
 const current_module = Ref{Module}(Main)
@@ -144,7 +148,13 @@ end
         @test is_symbolic_object(Dict("key" => MockSymbolics.Num()))       # Dict values
     end
 
-    @testset "5. Auto-completion Parsing (do_tab_complete)" begin
+    @testset "5. Plots Objects Recognition (is_plots_object)" begin
+        @test !is_plots_object(1)
+        @test !is_plots_object("plot")
+        @test is_plots_object(MockPlots.Plot())
+    end
+
+    @testset "6. Auto-completion Parsing (do_tab_complete)" begin
         buf_out = IOBuffer()
         orig_stdout[] = buf_out
 
@@ -164,7 +174,7 @@ end
         orig_stdout[] = stdout
     end
 
-    @testset "6. Stream Redirection (TMJuliaStdio)" begin
+    @testset "7. Stream Redirection (TMJuliaStdio)" begin
         old_stdout = stdout
         old_stderr = stderr
         buf_out = IOBuffer()
@@ -201,7 +211,7 @@ end
         orig_stderr[] = old_stderr
     end
 
-    @testset "7. TMJuliaStdio Properties" begin
+    @testset "8. TMJuliaStdio Properties" begin
         old_stdout = stdout
         rd, wr = redirect_stdout()
         try
@@ -213,7 +223,7 @@ end
         end
     end
 
-    @testset "8. Code Evaluation Core Logic" begin
+    @testset "9. Code Evaluation Core Logic" begin
         # These are the exact primitives used inside the main REPL loop
         @test include_string(Main, "1 + 2", "In[1]") == 3
         @test REPL.ends_with_semicolon("1 + 2;")
@@ -230,13 +240,13 @@ end
         @test replace("?sin", r"^\s*\?" => "") == "sin"
     end
 
-    @testset "9. Help Mode Integration" begin
+    @testset "10. Help Mode Integration" begin
         buf_help = IOBuffer()
         help_obj = Core.eval(Main, REPL.helpmode(buf_help, "sqrt"))
         @test help_obj isa Markdown.MD
     end
 
-    @testset "10. Additional MIME Displays" begin
+    @testset "11. Additional MIME Displays" begin
         buf_out = IOBuffer()
         orig_stdout[] = buf_out
 
@@ -263,7 +273,7 @@ end
         orig_stdout[] = stdout
     end
 
-    @testset "11. LaTeX Display Edge Cases" begin
+    @testset "12. LaTeX Display Edge Cases" begin
         buf_out = IOBuffer()
         orig_stdout[] = buf_out
 
@@ -282,7 +292,7 @@ end
         orig_stdout[] = stdout
     end
 
-    @testset "12. PDF Output Dispatch" begin
+    @testset "13. PDF Output Dispatch" begin
         buf_out = IOBuffer()
         orig_stdout[] = buf_out
         pdf_out(42)
@@ -290,7 +300,7 @@ end
         orig_stdout[] = stdout
     end
 
-    @testset "13. Completion Edge Cases" begin
+    @testset "14. Completion Edge Cases" begin
         buf_out = IOBuffer()
         orig_stdout[] = buf_out
 
@@ -313,7 +323,7 @@ end
         orig_stdout[] = stdout
     end
 
-    @testset "14. Symbolic Object Detection in Containers" begin
+    @testset "15. Symbolic Object Detection in Containers" begin
         @test is_symbolic_object([[MockSymbolics.Num()]])
         @test is_symbolic_object((a=MockSymPy.Sym(), b=1))
         @test is_symbolic_object(Dict(:x => [MockSymbolics.Num(), 1]))
@@ -324,7 +334,7 @@ end
         @test !is_symbolic_object(TestSymbolicLike.MyNum())
     end
 
-    @testset "15. Scientific Computing Workflows" begin
+    @testset "16. Scientific Computing Workflows" begin
         using LinearAlgebra
         A = [1.0 2.0; 3.0 4.0]
         @test det(A) ≈ -2.0
@@ -345,7 +355,7 @@ end
         @test !is_symbolic_object(π)
     end
 
-    @testset "16. Optional Symbolic Packages Integration" begin
+    @testset "17. Optional Symbolic Packages Integration" begin
         function pkg_available(pkg::String)
             try
                 @eval using $(Symbol(pkg))
@@ -402,16 +412,32 @@ end
         else
             @test_skip "Latexify.jl not installed"
         end
+
+        if pkg_available("Plots")
+            plt = @eval begin
+                using Plots
+                plot(1:10, rand(10))
+            end
+            @test is_plots_object(plt)
+            buf_out = IOBuffer()
+            orig_stdout[] = buf_out
+            display(InlineDisplay(), plt)
+            plt_out = String(take!(buf_out))
+            @test occursin("file:", plt_out)
+            orig_stdout[] = stdout
+        else
+            @test_skip "Plots.jl not installed"
+        end
     end
 
-    @testset "17. Protocol Escaping Edge Cases" begin
+    @testset "18. Protocol Escaping Edge Cases" begin
         @test mogan_escape("α + β = γ") == "α + β = γ"
         @test mogan_escape(string(DATA_ESCAPE, DATA_BEGIN, DATA_END)) ==
               string(DATA_ESCAPE, DATA_ESCAPE, DATA_ESCAPE, DATA_BEGIN, DATA_ESCAPE, DATA_END)
         @test mogan_escape("<EOF>") == "<EOF>"
     end
 
-    @testset "18. flush_all Utility" begin
+    @testset "19. flush_all Utility" begin
         @test_nowarn flush_all()
     end
 

--- a/TeXmacs/tests/0808.scm
+++ b/TeXmacs/tests/0808.scm
@@ -1,0 +1,173 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0806.scm
+;; DESCRIPTION : Tests for Julia Plots integration and PDF rendering
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (scheme base)
+        (scheme file)
+        (liii check)
+        (liii os)
+        (liii string))
+
+(load (string-append (getenv "TEXMACS_PATH") "/plugins/julia/progs/init-julia.scm"))
+
+(check-set-mode! 'report-failed)
+
+;; Helper function to read a physical file into a string
+(define (read-physical-file filepath)
+  (let ((port (open-input-file filepath)))
+    (let loop ((chars '()) (c (read-char port)))
+      (if (eof-object? c)
+          (begin
+            (close-input-port port)
+            (list->string (reverse chars)))
+          (loop (cons c chars) (read-char port))))))
+
+;; Helper to check if a physical file exists
+(define (physical-file-exists? filepath)
+  (catch #t
+    (lambda ()
+      (let ((port (open-input-file filepath)))
+        (close-input-port port)
+        #t))
+    (lambda args #f)))
+
+;; Helper to remove a physical file
+(define (physical-remove filepath)
+  (catch #t
+    (lambda ()
+      (remove filepath)
+      #t)
+    (lambda args #f)))
+
+;; Helper to resolve platform-specific absolute system path
+(define (get-system-path relative-path)
+  (url->system (system->url (string-append (getenv "TEXMACS_PATH") relative-path))))
+
+;; Helper to execute commands cross-platform using the correct system shell
+(define (run-shell-command cmd)
+  (if (os-windows?)
+      (os-call cmd)
+      (os-call (string-append "/bin/sh -c '" cmd "'"))))
+
+;; Helper to write lines physically using Scheme IO
+(define (write-physical-input filepath lines first?)
+  (if first?
+      (when (physical-file-exists? filepath) (physical-remove filepath)))
+  (let ((port (open-output-file filepath)))
+    (let loop ((rest lines))
+      (unless (null? rest)
+        (display (car rest) port)
+        (newline port)
+        (loop (cdr rest))))
+    (close-output-port port)))
+
+(define (string-contains-from str sub start)
+  (let ((len-str (string-length str))
+        (len-sub (string-length sub)))
+    (let loop ((i start))
+      (cond ((> (+ i len-sub) len-str) #f)
+            ((string=? (substring str i (+ i len-sub)) sub) i)
+            (else (loop (+ i 1)))))))
+
+(define (count-occurrences str sub)
+  (let ((len-sub (string-length sub)))
+    (let loop ((count 0) (start 0))
+      (let ((pos (string-contains-from str sub start)))
+        (if pos
+            (loop (+ count 1) (+ pos len-sub))
+            count)))))
+
+(define (extract-file-paths str)
+  (let ((len-str (string-length str)))
+    (let loop ((paths '()) (i 0))
+      (let ((pos (string-contains-from str "file:" i)))
+        (if pos
+            (let* ((start (+ pos 5))
+                   (end-pos (let find-end ((j start))
+                              (if (or (>= j len-str)
+                                      (char=? (string-ref str j) (integer->char 5))
+                                      (char=? (string-ref str j) #\newline))
+                                  j
+                                  (find-end (+ j 1))))))
+              (loop (cons (substring str start end-pos) paths) end-pos))
+            (reverse paths))))))
+
+;; Check if Plots Julia package is available
+(define (julia-plots-available?)
+  (and (supports-julia?)
+       (let* ((julia-path (url->system (find-binary-julia)))
+              (julia-bin (if (os-windows?) julia-path (string-append "env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH " julia-path))))
+         (== (run-shell-command (string-append julia-bin " --startup-file=no -e \"using Plots\"")) 0))))
+
+;; Session execution Plots tests
+(define (test-julia-plots)
+  (if (julia-plots-available?)
+      (let* ((temp-dir (os-temp-dir))
+             (input-path (url->system (system->url (string-append temp-dir "/0806_input.txt"))))
+             (output-path (url->system (system->url (string-append temp-dir "/0806_output.txt"))))
+             (julia-script (get-system-path "/plugins/julia/bin/julia.jl"))
+             (input-lines (list "using Plots"
+                                "<EOF>"
+                                "plot(1:10, rand(10))"
+                                "<EOF>"
+                                "f(x) = x^2 + x * sin(x)"
+                                "<EOF>"
+                                "plot(f, -5, 5, label=\"f(x) = x^2 + x*sin(x)\", title=\"test_img\", lw=2)"
+                                "<EOF>"
+                                "x = range(-pi, pi, length=100)"
+                                "<EOF>"
+                                "y = sin.(x)"
+                                "<EOF>"
+                                "plot(x, y, label=\"sin(x)\", xlabel=\"x_axis\", ylabel=\"y_axis\", color=:green)"
+                                "<EOF>")))
+        
+        ;; Clean up old files if they exist
+        (when (physical-file-exists? input-path) (physical-remove input-path))
+        (when (physical-file-exists? output-path) (physical-remove output-path))
+
+        ;; Write input commands physically
+        (write-physical-input input-path input-lines #t)
+
+        ;; Execute the julia session via cross-platform shell command
+        (let* ((julia-path (url->system (find-binary-julia)))
+               (julia-bin (if (os-windows?) julia-path (string-append "env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH " julia-path)))
+               (cmd (string-append julia-bin " --startup-file=no " julia-script " < " input-path " > " output-path " 2>&1")))
+          (run-shell-command cmd))
+
+        ;; Read the output file physically
+        (let* ((output (read-physical-file output-path))
+               (paths (extract-file-paths output)))
+          ;; Assertions: should output using "file:" protocol exactly 3 times with pdf paths
+          (check (count-occurrences output "file:") => 3)
+          (check (count-occurrences output ".pdf") => 3)
+          (check (length paths) => 3)
+          (check (and (physical-file-exists? (car paths))
+                      (physical-file-exists? (cadr paths))
+                      (physical-file-exists? (caddr paths))) => #t)
+          ;; Clean up generated PDF files
+          (when (physical-file-exists? (car paths)) (physical-remove (car paths)))
+          (when (physical-file-exists? (cadr paths)) (physical-remove (cadr paths)))
+          (when (physical-file-exists? (caddr paths)) (physical-remove (caddr paths)))
+        ) ;let
+
+        ;; Clean up
+        (physical-remove input-path)
+        (physical-remove output-path)
+      ) ;let
+      (display "Skipping physical Julia Plots tests because Julia or Plots is not supported.\n")
+  ) ;if
+) ;define
+
+;;; ========== 测试入口 ==========
+
+(tm-define (test_0806)
+  (test-julia-plots)
+  (check-report))

--- a/TeXmacs/tests/0808.scm
+++ b/TeXmacs/tests/0808.scm
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; MODULE      : 0806.scm
+;; MODULE      : 0808.scm
 ;; DESCRIPTION : Tests for Julia Plots integration and PDF rendering
 ;; COPYRIGHT   : (C) 2026 Mogan STEM
 ;;
@@ -168,6 +168,6 @@
 
 ;;; ========== 测试入口 ==========
 
-(tm-define (test_0806)
+(tm-define (test_0808)
   (test-julia-plots)
   (check-report))

--- a/TeXmacs/tests/0808.scm
+++ b/TeXmacs/tests/0808.scm
@@ -111,8 +111,8 @@
 (define (test-julia-plots)
   (if (julia-plots-available?)
       (let* ((temp-dir (os-temp-dir))
-             (input-path (url->system (system->url (string-append temp-dir "/0806_input.txt"))))
-             (output-path (url->system (system->url (string-append temp-dir "/0806_output.txt"))))
+             (input-path (url->system (system->url (string-append temp-dir "/0808_input.txt"))))
+             (output-path (url->system (system->url (string-append temp-dir "/0808_output.txt"))))
              (julia-script (get-system-path "/plugins/julia/bin/julia.jl"))
              (input-lines (list "using Plots"
                                 "<EOF>"
@@ -128,7 +128,7 @@
                                 "<EOF>"
                                 "plot(x, y, label=\"sin(x)\", xlabel=\"x_axis\", ylabel=\"y_axis\", color=:green)"
                                 "<EOF>")))
-        
+
         ;; Clean up old files if they exist
         (when (physical-file-exists? input-path) (physical-remove input-path))
         (when (physical-file-exists? output-path) (physical-remove output-path))

--- a/devel/0808.md
+++ b/devel/0808.md
@@ -7,6 +7,7 @@
 - `.github/workflows/ci-julia.yml` - 在 CI 中为 Julia 测试环境添加 `Plots` 依赖
 - `TeXmacs/plugins/julia/bin/julia.jl` - 设置 `GKSwstype` 环境变量禁用 GR GUI 弹窗
 - `TeXmacs/plugins/julia/bin/tmjl/display.jl` - 检测 `Plots` 对象、保存 PDF 图像并通过 `file:` 协议传回前端
+- `TeXmacs/plugins/julia/bin/tmjl/capture.jl` - 在标准错误拦截中自动过滤 GKS 缺失字符警告，防止插件标红
 - `TeXmacs/plugins/julia/progs/init-julia.scm` - Unix 启动器使用 `env -u` 隔离 `LD_LIBRARY_PATH` 等环境变量，规避 Qt 库版本冲突
 - `TeXmacs/plugins/julia/tests/runtests.jl` - 单元测试环境隔离并补全 `Plots` 检测与展示单元测试
 - `TeXmacs/tests/0808.scm` - 多场景分步绘图 E2E 集成测试
@@ -42,4 +43,4 @@ julia TeXmacs/plugins/julia/tests/runtests.jl
 1. 在 `julia.jl` 模块及测试环境 `runtests.jl` 中设置 `ENV["GKSwstype"] = "100"`，强制 GR 后端运行在 headless 模式
 2. 在 `display.jl` 中定义并捕获 `is_plots_object(x)`（通过包名及类型反射识别 `Plots.Plot`）。在 `InlineDisplay` 派发中通过 `Plots.savefig` 将图形保存为临时 PDF 文件，并输出 `file:<tmp_path>` 触发 Mogan 视图渲染
 3. 在 `init-julia.scm` 中，如果是非 Windows 平台，启动 Julia 前 prepend `env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH` 切断 Mogan 自带 Qt 动态库的路径污染，使 Julia GR 后端正常加载其独立的库
-4. 将 `0808.scm` 集成测试补充至 3 组涵盖函数、区间多步会话绘图的综合场景，并在 Scheme 侧进行严格的字符串统计、物理文件存在性检测以及生成文件的自动清理s
+4. 将 `0808.scm` 集成测试补充至 3 组涵盖函数、区间多步会话绘图的综合场景，并在 Scheme 侧进行严格的字符串统计、物理文件存在性检测以及生成文件的自动清理

--- a/devel/0808.md
+++ b/devel/0808.md
@@ -1,0 +1,45 @@
+# [0808] Julia 会话支持科学绘图
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `.github/workflows/ci-julia.yml` - 在 CI 中为 Julia 测试环境添加 `Plots` 依赖
+- `TeXmacs/plugins/julia/bin/julia.jl` - 设置 `GKSwstype` 环境变量禁用 GR GUI 弹窗
+- `TeXmacs/plugins/julia/bin/tmjl/display.jl` - 检测 `Plots` 对象、保存 PDF 图像并通过 `file:` 协议传回前端
+- `TeXmacs/plugins/julia/progs/init-julia.scm` - Unix 启动器使用 `env -u` 隔离 `LD_LIBRARY_PATH` 等环境变量，规避 Qt 库版本冲突
+- `TeXmacs/plugins/julia/tests/runtests.jl` - 单元测试环境隔离并补全 `Plots` 检测与展示单元测试
+- `TeXmacs/tests/0808.scm` - 多场景分步绘图 E2E 集成测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（集成/单元测试）
+在本地 Julia 中安装 "Plots" 包（`using Pkg; Pkg.add("Plots")`）
+
+1. E2E 集成测试：
+```bash
+xmake r 0808
+```
+
+2. Julia 单元测试：
+```bash
+julia TeXmacs/plugins/julia/tests/runtests.jl
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 点击 `插入`->`会话`，打开 Julia 会话
+2. 输入 `using Plots`，回车，应该无输出
+3. 输入 `plot(1:10, rand(10))`，回车，应该画出一张随机震荡的函数图
+4. 输入 `f(x) = x^2 + x * sin(x); plot(f, -5, 5, label="f(x) = x^2 + x*sin(x)", title="test_img", lw=2)`，回车，应该画出一张蓝色 $f(x)$ 函数图
+5. 输入 `x = range(-pi, pi, length=100); y = sin.(x); plot(x, y, label="sin(x)", xlabel="x_axis", ylabel="y_axis", color=:green)`，回车，应该画出一张绿色 $sin(x)$ 函数图
+
+## 4 What
+为 Julia 插件增加了对 `Plots` 绘图库的支持
+
+实现在会话中输入绘图命令时，不弹出外部 GUI 窗口，而是将图像静默保存为 PDF 直接嵌入渲染在 Mogan 会话的交互区域
+
+## 5 How
+1. 在 `julia.jl` 模块及测试环境 `runtests.jl` 中设置 `ENV["GKSwstype"] = "100"`，强制 GR 后端运行在 headless 模式
+2. 在 `display.jl` 中定义并捕获 `is_plots_object(x)`（通过包名及类型反射识别 `Plots.Plot`）。在 `InlineDisplay` 派发中通过 `Plots.savefig` 将图形保存为临时 PDF 文件，并输出 `file:<tmp_path>` 触发 Mogan 视图渲染
+3. 在 `init-julia.scm` 中，如果是非 Windows 平台，启动 Julia 前 prepend `env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH` 切断 Mogan 自带 Qt 动态库的路径污染，使 Julia GR 后端正常加载其独立的库
+4. 将 `0808.scm` 集成测试补充至 3 组涵盖函数、区间多步会话绘图的综合场景，并在 Scheme 侧进行严格的字符串统计、物理文件存在性检测以及生成文件的自动清理s


### PR DESCRIPTION
# [0808] Julia 会话支持科学绘图

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `.github/workflows/ci-julia.yml` - 在 CI 中为 Julia 测试环境添加 `Plots` 依赖
- `TeXmacs/plugins/julia/bin/julia.jl` - 设置 `GKSwstype` 环境变量禁用 GR GUI 弹窗
- `TeXmacs/plugins/julia/bin/tmjl/display.jl` - 检测 `Plots` 对象、保存 PDF 图像并通过 `file:` 协议传回前端
- `TeXmacs/plugins/julia/progs/init-julia.scm` - Unix 启动器使用 `env -u` 隔离 `LD_LIBRARY_PATH` 等环境变量，规避 Qt 库版本冲突
- `TeXmacs/plugins/julia/tests/runtests.jl` - 单元测试环境隔离并补全 `Plots` 检测与展示单元测试
- `TeXmacs/tests/0808.scm` - 多场景分步绘图 E2E 集成测试

## 3 如何测试

### 3.1 确定性测试（集成/单元测试）
在本地 Julia 中安装 "Plots" 包（`using Pkg; Pkg.add("Plots")`）

1. E2E 集成测试：
```bash
xmake r 0808
```

2. Julia 单元测试：
```bash
julia TeXmacs/plugins/julia/tests/runtests.jl
```

### 3.2 非确定性测试（文档验证）
1. 点击 `插入`->`会话`，打开 Julia 会话
2. 输入 `using Plots`，回车，应该无输出
3. 输入 `plot(1:10, rand(10))`，回车，应该画出一张随机震荡的函数图
4. 输入 `f(x) = x^2 + x * sin(x); plot(f, -5, 5, label="f(x) = x^2 + x*sin(x)", title="test_img", lw=2)`，回车，应该画出一张蓝色 $f(x)$ 函数图
5. 输入 `x = range(-pi, pi, length=100); y = sin.(x); plot(x, y, label="sin(x)", xlabel="x_axis", ylabel="y_axis", color=:green)`，回车，应该画出一张绿色 $sin(x)$ 函数图

## 4 What
为 Julia 插件增加了对 `Plots` 绘图库的支持

实现在会话中输入绘图命令时，不弹出外部 GUI 窗口，而是将图像静默保存为 PDF 直接嵌入渲染在 Mogan 会话的交互区域

## 5 How
1. 在 `julia.jl` 模块及测试环境 `runtests.jl` 中设置 `ENV["GKSwstype"] = "100"`，强制 GR 后端运行在 headless 模式
2. 在 `display.jl` 中定义并捕获 `is_plots_object(x)`（通过包名及类型反射识别 `Plots.Plot`）。在 `InlineDisplay` 派发中通过 `Plots.savefig` 将图形保存为临时 PDF 文件，并输出 `file:<tmp_path>` 触发 Mogan 视图渲染
3. 在 `init-julia.scm` 中，如果是非 Windows 平台，启动 Julia 前 prepend `env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH` 切断 Mogan 自带 Qt 动态库的路径污染，使 Julia GR 后端正常加载其独立的库
4. 将 `0808.scm` 集成测试补充至 3 组涵盖函数、区间多步会话绘图的综合场景，并在 Scheme 侧进行严格的字符串统计、物理文件存在性检测以及生成文件的自动清理s
