### PR TITLE
[0660] macOS 增强键盘导航与编辑快捷键（Ctrl+n/p/h/d）

### DIFF
--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -626,6 +626,10 @@
   ("C-k" (kill-paragraph))
   ("C-l" (refresh-window))
   ("C-y" (yank-paragraph))
+  ("C-n" (kbd-down))
+  ("C-p" (kbd-up))
+  ("C-h" (kbd-backspace))
+  ("C-d" (kbd-delete))
   ("A-q" (make 'symbol))
 
   ("C-O" (toggle-source-mode))

--- a/devel/0660.md
+++ b/devel/0660.md
@@ -1,0 +1,53 @@
+# [0660] macOS 增强 Cocoa / Emacs 键盘导航与编辑快捷键（Ctrl+N/P/H/D）
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/generic-kbd.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+在 macOS 平台，可以使用构建产物加载命令行进行按键绑定结果的断言校验：
+```bash
+# 校验 C-n, C-p, C-h, C-d 的解析结果
+TEXMACS_PATH=$(pwd)/TeXmacs build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM -headless -d -x "(begin (import (liii check)) (check (kbd-find-key-binding \"C-n\") => '(kbd-down)) (check (kbd-find-key-binding \"C-p\") => '(kbd-up)) (check (kbd-find-key-binding \"C-h\") => '(kbd-backspace)) (check (kbd-find-key-binding \"C-d\") => '(kbd-delete)) (check-report))"
+```
+
+### 3.2 非确定性测试（文档验证）
+手动测试验证：
+1. 打开 Mogan 并在编辑区域内输入多行文本。
+2. 将光标定位在中间行。
+3. 键盘按下 `Ctrl + N`，光标应当精确向下移动一行。
+4. 键盘按下 `Ctrl + P`，光标应当精确向上移动一行。
+5. 键盘按下 `Ctrl + H`，光标左侧的一个字符应当被删除（退格作用）。
+6. 键盘按下 `Ctrl + D`，光标右侧的一个字符应当被删除（向前删除作用）。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+在 macOS 操作系统中，增强并补全标准的 Cocoa Text System / Emacs 惯例轻量级快捷键：
+1. `ctrl+n` 绑定为向下移动一行（`(kbd-down)`）。
+2. `ctrl+p` 绑定为向上移动一行（`(kbd-up)`）。
+3. `ctrl+h` 绑定为向左删除字符（`(kbd-backspace)`）。
+4. `ctrl+d` 绑定为向右删除字符（`(kbd-delete)`）。
+
+## 6 Why
+在 macOS 上，系统原生文本控件和绝大多数编辑器均默认内置支持 Emacs 风格的快捷键布局。除已有的 `ctrl+a/e/b/f/k/y` 之外，`ctrl+n/p`（光标上下行移动）和 `ctrl+h/d`（向左/向右单字删除）也是这套 Cocoa Text System 标准方案中最核心的拼图。支持这些快捷键可以消除 macOS 原生键盘流用户的平台使用障碍，大幅提升输入和编辑效率。
+
+## 7 How
+在全局通用键盘映射配置模块 `TeXmacs/progs/generic/generic-kbd.scm` 的 `(:profile macos)` （macOS 专属键盘映射配置区）中，在已有的 Emacs 风格经典导航快捷键（如 `"C-a"`, `"C-e"`, `"C-b"`, `"C-f"` 等）后的 `"A-q"` 键位下方，追加如下四行定义：
+```scheme
+  ("C-n" (kbd-down))
+  ("C-p" (kbd-up))
+  ("C-h" (kbd-backspace))
+  ("C-d" (kbd-delete))
+```
+这样做不仅完全契合系统原有按键架构，免于增加额外的底层系统判断，也使得所有 macOS 平台专属的 Emacs 文本编辑快捷键在代码组织上更加集中、直观、规范。


### PR DESCRIPTION
根据 @devel/dddd.md，在 macOS 专属键盘配置文件块中，补全并增强了标准的 Cocoa Text System / Emacs 经典文字导航与编辑快捷键系列：

1. **第 1 个 Commit**：创建并完善了任务设计及验证文档 `devel/0660.md`。
2. **第 2 个 Commit**：在 `TeXmacs/progs/generic/generic-kbd.scm` 的 `(:profile macos)` 专属块中，追加了以下经典按键：
   - `Ctrl + N` -> 向下移动一行 (`(kbd-down)`)
   - `Ctrl + P` -> 向上移动一行 (`(kbd-up)`)
   - `Ctrl + H` -> 向左删除一个字符/退格 (`(kbd-backspace)`)
   - `Ctrl + D` -> 向右删除一个字符/向前删除 (`(kbd-delete)`)