### PR TITLE
[0823] 修复绘图区红十字光标消失

### DIFF
--- a/devel/0823.md
+++ b/devel/0823.md
@@ -9,10 +9,10 @@
 
 ## 3 如何测试
 
-### 3.1 确定性测试（启动验证）
+### 3.1 确定性测试（单元测试）
 ```bash
 xmake b stem
-xmake r stem --version
+xmake r stem
 ```
 
 ### 3.2 非确定性测试（交互验证）

--- a/devel/0823.md
+++ b/devel/0823.md
@@ -1,0 +1,51 @@
+# [0823] 修复绘图区红十字光标消失
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式
+- [0819.md](0819.md) - 修复拖动图形时填充色被污染
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_gui.cpp` — `gui_open()` 中补调 `initialize_colors()`，确保 Qt 构建下全局颜色常量（`red` 等）被初始化
+
+## 3 如何测试
+
+### 3.1 确定性测试（启动验证）
+```bash
+xmake b stem
+xmake r stem --version
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 进入绘图模式，移动鼠标，红十字光标应正常显示
+
+## 4 What
+`colors.cpp` 迁移到 moebius 合并后，回归出现：在绘图区移动鼠标时本应显示的红十字光标消失。
+
+## 5 Why
+迁移删除了原 `#ifdef QTTEXMACS` 分支对全局颜色常量的直接初始化：
+
+```cpp
+// 旧代码：Qt 构建直接初始化
+#ifdef QTTEXMACS
+color red = rgb_color (255, 0, 0);
+...
+#endif
+```
+
+新代码统一为只声明 `color black, white, red, green, blue;`，再依赖 `initialize_colors()` 运行时初始化。但 X11 移除后，`initialize_colors()` 的调用路径已不存在；Qt 构建此前一直靠直接初始化，迁移后全局常量保持零初始化（`color` 是 `unsigned int`，默认 0）。
+
+`edit_repaint.cpp` 的 `draw_graphics()` 用 `pencil (red, pixel)` 绘制红十字，`red == 0` 致使十字不可见。
+
+## 6 How
+在 Qt 启动入口 `gui_open()` 中调用 `initialize_colors()`：
+
+```cpp
+void
+gui_open (int& argc, char** argv) {
+  the_gui= tm_new<qt_gui_rep> (argc, argv);
+  initialize_colors ();
+  ...
+}
+```
+
+该位置在 `TeXmacs_main` 参数解析之后，`-r`（reverse video）等影响 `reverse_colors` 的选项已生效；同时也是所有 Qt 构建进入 GUI 的必经入口，最小化修改范围。

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -617,6 +617,10 @@ gui_open (int& argc, char** argv) {
   // new QApplication (argc,argv); now in texmacs.cpp
   the_gui= tm_new<qt_gui_rep> (argc, argv);
 
+  // 补初始化全局颜色常量（red 等），X11 移除后原调用路径已断
+  // 红十字光标等依赖 red 的绘制会失效，故在此初始化一下
+  initialize_colors ();
+
 #ifdef MACOSX_EXTENSIONS
   mac_begin_remote ();
 #endif


### PR DESCRIPTION
# [0823] 修复绘图区红十字光标消失

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式
- [0819.md](0819.md) - 修复拖动图形时填充色被污染

## 2 任务相关的代码文件
- `src/Plugins/Qt/qt_gui.cpp` — `gui_open()` 中补调 `initialize_colors()`，确保 Qt 构建下全局颜色常量（`red` 等）被初始化

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 进入绘图模式，移动鼠标，红十字光标应正常显示

## 4 What
`colors.cpp` 迁移到 moebius 合并后，回归出现：在绘图区移动鼠标时本应显示的红十字光标消失。

## 5 Why
迁移删除了原 `#ifdef QTTEXMACS` 分支对全局颜色常量的直接初始化：

```cpp
// 旧代码：Qt 构建直接初始化
#ifdef QTTEXMACS
color red = rgb_color (255, 0, 0);
...
#endif
```

新代码统一为只声明 `color black, white, red, green, blue;`，再依赖 `initialize_colors()` 运行时初始化。但 X11 移除后，`initialize_colors()` 的调用路径已不存在；Qt 构建此前一直靠直接初始化，迁移后全局常量保持零初始化（`color` 是 `unsigned int`，默认 0）。

`edit_repaint.cpp` 的 `draw_graphics()` 用 `pencil (red, pixel)` 绘制红十字，`red == 0` 致使十字不可见。

## 6 How
在 Qt 启动入口 `gui_open()` 中调用 `initialize_colors()`：

```cpp
void
gui_open (int& argc, char** argv) {
  the_gui= tm_new<qt_gui_rep> (argc, argv);
  initialize_colors ();
  ...
}
```

该位置在 `TeXmacs_main` 参数解析之后，`-r`（reverse video）等影响 `reverse_colors` 的选项已生效；同时也是所有 Qt 构建进入 GUI 的必经入口，最小化修改范围。
