### PR TITLE
[0821] 修复绘图区操作延迟 & 缩放时图形消失

### DIFF
--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -275,6 +275,7 @@
         (graphics-decorations-reset)
         (graphics-set-property "gr-frame" newfr)
         (graphics-set-property "magnify" magn)
+        (graphics-decorations-update)
       ) ;with
     ) ;if
   ) ;let*
@@ -305,6 +306,7 @@
           ) ;
       (graphics-decorations-reset)
       (graphics-set-property "gr-frame" newfr)
+      (graphics-decorations-update)
     ) ;let*
   ) ;when
 ) ;tm-define
@@ -321,6 +323,7 @@
       (if (> (length-decode h2) 0) (set! h h2))
       (graphics-decorations-reset)
       (graphics-set-extents w h)
+      (graphics-decorations-update)
     ) ;let*
   ) ;when
 ) ;tm-define
@@ -1114,6 +1117,7 @@
       (graphics-enter-mode (graphics-mode) val)
     ) ;begin
   ) ;if
+  (delayed (:idle 1) (update-menus))
 ) ;tm-define
 
 

--- a/devel/0821.md
+++ b/devel/0821.md
@@ -1,0 +1,39 @@
+# [0821] 修复绘图区操作延迟 & 缩放时图形消失
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式
+- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑
+- [0819.md](0819.md) - 修复拖动图形时填充色被污染
+- [0820.md](0820.md) - edit-props 模式吸收 move 的移动能力
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-main.scm`
+  - `graphics-set-mode` 用 `(delayed (:idle 1) (update-menus))` 延迟刷新菜单
+  - `graphics-zoom`/`graphics-move-origin`/`graphics-change-extents` 在 `graphics-decorations-reset` 后补 `graphics-decorations-update`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在绘图模式的工具栏中来回切换 `属性编辑`/`缩放`/`旋转` 或点击绘制各种对象，观察切换速度
+2. 绘制过程中触发鼠标缩放事件，图形不应消失
+
+## 4 What
+- 点击工具栏切换绘图模式时，绘图区已立即进入新模式，但工具栏按钮的选中高亮仍显示旧模式，存在明显延迟
+- 绘制图形中途触发其他鼠标事件（如**缩放**），正在绘制的临时图形会突然消失，commit 后或鼠标移动后才重新出现
+
+## 5 Why
+### 5.1 工具栏切换延迟
+`graphics-set-mode` 通过 `graphics-set-property` 修改 `gr-mode` 后立刻调用 `update-menus`。但树修改后 `(graphics-mode)` 依赖的 typesetter 环境需要一次事件循环才能同步，立即重建菜单时 `menu-expand` 读到的是旧模式，导致 toolbar 按旧状态渲染。
+
+### 5.2 缩放时图形消失
+`graphics-zoom`、`graphics-move-origin`、`graphics-change-extents` 在改变 `gr-frame`/`gr-geometry` 前都会调 `graphics-decorations-reset` 清空临时 `graphical-object` 覆盖层，但清完后没有调 `graphics-decorations-update` 重绘。临时覆盖层只能等到下一次鼠标移动触发 `edit_move` 时才恢复，因此图形在视图变换期间消失。
+
+## 6 How
+- `graphics-set-mode` 末尾把 `(update-menus)` 改为 `(delayed (:idle 1) (update-menus))`，等下一个 idle 事件环境同步完成后再刷新工具栏
+- `graphics-zoom`、`graphics-move-origin`、`graphics-change-extents` 在改完属性后补 `(graphics-decorations-update)`，立即用新的坐标系/尺寸重绘正在绘制/选中的装饰与图形


### PR DESCRIPTION
# [0821] 修复绘图区操作延迟 & 缩放时图形消失

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式
- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑
- [0819.md](0819.md) - 修复拖动图形时填充色被污染
- [0820.md](0820.md) - edit-props 模式吸收 move 的移动能力

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-main.scm`
  - `graphics-set-mode` 用 `(delayed (:idle 1) (update-menus))` 延迟刷新菜单
  - `graphics-zoom`/`graphics-move-origin`/`graphics-change-extents` 在 `graphics-decorations-reset` 后补 `graphics-decorations-update`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在绘图模式的工具栏中来回切换 `属性编辑`/`缩放`/`旋转` 或点击绘制各种对象，观察切换速度
2. 绘制过程中触发鼠标缩放事件，图形不应消失

## 4 What
- 点击工具栏切换绘图模式时，绘图区已立即进入新模式，但工具栏按钮的选中高亮仍显示旧模式，存在明显延迟
- 绘制图形中途触发其他鼠标事件（如**缩放**），正在绘制的临时图形会突然消失，commit 后或鼠标移动后才重新出现

## 5 Why
### 5.1 工具栏切换延迟
`graphics-set-mode` 通过 `graphics-set-property` 修改 `gr-mode` 后立刻调用 `update-menus`。但树修改后 `(graphics-mode)` 依赖的 typesetter 环境需要一次事件循环才能同步，立即重建菜单时 `menu-expand` 读到的是旧模式，导致 toolbar 按旧状态渲染。

### 5.2 缩放时图形消失
`graphics-zoom`、`graphics-move-origin`、`graphics-change-extents` 在改变 `gr-frame`/`gr-geometry` 前都会调 `graphics-decorations-reset` 清空临时 `graphical-object` 覆盖层，但清完后没有调 `graphics-decorations-update` 重绘。临时覆盖层只能等到下一次鼠标移动触发 `edit_move` 时才恢复，因此图形在视图变换期间消失。

## 6 How
- `graphics-set-mode` 末尾把 `(update-menus)` 改为 `(delayed (:idle 1) (update-menus))`，等下一个 idle 事件环境同步完成后再刷新工具栏
- `graphics-zoom`、`graphics-move-origin`、`graphics-change-extents` 在改完属性后补 `(graphics-decorations-update)`，立即用新的坐标系/尺寸重绘正在绘制/选中的装饰与图形
