### PR TITLE
[0819] 修复拖动图形时填充色被污染

### DIFF
--- a/TeXmacs/tests/tmu/0819.tmu
+++ b/TeXmacs/tests/tmu/0819.tmu
@@ -1,0 +1,15 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|number-europe|preview-ref>>
+
+<\body>
+  <with|gr-mode|<tuple|group-edit|move>|gr-frame|<tuple|scale|1cm|<tuple|0.5gw|0.5gh>>|gr-geometry|<tuple|geometry|1par|0.6par>|gr-grid|<tuple|cartesian|<point|0|0>|1>|gr-edit-grid-aspect|<tuple|<tuple|axes|none>|<tuple|1|none>|<tuple|10|none>>|gr-edit-grid|<tuple|cartesian|<point|0|0>|1>|<graphics||<with|fill-color|pastel magenta|<cline|<point|-2.366666666666667|2.5000000000000004>|<point|-2.366666666666667|-1.5>|<point|-1.366666666666667|1.5>>>|<cline|<point|0.42000000000000004|2.2571428571428562>|<point|0.42000000000000004|0.2571428571428571>|<point|1.8200000000000007|1.2571428571428571>>>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|087C9680-2B17-4100-8BC7-C38A878B5970>
+  </collection>
+</initial>

--- a/devel/0819.md
+++ b/devel/0819.md
@@ -1,0 +1,37 @@
+# [0819] 修复拖动图形时填充色被污染
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式
+- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑
+
+## 2 任务相关的代码文件
+- `src/Edit/Interface/edit_graphics.cpp` — `set_graphical_object` 排版 `go_box` 前临时把 `FILL_COLOR` 置 `none`，避免继承光标所在对象的填充色
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 打开 `TeXmacs/tests/tmu/0819.tmu`
+2. 在 `移动`/`缩放`/`旋转` 模式下，先选中左边有色的三角形拖拽它，结束里立刻选中右边无色的三角形进行拖拽
+3. 操作过程中右边无色的三角形应保持无色，不再在拖拽过程中变成前面那个三角形的填充色
+4. 松手后右边三角形的颜色也应保持无色，再对左边有色的三角形进行操作，也应该正常
+
+## 4 What
+选中一个图形后立即拖动/缩放/旋转它，拖动过程中该图形的填充色会变成刚操作过的另一个图形的填充色，松手后再次拖动/缩放/旋转恢复正常
+
+## 5 Why
+绘图区的拖动/缩放/旋转预览靠 `go_box`（`graphical_object` 经 `typeset_as_concat` 排版出的 box）叠加渲染。`set_graphical_object` 排版 `go_box` 时借用了 `get_typesetter()->env`——这个环境反映的是**光标当前位置**，而非被拖对象本身。
+
+当光标停留在带 `fill-color` 的 `with` 对象内时（典型场景：刚给某对象改过填充色，选中操作把光标留在了它内部），`env[FILL_COLOR]` 变量被污染成该颜色。排版 `<graphics>` 容器时 `typeset_graphics` 会调 `env->update_color()`，它读 `env[FILL_COLOR]` 重算 `fill_brush`，于是把污染色灌进环境。被拖对象的轮廓是裸 `point`/`concat`（无 `with` 包裹、自身 `fill-color` 为 default），排版时直接继承了这个被污染的 `fill_brush`，被错误填充；而自带 `with "fill-color"` 的对象进入 `with` 时会重新 `update_color` 恢复自身颜色，所以不受影响——这正解释了"只有无色对象被污染、有色对象正常"。
+
+## 6 How
+`set_graphical_object` 排版 `go_box` 期间，用 `local_begin`/`local_end` 临时把 `env[FILL_COLOR]` 覆盖为 `"none"`，排完恢复原值。
+
+这样 `typeset_graphics` 的 `update_color` 读到的是 `none`，裸对象得到透明填充。
+
+自带 `with` 的对象照常恢复自身颜色，不会有影响的风险。

