### PR TITLE
[0826] 绘图区支持删除选中的图形对象

### DIFF
--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -300,6 +300,7 @@
          (clipboard-cut "primary")
         ) ;
         ((inside-graphical-text?) (if forward? (kbd-delete) (kbd-backspace)))
+        ((graphics-selection-active?) (remove-selected-objects))
         (else (edit_delete))
   ) ;cond
 ) ;tm-define

--- a/devel/0826.md
+++ b/devel/0826.md
@@ -1,0 +1,34 @@
+# [0826] 绘图区支持删除选中的图形对象
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-kbd.scm`
+  - `graphics-kbd-remove`：新增 `(graphics-selection-active?)` 分支，有图形选区时调用 `remove-selected-objects`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 进入绘图区，框选一个或多个对象；
+2. 鼠标移到空白处（不悬停在任何对象上），按 Delete / Backspace，应删除已选中的对象；
+3. 无选中对象时，Delete / Backspace 行为不变：鼠标悬停在对象上时删除该对象，否则无操作；
+
+## 4 What
+- 组合编辑模式下，Delete / Backspace 不再依赖鼠标必须悬停在对象上才能删除；
+- 只要存在图形选区（`the-sketch` 非空），按 Delete / Backspace 直接删除选区内的对象集合；
+- 不影响原有单对象删除、文本内编辑删除和文档级选区剪切逻辑。
+
+## 5 How
+- `graphics-kbd-remove` 在 `inside-graphical-text?` 判断之后、`edit_delete` 回退之前，插入分支：
+  ```scheme
+  ((graphics-selection-active?) (remove-selected-objects))
+  ```
+- `graphics-selection-active?` 即 `(nnull? (sketch-get))`，复用已有判断；
+- `remove-selected-objects` 通过 `sketch-checkout` / `sketch-reset` / `sketch-commit` 删除选区，与 Shift+中键删除走同一条路径。


### PR DESCRIPTION
# [0826] 绘图区支持删除选中的图形对象

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-kbd.scm`
  - `graphics-kbd-remove`：新增 `(graphics-selection-active?)` 分支，有图形选区时调用 `remove-selected-objects`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 进入绘图区，框选一个或多个对象；
2. 鼠标移到空白处（不悬停在任何对象上），按 Delete / Backspace，应删除已选中的对象；
3. 无选中对象时，Delete / Backspace 行为不变：鼠标悬停在对象上时删除该对象，否则无操作；

## 4 What
- 组合编辑模式下，Delete / Backspace 不再依赖鼠标必须悬停在对象上才能删除；
- 只要存在图形选区（`the-sketch` 非空），按 Delete / Backspace 直接删除选区内的对象集合；
- 不影响原有单对象删除、文本内编辑删除和文档级选区剪切逻辑。

## 5 How
- `graphics-kbd-remove` 在 `inside-graphical-text?` 判断之后、`edit_delete` 回退之前，插入分支：
  ```scheme
  ((graphics-selection-active?) (remove-selected-objects))
  ```
- `graphics-selection-active?` 即 `(nnull? (sketch-get))`，复用已有判断；
- `remove-selected-objects` 通过 `sketch-checkout` / `sketch-reset` / `sketch-commit` 删除选区，与 Shift+中键删除走同一条路径。
