### PR TITLE
[0822] 方向键微移选中对象

### DIFF
--- a/TeXmacs/progs/graphics/graphics-group.scm
+++ b/TeXmacs/progs/graphics/graphics-group.scm
@@ -702,13 +702,16 @@
 (tm-define (graphics-should-nudge dx dy)
   (:state graphics-state)
   (and (not sticky-point)
-       (graphics-selection-active?)
-       (begin
-         (sketch-checkout)
-         (sketch-transform tree->stree)
-         (sketch-transform (group-translate dx dy))
-         (sketch-commit)
-         #t)))
+    (graphics-selection-active?)
+    (begin
+      (sketch-checkout)
+      (sketch-transform tree->stree)
+      (sketch-transform (group-translate dx dy))
+      (sketch-commit)
+      #t
+    ) ;begin
+  ) ;and
+) ;tm-define
 
 (tm-define (graphics-copy)
   (:state graphics-state)

--- a/TeXmacs/progs/graphics/graphics-group.scm
+++ b/TeXmacs/progs/graphics/graphics-group.scm
@@ -697,6 +697,19 @@
   (nnull? (sketch-get))
 ) ;tm-define
 
+;; 方向键微移当前选中的对象集合
+;; 复用鼠标拖动的 checkout/transform/commit 路径；无选中时 #f 回退
+(tm-define (graphics-should-nudge dx dy)
+  (:state graphics-state)
+  (and (not sticky-point)
+       (graphics-selection-active?)
+       (begin
+         (sketch-checkout)
+         (sketch-transform tree->stree)
+         (sketch-transform (group-translate dx dy))
+         (sketch-commit)
+         #t)))
+
 (tm-define (graphics-copy)
   (:state graphics-state)
   (set! paste-times 0)

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -79,6 +79,18 @@
 (tm-define (graphics-arrow-up)
   (or (graphics-should-nudge 0 0.1) (graphics-move-origin-up))
 ) ;tm-define
+(tm-define (graphics-arrow-left-fast)
+  (or (graphics-should-nudge -1.0 0) (graphics-move-origin-left-fast))
+) ;tm-define
+(tm-define (graphics-arrow-right-fast)
+  (or (graphics-should-nudge 1.0 0) (graphics-move-origin-right-fast))
+) ;tm-define
+(tm-define (graphics-arrow-down-fast)
+  (or (graphics-should-nudge 0 -1.0) (graphics-move-origin-down-fast))
+) ;tm-define
+(tm-define (graphics-arrow-up-fast)
+  (or (graphics-should-nudge 0 1.0) (graphics-move-origin-up-fast))
+) ;tm-define
 
 (tm-define (graphics-decrease-hsize) (graphics-change-extents "-0.1cm" "0cm"))
 (tm-define (graphics-increase-hsize) (graphics-change-extents "+0.1cm" "0cm"))
@@ -132,10 +144,10 @@
  ("right" (graphics-arrow-right))
  ("down" (graphics-arrow-down))
  ("up" (graphics-arrow-up))
- ("S-left" (graphics-move-origin-left-fast))
- ("S-right" (graphics-move-origin-right-fast))
- ("S-down" (graphics-move-origin-down-fast))
- ("S-up" (graphics-move-origin-up-fast))
+ ("S-left" (graphics-arrow-left-fast))
+ ("S-right" (graphics-arrow-right-fast))
+ ("S-down" (graphics-arrow-down-fast))
+ ("S-up" (graphics-arrow-up-fast))
  ("home" (graphics-zmove 'foreground))
  ("end" (graphics-zmove 'background))
  ("pageup" (graphics-zmove 'closer))

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -65,6 +65,21 @@
 ) ;tm-define
 (tm-define (graphics-move-origin-up-fast) (graphics-move-origin "0gw" "-0.1gh"))
 
+;; 方向键在 group-edit 且有选中对象时微移选中对象
+;; 否则回退到平移整个坐标系
+(tm-define (graphics-arrow-left)
+  (or (graphics-should-nudge -0.1 0)
+      (graphics-move-origin-left))) ;tm-define
+(tm-define (graphics-arrow-right)
+  (or (graphics-should-nudge 0.1 0)
+      (graphics-move-origin-right))) ;tm-define
+(tm-define (graphics-arrow-down)
+  (or (graphics-should-nudge 0 -0.1)
+      (graphics-move-origin-down))) ;tm-define
+(tm-define (graphics-arrow-up)
+  (or (graphics-should-nudge 0 0.1)
+      (graphics-move-origin-up))) ;tm-define
+
 (tm-define (graphics-decrease-hsize) (graphics-change-extents "-0.1cm" "0cm"))
 (tm-define (graphics-increase-hsize) (graphics-change-extents "+0.1cm" "0cm"))
 (tm-define (graphics-decrease-vsize) (graphics-change-extents "0cm" "-0.1cm"))
@@ -113,10 +128,10 @@
  ("b" (graphics-set-origin "0gw" "0gh"))
  ("#" (graphics-toggle-grid))
  ("!" (open-plots-editor "scheme" "default" ""))
- ("left" (graphics-move-origin-left))
- ("right" (graphics-move-origin-right))
- ("down" (graphics-move-origin-down))
- ("up" (graphics-move-origin-up))
+ ("left" (graphics-arrow-left))
+ ("right" (graphics-arrow-right))
+ ("down" (graphics-arrow-down))
+ ("up" (graphics-arrow-up))
  ("S-left" (graphics-move-origin-left-fast))
  ("S-right" (graphics-move-origin-right-fast))
  ("S-down" (graphics-move-origin-down-fast))

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -68,17 +68,17 @@
 ;; 方向键在 group-edit 且有选中对象时微移选中对象
 ;; 否则回退到平移整个坐标系
 (tm-define (graphics-arrow-left)
-  (or (graphics-should-nudge -0.1 0)
-      (graphics-move-origin-left))) ;tm-define
+  (or (graphics-should-nudge -0.1 0) (graphics-move-origin-left))
+) ;tm-define
 (tm-define (graphics-arrow-right)
-  (or (graphics-should-nudge 0.1 0)
-      (graphics-move-origin-right))) ;tm-define
+  (or (graphics-should-nudge 0.1 0) (graphics-move-origin-right))
+) ;tm-define
 (tm-define (graphics-arrow-down)
-  (or (graphics-should-nudge 0 -0.1)
-      (graphics-move-origin-down))) ;tm-define
+  (or (graphics-should-nudge 0 -0.1) (graphics-move-origin-down))
+) ;tm-define
 (tm-define (graphics-arrow-up)
-  (or (graphics-should-nudge 0 0.1)
-      (graphics-move-origin-up))) ;tm-define
+  (or (graphics-should-nudge 0 0.1) (graphics-move-origin-up))
+) ;tm-define
 
 (tm-define (graphics-decrease-hsize) (graphics-change-extents "-0.1cm" "0cm"))
 (tm-define (graphics-increase-hsize) (graphics-change-extents "+0.1cm" "0cm"))

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -307,6 +307,11 @@
       (graphics-decorations-reset)
       (graphics-set-property "gr-frame" newfr)
       (graphics-decorations-update)
+      (delayed (:idle 1)
+        (when (and current-x current-y)
+          (edit_move (car (graphics-mode)) current-x current-y)
+        ) ;when
+      ) ;delayed
     ) ;let*
   ) ;when
 ) ;tm-define

--- a/devel/0822.md
+++ b/devel/0822.md
@@ -1,0 +1,37 @@
+# [0822] 方向键微移选中对象
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式
+- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑
+- [0820.md](0820.md) - edit-props 模式吸收 move 的移动能力
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-kbd.scm`
+  - 新增 `graphics-arrow-left/right/down/up`：方向键分派，有选中则微移对象，否则回退到平移坐标系
+  - `kbd-map` 中 `left/right/down/up` 由 `graphics-move-origin-*` 改绑到 `graphics-arrow-*`
+- `TeXmacs/progs/graphics/graphics-group.scm`
+  - 新增 `graphics-should-nudge dx dy`：复用鼠标拖动的 checkout/transform/commit 路径整体平移选中集合
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 进入绘图区，选中一个对象，按方向键应微移选中对象（每次 0.1 图形单位），坐标系不动
+2. 取消选中一个对象，按方向键应平移整个坐标系；
+3. 鼠标悬浮在这个对象上，按方向键平移坐标系时，蓝色边框不应该有 delay
+
+## 4 What
+- 有选中对象时，方向键应移动当前选中的对象，而非移动整个坐标系
+- 无选中对象时，方向键行为不变（平移坐标系）
+- 坐标系平移后，鼠标悬停的蓝色边框/控制点应立即跟随，不应等鼠标移动才对齐
+
+## 5 How
+- `graphics-should-nudge dx dy`：当 `sticky-point` 为假且 `(graphics-selection-active?)`（sketch 非空）时，依次 `sketch-checkout` → `sketch-transform tree->stree`（转 stree）→ `sketch-transform (group-translate dx dy)`（平移）→ `sketch-commit`，复用与鼠标拖动完全相同的 checkout/transform/commit 路径，撤销与装饰层一致；返回 `#t`。否则返回 `#f`。
+- `graphics-arrow-left/right/down/up`：用 `(or (graphics-should-nudge dx dy) (graphics-move-origin-*))` 短路分派——nudge 成功则不执行后半段，无选中回退到平移坐标系。
+- `kbd-map` 把 `left/right/down/up` 改绑到 `graphics-arrow-*`；`S-方向键` 保持原 `graphics-move-origin-*-fast` 平移。
+- 坐标系平移后刷新悬停命中：`graphics-move-origin` 改 `gr-frame` 后 typesetter 需一拍才用新坐标系排版（命中重算 `graphical-select` 读排版后盒子位置，立即重算仍用旧布局），故在 `graphics-decorations-update` 后用 `(delayed (:idle 1) ...)` 推迟到下个 idle，再用当前鼠标坐标调 `edit_move`（其 `:state graphics-state` 标注会重跑 `select-choose` 重算 `current-path`）刷新装饰。键盘/wheel/菜单平移都经此函数，一并修好。

--- a/devel/0822.md
+++ b/devel/0822.md
@@ -22,16 +22,18 @@ xmake r stem
 
 ### 3.2 非确定性测试（交互验证）
 1. 进入绘图区，选中一个对象，按方向键应微移选中对象（每次 0.1 图形单位），坐标系不动
-2. 取消选中一个对象，按方向键应平移整个坐标系；
-3. 鼠标悬浮在这个对象上，按方向键平移坐标系时，蓝色边框不应该有 delay
+2. 按住 Shift+方向键应微移选中对象（每次 1.0 图形单位），坐标系不动
+3. 取消选中一个对象，按方向键应平移整个坐标系；
+4. 鼠标悬浮在这个对象上，按方向键平移坐标系时，蓝色边框不应该有 delay
 
 ## 4 What
 - 有选中对象时，方向键应移动当前选中的对象，而非移动整个坐标系
 - 无选中对象时，方向键行为不变（平移坐标系）
+- Shift+方向键同样微移选中对象，加速量为普通 nudge（`0.1`）的 10 倍（`1.0` 图形单位），对齐原版平移坐标系 `0.1gw`/`0.01gw` 的 10 倍加速比；无选中则保持原 fast 平移坐标系行为
 - 坐标系平移后，鼠标悬停的蓝色边框/控制点应立即跟随，不应等鼠标移动才对齐
 
 ## 5 How
 - `graphics-should-nudge dx dy`：当 `sticky-point` 为假且 `(graphics-selection-active?)`（sketch 非空）时，依次 `sketch-checkout` → `sketch-transform tree->stree`（转 stree）→ `sketch-transform (group-translate dx dy)`（平移）→ `sketch-commit`，复用与鼠标拖动完全相同的 checkout/transform/commit 路径，撤销与装饰层一致；返回 `#t`。否则返回 `#f`。
 - `graphics-arrow-left/right/down/up`：用 `(or (graphics-should-nudge dx dy) (graphics-move-origin-*))` 短路分派——nudge 成功则不执行后半段，无选中回退到平移坐标系。
-- `kbd-map` 把 `left/right/down/up` 改绑到 `graphics-arrow-*`；`S-方向键` 保持原 `graphics-move-origin-*-fast` 平移。
+- `graphics-arrow-*-fast`：同上分派但传 `1.0`（10 倍）nudge 量，回退到 `graphics-move-origin-*-fast`；`kbd-map` 把 `S-方向键` 改绑到 `graphics-arrow-*-fast`。
 - 坐标系平移后刷新悬停命中：`graphics-move-origin` 改 `gr-frame` 后 typesetter 需一拍才用新坐标系排版（命中重算 `graphical-select` 读排版后盒子位置，立即重算仍用旧布局），故在 `graphics-decorations-update` 后用 `(delayed (:idle 1) ...)` 推迟到下个 idle，再用当前鼠标坐标调 `edit_move`（其 `:state graphics-state` 标注会重跑 `select-choose` 重算 `current-path`）刷新装饰。键盘/wheel/菜单平移都经此函数，一并修好。


### PR DESCRIPTION
# [0822] 方向键微移选中对象

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式
- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑
- [0820.md](0820.md) - edit-props 模式吸收 move 的移动能力

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-kbd.scm`
  - 新增 `graphics-arrow-left/right/down/up`：方向键分派，有选中则微移对象，否则回退到平移坐标系
  - `kbd-map` 中 `left/right/down/up` 由 `graphics-move-origin-*` 改绑到 `graphics-arrow-*`
- `TeXmacs/progs/graphics/graphics-group.scm`
  - 新增 `graphics-should-nudge dx dy`：复用鼠标拖动的 checkout/transform/commit 路径整体平移选中集合

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 进入绘图区，选中一个对象，按方向键应微移选中对象（每次 0.1 图形单位），坐标系不动
2. 按住 Shift+方向键应微移选中对象（每次 1.0 图形单位），坐标系不动
3. 取消选中一个对象，按方向键应平移整个坐标系；
4. 鼠标悬浮在这个对象上，按方向键平移坐标系时，蓝色边框不应该有 delay

## 4 What
- 有选中对象时，方向键应移动当前选中的对象，而非移动整个坐标系
- 无选中对象时，方向键行为不变（平移坐标系）
- Shift+方向键同样微移选中对象，加速量为普通 nudge（`0.1`）的 10 倍（`1.0` 图形单位），对齐原版平移坐标系 `0.1gw`/`0.01gw` 的 10 倍加速比；无选中则保持原 fast 平移坐标系行为
- 坐标系平移后，鼠标悬停的蓝色边框/控制点应立即跟随，不应等鼠标移动才对齐

## 5 How
- `graphics-should-nudge dx dy`：当 `sticky-point` 为假且 `(graphics-selection-active?)`（sketch 非空）时，依次 `sketch-checkout` → `sketch-transform tree->stree`（转 stree）→ `sketch-transform (group-translate dx dy)`（平移）→ `sketch-commit`，复用与鼠标拖动完全相同的 checkout/transform/commit 路径，撤销与装饰层一致；返回 `#t`。否则返回 `#f`。
- `graphics-arrow-left/right/down/up`：用 `(or (graphics-should-nudge dx dy) (graphics-move-origin-*))` 短路分派——nudge 成功则不执行后半段，无选中回退到平移坐标系。
- `graphics-arrow-*-fast`：同上分派但传 `1.0`（10 倍）nudge 量，回退到 `graphics-move-origin-*-fast`；`kbd-map` 把 `S-方向键` 改绑到 `graphics-arrow-*-fast`。
- 坐标系平移后刷新悬停命中：`graphics-move-origin` 改 `gr-frame` 后 typesetter 需一拍才用新坐标系排版（命中重算 `graphical-select` 读排版后盒子位置，立即重算仍用旧布局），故在 `graphics-decorations-update` 后用 `(delayed (:idle 1) ...)` 推迟到下个 idle，再用当前鼠标坐标调 `edit_move`（其 `:state graphics-state` 标注会重跑 `select-choose` 重算 `current-path`）刷新装饰。键盘/wheel/菜单平移都经此函数，一并修好。
