### PR TITLE
[0814] 复制图片到外部应用

### DIFF
--- a/devel/0814.md
+++ b/devel/0814.md
@@ -1,0 +1,48 @@
+# [0814] 复制图片到外部应用
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_gui.cpp` — 复制单个 `<image>` 选区时，向剪贴板额外写入标准 `image/png`，使外部应用（Word、飞书、Kimi、网页端 chat 等）可粘贴
+- `src/Typeset/Bridge/typesetter.cpp` - 禁用 `notify_insert` 中的完整输出，防止插入图片时输出 RAW_DATA
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 截图后粘贴插入一张图片，直接选中图片（无需进入 `<with>` 内部）后复制，在 `飞书`、`Word`、`Web AI`、`Claude Code CLI` 等多种类型的外部应用中粘贴，确认能正常显示图片（一定要测试 Word、PowerPoint 这类，其识别图片逻辑更严格）
+2. 插入嵌入式图片 `插入->图片->插入图片`，选中后复制，在上述多种外部应用中粘贴，确认能正常显示图片
+
+## 4 What
+在文档中的图片无法正常复制并发送给 Kimi Chat、Word、飞书等外部应用
+
+## 5 Why
+Mogan 原有复制只写私有 `application/x-texmacs-clipboard` + verbatim 纯文本
+
+外部应用（如 Word）不认私有 mime，且有的会优先取 `text/plain`（对图片选区为空），结果粘不出任何内容
+
+## 6 How
+### 6.1 识别单图片选区：`selection_image_url`
+选区内容 `t` 经 `selection_set` 包装为 `("texmacs", content, mode, lan)`，content 即 `t[1]`
+
+`selection_image_url` 先剥掉外层 `(with var val ... body)` 外壳（`WITH` 节点为奇数个，body 是末子节点），再判断是否 `(image src w h "" "")`：
+- 内嵌图片：`(tuple (raw-data <id>) <ext>)` $\to$ 构造 `ramdisc://` url
+- 链接图片及其余：返回 `url_none()`（不处理相对路径）
+
+### 6.2 写剪贴板：`attach_selection_image`
+按原始像素加载图片——**不使用 `get_image`**，因为它会按排版用的逻辑尺寸（HiDPI 下为物理像素的一半）缩放，导致画质降低
+
+因此使用 `qt_load_image_from_ramdisc` 直接拿到原始物理像素。加载后：
+- `md->setImageData(copy)` 走 Qt 原生通道（Mogan 自身、部分软件用）
+- `md->setData("image/png", png)` 写入标准 PNG 字节流——部分外部应用不认 Qt 私有的 `application/x-qt-image`，需标准 `image/png` 才能粘贴
+
+### 6.3 在 `set_selection` 中接入
+在 `format == "default"` 分支写完私有 mime（`application/x-texmacs-clipboard` + `application/x-texmacs-pid`）后、写 `text/plain` 之前，若 `attach_selection_image` 命中则 `cb->setMimeData` 后直接 `return`：
+- 内粘无损：靠私有 mime + 内存字典 `selection_t`，与 PID 自识别配合
+- 不写 `text/plain`：**否则 Word 优先取空文本导致粘贴失败！！**

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -18,12 +18,12 @@
 #include "dictionary.hpp"
 #include "file.hpp" // added for copy_as_graphics
 #include "image_files.hpp"
-#include "qt_picture.hpp"
 #include "iterator.hpp"
 #include "locale.hpp"
 #include "message.hpp"
 #include "new_window.hpp"
 #include "preferences.hpp"
+#include "qt_picture.hpp"
 #include "scheme.hpp"
 #include "server.hpp"
 #include "tm_file.hpp"
@@ -387,9 +387,12 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
   return true;
 }
 
