### PR TITLE
[0394] 修复菜单快捷键显示 bug

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1225,12 +1225,6 @@
   ) ;when
 ) ;tm-define
 (tm-define (kbd-paste-verbatim) (clipboard-paste-import "verbatim" "primary"))
-(tm-define (kbd-paste-dispatch)
-  (if (== (get-preference "magic-paste-shortcut") "ctrl+v")
-    (kbd-magic-paste)
-    (kbd-paste)
-  ) ;if
-) ;tm-define
 (tm-define (kbd-cancel) (clipboard-clear "primary"))
 
 ;; ocr-paste
@@ -1470,13 +1464,6 @@
   (when (defined? 'tutorial-notify-action)
     (tutorial-notify-action "ocr-paste")
   ) ;when
-) ;tm-define
-
-(tm-define (kbd-magic-paste-dispatch)
-  (if (== (get-preference "magic-paste-shortcut") "ctrl+v")
-    (kbd-paste)
-    (kbd-magic-paste)
-  ) ;if
 ) ;tm-define
 
 (tm-define (any-image-context?)

--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -786,9 +786,7 @@
   ("std s" (save-buffer))
   ("std S" (choose-file save-buffer-as "Save TeXmacs file" "action_save_as"))
   ("std u" (toggle-underlined))
-  ("std v" (kbd-paste-dispatch))
   ("std A-v" (interactive-paste-special))
-  ("std V" (kbd-magic-paste-dispatch))
   ("std w" (close-document))
   ("std W" (close-document*))
   ("std x" (kbd-cut))
@@ -818,4 +816,10 @@
   ;; added for convenience
   ("search std F" (search-next-match #f))
 ) ;kbd-map
+
+;; std v / std V 按偏好绑死，避免 dispatch 中间层导致菜单快捷键反查失败（参见 devel/0394.md）
+(if (== (get-preference "magic-paste-shortcut") "ctrl+v")
+  (kbd-map ("std v" (kbd-magic-paste)) ("std V" (kbd-paste)))
+  (kbd-map ("std v" (kbd-paste)) ("std V" (kbd-magic-paste)))
+) ;if
 ;; added for convenience

--- a/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
@@ -164,7 +164,7 @@
       ) ;enum
     ) ;item
     (item (text "Magic paste shortcut:")
-      (enum (set-pretty-preference "magic-paste-shortcut" answer)
+      (enum (set-pretty-preference* "magic-paste-shortcut" answer)
         '("Ctrl+Shift+V" "Ctrl+V")
         (get-pretty-preference "magic-paste-shortcut")
         "18em"

--- a/devel/0394.md
+++ b/devel/0394.md
@@ -1,0 +1,119 @@
+# [0394] 修复魔法粘贴快捷键交换偏好导致的菜单快捷键显示 bug
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0392.md](0392.md) - 魔法粘贴快捷键交换偏好（本次修复的回归源头）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/generic-kbd.scm` - `std v` / `std V` 改为根据偏好一次性绑死，
+  不再走 dispatch
+- `TeXmacs/progs/generic/generic-edit.scm` - 删除 `kbd-paste-dispatch` /
+  `kbd-magic-paste-dispatch` 两个中间层函数
+- `TeXmacs/progs/texmacs/menus/preferences-widgets.scm` - 「魔法粘贴快捷键」下拉框改用
+  `set-pretty-preference*`，偏好变更弹"需要重启"确认对话框
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无（纯 Scheme 改动，不涉及 C++ 单测）。
+
+### 3.2 非确定性测试（手工验证）
+1. `xmake b stem` 构建通过
+2. 默认偏好（`Ctrl+Shift+V`）下：
+   - 主菜单 / 右键菜单的「Paste」显示快捷键 `Ctrl+V`
+   - 「Magic paste」显示快捷键 `Ctrl+Shift+V`
+   - `Ctrl+V` → 普通粘贴；`Ctrl+Shift+V` → 魔法粘贴
+3. 切换偏好为 `Ctrl+V`：
+   - 弹"Requires restarting Mogan STEM to take full effect. Restart now?"对话框
+   - 点"是"→ 自动 `save-all-buffers` + `restart-TeXmacs`
+   - 重启后菜单显示互换：「Paste」显示 `Ctrl+Shift+V`，「Magic paste」显示 `Ctrl+V`
+   - `Ctrl+V` → 魔法粘贴；`Ctrl+Shift+V` → 普通粘贴
+4. 验证语音命令 "paste"、`S-insert`、`emacs y`、`F18` 等其他粘贴入口仍走普通粘贴
+   （不受偏好影响，保持 0392 的核心约束）
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main          # 格式化变更的 .scm
+xmake b stem                          # 主项目构建
+```
+
+按 CLAUDE.md：第一个 commit 新建本任务文档，后续 commit 为代码改动；提交信息格式 `[0394] 简述`。
+
+## 5 What
+
+1. `generic-kbd.scm`：把 `("std v" (kbd-paste-dispatch))` / `("std V" (kbd-magic-paste-dispatch))`
+   改为根据偏好 `kbd-map` 一次性绑死到 `kbd-paste` / `kbd-magic-paste`。
+2. `generic-edit.scm`：删除 `kbd-paste-dispatch` 和 `kbd-magic-paste-dispatch` 两个函数。
+3. `preferences-widgets.scm`：「Magic paste shortcut」下拉框从 `set-pretty-preference` 改为
+   `set-pretty-preference*`，偏好变更弹重启确认对话框（复用已有基础设施）。
+
+## 6 Why
+
+### 6.1 问题现象
+
+[0392] 引入 dispatch 函数后，菜单项「Paste」/「Magic paste」的快捷键列显示为空或乱码。
+
+### 6.2 根因
+
+菜单项 `("Paste" (kbd-paste))` 显示快捷键时，通过 `kbd-find-inv-binding`
+（`kbd-define.scm:185`）反查"哪个键绑定到 `(kbd-paste)` 这个符号"。反查只看直接绑定。
+
+dispatch 引入后，`std v` / `std V` 都绑给了 `kbd-paste-dispatch` /
+`kbd-magic-paste-dispatch`，**没有任何键直接绑定** `kbd-paste` 或 `kbd-magic-paste`，
+所以反查返回空字符串，菜单快捷键列显示异常。
+
+### 6.3 为什么不直接改 kbd-paste 本身
+
+0392 设计文档（`devel/0392.md` 7.1 节）明确了核心约束：`kbd-paste` / `kbd-magic-paste`
+在仓库内被多处调用（菜单项、speech、`S-insert`、`emacs y`、`F18` 等）。如果直接在
+`kbd-paste` 内部根据偏好分派，会**全局**改变这些调用点的语义——例如语音命令 "paste"
+也会触发魔法粘贴，与用户预期不符。
+
+本次修复保留了这一约束：仍然不动 `kbd-paste` / `kbd-magic-paste` 本身，只是在
+`std v` / `std V` 入口层根据偏好一次性绑死，让反查能正确工作。
+
+### 6.4 为什么需要强制重启
+
+`kbd-map` 是在 Scheme 模块加载时执行的顶层调用，运行时改偏好不会自动重绑。
+为了让偏好切换后行为一致，参照已有的 `look and feel`、`gui theme` 等"需要重启"
+偏好项的模式：用 `set-pretty-preference*` 在偏好变更时弹"Requires restarting...
+Restart now?"确认对话框，用户点"是"自动 `save-all-buffers` + `restart-TeXmacs`。
+
+## 7 How
+
+### 7.1 启动时按偏好绑死
+
+`generic-kbd.scm` 顶层：
+
+```scheme
+(if (== (get-preference "magic-paste-shortcut") "ctrl+v")
+  (kbd-map
+    ("std v" (kbd-magic-paste))
+    ("std V" (kbd-paste)))
+  (kbd-map
+    ("std v" (kbd-paste))
+    ("std V" (kbd-magic-paste))))
+```
+
+`kbd-map` 是宏（`kbd-define.scm:375-378`），展开为 `(begin ...)` 内的
+`kbd-new-entry` 调用，在 `if` 内运行时执行无问题。`insert-menu.scm:203` 和
+`format-menu.scm:193` 已有顶层 `get-preference` + 条件分支的先例。
+
+### 7.2 偏好变更弹重启确认
+
+`set-pretty-preference*` 已在 `preferences-widgets.scm:26-45` 定义，内部用
+`restart-required-message`（`preferences-menu.scm:29-32`）+ `user-confirm` + 自动重启。
+直接复用，无新代码。
+
+### 7.3 反查能正确工作的原理
+
+修复后：
+- 偏好 `ctrl+shift+v`（默认）：`std v` 绑 `kbd-paste`，`std V` 绑 `kbd-magic-paste`
+  → 反查 `kbd-paste` 得 `Ctrl+V`，反查 `kbd-magic-paste` 得 `Ctrl+Shift+V`
+- 偏好 `ctrl+v`：互换
+  → 反查 `kbd-paste` 得 `Ctrl+Shift+V`，反查 `kbd-magic-paste` 得 `Ctrl+V`
+
+菜单快捷键列正确显示，且与实际行为一致。


### PR DESCRIPTION
## Summary

修复 [0392] 引入的回归：菜单「Paste」/「Magic paste」的快捷键列显示为空或乱码。

### 根因

[0392] 为了让偏好切换不污染其他调用点（语音、S-insert、菜单直调等），引入了两个 dispatch 函数：

- `("std v" (kbd-paste-dispatch))`
- `("std V" (kbd-magic-paste-dispatch))`

但菜单显示快捷键时通过 `kbd-find-inv-binding` 反查"哪个键绑定到 `(kbd-paste)` 这个符号"——反查只看直接绑定。dispatch 之后没有任何键直接绑定 `kbd-paste` / `kbd-magic-paste`，所以菜单列空白。

### 修复

按偏好启动时一次性绑死 `std v` / `std V` 到 `kbd-paste` / `kbd-magic-paste`，删掉 dispatch 中间层。偏好切换弹"Requires restarting..."对话框（复用已有 `set-pretty-preference*` 基础设施，与 look and feel / gui theme 一致）。

保持了 0392 的核心约束（不改 `kbd-paste` / `kbd-magic-paste` 本身，其他调用点不受影响）。

## 改动

| 文件 | 改动 |
|------|------|
| `generic-kbd.scm` | std profile 删掉 `std v` / `std V` 两行；块末加按偏好绑死的 `if + kbd-map` |
| `generic-edit.scm` | 删除 `kbd-paste-dispatch` 和 `kbd-magic-paste-dispatch` |
| `preferences-widgets.scm` | magic-paste-shortcut enum 改用 `set-pretty-preference*` |

净变更：+7 / -16。

## Test plan

- [ ] `xmake b stem` 构建通过
- [ ] 默认偏好（Ctrl+Shift+V）下，菜单「Paste」显示 `Ctrl+V`，「Magic paste」显示 `Ctrl+Shift+V`
- [ ] 默认偏好下，`Ctrl+V` 触发普通粘贴，`Ctrl+Shift+V` 触发魔法粘贴
- [ ] 切换偏好为 `Ctrl+V` 时弹"Requires restarting..."确认对话框
- [ ] 点"是"自动重启后，菜单快捷键显示与实际行为互换
- [ ] 语音命令 "paste"、`S-insert`、`emacs y`、`F18` 等其他粘贴入口仍走普通粘贴

## 相关

- 任务文档：`devel/0394.md`
- 回归源头：#3877 ([0392])