### PR TITLE
[0816] 修复页码 hanzi 样式无法显示

### DIFF
--- a/TeXmacs/fonts/font-substitutions.scm
+++ b/TeXmacs/fonts/font-substitutions.scm
@@ -32,6 +32,7 @@
 ((UnBatang typewriter) (UnGungseo))
 
 ((concrete cjk) (Noto\ CJK\ SC))
+((roman typewriter cjk) (Noto\ CJK\ SC))
 ((roman cjk) (Noto\ CJK\ SC))
 ((Stix cjk) (Noto\ CJK\ SC))
 

--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -1019,6 +1019,7 @@
 ("gui" "界面")
 ("h modifier" "")
 ("hangul" "谚文")
+("hanzi style" "一, 二, 三")
 ("happy typing" "")
 ("has been aborted" "")
 ("has completed its task" "")

--- a/TeXmacs/progs/generic/document-widgets.scm
+++ b/TeXmacs/progs/generic/document-widgets.scm
@@ -381,6 +381,7 @@
                                ) ;
                            (when (and (filled? ps) (filled? pe) (filled? nt))
                              (assign-page-number u ps pe nt)
+                             (set! nt "")
                              (delayed (:pause 100) (refresh-now "pn-editor"))
                            ) ;when
                          ) ;let*

--- a/TeXmacs/progs/generic/document-widgets.scm
+++ b/TeXmacs/progs/generic/document-widgets.scm
@@ -292,7 +292,7 @@
     ("1, 2, 3" . "arabic")
     ("i, ii, iii" . "roman")
     ("I, II, III" . "Roman")
-    ("一, 二, 三" . "hanzi")
+    ("hanzi style" . "hanzi")
     ("(blank page number)" . "blank"))
 ) ;define
 ;; pn-text-alist 为其反向映射 (内部值 . 显示文本)，供 enum 显示当前项

--- a/devel/0816.md
+++ b/devel/0816.md
@@ -1,0 +1,42 @@
+# [0816] 修复页码 hanzi 样式无法显示
+
+## 1 相关文档
+- [202_9.md](202_9.md) - 新增页码样式功能 & 修复页码显示（hanzi 在此引入，当时正常）
+- [222_41.md](222_41.md) - 页码改进（引入回归的提交）
+- [0812.md](0812.md) - 优化页码功能（继承了回归但非根因）
+
+## 2 任务相关的代码文件
+
+### Scheme
+- `TeXmacs/progs/generic/document-widgets.scm` — hanzi 候选键 `"一, 二, 三"` 改为纯 ASCII 的 `"hanzi style"`；Apply 后复位样式选择，防误触
+- `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` — 新增 `("hanzi style" "一, 二, 三")`，让 enum 经 translate 显示成中文
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（文档验证）
+1. 打开 `文档->页码`，样式下拉选 `一, 二, 三`（hanzi），点 `应用`；
+2. 文档对应页脚应正确显示汉字页码（一、二、三），不再出现 `<error|bad number>`；
+3. `页码映射` 框中 hanzi 范围的映射同样显示汉字（如 `1 -> 一`）；
+4. 应用后样式下拉应自动跳回 `请选择一种样式`，再次点 `应用` 无反应（防误触）。
+
+## 4 What
+
+1. 修复页码样式选 hanzi 时页码显示为 `<error|bad number>` 的回归。
+2. Apply 后样式选择复位为未选择，防止连续误触覆盖页码。
+
+## 5 Why
+
+`<error|bad number>` 来自 C++ `exec_number` 的 ERROR 兜底，说明宏里的样式名已失效——`nt` 是 `#f`。
+
+`nt=#f` 出在 enum 回调 `(assoc-ref pn-style-alist answer)`。mogan 的 enum 控件对候选调 `translate` 显示、回调再反查原值，这条链路对纯 ASCII 候选键稳定；但 hanzi 的候选键是含汉字的 `"一, 二, 三"`，跨 Scheme↔Qt 边界后与 scheme 字面量不再字节相等，反查失败 → `nt=#f`。其余候选键（`"1, 2, 3"` 等）纯 ASCII 不受影响。222_41 把候选改成中文显示文本并依赖字符串匹配反查，回归由此引入；0812 的 `assoc-ref` 继承了该问题。
+
+## 6 How
+
+- 保留 0812 的 alist/assoc-ref 架构，仅把唯一含汉字的候选键换成纯 ASCII 的 `"hanzi style"`，跨边界不再失配；中文显示交给 enum 的 `translate`，在字典补 `("hanzi style" "一, 二, 三")`。
+- Apply 成功后 `(set! nt "")` 复位，refreshable 重建使 enum 跳回 `请选择一种样式` 占位，`filled?` 检查再次挡住空串，防误触。

--- a/devel/0816.md
+++ b/devel/0816.md
@@ -10,6 +10,7 @@
 ### Scheme
 - `TeXmacs/progs/generic/document-widgets.scm` — hanzi 候选键 `"一, 二, 三"` 改为纯 ASCII 的 `"hanzi style"`；Apply 后复位样式选择，防误触
 - `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` — 新增 `("hanzi style" "一, 二, 三")`，让 enum 经 translate 显示成中文