-// 解析单个图片在内存中的路径，只能处理嵌入式图片
+// 解析单个图片在内存中的路径，只处理嵌入式图片
 static url
 selection_image_url (tree t) {
+  // 支持外层套 with 环境（用于对齐等），剥壳后取内层 image 节点
+  while (is_func (t, WITH) && (N (t) & 1) == 1 && N (t) > 2)
+    t= t[N (t) - 1];
   if (!is_func (t, IMAGE, 5)) return url_none ();
   tree image_tree= t[0];
   if (is_atomic (image_tree)) {
@@ -409,35 +412,19 @@ static bool
 attach_selection_image (QMimeData* md, tree t) {
   url src= selection_image_url (t);
   if (is_none (src)) return false;
-  int iw= 0, ih= 0;
-  image_size (src, iw, ih);
-  if (iw <= 0 || ih <= 0) return false;
-  QImage* im= get_image (src, iw, ih, "", 1);
-  if (im == NULL || im->isNull ()) return false;
-#ifdef LIII_DEBUG
-  cout << "[clip-image] src=" << as_string (src) << " size=" << iw << "x" << ih
-       << " qimg=" << im->width () << "x" << im->height ()
-       << " fmt=" << (int) im->format () << "\n";
-#endif
-  QImage copy= im->copy ().convertToFormat (QImage::Format_ARGB32);
+  QImage img;
+  // 直接按原始像素加载：get_image 会按排版用的逻辑尺寸
+  // （HiDPI下为物理像素的一半）缩放，导致画质降低
+  bool loaded= qt_load_image_from_ramdisc (src, img);
+  if (!loaded || img.isNull ()) return false;
+  QImage copy= img.convertToFormat (QImage::Format_ARGB32);
   md->setImageData (copy);
-  // 外部应用（Word、飞书、网页AIchat等）不认QT私有的 application/x-qt-image，故额外写入标准 image/png
+  // 外部应用（Word、飞书、网页AIchat等）不认QT私有的
+  // application/x-qt-image，故额外写入标准 image/png
   QByteArray png;
   QBuffer    buf (&png);
   buf.open (QIODevice::WriteOnly);
   if (copy.save (&buf, "PNG")) md->setData ("image/png", png);
-#ifdef LIII_DEBUG
-  cout << "[clip-image] pngBytes=" << png.size () << "\n";
-  QStringList fmts= md->formats ();
-  string fmtlist;
-  for (int i= 0; i < fmts.size (); i++) {
-    if (i > 0) fmtlist << ", ";
-    fmtlist << from_qstring_utf8 (fmts[i]);
-  }
-  cout << "[clip-image] hasImage=" << md->hasImage ()
-       << " hasText=" << md->hasText ()
-       << " nFormats=" << fmts.size () << " formats=" << fmtlist << "\n";
-#endif
   return true;
 }
 
@@ -473,7 +460,8 @@ qt_gui_rep::set_selection (string key, tree t, string s, string sv, string sh,
 
       selection= c_string (sv);
 
-      // 单图片复制：写入 image/png 供外部粘贴，并跳过 text/plain（Word 会优先取 text/plain 导致粘贴失败）
+      // 单图片复制：写入 image/png 供外部粘贴，并跳过 text/plain
+      // （Word 会优先取text/plain 导致粘贴失败）
       if (is_tuple (t, "texmacs", 3) && attach_selection_image (md, t[1])) {
         cb->setMimeData (md, mode);
         return true;

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -17,6 +17,8 @@
 #include "convert.hpp"
 #include "dictionary.hpp"
 #include "file.hpp" // added for copy_as_graphics
+#include "image_files.hpp"
+#include "qt_picture.hpp"
 #include "iterator.hpp"
 #include "locale.hpp"
 #include "message.hpp"
@@ -385,6 +387,60 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
   return true;
 }
 
+// 解析单个图片在内存中的路径，只能处理嵌入式图片
+static url
+selection_image_url (tree t) {
+  if (!is_func (t, IMAGE, 5)) return url_none ();
+  tree image_tree= t[0];
+  if (is_atomic (image_tree)) {
+    url im= url_system (image_tree->label);
+    if (is_rooted (im)) return im;
+  }
+  else if (is_func (image_tree, TUPLE, 2) &&
+           is_func (image_tree[0], RAW_DATA, 1) &&
+           is_atomic (image_tree[0][0]) && is_atomic (image_tree[1])) {
+    return url_ramdisc (image_tree[0][0]->label) *
+           url ("image." * image_tree[1]->label);
+  }
+  return url_none ();
+}
+
+static bool
+attach_selection_image (QMimeData* md, tree t) {
+  url src= selection_image_url (t);
+  if (is_none (src)) return false;
+  int iw= 0, ih= 0;
+  image_size (src, iw, ih);
+  if (iw <= 0 || ih <= 0) return false;
+  QImage* im= get_image (src, iw, ih, "", 1);
+  if (im == NULL || im->isNull ()) return false;
+#ifdef LIII_DEBUG
+  cout << "[clip-image] src=" << as_string (src) << " size=" << iw << "x" << ih
+       << " qimg=" << im->width () << "x" << im->height ()
+       << " fmt=" << (int) im->format () << "\n";
+#endif
+  QImage copy= im->copy ().convertToFormat (QImage::Format_ARGB32);
+  md->setImageData (copy);
+  // 外部应用（Word、飞书、网页AIchat等）不认QT私有的 application/x-qt-image，故额外写入标准 image/png
+  QByteArray png;
+  QBuffer    buf (&png);
+  buf.open (QIODevice::WriteOnly);
+  if (copy.save (&buf, "PNG")) md->setData ("image/png", png);
+#ifdef LIII_DEBUG
+  cout << "[clip-image] pngBytes=" << png.size () << "\n";
+  QStringList fmts= md->formats ();
+  string fmtlist;
+  for (int i= 0; i < fmts.size (); i++) {
+    if (i > 0) fmtlist << ", ";
+    fmtlist << from_qstring_utf8 (fmts[i]);
+  }
+  cout << "[clip-image] hasImage=" << md->hasImage ()
+       << " hasText=" << md->hasText ()
+       << " nFormats=" << fmts.size () << " formats=" << fmtlist << "\n";
+#endif
+  return true;
+}
+
 bool
 qt_gui_rep::set_selection (string key, tree t, string s, string sv, string sh,
                            string format) {
@@ -416,6 +472,12 @@ qt_gui_rep::set_selection (string key, tree t, string s, string sv, string sh,
       // tm_delete_array (selection);
 
       selection= c_string (sv);
+
+      // 单图片复制：写入 image/png 供外部粘贴，并跳过 text/plain（Word 会优先取 text/plain 导致粘贴失败）
+      if (is_tuple (t, "texmacs", 3) && attach_selection_image (md, t[1])) {
+        cb->setMimeData (md, mode);
+        return true;
+      }
     }
 
     string enc= get_preference ("texmacs->verbatim:encoding");

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -17,13 +17,11 @@
 #include "convert.hpp"
 #include "dictionary.hpp"
 #include "file.hpp" // added for copy_as_graphics
-#include "image_files.hpp"
 #include "iterator.hpp"
 #include "locale.hpp"
 #include "message.hpp"
 #include "new_window.hpp"
 #include "preferences.hpp"
-#include "qt_picture.hpp"
 #include "scheme.hpp"
 #include "server.hpp"
 #include "tm_file.hpp"

--- a/src/Typeset/Bridge/typesetter.cpp
+++ b/src/Typeset/Bridge/typesetter.cpp
@@ -225,7 +225,8 @@ notify_assign (typesetter ttt, path p, tree u) {
 void
 notify_insert (typesetter ttt, path p, tree u) {
 #ifdef LIII_DEBUG
-  cout << "Insert " << p << ", " << u << "\n";
+  // cout << "Insert " << p << ", " << u << "\n";
+  cout << "Insert ...\n";
 #endif
   ttt->br->notify_insert (p, u);
 }


### PR DESCRIPTION
# [0814] 复制图片到外部应用

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `src/Plugins/Qt/qt_gui.cpp` — 复制单个 `<image>` 选区时，向剪贴板额外写入标准 `image/png`，使外部应用（Word、飞书、Kimi、网页端 chat 等）可粘贴
- `src/Typeset/Bridge/typesetter.cpp` - 禁用 `notify_insert` 中的完整输出，防止插入图片时输出 RAW_DATA

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（文档验证）
1. 截图后粘贴插入一张图片，直接选中图片（无需进入 `<with>` 内部）后复制，在 `飞书`、`Word`、`Web AI`、`Claude Code CLI` 等多种类型的外部应用中粘贴，确认能正常显示图片（一定要测试 Word、PowerPoint 这类，其识别图片逻辑更严格）
2. 插入嵌入式图片 `插入->图片->插入图片`，选中后复制，在上述多种外部应用中粘贴，确认能正常显示图片

## 4 What
在文档中的图片无法正常复制并发送给 Kimi Chat、Word、飞书等外部应用

## 5 Why
Mogan 原有复制只写私有 `application/x-texmacs-clipboard` + verbatim 纯文本

外部应用（如 Word）不认私有 mime，且有的会优先取 `text/plain`（对图片选区为空），结果粘不出任何内容

## 6 How
### 6.1 识别单图片选区：`selection_image_url`
选区内容 `t` 经 `selection_set` 包装为 `("texmacs", content, mode, lan)`，content 即 `t[1]`

`selection_image_url` 先剥掉外层 `(with var val ... body)` 外壳（`WITH` 节点为奇数个，body 是末子节点），再判断是否 `(image src w h "" "")`：
- 内嵌图片：`(tuple (raw-data <id>) <ext>)` $\to$ 构造 `ramdisc://` url
- 链接图片及其余：返回 `url_none()`（不处理相对路径）

### 6.2 写剪贴板：`attach_selection_image`
按原始像素加载图片——**不使用 `get_image`**，因为它会按排版用的逻辑尺寸（HiDPI 下为物理像素的一半）缩放，导致画质降低

因此使用 `qt_load_image_from_ramdisc` 直接拿到原始物理像素。加载后：
- `md->setImageData(copy)` 走 Qt 原生通道（Mogan 自身、部分软件用）
- `md->setData("image/png", png)` 写入标准 PNG 字节流——部分外部应用不认 Qt 私有的 `application/x-qt-image`，需标准 `image/png` 才能粘贴

### 6.3 在 `set_selection` 中接入
在 `format == "default"` 分支写完私有 mime（`application/x-texmacs-clipboard` + `application/x-texmacs-pid`）后、写 `text/plain` 之前，若 `attach_selection_image` 命中则 `cb->setMimeData` 后直接 `return`：
- 内粘无损：靠私有 mime + 内存字典 `selection_t`，与 PID 自识别配合
- 不写 `text/plain`：**否则 Word 优先取空文本导致粘贴失败！！**
