### PR TITLE
[0825] 绘图模式按图形类型保存属性配置

### DIFF
--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -1119,6 +1119,9 @@
     (begin
       (graphics-group-start)
       (graphics-set-property "gr-mode" `(tuple ,@(map symbol->string val)))
+      (when (func? val 'edit 1)
+        (graphics-restore-type-config (cadr val))
+      ) ;when
       (graphics-enter-mode (graphics-mode) val)
     ) ;begin
   ) ;if

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -383,6 +383,7 @@
           ((== val (graphics-attribute-default var)) (graphics-remove-property var))
           (p (path-insert-with p var val))
     ) ;cond
+    (when (not (tree? val)) (graphics-sync-type-config var val))
   ) ;with
 ) ;tm-define
 
@@ -416,6 +417,88 @@
 
 (tm-define (multiply-magnify m1 m2)
   (number->magnify (* (magnify->number m1) (magnify->number m2)))
+) ;tm-define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Per-type property configuration (gr-props-<type>)
+;;
+;; 为每种图形类型各存一份独立的属性配置，随文档持久化于 <graphics> 外层
+;; with 变量 gr-props-<type>（成对 属性名 值 的 tuple，仅存相关且非默认项）。
+;; 改属性时实时写入当前类型存储；切换类型时把目标存储恢复到全局 gr-*。
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; per-type 配置对应的 <graphics> with 变量名
+(tm-define (graphics-props-var tag)
+  (string-append "gr-props-" (symbol->string tag))
+) ;tm-define
+
+;; 单条 gr-* 写入时，实时并入当前绘制类型的配置
+;; 排除 gr-mode 与 gr-props-* 自身（避免递归）
+(tm-define (graphics-sync-type-config var val)
+  (let* ((m (graphics-mode))
+         (tag (and (func? m 'edit 1) (cadr m)))
+         (attr (and (gr-prefixed? var) (gr-unprefix var))))
+    (when (and tag attr (!= var "gr-mode")
+               (not (string-starts? var "gr-props-"))
+               (graphics-mode-attribute? `(edit ,tag) attr))
+      (with tab (graphics-get-type-config tag)
+        (if (and val (!= val "default") (!= val (graphics-attribute-default attr)))
+          (ahash-set! tab attr val)
+          (ahash-remove! tab attr)
+        ) ;if
+        (graphics-set-type-config tag tab)
+      ) ;with
+    ) ;when
+  ) ;let*
+) ;tm-define
+
+;; 读取当前类型的配置（属性名 -> 值），未存则空表
+(tm-define (graphics-get-type-config tag)
+  (let* ((tab (make-ahash-table))
+         (raw (graphics-get-property (graphics-props-var tag))))
+    (when (and (pair? raw) (== (car raw) 'tuple))
+      (with l (cdr raw)
+        (while (nnull? l)
+          (ahash-set! tab (car l) (cadr l))
+          (set! l (cddr l))
+        ) ;while
+      ) ;with
+    ) ;when
+    tab
+  ) ;let*
+) ;tm-define
+
+;; 把配置写回 gr-props-<type>
+(tm-define (graphics-set-type-config tag tab)
+  (with p (graphics-graphics-path)
+    (when p
+      (with pairs (append-map (lambda (x) (list (car x) (cdr x))) (ahash-table->list tab))
+        (if (null? pairs)
+          (path-remove-with p (graphics-props-var tag))
+          (path-insert-with p (graphics-props-var tag) `(tuple ,@pairs))
+        ) ;if
+      ) ;with
+    ) ;when
+  ) ;with
+) ;tm-define
+
+;; 把该类型的配置回填到全局 gr-*
+(tm-define (graphics-restore-type-config tag)
+  (let* ((attrs (graphics-mode-attributes `(edit ,tag)))
+         (tab (graphics-get-type-config tag))
+         (p (graphics-graphics-path)))
+    (when (and (nnull? attrs) p)
+      (for (attr attrs)
+        (let* ((var (gr-prefix attr))
+               (val (or (ahash-ref tab attr) "default")))
+          (if (or (== val "default") (== val (graphics-attribute-default attr)))
+            (path-remove-with p var)
+            (path-insert-with p var val)
+          ) ;if
+        ) ;let*
+      ) ;for
+    ) ;when
+  ) ;let*
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -383,7 +383,7 @@
           ((== val (graphics-attribute-default var)) (graphics-remove-property var))
           (p (path-insert-with p var val))
     ) ;cond
-    (unless (tree? val) (graphics-sync-type-config var val))
+    (unless (or (tree? val) graphics-on-restore) (graphics-sync-type-config var val))
   ) ;with
 ) ;tm-define
 
@@ -431,6 +431,9 @@
 (tm-define (graphics-props-var tag)
   (string-append "gr-props-" (symbol->string tag))
 ) ;tm-define
+
+;; restore 期间不应再触发 sync 回写存储
+(define graphics-on-restore #f)
 
 ;; 单条 gr-* 写入时，实时并入当前 type 的配置
 ;; 排除 gr-mode 与 gr-props-* 自身（避免递归）
@@ -484,21 +487,19 @@
 
 ;; 把该 type 的配置回填到全局 gr-*
 (tm-define (graphics-restore-type-config tag)
-  (let* ((attrs (graphics-mode-attributes `(edit ,tag)))
-         (tab (graphics-get-type-config tag))
-         (p (graphics-graphics-path)))
-    (when (and (nnull? attrs) p)
-      (for (attr attrs)
-        (let* ((var (gr-prefix attr))
-               (val (or (ahash-ref tab attr) "default")))
-          (if (or (== val "default") (== val (graphics-attribute-default attr)))
-            (path-remove-with p var)
-            (path-insert-with p var val)
-          ) ;if
-        ) ;let*
-      ) ;for
+  (with attrs (graphics-mode-attributes `(edit ,tag))
+    (when (nnull? attrs)
+      (with tab (graphics-get-type-config tag)
+        ;; 清除选中，避免误改选中对象
+        (sketch-reset)
+        (set! graphics-on-restore #t)
+        (for (attr attrs)
+          (graphics-set-property (gr-prefix attr) (or (ahash-ref tab attr) "default"))
+        ) ;for
+        (set! graphics-on-restore #f)
+      ) ;with
     ) ;when
-  ) ;let*
+  ) ;with
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -383,7 +383,7 @@
           ((== val (graphics-attribute-default var)) (graphics-remove-property var))
           (p (path-insert-with p var val))
     ) ;cond
-    (when (not (tree? val)) (graphics-sync-type-config var val))
+    (unless (tree? val) (graphics-sync-type-config var val))
   ) ;with
 ) ;tm-define
 
@@ -420,11 +420,11 @@
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Per-type property configuration (gr-props-<type>)
+;; per type property configuration (gr-props-<type>)
 ;;
-;; 为每种图形类型各存一份独立的属性配置，随文档持久化于 <graphics> 外层
-;; with 变量 gr-props-<type>（成对 属性名 值 的 tuple，仅存相关且非默认项）。
-;; 改属性时实时写入当前类型存储；切换类型时把目标存储恢复到全局 gr-*。
+;; 为每种图形类型（type）各存一份独立的属性配置，随文档持久化于 <graphics> 外层
+;; with 变量 gr-props-<type>（成对 "属性名" "值" 的 tuple，仅存相关且非默认项）
+;; 改属性时实时写入当前 type 存储；切换 type 时把目标存储恢复到全局 gr-*
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; per-type 配置对应的 <graphics> with 变量名
@@ -432,7 +432,7 @@
   (string-append "gr-props-" (symbol->string tag))
 ) ;tm-define
 
-;; 单条 gr-* 写入时，实时并入当前绘制类型的配置
+;; 单条 gr-* 写入时，实时并入当前 type 的配置
 ;; 排除 gr-mode 与 gr-props-* 自身（避免递归）
 (tm-define (graphics-sync-type-config var val)
   (let* ((m (graphics-mode))
@@ -452,7 +452,7 @@
   ) ;let*
 ) ;tm-define
 
-;; 读取当前类型的配置（属性名 -> 值），未存则空表
+;; 读取当前 type 的配置（属性名 -> 值），未存则空表
 (tm-define (graphics-get-type-config tag)
   (let* ((tab (make-ahash-table))
          (raw (graphics-get-property (graphics-props-var tag))))
@@ -482,7 +482,7 @@
   ) ;with
 ) ;tm-define
 
-;; 把该类型的配置回填到全局 gr-*
+;; 把该 type 的配置回填到全局 gr-*
 (tm-define (graphics-restore-type-config tag)
   (let* ((attrs (graphics-mode-attributes `(edit ,tag)))
          (tab (graphics-get-type-config tag))

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -383,7 +383,9 @@
           ((== val (graphics-attribute-default var)) (graphics-remove-property var))
           (p (path-insert-with p var val))
     ) ;cond
-    (unless (or (tree? val) graphics-on-restore) (graphics-sync-type-config var val))
+    (unless (or (tree? val) graphics-on-restore)
+      (graphics-sync-type-config var val)
+    ) ;unless
   ) ;with
 ) ;tm-define
 
@@ -433,6 +435,7 @@
 ) ;tm-define
 
 ;; restore 期间不应再触发 sync 回写存储
+
 (define graphics-on-restore #f)
 
 ;; 单条 gr-* 写入时，实时并入当前 type 的配置
@@ -440,11 +443,16 @@
 (tm-define (graphics-sync-type-config var val)
   (let* ((m (graphics-mode))
          (tag (and (func? m 'edit 1) (cadr m)))
-         (attr (and (gr-prefixed? var) (gr-unprefix var))))
-    (when (and tag attr (!= var "gr-mode")
-               (not (string-starts? var "gr-props-"))
-               (graphics-mode-attribute? `(edit ,tag) attr))
-      (with tab (graphics-get-type-config tag)
+         (attr (and (gr-prefixed? var) (gr-unprefix var)))
+        ) ;
+    (when (and tag
+            attr
+            (!= var "gr-mode")
+            (not (string-starts? var "gr-props-"))
+            (graphics-mode-attribute? `(edit ,tag) attr)
+          ) ;and
+      (with tab
+        (graphics-get-type-config tag)
         (if (and val (!= val "default") (!= val (graphics-attribute-default attr)))
           (ahash-set! tab attr val)
           (ahash-remove! tab attr)
@@ -458,13 +466,12 @@
 ;; 读取当前 type 的配置（属性名 -> 值），未存则空表
 (tm-define (graphics-get-type-config tag)
   (let* ((tab (make-ahash-table))
-         (raw (graphics-get-property (graphics-props-var tag))))
+         (raw (graphics-get-property (graphics-props-var tag)))
+        ) ;
     (when (and (pair? raw) (== (car raw) 'tuple))
-      (with l (cdr raw)
-        (while (nnull? l)
-          (ahash-set! tab (car l) (cadr l))
-          (set! l (cddr l))
-        ) ;while
+      (with l
+        (cdr raw)
+        (while (nnull? l) (ahash-set! tab (car l) (cadr l)) (set! l (cddr l)))
       ) ;with
     ) ;when
     tab
@@ -473,9 +480,11 @@
 
 ;; 把配置写回 gr-props-<type>
 (tm-define (graphics-set-type-config tag tab)
-  (with p (graphics-graphics-path)
+  (with p
+    (graphics-graphics-path)
     (when p
-      (with pairs (append-map (lambda (x) (list (car x) (cdr x))) (ahash-table->list tab))
+      (with pairs
+        (append-map (lambda (x) (list (car x) (cdr x))) (ahash-table->list tab))
         (if (null? pairs)
           (path-remove-with p (graphics-props-var tag))
           (path-insert-with p (graphics-props-var tag) `(tuple ,@pairs))
@@ -487,9 +496,11 @@
 
 ;; 把该 type 的配置回填到全局 gr-*
 (tm-define (graphics-restore-type-config tag)
-  (with attrs (graphics-mode-attributes `(edit ,tag))
+  (with attrs
+    (graphics-mode-attributes `(edit ,tag))
     (when (nnull? attrs)
-      (with tab (graphics-get-type-config tag)
+      (with tab
+        (graphics-get-type-config tag)
         ;; 清除选中，避免误改选中对象
         (sketch-reset)
         (set! graphics-on-restore #t)

--- a/devel/0825.md
+++ b/devel/0825.md
@@ -1,0 +1,50 @@
+# [0825] 绘图模式按图形类型保存属性配置
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式
+- [0819.md](0819.md) - 修复拖动图形时填充色被污染
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-utils.scm` — 新增 per-type 配置存储层（`gr-props-<type>`），并给 `graphics-set-property` 加实时同步
+- `TeXmacs/progs/graphics/graphics-main.scm` — `graphics-set-mode` 切换类型时恢复目标配置
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 进入绘图模式，切到 `点`/`折线`/`多边形` 等任意图形类型，修改它们的颜色、背景色、线宽、样式等属性
+2. 在不同的图形类型间切换，确认每种类型的属性配置能正常储存和加载，切换时不会出现属性覆盖
+3. 用这种图形绘制的时候，绘制出来的图形应该继承该类型的属性配置，在之后用 `属性编辑` 工具修改时不应影响该类型的配置
+4. 绘制完多种类型多种配置的图形后，全选并整体覆盖成某一种配置，再检查各自图形类型的配置，也不应被覆盖
+5. 保存文档后重开，切换工具时各类型的配置应仍在，绘制时仍然可以正常继承该类型的属性配置
+
+## 4 What
+绘图模式下，颜色、线宽、点样式等属性只有一份全局配置（存于 `<graphics>` 外层 `with` 的 `gr-*` 变量）。
+
+切换图形类型（`点`/`折线`/`多边形`）时配置互相覆盖，画完点改了线宽，下次画线又得重设。
+
+本次为每种图形类型各存一份独立的属性配置，随文档持久化；切换类型时自动恢复成该类型上次用过的配置。
+
+## 5 How
+
+### 数据模型
+每种图形类型的配置存于 `<graphics>` 外层 `with` 变量 `gr-props-<type>`（`<type>` 取自当前 `gr-mode` 的 cadr，如 `point`/`line`/`cline`），值为成对（属性名 值）的 `tuple`，只存该类型相关且非默认的属性。相关属性集复用现有 `graphics-mode-attributes`。
+
+属性栏、`graphics-enrich`、C++ 渲染都只读全局 `gr-*`，因此无需改动它们。只做全局 `gr-*` 与 per-type 存储间的同步。
+
+### 新增函数（`graphics-utils.scm`）
+- `graphics-props-var tag` — 由类型 tag 拼出对应的 `<graphics>` with 变量名 `gr-props-<tag>`。
+- `graphics-get-type-config tag` — 读取该类型的配置，返回属性名到值的哈希表；未存则空表。
+- `graphics-set-type-config tag tab` — 把配置写回 `gr-props-<type>`。
+- `graphics-sync-type-config var val` — 用户改某条 `gr-*` 时，把它并入当前绘制类型的配置。`gr-mode` 与 `gr-props-*` 自身跳过。
+- `graphics-restore-type-config tag` — 把该类型的配置回填到全局 `gr-*`。
+
+### 改动点
+- `graphics-utils.scm` 的 `graphics-set-property`：末尾 `(unless (or (tree? val) graphics-on-restore) (graphics-sync-type-config ...))`，使每次改属性实时落入当前类型存储。
+- `graphics-utils.scm` 的 `graphics-restore-type-config`：逐个属性调 `graphics-set-property` 回填全局 `gr-*`。前置 `sketch-reset` 清除选中避免误改选中对象，置位 `graphics-on-restore` 守卫避免回填再触发 sync。
+- `graphics-main.scm` 的 `graphics-set-mode`：写完新 `gr-mode` 后，若新模式是 `edit`，调 `graphics-restore-type-config` 恢复目标类型配置。


### PR DESCRIPTION
# [0825] 绘图模式按图形类型保存属性配置

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式
- [0819.md](0819.md) - 修复拖动图形时填充色被污染

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-utils.scm` — 新增 per-type 配置存储层（`gr-props-<type>`），并给 `graphics-set-property` 加实时同步
- `TeXmacs/progs/graphics/graphics-main.scm` — `graphics-set-mode` 切换类型时恢复目标配置

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 进入绘图模式，切到 `点`/`折线`/`多边形` 等任意图形类型，修改它们的颜色、背景色、线宽、样式等属性
2. 在不同的图形类型间切换，确认每种类型的属性配置能正常储存和加载，切换时不会出现属性覆盖
3. 用这种图形绘制的时候，绘制出来的图形应该继承该类型的属性配置，在之后用 `属性编辑` 工具修改时不应影响该类型的配置
4. 绘制完多种类型多种配置的图形后，全选并整体覆盖成某一种配置，再检查各自图形类型的配置，也不应被覆盖
5. 保存文档后重开，切换工具时各类型的配置应仍在，绘制时仍然可以正常继承该类型的属性配置

## 4 What
绘图模式下，颜色、线宽、点样式等属性只有一份全局配置（存于 `<graphics>` 外层 `with` 的 `gr-*` 变量）。

切换图形类型（`点`/`折线`/`多边形`）时配置互相覆盖，画完点改了线宽，下次画线又得重设。

本次为每种图形类型各存一份独立的属性配置，随文档持久化；切换类型时自动恢复成该类型上次用过的配置。

## 5 How

### 数据模型
每种图形类型的配置存于 `<graphics>` 外层 `with` 变量 `gr-props-<type>`（`<type>` 取自当前 `gr-mode` 的 cadr，如 `point`/`line`/`cline`），值为成对（属性名 值）的 `tuple`，只存该类型相关且非默认的属性。相关属性集复用现有 `graphics-mode-attributes`。

属性栏、`graphics-enrich`、C++ 渲染都只读全局 `gr-*`，因此无需改动它们。只做全局 `gr-*` 与 per-type 存储间的同步。

### 新增函数（`graphics-utils.scm`）
- `graphics-props-var tag` — 由类型 tag 拼出对应的 `<graphics>` with 变量名 `gr-props-<tag>`。
- `graphics-get-type-config tag` — 读取该类型的配置，返回属性名到值的哈希表；未存则空表。
- `graphics-set-type-config tag tab` — 把配置写回 `gr-props-<type>`。
- `graphics-sync-type-config var val` — 用户改某条 `gr-*` 时，把它并入当前绘制类型的配置。`gr-mode` 与 `gr-props-*` 自身跳过。
- `graphics-restore-type-config tag` — 把该类型的配置回填到全局 `gr-*`。

### 改动点
- `graphics-utils.scm` 的 `graphics-set-property`：末尾 `(unless (or (tree? val) graphics-on-restore) (graphics-sync-type-config ...))`，使每次改属性实时落入当前类型存储。
- `graphics-utils.scm` 的 `graphics-restore-type-config`：逐个属性调 `graphics-set-property` 回填全局 `gr-*`。前置 `sketch-reset` 清除选中避免误改选中对象，置位 `graphics-on-restore` 守卫避免回填再触发 sync。
- `graphics-main.scm` 的 `graphics-set-mode`：写完新 `gr-mode` 后，若新模式是 `edit`，调 `graphics-restore-type-config` 恢复目标类型配置。