+- `TeXmacs/fonts/font-substitutions.scm` — 新增 `tt` 族 CJK 字体回退规则，保证 Mac 等宽字体下汉字可见
 
 ## 3 如何测试
 
@@ -36,7 +37,10 @@ xmake r stem
 
 `nt=#f` 出在 enum 回调 `(assoc-ref pn-style-alist answer)`。mogan 的 enum 控件对候选调 `translate` 显示、回调再反查原值，这条链路对纯 ASCII 候选键稳定；但 hanzi 的候选键是含汉字的 `"一, 二, 三"`，跨 Scheme↔Qt 边界后与 scheme 字面量不再字节相等，反查失败 → `nt=#f`。其余候选键（`"1, 2, 3"` 等）纯 ASCII 不受影响。222_41 把候选改成中文显示文本并依赖字符串匹配反查，回归由此引入；0812 的 `assoc-ref` 继承了该问题。
 
+另外，页码映射框用 `(with "font-family" "tt" ...)` 渲染以保持等宽。`tt` 族对应 typewriter 等宽变体；在 Mac 上该族原本没有 CJK 回退，`((roman cjk) (Noto CJK SC))` 这条通用规则会误匹配到 `(roman typewriter cjk)`，给 `Noto CJK SC` 强加上不存在的 `typewriter` 变体，导致汉字无法渲染。Windows 上 `tt` 族能回退到含中文的字体，因此没有暴露该问题。
+
 ## 6 How
 
 - 保留 0812 的 alist/assoc-ref 架构，仅把唯一含汉字的候选键换成纯 ASCII 的 `"hanzi style"`，跨边界不再失配；中文显示交给 enum 的 `translate`，在字典补 `("hanzi style" "一, 二, 三")`。
 - Apply 成功后 `(set! nt "")` 复位，refreshable 重建使 enum 跳回 `请选择一种样式` 占位，`filled?` 检查再次挡住空串，防误触。
+- 保持映射框 `"tt"` 等宽字体不变，为 `tt` 族新增更具体的 CJK 回退规则 `((roman typewriter cjk) (Noto\ CJK\ SC))`，并放在 `((roman cjk) ...)` 之前。该规则让 `tt` 族遇到 CJK 字符时先剥离 `typewriter` 再回退到 `Noto CJK SC`，避免被更宽泛的 `((roman cjk) ...)` 先命中而保留不存在的 `typewriter` 变体。ASCII 部分仍使用原等宽字体，中文部分使用普通 CJK 字体。


### PR DESCRIPTION
# [0816] 修复页码 hanzi 样式无法显示

## 1 相关文档
- [202_9.md](202_9.md) - 新增页码样式功能 & 修复页码显示（hanzi 在此引入，当时正常）
- [222_41.md](222_41.md) - 页码改进（引入回归的提交）
- [0812.md](0812.md) - 优化页码功能（继承了回归但非根因）

## 2 任务相关的代码文件

### Scheme
- `TeXmacs/progs/generic/document-widgets.scm` — hanzi 候选键 `"一, 二, 三"` 改为纯 ASCII 的 `"hanzi style"`；Apply 后复位样式选择，防误触
- `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` — 新增 `("hanzi style" "一, 二, 三")`，让 enum 经 translate 显示成中文

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（文档验证）
1. 打开 `文档->页码`，样式下拉选 `一, 二, 三`（hanzi），点 `应用`；
2. 文档对应页脚应正确显示汉字页码（一、二、三），不再出现 `<error|bad number>`；
3. `页码映射` 框中 hanzi 范围的映射同样显示汉字（如 `1 -> 一`）；
4. 应用后样式下拉应自动跳回 `请选择一种样式`，再次点 `应用` 无反应（防误触）。

## 4 What

1. 修复页码样式选 hanzi 时页码显示为 `<error|bad number>` 的回归。
2. Apply 后样式选择复位为未选择，防止连续误触覆盖页码。

## 5 Why

`<error|bad number>` 来自 C++ `exec_number` 的 ERROR 兜底，说明宏里的样式名已失效——`nt` 是 `#f`。

`nt=#f` 出在 enum 回调 `(assoc-ref pn-style-alist answer)`。mogan 的 enum 控件对候选调 `translate` 显示、回调再反查原值，这条链路对纯 ASCII 候选键稳定；但 hanzi 的候选键是含汉字的 `"一, 二, 三"`，跨 Scheme↔Qt 边界后与 scheme 字面量不再字节相等，反查失败 → `nt=#f`。其余候选键（`"1, 2, 3"` 等）纯 ASCII 不受影响。222_41 把候选改成中文显示文本并依赖字符串匹配反查，回归由此引入；0812 的 `assoc-ref` 继承了该问题。

## 6 How

- 保留 0812 的 alist/assoc-ref 架构，仅把唯一含汉字的候选键换成纯 ASCII 的 `"hanzi style"`，跨边界不再失配；中文显示交给 enum 的 `translate`，在字典补 `("hanzi style" "一, 二, 三")`。
- Apply 成功后 `(set! nt "")` 复位，refreshable 重建使 enum 跳回 `请选择一种样式` 占位，`filled?` 检查再次挡住空串，防误触。
