### PR TITLE
[0811] 修复 manual 样式下 ref 失效

### DIFF
--- a/TeXmacs/styles/documentation/manual.ts
+++ b/TeXmacs/styles/documentation/manual.ts
@@ -58,7 +58,7 @@
 
   <assign|verbatim|<macro|body|<style-with|src-compact|none|<surround|<vspace*|0.5fn><no-page-break*>|<vspace|0.5fn><no-indent*>|<with|font-family|tt|language|verbatim|<arg|body>>>>>>
 
-  <assign|big-figure|<macro|fig|cap|<style-with|src-compact|none|<surround|<style-with|src-compact|none|<vspace*|1fn><no-indent><assign|figure-nr|<plus|<figure-nr>|1>><set-binding|<prefix><figure-nr>>>|<style-with|src-compact|none|<vspace|1fn><no-indent*>>|<tabular*|<tformat|<twith|table-width|1par>|<cwith|3|3|1|1|cell-hyphen|t>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<cwith|2|2|1|1|cell-height|0.5fn>|<table|<row|<cell|<arg|fig>>>|<row|<cell|>>|<row|<\cell>
+  <assign|big-figure|<macro|fig|cap|<style-with|src-compact|none|<surround|<style-with|src-compact|none|<vspace*|1fn><no-indent><assign|figure-nr|<plus|<figure-nr>|1>><set-binding|<figure-nr>>>|<style-with|src-compact|none|<vspace|1fn><no-indent*>>|<tabular*|<tformat|<twith|table-width|1par>|<cwith|3|3|1|1|cell-hyphen|t>|<cwith|1|-1|1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-rsep|0spc>|<cwith|2|2|1|1|cell-height|0.5fn>|<table|<row|<cell|<arg|fig>>>|<row|<cell|>>|<row|<\cell>
     <with|font-size|0.84|<surround|<with|font-series|bold|<localize|Figure>
     <figure-nr>. >||<arg|cap>>>
   </cell>>>>>>>>>

--- a/devel/0811.md
+++ b/devel/0811.md
@@ -1,0 +1,38 @@
+# [0811] 修复 manual 样式下 ref 失效
+
+## 1 相关文档
+- 无
+
+## 2 任务相关的代码文件
+- `TeXmacs/styles/documentation/manual.ts` - manual 样式文件，重定义了 `big-figure` 宏
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 清空缓存目录（linux下为`~/.cache/MoganLab`，windows下为`%localappdata%/MoganLab`，macos下为`~/Library/Caches/MoganLab`）
+2. 进入文档，选择 Documentation -> Manual 样式
+3. 插入\big-figure，打一个label
+4. 任意地方 ref 这个 label 后，渲染应该正常，不应该报错“<error|compound prefix>”
+
+## 4 What
+删除 `manual.ts` 样式文件中的多余 `<prefix>` 定义，修复 ref 失效
+
+### 删除后会有影响吗？
+没有不良影响。因为 `manual.ts` 的 `big-figure` 中，图片标题底部的编号是硬编码直接输出 `<figure-nr>` 的（即显示为 `Figure <figure-nr>.`），不带有任何前缀。因此在 `set-binding` 绑定时去除 `<prefix>` 标签，能够确保引用的数字与实际渲染出来的标题数字完全一致
+
+#### 对比标准 `env-base.ts` 中的定义说明（防范隐患）：
+在标准的宏包定义 `packages/environment/env-base.ts` 中，引用的绑定值采用的是：
+
+```xml
+<set-binding|<compound|the-figure>>
+```
+
+即绑定至标准宏 `<the-figure>`。标准设计的好处在于，其图片底部的标题渲染与引用绑定都统一动态调用 `<the-figure>`。因此，即使 `<the-figure>` 的前缀样式发生改变（如通过 `display-std-env` 格式化为 `Chapter.Figure` 样式），底部的标题和正文的引用也会一并同步更改，不会有不一致的问题
+
+而在 `manual.ts`（"The old manual style"）中，Joris 采用了较为简化的硬编码表格 `tabular*`，底部标题编号也是通过 `<figure-nr>` 静态排版输出，并不会动态随 `<the-figure>` 的宏重写而改变


### PR DESCRIPTION
# [0811] 修复 manual 样式下 ref 失效

## 1 相关文档
- 无

## 2 任务相关的代码文件
- `TeXmacs/styles/documentation/manual.ts` - manual 样式文件，重定义了 `big-figure` 宏

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（文档验证）
1. 清空缓存目录（linux下为`~/.cache/MoganLab`，windows下为`%localappdata%/MoganLab`，macos下为`~/Library/Caches/MoganLab`）
2. 进入文档，选择 Documentation -> Manual 样式
3. 插入\big-figure，打一个label
4. 任意地方 ref 这个 label 后，渲染应该正常，不应该报错“<error|compound prefix>”

## 4 What
删除 `manual.ts` 样式文件中的多余 `<prefix>` 定义，修复 ref 失效

### 删除后会有影响吗？
没有不良影响。因为 `manual.ts` 的 `big-figure` 中，图片标题底部的编号是硬编码直接输出 `<figure-nr>` 的（即显示为 `Figure <figure-nr>.`），不带有任何前缀。因此在 `set-binding` 绑定时去除 `<prefix>` 标签，能够确保引用的数字与实际渲染出来的标题数字完全一致

#### 对比标准 `env-base.ts` 中的定义说明（防范隐患）：
在标准的宏包定义 `packages/environment/env-base.ts` 中，引用的绑定值采用的是：

```xml
<set-binding|<compound|the-figure>>
```

即绑定至标准宏 `<the-figure>`。标准设计的好处在于，其图片底部的标题渲染与引用绑定都统一动态调用 `<the-figure>`。因此，即使 `<the-figure>` 的前缀样式发生改变（如通过 `display-std-env` 格式化为 `Chapter.Figure` 样式），底部的标题和正文的引用也会一并同步更改，不会有不一致的问题

而在 `manual.ts`（"The old manual style"）中，Joris 采用了较为简化的硬编码表格 `tabular*`，底部标题编号也是通过 `<figure-nr>` 静态排版输出，并不会动态随 `<the-figure>` 的宏重写而改变
