### PR TITLE
[0820] edit-props 模式吸收 move 的移动能力

### DIFF
--- a/TeXmacs/progs/graphics/graphics-drd.scm
+++ b/TeXmacs/progs/graphics/graphics-drd.scm
@@ -322,7 +322,6 @@
 (tm-define (graphics-mode-attributes mode)
   (cond ((func? mode 'edit 1) (graphics-attributes (cadr mode)))
         ((func? mode 'hand-edit 1) (graphics-attributes (cadr mode)))
-        ((== mode '(group-edit props)) (graphics-all-attributes))
         ((== mode '(group-edit edit-props)) (graphics-all-attributes))
         (else '())
   ) ;cond

--- a/TeXmacs/progs/graphics/graphics-env.scm
+++ b/TeXmacs/progs/graphics/graphics-env.scm
@@ -568,7 +568,7 @@
 ;; modes in which the cursor should become hand-style, see graphics-main.scm too.
 
 (define hand-modes
-  '((tuple "group-edit" "move")
+  '((tuple "group-edit" "edit-props")
     (tuple "group-edit" "rotate")
     (tuple "group-edit" "zoom"))
 ) ;define

--- a/TeXmacs/progs/graphics/graphics-group.scm
+++ b/TeXmacs/progs/graphics/graphics-group.scm
@@ -24,6 +24,8 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Group edit mode
+;;
+;; NOTE: 原 (group-edit move) 模式已完全并入 (group-edit edit-props)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; State
@@ -212,18 +214,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Copy and paste attribute style
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(tm-define (graphics-assign-props p obj)
-  (let* ((l1 (graphics-all-attributes))
-         (l2 (map gr-prefix l1))
-         (l3 (map (graphics-get-property-at p) l2))
-         (l4 (map cons l1 l3))
-         (tab (list->ahash-table l4))
-        ) ;
-    (graphics-remove p 'memoize-layer)
-    (graphics-group-enrich-insert-table (stree-radical obj) tab #f)
-  ) ;let*
-) ;tm-define
 
 (tm-define (graphics-get-props p)
   (and-with t
@@ -448,30 +438,6 @@
        (group-selected-objects)
      ) ;if
     ) ;
-    ((and (not multiselecting) (== (cadr (graphics-mode)) 'props))
-     (if (null? (sketch-get))
-       (if p
-         (begin
-           (set! obj (stree-at p))
-           (set! current-path (graphics-assign-props p obj))
-           (set! current-obj obj)
-           (graphics-decorations-update)
-         ) ;begin
-       ) ;if
-       (with l
-         '()
-         (for (o (sketch-get))
-           (with p
-             (graphics-assign-props (tree->path o) (tree->stree o))
-             (set! l (cons (path->tree p) l))
-           ) ;with
-         ) ;for
-         (sketch-set! (reverse l))
-         (graphics-decorations-update)
-       ) ;with
-     ) ;if
-     (graphics-group-start)
-    ) ;
     ((and (not multiselecting) (or p (nnull? (sketch-get))))
      (if (null? (sketch-get)) (any_toggle-select #f #f p obj))
      (store-important-points)
@@ -536,11 +502,7 @@
 ) ;tm-define
 
 (define (any_unselect-all p obj)
-  (cond ((nnull? (sketch-get)) (sketch-reset) (graphics-decorations-update))
-        ((and p (not multiselecting) (== (cadr (graphics-mode)) 'props))
-         (graphics-get-props p)
-        ) ;
-  ) ;cond
+  (if (nnull? (sketch-get)) (sketch-reset) (graphics-decorations-update))
 ) ;define
 
 (tm-define (unselect-everything) (any_unselect-all #f #f))
@@ -565,7 +527,7 @@
           (set! y (s2f y))
           (with mode
             (graphics-mode)
-            (cond ((== (cadr mode) 'move)
+            (cond ((== (cadr mode) 'edit-props)
                    (sketch-transform (group-translate (- x group-old-x) (- y group-old-y)))
                   ) ;
                   ((== (cadr mode) 'zoom)

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -1074,17 +1074,24 @@
 (tm-define (graphics-mode)
   (with m
     (tree->stree (get-env-tree "gr-mode"))
-    (cond ((string? m) `(edit ,(string->symbol m)))
-          ((== m '(uninit)) '(edit none))
-          ((and (pair? m) (== (car m) 'concat))
-           ;; Handle concat structure, find tuple element
-           (with tuple-elem
-             (list-find (cdr m) (lambda (x) (and (pair? x) (== (car x) 'tuple))))
-             (if tuple-elem (map string->symbol (cdr tuple-elem)) '(edit none))
-           ) ;with
-          ) ;
-          ((pair? m) (map string->symbol (cdr m)))
-    ) ;cond
+    ((lambda (r)
+       ;; 兼容旧文档：(group-edit move) 与 (group-edit props)
+       ;; 并入 (group-edit edit-props)
+       (if (or (equal? r '(group-edit move)) (equal? r '(group-edit props)))
+         '(group-edit edit-props)
+         r))
+     (cond ((string? m) `(edit ,(string->symbol m)))
+           ((== m '(uninit)) '(edit none))
+           ((and (pair? m) (== (car m) 'concat))
+            ;; Handle concat structure, find tuple element
+            (with tuple-elem
+              (list-find (cdr m) (lambda (x) (and (pair? x) (== (car x) 'tuple))))
+              (if tuple-elem (map string->symbol (cdr tuple-elem)) '(edit none))
+            ) ;with
+           ) ;
+           ((pair? m) (map string->symbol (cdr m)))
+     ) ;cond
+    ) ;lambda
   ) ;with
 ) ;tm-define
 

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -1079,7 +1079,9 @@
        ;; 并入 (group-edit edit-props)
        (if (or (equal? r '(group-edit move)) (equal? r '(group-edit props)))
          '(group-edit edit-props)
-         r))
+         r
+       ) ;if
+     ) ;lambda
      (cond ((string? m) `(edit ,(string->symbol m)))
            ((== m '(uninit)) '(edit none))
            ((and (pair? m) (== (car m) 'concat))
@@ -1091,7 +1093,7 @@
            ) ;
            ((pair? m) (map string->symbol (cdr m)))
      ) ;cond
-    ) ;lambda
+    ) ;
   ) ;with
 ) ;tm-define
 

--- a/TeXmacs/progs/graphics/graphics-menu.scm
+++ b/TeXmacs/progs/graphics/graphics-menu.scm
@@ -373,7 +373,6 @@
  ) ;assuming
  ---
  ("Set properties" (graphics-set-mode '(group-edit edit-props)))
- ("Move objects" (graphics-set-mode '(group-edit move)))
  ("Resize objects" (graphics-set-mode '(group-edit zoom)))
  ("Rotate objects" (graphics-set-mode '(group-edit rotate)))
  ("Group/ungroup" (graphics-set-mode '(group-edit group-ungroup)))
@@ -942,12 +941,6 @@
   ) ;check
   (graphics-set-mode '(group-edit edit-props))
  ) ;
- ((check (balloon (icon "tm_group_move.xpm") "Move objects")
-    "v"
-    (== (graphics-mode) '(group-edit move))
-  ) ;check
-  (graphics-set-mode '(group-edit move))
- ) ;
  ((check (balloon (icon "tm_group_zoom.xpm") "Zoom/unzoom objects")
     "v"
     (== (graphics-mode) '(group-edit zoom))
@@ -1236,10 +1229,8 @@
         ((== s '(edit text-at)) "text")
         ((== s '(edit math-at)) "mathematics")
         ((== s '(edit document-at)) "long text")
-        ((== s '(group-edit props)) "properties")
         ((== s '(group-edit edit-props)) "set properties")
         ((== s '(group-edit animate)) "animate")
-        ((== s '(group-edit move)) "move")
         ((== s '(group-edit zoom)) "resize")
         ((== s '(group-edit rotate)) "rotate")
         ((== s '(hand-edit penscript)) "penscript")

--- a/TeXmacs/progs/graphics/graphics-single.scm
+++ b/TeXmacs/progs/graphics/graphics-single.scm
@@ -255,8 +255,8 @@
             (with saved-path
               current-path
               (set! graphics-texmacs-pointer "none")
-              (graphics-set-mode '(group-edit move))
-              ;; 将当前对象切换到 move 模式后，重新选中该对象
+              (graphics-set-mode '(group-edit edit-props))
+              ;; 将当前对象切换到 edit-props 模式后，重新选中该对象
               (when saved-path
                 (with t
                   (path->tree saved-path)

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -375,17 +375,6 @@
   (with val (graphics-get-raw-property var) (tm->stree val))
 ) ;tm-define
 
-(tm-define ((graphics-get-property-at p) var)
-  (with r
-    (if (and (pair? p) (in? var (list "gr-gid" "gr-anim-id")))
-      (graphics-path-property p (string-drop var 3))
-      (graphics-get-property var)
-    ) ;if
-    ;; (display* p ", " var " ~~> " r "\n")
-    r
-  ) ;with
-) ;tm-define
-
 (tm-define (graphics-set-property var val)
   (with p
     (graphics-graphics-path)
@@ -414,6 +403,7 @@
   (cond ((number? m) m)
         ((== m "default") 1)
         ((== m #f) 1)
+        ((== m "mixed") 1)
         (else (string->number m))
   ) ;cond
 ) ;tm-define
@@ -518,10 +508,6 @@
 
 (tm-define (graphics-group-enrich-insert t)
   (graphics-group-insert (graphics-enrich t))
-) ;tm-define
-
-(tm-define (graphics-group-enrich-insert-table t tab go-into)
-  (graphics-group-insert-bis (graphics-enrich-bis t "default" tab) go-into)
 ) ;tm-define
 
 (tm-define (graphics-group-start)

--- a/devel/0820.md
+++ b/devel/0820.md
@@ -1,0 +1,51 @@
+# [0820] edit-props 模式吸收 move 的移动能力
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式（前置任务）
+- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑（前置任务）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-group.scm` — 删除 `graphics-assign-props` 及 `start-operation`/`any_unselect-all` 的 props 死分支；`edit_move` 的 translate case 由 `'move` 改为 `'edit-props`；group-edit 段头加吸收说明
+- `TeXmacs/progs/graphics/graphics-env.scm` — `hand-modes` 把 `move` 替换为 `edit-props`
+- `TeXmacs/progs/graphics/graphics-menu.scm` — 删除 move 工具栏按钮、菜单项及模式名映射中的 `move`/`props`
+- `TeXmacs/progs/graphics/graphics-main.scm` — `graphics-mode` 运行时把残留的 `(group-edit move)`/`(group-edit props)` 透明归一化为 `(group-edit edit-props)`
+- `TeXmacs/progs/graphics/graphics-single.scm` — `object_commit` 绘制后自动切换的目标由 `(group-edit move)` 改为 `(group-edit edit-props)`
+- `TeXmacs/progs/graphics/graphics-drd.scm` — 删除 `graphics-mode-attributes` 的 props 死分支
+- `TeXmacs/progs/graphics/graphics-utils.scm` — 删除 `graphics-get-property-at`、`graphics-group-enrich-insert-table` 两个无调用方的死代码；`magnify->number` 对 `"mixed"` 兜底为 1
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 进入绘图区，绘制一个图形，应自动进入 `属性编辑` 模式（而非 `移动`），刚绘制的图形保持选中
+2. 在 `属性编辑` 模式下拖动选中对象，对象随鼠标移动；拖动中光标为 closehand，松手回 normal
+3. 在空白处单击后拖拽，应拉出框选框；松开后框内图形全部被选中（不应崩溃）
+4. 选中对象后在上方属性面板修改属性（填充色、线宽等），属性应实时生效
+5. 切换到 `缩放`/`旋转` 工具再切回 `属性编辑`，选中集合应保持不变
+6. 工具栏已无 `移动` 按钮，只剩 `属性编辑`/`缩放`/`旋转`/`组合` 等
+
+## 4 What
+合并 move 与 edit-props：删除独立的 `(group-edit move)` 模式，由 `(group-edit edit-props)` 完全吸收其对象移动能力，同时保留 edit-props 原有的属性编辑功能不变。
+
+## 5 How
+### 5.1 edit-props 获得移动能力
+`edit_move` 的 sticky-point 分支里，translate case 的模式匹配由 `'move` 改为 `'edit-props`。拖动选中对象时 `edit_start-drag` → `start-operation 'move` → 走 move 通用分支（`sketch-checkout` 置 sticky-point）→ `edit_move` 用 `group-translate` 平移，与原 move 模式同路径。属性编辑路径（`graphics-set-property`/`graphics-apply-props` 等 `:require` 守卫）完全不变。
+
+### 5.2 删除 move 模式
+移除 move 工具栏按钮、菜单项及模式名映射。`hand-modes` 把 `move` 换成 `edit-props`，使拖动光标（closehand/normal）在 edit-props 下生效。`object_commit` 绘制后自动切换的目标由 move 改为 edit-props。
+
+### 5.3 旧文档兼容
+`graphics-mode` 用 `((lambda (r) (if (or (equal? r '(group-edit move)) (equal? r '(group-edit props))) '(group-edit edit-props) r)) (cond ...))` 的形式，把残留的 `move`/`props` 在运行时透明归一化为 `edit-props`。持久化层不动（文档里 `gr-mode` 仍是原值，直到用户主动切模式才被覆盖），加载即生效，不崩溃、无功能退化。
+
+### 5.4 修复框选崩溃
+edit-props 继承框选能力后，`get-local-magnify` 在"edit-props + 有选中 + 框选中"组合下会命中 `graphics-get-property` 的 edit-props 重载（返回选中集合并属性 `"mixed"`），`magnify->number "mixed"` 崩溃。在 `magnify->number` 对 `"mixed"` 兜底为 1 修复——装饰图形（框选框、选中标记）的 magnify 本就不该是混合值，`"mixed"` 是属性面板的显示概念，不应参与数值运算。
+
+## PS：本次删除的死代码无风险
+- **`graphics-assign-props`** 及其调用的 **`graphics-get-property-at`**、**`graphics-group-enrich-insert-table`**：`graphics-assign-props` 的唯一调用方是 `start-operation` 的 props 分支，该分支守卫 `(== (cadr (graphics-mode)) 'props)` 在真实模式下恒为假（属性模式是 `(group-edit edit-props)`，`(cadr mode)` 是 `'edit-props` 而非 `'props`），从未执行；删分支后这三个函数全仓库无调用方。
+- **`start-operation` / `any_unselect-all` / `graphics-mode-attributes` 的 props 分支**：同样匹配不可达的 `'props`。`'props` 仅由 C++ 升级器把古文档 `edit-prop` 升级产生，但本次改动已让 `graphics-mode` 把 `(group-edit props)` 运行时归一化为 `(group-edit edit-props)`，古文档加载后直接走 edit-props 正常路径，props 分支彻底不可达。
+- 属性编辑的正经路径（面板 `graphics-set-property` 的 `:require` 守卫、键盘 return `graphics-apply-props`、S-return `graphics-get-props`）均不经过被删代码，功能完整保留。


### PR DESCRIPTION
# [0820] edit-props 模式吸收 move 的移动能力

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式（前置任务）
- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑（前置任务）

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-group.scm` — 删除 `graphics-assign-props` 及 `start-operation`/`any_unselect-all` 的 props 死分支；`edit_move` 的 translate case 由 `'move` 改为 `'edit-props`；group-edit 段头加吸收说明
- `TeXmacs/progs/graphics/graphics-env.scm` — `hand-modes` 把 `move` 替换为 `edit-props`
- `TeXmacs/progs/graphics/graphics-menu.scm` — 删除 move 工具栏按钮、菜单项及模式名映射中的 `move`/`props`
- `TeXmacs/progs/graphics/graphics-main.scm` — `graphics-mode` 运行时把残留的 `(group-edit move)`/`(group-edit props)` 透明归一化为 `(group-edit edit-props)`
- `TeXmacs/progs/graphics/graphics-single.scm` — `object_commit` 绘制后自动切换的目标由 `(group-edit move)` 改为 `(group-edit edit-props)`
- `TeXmacs/progs/graphics/graphics-drd.scm` — 删除 `graphics-mode-attributes` 的 props 死分支
- `TeXmacs/progs/graphics/graphics-utils.scm` — 删除 `graphics-get-property-at`、`graphics-group-enrich-insert-table` 两个无调用方的死代码；`magnify->number` 对 `"mixed"` 兜底为 1

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 进入绘图区，绘制一个图形，应自动进入 `属性编辑` 模式（而非 `移动`），刚绘制的图形保持选中
2. 在 `属性编辑` 模式下拖动选中对象，对象随鼠标移动；拖动中光标为 closehand，松手回 normal
3. 在空白处单击后拖拽，应拉出框选框；松开后框内图形全部被选中（不应崩溃）
4. 选中对象后在上方属性面板修改属性（填充色、线宽等），属性应实时生效
5. 切换到 `缩放`/`旋转` 工具再切回 `属性编辑`，选中集合应保持不变
6. 工具栏已无 `移动` 按钮，只剩 `属性编辑`/`缩放`/`旋转`/`组合` 等

## 4 What
合并 move 与 edit-props：删除独立的 `(group-edit move)` 模式，由 `(group-edit edit-props)` 完全吸收其对象移动能力，同时保留 edit-props 原有的属性编辑功能不变。

## 5 How
### 5.1 edit-props 获得移动能力
`edit_move` 的 sticky-point 分支里，translate case 的模式匹配由 `'move` 改为 `'edit-props`。拖动选中对象时 `edit_start-drag` → `start-operation 'move` → 走 move 通用分支（`sketch-checkout` 置 sticky-point）→ `edit_move` 用 `group-translate` 平移，与原 move 模式同路径。属性编辑路径（`graphics-set-property`/`graphics-apply-props` 等 `:require` 守卫）完全不变。

### 5.2 删除 move 模式
移除 move 工具栏按钮、菜单项及模式名映射。`hand-modes` 把 `move` 换成 `edit-props`，使拖动光标（closehand/normal）在 edit-props 下生效。`object_commit` 绘制后自动切换的目标由 move 改为 edit-props。

### 5.3 旧文档兼容
`graphics-mode` 用 `((lambda (r) (if (or (equal? r '(group-edit move)) (equal? r '(group-edit props))) '(group-edit edit-props) r)) (cond ...))` 的形式，把残留的 `move`/`props` 在运行时透明归一化为 `edit-props`。持久化层不动（文档里 `gr-mode` 仍是原值，直到用户主动切模式才被覆盖），加载即生效，不崩溃、无功能退化。

### 5.4 修复框选崩溃
edit-props 继承框选能力后，`get-local-magnify` 在"edit-props + 有选中 + 框选中"组合下会命中 `graphics-get-property` 的 edit-props 重载（返回选中集合并属性 `"mixed"`），`magnify->number "mixed"` 崩溃。在 `magnify->number` 对 `"mixed"` 兜底为 1 修复——装饰图形（框选框、选中标记）的 magnify 本就不该是混合值，`"mixed"` 是属性面板的显示概念，不应参与数值运算。

## PS：本次删除的死代码无风险
- **`graphics-assign-props`** 及其调用的 **`graphics-get-property-at`**、**`graphics-group-enrich-insert-table`**：`graphics-assign-props` 的唯一调用方是 `start-operation` 的 props 分支，该分支守卫 `(== (cadr (graphics-mode)) 'props)` 在真实模式下恒为假（属性模式是 `(group-edit edit-props)`，`(cadr mode)` 是 `'edit-props` 而非 `'props`），从未执行；删分支后这三个函数全仓库无调用方。
- **`start-operation` / `any_unselect-all` / `graphics-mode-attributes` 的 props 分支**：同样匹配不可达的 `'props`。`'props` 仅由 C++ 升级器把古文档 `edit-prop` 升级产生，但本次改动已让 `graphics-mode` 把 `(group-edit props)` 运行时归一化为 `(group-edit edit-props)`，古文档加载后直接走 edit-props 正常路径，props 分支彻底不可达。
- 属性编辑的正经路径（面板 `graphics-set-property` 的 `:require` 守卫、键盘 return `graphics-apply-props`、S-return `graphics-get-props`）均不经过被删代码，功能完整保留。
