### PR TITLE
[0817] 绘图后自动切换到移动模式

### DIFF
--- a/TeXmacs/progs/graphics/graphics-single.scm
+++ b/TeXmacs/progs/graphics/graphics-single.scm
@@ -38,6 +38,7 @@
 ;; Basic operations (setting the object)
 
 ;; 是否正在新建图形（object_commit 后切到 move 模式）
+
 (define creating-object? #f)
 
 (define (object-set! o . opt)
@@ -251,7 +252,8 @@
           (graphics-forget-states)
           (when creating-object?
             (set! creating-object? #f)
-            (with saved-path current-path
+            (with saved-path
+              current-path
               (set! graphics-texmacs-pointer "none")
               (graphics-set-mode '(group-edit move))
               ;; 将当前对象切换到 move 模式后，重新选中该对象

--- a/TeXmacs/progs/graphics/graphics-single.scm
+++ b/TeXmacs/progs/graphics/graphics-single.scm
@@ -37,6 +37,9 @@
 
 ;; Basic operations (setting the object)
 
+;; 是否正在新建图形（object_commit 后切到 move 模式）
+(define creating-object? #f)
+
 (define (object-set! o . opt)
   (set! layer-of-last-removed-object #f)
   (set! current-obj o)
@@ -122,6 +125,8 @@
 (tm-define (object_create tag x y)
   (:require (or (in? tag gr-tags-curves) (or (in? tag gr-tags-user) (in? tag new-gr-tags)))
   ) ;:require
+  ;; 图形新建时触发 creating-object?
+  (set! creating-object? #t)
   (with o
     (graphics-enrich `(,tag (point ,x ,y) (point ,x ,y)))
     (graphics-store-state 'start-create)
@@ -209,6 +214,8 @@
 ;; Basic operations (checkout & commit)
 
 (define (object_checkout)
+  ;; 已有图形修改时不触发 creating-object?
+  (set! creating-object? #f)
   (sketch-set! `(,(path->tree current-path)))
   (sketch-checkout)
   ;; (display* "Checked out " (sketch-get) "\n")
@@ -242,6 +249,24 @@
           (set! current-obj (stree-radical obj))
           (set! current-point-no #f)
           (graphics-forget-states)
+          (when creating-object?
+            (set! creating-object? #f)
+            (with saved-path current-path
+              (set! graphics-texmacs-pointer "none")
+              (graphics-set-mode '(group-edit move))
+              ;; 将当前对象切换到 move 模式后，重新选中该对象
+              (when saved-path
+                (with t
+                  (path->tree saved-path)
+                  (when t
+                    (sketch-toggle t)
+                    (graphics-decorations-update)
+                  ) ;when
+                ) ;with
+              ) ;when
+              (set! current-obj '(nothing))
+            ) ;with
+          ) ;when
         ) ;with
       ) ;with
     ) ;if

--- a/devel/0817.md
+++ b/devel/0817.md
@@ -1,0 +1,48 @@
+# [0817] 绘图后自动切换到移动模式
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-single.scm` — 新增 `creating-object?` 状态，图形新建并提交后自动切到 `(group-edit move)`
+- `src/Edit/Interface/edit_mouse.cpp` — `move` 事件兜底分支增加 `over_graphics` 判断，避免鼠标悬停在绘图区时被强制重置为 normal 光标
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 进入绘图区，选择 `矩形`/`圆形`/`椭圆`/`多边形`/`折线`/`闭合曲线` 等工具绘制一个图形
+2. 画好图形（触发 `object_commit`）后应自动进入 `移动对象` 模式（光标变为 openhand），且刚绘制的图形保持选中
+3. 在移动模式下点击并拖动该图形，拖动过程中光标应变为 closehand，释放后恢复 openhand
+4. 移动鼠标在绘图区内晃动，光标应稳定保持手型，不会闪回默认箭头
+5. 选择 `点` 工具绘制单点，绘制后应**不**自动切换到移动模式，保持原模式
+
+## 4 What
+绘图区绘制完一个图形（矩形、圆、线条等）后，仍停留在原绘制模式，用户需要手动切到移动模式才能拖动图形
+
+## 6 How
+### 6.1 标记新建状态 `creating-object?`
+在 `graphics-single.scm` 新增状态变量：
+- `object_create` 的曲线/闭合图形/圆角矩形分支开头置 `(set! creating-object? #t)`
+- `object_checkout`（编辑已有图形）开头置 `(set! creating-object? #f)`，避免拖动已有图形控制点时误切模式
+
+### 6.2 提交后自动切 move 模式
+`object_commit` 成功提交图形后，若 `creating-object?` 为 `#t`：
+1. 清掉编辑模式遗留的红色十字光标状态 `(set! graphics-texmacs-pointer "none")`
+2. 调用 `(graphics-set-mode '(group-edit move))` 切换模式
+3. 用保存的 `current-path` 把刚提交的图形重新 `sketch-toggle` 回选中集，保持可选中/可拖动
+4. 重置 `current-obj` 为 `'(nothing)`，与 group-edit 模式状态保持一致
+
+### 6.3 防止 move 事件重置光标
+`edit_mouse.cpp` 中处理 `move` 事件的兜底分支原本无条件 `set_cursor_style ("normal")`
+
+当鼠标实际悬停在绘图区上时，该逻辑会覆盖 graphics 模式通过 `set-cursor-style` 设置的手型光标，故改为改为：
+```cpp
+if (!over_graphics (x, y)) set_cursor_style ("normal");
+```
+只在鼠标确实不在绘图区上方时才重置为默认光标

--- a/src/Edit/Interface/edit_mouse.cpp
+++ b/src/Edit/Interface/edit_mouse.cpp
@@ -959,7 +959,7 @@ edit_interface_rep::mouse_any (string type, SI x, SI y, int mods, time_t t,
     hide_text_popup ();
   }
   else {
-    set_cursor_style ("normal");
+    if (!over_graphics (x, y)) set_cursor_style ("normal");
 #ifdef QTTEXMACS
     hide_image_popup ();
 #endif


### PR DESCRIPTION
# [0817] 绘图后自动切换到移动模式

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-single.scm` — 新增 `creating-object?` 状态，图形新建并提交后自动切到 `(group-edit move)`
- `src/Edit/Interface/edit_mouse.cpp` — `move` 事件兜底分支增加 `over_graphics` 判断，避免鼠标悬停在绘图区时被强制重置为 normal 光标

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 进入绘图区，选择 `矩形`/`圆形`/`椭圆`/`多边形`/`折线`/`闭合曲线` 等工具绘制一个图形
2. 画好图形（触发 `object_commit`）后应自动进入 `移动对象` 模式（光标变为 openhand），且刚绘制的图形保持选中
3. 在移动模式下点击并拖动该图形，拖动过程中光标应变为 closehand，释放后恢复 openhand
4. 移动鼠标在绘图区内晃动，光标应稳定保持手型，不会闪回默认箭头
5. 选择 `点` 工具绘制单点，绘制后应**不**自动切换到移动模式，保持原模式

## 4 What
绘图区绘制完一个图形（矩形、圆、线条等）后，仍停留在原绘制模式，用户需要手动切到移动模式才能拖动图形

## 6 How
### 6.1 标记新建状态 `creating-object?`
在 `graphics-single.scm` 新增状态变量：
- `object_create` 的曲线/闭合图形/圆角矩形分支开头置 `(set! creating-object? #t)`
- `object_checkout`（编辑已有图形）开头置 `(set! creating-object? #f)`，避免拖动已有图形控制点时误切模式

### 6.2 提交后自动切 move 模式
`object_commit` 成功提交图形后，若 `creating-object?` 为 `#t`：
1. 清掉编辑模式遗留的红色十字光标状态 `(set! graphics-texmacs-pointer "none")`
2. 调用 `(graphics-set-mode '(group-edit move))` 切换模式
3. 用保存的 `current-path` 把刚提交的图形重新 `sketch-toggle` 回选中集，保持可选中/可拖动
4. 重置 `current-obj` 为 `'(nothing)`，与 group-edit 模式状态保持一致

### 6.3 防止 move 事件重置光标
`edit_mouse.cpp` 中处理 `move` 事件的兜底分支原本无条件 `set_cursor_style ("normal")`

当鼠标实际悬停在绘图区上时，该逻辑会覆盖 graphics 模式通过 `set-cursor-style` 设置的手型光标，故改为改为：
```cpp
if (!over_graphics (x, y)) set_cursor_style ("normal");
```
只在鼠标确实不在绘图区上方时才重置为默认光标