--- a/src/Edit/Interface/edit_graphics.cpp
+++ b/src/Edit/Interface/edit_graphics.cpp
@@ -395,6 +395,8 @@ edit_graphics_rep::set_graphical_object (tree t) {
   // tree old_fr= env->local_begin (GR_FRAME, (tree) find_frame ());
   frame f_env= env->fr;
   env->fr    = find_frame ();
+  // 排版 go_box 借用了反映光标位置的环境，临时把 FILL_COLOR 置 none，避免裸对象继承光标所在对象的填充色。
+  tree old_fc= env->local_begin (FILL_COLOR, "none");
   if (!is_nil (env->fr)) {
     int i, n= 0;
     go_box= typeset_as_concat (env, t, path (0));
@@ -415,6 +417,7 @@ edit_graphics_rep::set_graphical_object (tree t) {
       go_box= composite_box (path (0), bx);
     }
   }
+  env->local_end (FILL_COLOR, old_fc);
   env->fr= f_env;
   // env->local_end (GR_FRAME, old_fr);
 }

--- a/src/Edit/Interface/edit_graphics.cpp
+++ b/src/Edit/Interface/edit_graphics.cpp
@@ -395,7 +395,8 @@ edit_graphics_rep::set_graphical_object (tree t) {
   // tree old_fr= env->local_begin (GR_FRAME, (tree) find_frame ());
   frame f_env= env->fr;
   env->fr    = find_frame ();
-  // 排版 go_box 借用了反映光标位置的环境，临时把 FILL_COLOR 置 none，避免裸对象继承光标所在对象的填充色。
+  // 排版 go_box 借用了反映光标位置的环境，临时把 FILL_COLOR 置
+  // none，避免裸对象继承光标所在对象的填充色。
   tree old_fc= env->local_begin (FILL_COLOR, "none");
   if (!is_nil (env->fr)) {
     int i, n= 0;


### PR DESCRIPTION
# [0819] 修复拖动图形时填充色被污染

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式
- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑

## 2 任务相关的代码文件
- `src/Edit/Interface/edit_graphics.cpp` — `set_graphical_object` 排版 `go_box` 前临时把 `FILL_COLOR` 置 `none`，避免继承光标所在对象的填充色

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 打开 `TeXmacs/tests/tmu/0819.tmu`
2. 在 `移动`/`缩放`/`旋转` 模式下，先选中左边有色的三角形拖拽它，结束里立刻选中右边无色的三角形进行拖拽
3. 操作过程中右边无色的三角形应保持无色，不再在拖拽过程中变成前面那个三角形的填充色
4. 松手后右边三角形的颜色也应保持无色，再对左边有色的三角形进行操作，也应该正常

## 4 What
选中一个图形后立即拖动/缩放/旋转它，拖动过程中该图形的填充色会变成刚操作过的另一个图形的填充色，松手后再次拖动/缩放/旋转恢复正常

## 5 Why
绘图区的拖动/缩放/旋转预览靠 `go_box`（`graphical_object` 经 `typeset_as_concat` 排版出的 box）叠加渲染。`set_graphical_object` 排版 `go_box` 时借用了 `get_typesetter()->env`——这个环境反映的是**光标当前位置**，而非被拖对象本身。

当光标停留在带 `fill-color` 的 `with` 对象内时（典型场景：刚给某对象改过填充色，选中操作把光标留在了它内部），`env[FILL_COLOR]` 变量被污染成该颜色。排版 `<graphics>` 容器时 `typeset_graphics` 会调 `env->update_color()`，它读 `env[FILL_COLOR]` 重算 `fill_brush`，于是把污染色灌进环境。被拖对象的轮廓是裸 `point`/`concat`（无 `with` 包裹、自身 `fill-color` 为 default），排版时直接继承了这个被污染的 `fill_brush`，被错误填充；而自带 `with "fill-color"` 的对象进入 `with` 时会重新 `update_color` 恢复自身颜色，所以不受影响——这正解释了"只有无色对象被污染、有色对象正常"。

## 6 How
`set_graphical_object` 排版 `go_box` 期间，用 `local_begin`/`local_end` 临时把 `env[FILL_COLOR]` 覆盖为 `"none"`，排完恢复原值。

这样 `typeset_graphics` 的 `update_color` 读到的是 `none`，裸对象得到透明填充。

自带 `with` 的对象照常恢复自身颜色，不会有影响的风险。
