### PR TITLE
[0810] 修复图片缩放突变问题

### DIFF
--- a/TeXmacs/progs/generic/format-geometry-edit.scm
+++ b/TeXmacs/progs/generic/format-geometry-edit.scm
@@ -780,14 +780,12 @@
            (sy (tmpt->cm dy))
            (nw (- ow sx))
            (nh (- oh sy))
-           (uniform-scale (lambda (scale-x scale-y)
-                            (let* ((scale (if (or (> scale-x 1) (> scale-y 1))
-                                            (max scale-x scale-y)
-                                            (min scale-x scale-y)
-                                          ) ;if
-                                   ) ;scale
-                                  ) ;
-                              (let* ((nw (* ow scale)) (nh (* oh scale)))
+            (uniform-scale (lambda (scale-x scale-y)
+                             (let* ((ow2 (* ow ow))
+                                    (oh2 (* oh oh))
+                                    (scale (/ (+ (* scale-x ow2) (* scale-y oh2)) (+ ow2 oh2)))
+                                   ) ;
+                               (let* ((nw (* ow scale)) (nh (* oh scale)))
                                 (when (> nw 0.1)
                                   (tree-set! t 1 (cm->str nw))
                                 ) ;when

--- a/TeXmacs/progs/generic/format-geometry-edit.scm
+++ b/TeXmacs/progs/generic/format-geometry-edit.scm
@@ -780,12 +780,12 @@
            (sy (tmpt->cm dy))
            (nw (- ow sx))
            (nh (- oh sy))
-            (uniform-scale (lambda (scale-x scale-y)
-                             (let* ((ow2 (* ow ow))
-                                    (oh2 (* oh oh))
-                                    (scale (/ (+ (* scale-x ow2) (* scale-y oh2)) (+ ow2 oh2)))
-                                   ) ;
-                               (let* ((nw (* ow scale)) (nh (* oh scale)))
+           (uniform-scale (lambda (scale-x scale-y)
+                            (let* ((ow2 (* ow ow))
+                                   (oh2 (* oh oh))
+                                   (scale (/ (+ (* scale-x ow2) (* scale-y oh2)) (+ ow2 oh2)))
+                                  ) ;
+                              (let* ((nw (* ow scale)) (nh (* oh scale)))
                                 (when (> nw 0.1)
                                   (tree-set! t 1 (cm->str nw))
                                 ) ;when

--- a/devel/0810.md
+++ b/devel/0810.md
@@ -1,0 +1,53 @@
+# [0810] 修复图片缩放突变问题
+
+## 1 相关文档
+- [201_59.md](201_59.md) - 图片支持鼠标缩放
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/format-geometry-edit.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 插入一张图片（ `图片` 按钮下的 `链接图片` 或 `插入图片` 皆可），选中图片（鼠标点击）后，拖动几个操控点
+2. 在反复拖动操纵点的过程中，观察图片缩放是否出现突变现象（即图片大小突然变大或变小），预计此bug会消失
+
+## 4 What
+修复了当鼠标拖动图片 handles 进行缩放时，在某处图片会突然放大或缩小的 bug
+
+## 5 Why
+在原等比例缩放算法中，计算合并缩放比 $s$ 采用了存在突变的非线性分支决策：
+$$
+s = \begin{cases} 
+\max(s_x, s_y) & \text{if } (s_x > 1) \lor (s_y > 1) \\
+\min(s_x, s_y) & \text{if } (s_x \le 1) \land (s_y \le 1)
+\end{cases}
+$$
+在拖动跨越 $1.0$ 临界线时，由于鼠标移动无法精确匹配原图比例，导致 $s_x$ 和 $s_y$ 不同步跨越 $1.0$。在临界判断切换时，缩放比 $s$ 会在 $\max$ 和 $\min$ 之间发生突变，大小为 $|s_x - s_y|$，导致此处缩放出现卡顿感
+
+## 6 How
+设图片的基准对角线向量为 $\vec{d} = \left[\begin{array}{c} W\\ H \end{array}\right]$，鼠标当前拉伸到的绝对目标向量为 $\vec{m} = \left[\begin{array}{c} W+sx\\ H+sy \end{array}\right]$。
+通过计算 $\vec{m}$ 在对角线向量 $\vec{d}$ 上的正交投影，直接得到统一缩放比 $s_{\text{proj}}$：
+$$
+s_{\text{proj}} = \frac{m^{\top} d}{d^{\top} d} = \frac{(W + sx)W + (H + sy)H}{W^2 + H^2}
+$$
+结合轴向缩放比例定义 $s_x = \frac{W+sx}{W}$， $s_y = \frac{H+sy}{H}$，代入化简即可得到光滑连续的加权平均公式：
+$$
+s = s_{\text{proj}} = s_x \cdot \frac{W^2}{W^2 + H^2} + s_y \cdot \frac{H^2}{W^2 + H^2}
+$$
+通过将宽高缩放进行线性组合得到合并缩放 $s$，在 $\mathbb{R}^2$ 上连续，从而消除了缩放时的突变
+
+在 `format-geometry-edit.scm` 中，将 `uniform-scale` 原先基于 `if`/`min`/`max` 的计算替换为对角线投影的加权平均值，避免任何分支逻辑：
+```scheme
+(uniform-scale (lambda (scale-x scale-y)
+                 (let* ((ow2 (* ow ow))
+                        (oh2 (* oh oh))
+                        (scale (/ (+ (* scale-x ow2) (* scale-y oh2)) (+ ow2 oh2))))
+                   ...)))
+```


### PR DESCRIPTION
# [0810] 修复图片缩放突变问题

## 1 相关文档
- [201_59.md](201_59.md) - 图片支持鼠标缩放

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/format-geometry-edit.scm`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（文档验证）
1. 插入一张图片（ `图片` 按钮下的 `链接图片` 或 `插入图片` 皆可），选中图片（鼠标点击）后，拖动几个操控点
2. 在反复拖动操纵点的过程中，观察图片缩放是否出现突变现象（即图片大小突然变大或变小），预计此bug会消失

## 4 What
修复了当鼠标拖动图片 handles 进行缩放时，在某处图片会突然放大或缩小的 bug

## 5 Why
在原等比例缩放算法中，计算合并缩放比 $s$ 采用了存在突变的非线性分支决策：
$$
s = \begin{cases} 
\max(s_x, s_y) & \text{if } (s_x > 1) \lor (s_y > 1) \\
\min(s_x, s_y) & \text{if } (s_x \le 1) \land (s_y \le 1)
\end{cases}
$$
在拖动跨越 $1.0$ 临界线时，由于鼠标移动无法精确匹配原图比例，导致 $s_x$ 和 $s_y$ 不同步跨越 $1.0$。在临界判断切换时，缩放比 $s$ 会在 $\max$ 和 $\min$ 之间发生突变，大小为 $|s_x - s_y|$，导致此处缩放出现卡顿感

## 6 How
设图片的基准对角线向量为 $\vec{d} = \left[\begin{array}{c} W\\ H \end{array}\right]$，鼠标当前拉伸到的绝对目标向量为 $\vec{m} = \left[\begin{array}{c} W+sx\\ H+sy \end{array}\right]$。
通过计算 $\vec{m}$ 在对角线向量 $\vec{d}$ 上的正交投影，直接得到统一缩放比 $s_{\text{proj}}$：
$$
s_{\text{proj}} = \frac{m^{\top} d}{d^{\top} d} = \frac{(W + sx)W + (H + sy)H}{W^2 + H^2}
$$
结合轴向缩放比例定义 $s_x = \frac{W+sx}{W}$， $s_y = \frac{H+sy}{H}$，代入化简即可得到光滑连续的加权平均公式：
$$
s = s_{\text{proj}} = s_x \cdot \frac{W^2}{W^2 + H^2} + s_y \cdot \frac{H^2}{W^2 + H^2}
$$
通过将宽高缩放进行线性组合得到合并缩放 $s$，在 $\mathbb{R}^2$ 上连续，从而消除了缩放时的突变

在 `format-geometry-edit.scm` 中，将 `uniform-scale` 原先基于 `if`/`min`/`max` 的计算替换为对角线投影的加权平均值，避免任何分支逻辑：
```scheme
(uniform-scale (lambda (scale-x scale-y)
                 (let* ((ow2 (* ow ow))
                        (oh2 (* oh oh))
                        (scale (/ (+ (* scale-x ow2) (* scale-y oh2)) (+ ow2 oh2))))
                   ...)))
```
