### PR TITLE
[0827] 插件 I/O 协议统一为 UTF-8

### DIFF
--- a/.github/workflows/ci-julia.yml
+++ b/.github/workflows/ci-julia.yml
@@ -1,4 +1,4 @@
-name: Julia Plugin CI
+name: CI for Julia Plugin
 
 on:
   push:

--- a/TeXmacs/plugins/goldfish/goldfish/goldfish/repl.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/goldfish/repl.scm
@@ -61,13 +61,13 @@
         (lambda args
           (begin
             (flush-scheme (string-append "(errput (document "
-                               (goldfish-quote (symbol->string (car args)))
-                               (if (and (>= (length args) 2) (not (null? (cadr args))))
-                                 (goldfish-quote (object->string (cadr args)))
-                                 ""
-                               ) ;if
-                               "))"
-                             ) ;string-append
+                            (goldfish-quote (symbol->string (car args)))
+                            (if (and (>= (length args) 2) (not (null? (cadr args))))
+                              (goldfish-quote (object->string (cadr args)))
+                              ""
+                            ) ;if
+                            "))"
+                          ) ;string-append
             ) ;flush-scheme
           ) ;begin
         ) ;lambda

--- a/TeXmacs/plugins/goldfish/goldfish/goldfish/repl.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/goldfish/repl.scm
@@ -50,8 +50,8 @@
 
     (define (goldfish-print obj)
       (if (eq? obj #<unspecified>)
-        (flush-scheme-u8 "")
-        (flush-scheme-u8 (build-goldfish-result obj))
+        (flush-scheme "")
+        (flush-scheme (build-goldfish-result obj))
       ) ;if
     ) ;define
 
@@ -60,7 +60,7 @@
         (lambda () (goldfish-print (eval-string code (rootlet))))
         (lambda args
           (begin
-            (flush-scheme-u8 (string-append "(errput (document "
+            (flush-scheme (string-append "(errput (document "
                                (goldfish-quote (symbol->string (car args)))
                                (if (and (>= (length args) 2) (not (null? (cadr args))))
                                  (goldfish-quote (object->string (cadr args)))
@@ -68,7 +68,7 @@
                                ) ;if
                                "))"
                              ) ;string-append
-            ) ;flush-scheme-u8
+            ) ;flush-scheme
           ) ;begin
         ) ;lambda
       ) ;catch

--- a/TeXmacs/plugins/goldfish/goldfish/texmacs/protocol.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/texmacs/protocol.scm
@@ -10,7 +10,6 @@
     flush-verbatim
     flush-prompt
     flush-scheme
-    flush-scheme-u8
     flush-file
     flush-markdown
     flush-latex
@@ -44,20 +43,13 @@
     ) ;define
 
     (define (flush-verbatim msg)
-      (flush-any (string-append "verbatim:" msg))
+      (flush-any (string-append "utf8:" msg))
     ) ;define
 
     (define (flush-scheme msg)
       (if (string? msg)
         (flush-any (string-append "scheme:" msg))
         (flush-any (string-append "scheme:" (object->string msg)))
-      ) ;if
-    ) ;define
-
-    (define (flush-scheme-u8 msg)
-      (if (string? msg)
-        (flush-any (string-append "scheme_u8:" msg))
-        (flush-any (string-append "scheme_u8:" (object->string msg)))
       ) ;if
     ) ;define
 

--- a/TeXmacs/plugins/julia/bin/tmjl/capture.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/capture.jl
@@ -62,7 +62,7 @@ Base.flush(io::TMJuliaStdio) = begin
         filtered_lines = filter(line -> !occursin("GKS: glyph missing from current font", line), lines)
         filtered_buf = join(filtered_lines, '\n')
         if filtered_buf != ""
-            tm_err(VERBATIM, filtered_buf)
+            tm_err(U8_TEXT, filtered_buf)
         end
     end
 end

--- a/TeXmacs/plugins/julia/bin/tmjl/protocol.jl
+++ b/TeXmacs/plugins/julia/bin/tmjl/protocol.jl
@@ -13,7 +13,7 @@ const DATA_BEGIN = Char(2)
 const DATA_END = Char(5)
 const DATA_ESCAPE = Char(27)
 const DATA_COMMAND = Char(16)
-const VERBATIM = "verbatim:"
+const U8_TEXT = "utf8:"
 const SCHEME = "scheme:"
 const COMMAND = "command:"
 const PROMPT = "prompt#"
@@ -25,7 +25,7 @@ mogan_escape(data) = replace(replace(replace(data,
   
 # Mogan expects all output to be bracketed in a DATA_BEGIN and DATA_END
 # so that it can determine when the plugin ended the interaction        
-tm_begin() = write(orig_stdout[], DATA_BEGIN, VERBATIM)
+tm_begin() = write(orig_stdout[], DATA_BEGIN, U8_TEXT)
 tm_end() = begin
     write(orig_stdout[], DATA_END)
     flush(orig_stdout[]) 

--- a/TeXmacs/plugins/julia/tests/runtests.jl
+++ b/TeXmacs/plugins/julia/tests/runtests.jl
@@ -71,7 +71,7 @@ end
 
         # Test tm_begin
         tm_begin()
-        @test String(take!(buf_out)) == string(DATA_BEGIN, VERBATIM)
+        @test String(take!(buf_out)) == string(DATA_BEGIN, U8_TEXT)
 
         # Test tm_end
         tm_end()
@@ -86,8 +86,8 @@ end
         @test String(take!(buf_out)) == string(DATA_BEGIN, "latex:", "x^2", DATA_END)
 
         # Test tm_err with header
-        tm_err("verbatim:", "load-error")
-        @test String(take!(buf_err)) == string(DATA_BEGIN, "verbatim:", "load-error", DATA_END)
+        tm_err("utf8:", "load-error")
+        @test String(take!(buf_err)) == string(DATA_BEGIN, "utf8:", "load-error", DATA_END)
 
         # Restore original IO streams
         orig_stdout[] = stdout
@@ -204,7 +204,7 @@ end
             flush(stdio_err)
             err_data = String(take!(buf_err))
             @test occursin("stderr-line", err_data)
-            @test occursin(VERBATIM, err_data)
+            @test occursin(U8_TEXT, err_data)
         finally
             redirect_stderr(old_stderr)
         end

--- a/TeXmacs/plugins/llm/goldfish/tm-llm.scm
+++ b/TeXmacs/plugins/llm/goldfish/tm-llm.scm
@@ -40,7 +40,7 @@
 (define (eval-and-print data)
   (if (> (string-length data) *large-data-threshold*)
     (flush-verbatim (llm-write-temp-file data))
-    (flush-scheme-u8 data)
+    (flush-scheme data)
   ) ;if
 ) ;define
 

--- a/TeXmacs/plugins/maxima/lisp/texmacs-maxima.lisp
+++ b/TeXmacs/plugins/maxima/lisp/texmacs-maxima.lisp
@@ -14,7 +14,7 @@
 (setf *prompt-prefix* "channel:promptlatex:\\red ")
 (setf *prompt-suffix* "\\black")
 ;(setf *general-display-prefix* "verbatim:")
-(setf *maxima-prolog* "verbatim:")
+(setf *maxima-prolog* "utf8:")
 (setf *maxima-epilog* "latex:\\red The end\\black")
 #-gcl(setf *debug-io* (make-two-way-stream *standard-input* *standard-output*))
 #+(or cmu sbcl scl)

--- a/TeXmacs/plugins/python/bin/python.pex
+++ b/TeXmacs/plugins/python/bin/python.pex
@@ -28,7 +28,6 @@ from tmpy.protocol import (
     flush_prompt,
     flush_ps,
     flush_scheme,
-    flush_scheme_u8,
     flush_verbatim,
     flush_latex,
 )
@@ -100,7 +99,7 @@ def flush_output(data):
         flush_matplotlib_figure(fig)
     elif is_dataframe_object(data):
         dfstr = convert_dataframe_to_scheme_str(data)
-        flush_scheme_u8(dfstr)
+        flush_scheme(dfstr)
     elif is_sympy_object(data):
         flush_latex("\\rmfamily{" + latex(data) + "}")
     elif is_pil_object(data):

--- a/TeXmacs/plugins/python/bin/tmpy/protocol.py
+++ b/TeXmacs/plugins/python/bin/tmpy/protocol.py
@@ -69,9 +69,6 @@ def flush_command(command):
 def flush_scheme(scheme):
     flush_any("scheme:" + scheme)
 
-def flush_scheme_u8(scheme):
-    flush_any("scheme_u8:" + scheme)
-
 def flush_latex(latex):
     flush_any("latex:$" + latex + "$")
 

--- a/TeXmacs/progs/utils/plugins/plugin-cmd.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-cmd.scm
@@ -29,7 +29,7 @@
 ) ;tm-define
 
 (define (hacked-texmacs->code x)
-  (with r (texmacs->code x) (string-replace r "`" "`"))
+  (with r (texmacs->code x "utf-8") (string-replace r "`" "`"))
 ) ;define
 
 (tm-define (verbatim-serialize lan t)
@@ -43,8 +43,8 @@
   (with u
     (pre-serialize lan t)
     (string-append (char->string #\x02)
-      "verbatim:"
-      (escape-generic (texmacs->code u))
+      "utf8:"
+      (escape-generic (texmacs->code u "utf-8"))
       (char->string #\x05)
     ) ;string-append
   ) ;with

--- a/TeXmacs/tests/0801.scm
+++ b/TeXmacs/tests/0801.scm
@@ -116,8 +116,8 @@
         ;; Read the output file physically
         (let ((output (read-physical-file output-path)))
           ;; Assertions based on "How to Test" in 0801.md
-          (check (string-contains? output "verbatim:3") => #t)
-          (check (string-contains? output "verbatim:HELP:") => #t)
+          (check (string-contains? output "utf8:3") => #t)
+          (check (string-contains? output "utf8:HELP:") => #t)
           (check (string-contains? output "2×2 Matrix{Float64}:") => #t)
           (check (string-contains? output "DomainError") => #t)
           (check (string-contains? output "UndefVarError") => #t)

--- a/TeXmacs/tests/0804.scm
+++ b/TeXmacs/tests/0804.scm
@@ -149,7 +149,7 @@
           (check (string-contains? output "2 ~ x ~ \\sin\\left( x \\right)") => #t)
           (check (string-contains? output "x + y") => #t)
           (check (string-contains? output "x^{2} + 2 ~ x ~ y + y^{2}") => #t)
-          (check (string-contains? output "verbatim:3") => #t)
+          (check (string-contains? output "utf8:3") => #t)
           (check (string-contains? output "3-element Vector{Int64}:") => #t)
         ) ;let
 

--- a/TeXmacs/tests/0827.scm
+++ b/TeXmacs/tests/0827.scm
@@ -1,0 +1,135 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0827.scm
+;; DESCRIPTION : Tests for UTF-8 plugin I/O protocol adaptation
+;; COPYRIGHT   : (C) 2026 AcceleratorX
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (scheme base)
+        (liii check)
+        (liii string))
+
+(check-set-mode! 'report-failed)
+
+;;; ========== Helpers ==========
+
+(define (utf8-verbatim-opts)
+  (acons "verbatim->texmacs:encoding" "utf-8" '()))
+
+(define (utf8-verbatim-out-opts)
+  (acons "texmacs->verbatim:encoding" "utf-8" '()))
+
+(define (roundtrip-utf8-verbatim s)
+  (texmacs->verbatim-snippet
+    (verbatim-snippet->texmacs s (utf8-verbatim-opts))
+    (utf8-verbatim-out-opts)))
+
+(define (scheme-snippet->string s)
+  (texmacs->stm (stm-snippet->texmacs s)))
+
+;;; ========== Verbatim UTF-8 roundtrip ==========
+
+(define (test-verbatim-utf8-roundtrip)
+  ;; CJK characters
+  (check (roundtrip-utf8-verbatim "中文测试") => "中文测试")
+  ;; Greek letters
+  (check (roundtrip-utf8-verbatim "αβγδ") => "αβγδ")
+  ;; Mixed ASCII and CJK
+  (check (roundtrip-utf8-verbatim "Hello 世界") => "Hello 世界")
+  ;; Math symbols
+  (check (roundtrip-utf8-verbatim "∑∏∫√") => "∑∏∫√")
+) ;define
+
+;;; ========== scheme: channel with UTF-8 strings ==========
+
+(define (test-scheme-utf8-string)
+  ;; CJK inside Scheme string literal
+  (check (string-contains? (scheme-snippet->string "(frac \"分子\" \"分母\")")
+                           "分子") => #t)
+  (check (string-contains? (scheme-snippet->string "(frac \"分子\" \"分母\")")
+                           "分母") => #t)
+
+  ;; Greek letters inside Scheme string literal
+  (check (string-contains? (scheme-snippet->string "(greek \"αβγ\")")
+                           "αβγ") => #t)
+
+  ;; Emoji inside Scheme string literal
+  (check (string-contains? (scheme-snippet->string "(emoji \"🎉\")")
+                           "🎉") => #t)
+
+  ;; Mixed ASCII and CJK
+  (check (string-contains? (scheme-snippet->string "(document \"Hello 世界\")")
+                           "Hello 世界") => #t)
+) ;define
+
+;;; ========== scheme: channel with UTF-8 unquoted symbols ==========
+
+(define (test-scheme-utf8-symbol)
+  ;; Unquoted UTF-8 symbols should also survive parsing
+  (check (string-contains? (scheme-snippet->string "(chinese 汉语 条目)")
+                           "汉语") => #t)
+  (check (string-contains? (scheme-snippet->string "(chinese 汉语 条目)")
+                           "条目") => #t)
+) ;define
+
+;;; ========== utf8-tree -> herk-tree conversion ==========
+
+(define (test-utf8-tree-to-herk-tree)
+  (define utf8-tree (stm-snippet->texmacs "(frac \"分子\" \"分母\")"))
+  (define herk-tree (utf8-tree->herk-tree utf8-tree))
+  (define herk-str (texmacs->stm herk-tree))
+
+  ;; CJK codepoints should become <#XXXX> escapes in Herk
+  (check (string-contains? herk-str "<#5206>") => #t)
+  (check (string-contains? herk-str "<#5B50>") => #t)
+  (check (string-contains? herk-str "<#6BCD>") => #t)
+
+  ;; Greek letters that are in Herk table should become single bytes,
+  ;; but the original UTF-8 should no longer be present
+  (define greek-utf8 (stm-snippet->texmacs "(greek \"αβγ\")"))
+  (define greek-herk (utf8-tree->herk-tree greek-utf8))
+  (define greek-herk-str (texmacs->stm greek-herk))
+  (check (string-contains? greek-herk-str "αβγ") => #f)
+) ;define
+
+;;; ========== <#XXXX> literal preservation ==========
+
+(define (test-cork-escape-preservation)
+  ;; Plugins may send literal <#XXXX> instead of raw UTF-8 bytes.
+  ;; These should be preserved through scheme_to_tree and tree_utf8_to_herk.
+  (define t (stm-snippet->texmacs "(frac <#5206><#5B50> <#5206><#6BCD>)"))
+  (define herk-t (utf8-tree->herk-tree t))
+  (define herk-str (texmacs->stm herk-t))
+
+  (check (string-contains? herk-str "<#5206>") => #t)
+  (check (string-contains? herk-str "<#5B50>") => #t)
+  (check (string-contains? herk-str "<#6BCD>") => #t)
+) ;define
+
+;;; ========== Backward compatibility: old scheme_u8 payload ==========
+
+(define (test-scheme-u8-backward-compat)
+  ;; The protocol still accepts scheme_u8: blocks; they are handled
+  ;; exactly like scheme: blocks.  We cannot send a raw block from
+  ;; Scheme easily, but we can verify the conversion function path
+  ;; that scheme_u8: would have used.
+  (define utf8-tree (stm-snippet->texmacs "(frac \"分子\" \"分母\")"))
+  (define herk-tree (utf8-tree->herk-tree utf8-tree))
+  (check (tree? herk-tree) => #t)
+) ;define
+
+;;; ========== Test entry ==========
+
+(tm-define (test_0827)
+  (test-verbatim-utf8-roundtrip)
+  (test-scheme-utf8-string)
+  (test-scheme-utf8-symbol)
+  (test-utf8-tree-to-herk-tree)
+  (test-cork-escape-preservation)
+  (test-scheme-u8-backward-compat)
+  (check-report))

--- a/TeXmacs/tests/tm/66_6.tm
+++ b/TeXmacs/tests/tm/66_6.tm
@@ -33,15 +33,15 @@
     <\unfolded-io>
       \<gtr\>\<gtr\>\<gtr\>\ 
     <|unfolded-io>
-      flush_any ("scheme_u8:(frac 1 2)")
+      flush_any ("scheme:(frac 1 2)")
     <|unfolded-io>
       <frac|1|2>
     </unfolded-io>
 
     <\unfolded-io>
-      \<gtr\>\<gtr\>\<gtr\>\ 
+      \<gtr\>\<gtr\>\<gtr\>\
     <|unfolded-io>
-      flush_any ("scheme_u8:(frac \<#5206\>\<#5B50\> \<#5206\>\<#6BCD\>)")
+      flush_any ("scheme:(frac \<#5206\>\<#5B50\> \<#5206\>\<#6BCD\>)")
     <|unfolded-io>
       <frac|\<#5206\>\<#5B50\>|\<#5206\>\<#6BCD\>>
     </unfolded-io>

--- a/devel/0827.md
+++ b/devel/0827.md
@@ -1,0 +1,39 @@
+# [0827] 插件 I/O 协议统一为 UTF-8
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Data/Convert/Generic/input.cpp` / `input.hpp` — `verbatim:` 按 UTF-8 解析，`scheme:` 与 `scheme_u8:` 合并，删除 `MODE_SCHEME_UTF8`
+- `TeXmacs/progs/utils/plugins/plugin-cmd.scm` — 默认序列化器显式使用 UTF-8，`generic-serialize` 改发 `utf8:` 块
+- `TeXmacs/plugins/julia/bin/tmjl/protocol.jl` / `capture.jl` — `VERBATIM` 改名为 `U8_TEXT`，输出 `utf8:`
+- `TeXmacs/plugins/maxima/lisp/texmacs-maxima.lisp` — `*maxima-prolog*` 改为 `utf8:`
+- `TeXmacs/plugins/goldfish/goldfish/texmacs/protocol.scm` / `goldfish/repl.scm` — `flush-verbatim` 改发 `utf8:`，`flush-scheme-u8` 删除并改用 `flush-scheme`
+- `TeXmacs/plugins/python/bin/python.pex` / `tmpy/protocol.py` — 删除 `flush_scheme_u8`，统一用 `flush_scheme`
+- `TeXmacs/plugins/llm/goldfish/tm-llm.scm` — 改用 `flush-scheme`
+- `TeXmacs/tests/0801.scm` / `0804.scm` / `tm/66_6.tm` — 更新期望的协议标签
+- `TeXmacs/tests/0827.scm` — 新增 UTF-8 适配集成测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r 0801
+xmake r 0804
+xmake r 0827
+```
+
+### 3.2 非确定性测试（文档验证）
+
+## 4 What
+- 插件 I/O 协议统一为 UTF-8
+- 统一 `scheme_flush_u8` 与 `scheme_flush` 支持 UTF-8，删除 `scheme_flush_u8`
+- `verbatim:` 走编码自动猜测，统一插件 I/O 为 `utf8:` 走 UTF-8
+
+## 5 How
+1. `input.cpp` 中 `verbatim_flush` 与 `file_flush` 错误信息统一按 `"utf-8"` 解析；`scheme_flush` 改为 `tree_utf8_to_herk (scheme_to_tree (buf))`（原 `scheme_flush_u8` 逻辑），删除 `scheme_u8:`、`MODE_SCHEME_UTF8`。
+2. `plugin-cmd.scm` 中 `verbatim-serialize` 显式指定 `"utf-8"`，`generic-serialize` 改发 `utf8:` 块。
+3. Python、Julia、Goldfish、Maxima、LLM 等插件统一改为发送 `utf8:` / `scheme:`。
+4. `0801.scm`、`0804.scm`、`66_6.tm`、Julia `runtests.jl` 更新协议标签期望。
+5. 新增 `0827.scm` 覆盖 verbatim 往返、scheme UTF-8 字符串/符号、Herk 转换、`<#XXXX>` 字面量保留等场景。

--- a/src/Data/Convert/Generic/input.cpp
+++ b/src/Data/Convert/Generic/input.cpp
@@ -46,8 +46,7 @@ using moebius::data::scheme_to_tree;
 #define MODE_COMMAND 8
 #define MODE_XFORMAT 9
 #define MODE_FILE 10
-#define MODE_SCHEME_UTF8 11
-#define MODE_MARKDOWN 12
+#define MODE_MARKDOWN 11
 
 /******************************************************************************
  * Universal data input
@@ -79,7 +78,6 @@ texmacs_input_rep::get_mode (string s) {
   if (s == "channel") return MODE_CHANNEL;
   if (s == "command") return MODE_COMMAND;
   if (s == "file") return MODE_FILE;
-  if (s == "scheme_u8") return MODE_SCHEME_UTF8;
   if (s == "markdown") return MODE_MARKDOWN;
   if (format_exists (s)) return MODE_XFORMAT;
   return MODE_VERBATIM;
@@ -253,9 +251,6 @@ texmacs_input_rep::flush (bool force) {
   case MODE_FILE:
     file_flush (force);
     break;
-  case MODE_SCHEME_UTF8:
-    scheme_u8_flush (force);
-    break;
   default:
     TM_FAILED ("invalid mode");
     break;
@@ -265,7 +260,7 @@ texmacs_input_rep::flush (bool force) {
 void
 texmacs_input_rep::verbatim_flush (bool force) {
   if (force || ends (buf, "\n")) {
-    if (!ignore_verb) write (verbatim_to_tree (buf, false, "auto"));
+    if (!ignore_verb) write (verbatim_to_tree (buf, false, "utf-8"));
     else if (DEBUG_IO) debug_io << "ignore verbatim (aborted input)" << LF;
     buf= "";
   }
@@ -284,14 +279,6 @@ texmacs_input_rep::utf8_flush (bool force) {
 
 void
 texmacs_input_rep::scheme_flush (bool force) {
-  if (force) {
-    write (simplify_correct (scheme_to_tree (buf)));
-    buf= "";
-  }
-}
-
-void
-texmacs_input_rep::scheme_u8_flush (bool force) {
   if (force) {
     write (simplify_correct (tree_utf8_to_herk (scheme_to_tree (buf))));
     buf= "";
@@ -455,15 +442,15 @@ texmacs_input_rep::file_flush (bool force) {
 
     if (!validate_h_unit (h_unit)) {
       string err_msg= h_unit * " is not allowed, please pt, px or pag!";
-      write (verbatim_to_tree (err_msg, false, "auto"));
+      write (verbatim_to_tree (err_msg, false, "utf-8"));
     }
     else if (!validate_w_unit (w_unit)) {
       string err_msg= w_unit * " is not allowed, please pt, px or par!";
-      write (verbatim_to_tree (err_msg, false, "auto"));
+      write (verbatim_to_tree (err_msg, false, "utf-8"));
     }
     else if (!exists (file)) {
       string err_msg= "[" * as_string (file) * "] does not exist";
-      write (verbatim_to_tree (err_msg, false, "auto"));
+      write (verbatim_to_tree (err_msg, false, "utf-8"));
     }
     else {
       string type= suffix (file);
@@ -496,7 +483,7 @@ texmacs_input_rep::file_flush (bool force) {
       }
       else {
         string err_msg= "Do not support file type with suffix: [" * type * "]";
-        write (verbatim_to_tree (err_msg, false, "auto"));
+        write (verbatim_to_tree (err_msg, false, "utf-8"));
       }
     }
     buf= "";

--- a/src/Data/Convert/Generic/input.hpp
+++ b/src/Data/Convert/Generic/input.hpp
@@ -40,7 +40,6 @@ struct texmacs_input_rep : concrete_struct {
   void verbatim_flush (bool force= false);
   void utf8_flush (bool force= false);
   void scheme_flush (bool force= false);
-  void scheme_u8_flush (bool force= false);
   void latex_flush (bool force= false);
   void markdown_flush (bool force= false);
   void html_flush (bool force= false);


### PR DESCRIPTION
# [0827] 插件 I/O 协议统一为 UTF-8

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `src/Data/Convert/Generic/input.cpp` / `input.hpp` — `verbatim:` 按 UTF-8 解析，`scheme:` 与 `scheme_u8:` 合并，删除 `MODE_SCHEME_UTF8`
- `TeXmacs/progs/utils/plugins/plugin-cmd.scm` — 默认序列化器显式使用 UTF-8，`generic-serialize` 改发 `utf8:` 块
- `TeXmacs/plugins/julia/bin/tmjl/protocol.jl` / `capture.jl` — `VERBATIM` 改名为 `U8_TEXT`，输出 `utf8:`
- `TeXmacs/plugins/maxima/lisp/texmacs-maxima.lisp` — `*maxima-prolog*` 改为 `utf8:`
- `TeXmacs/plugins/goldfish/goldfish/texmacs/protocol.scm` / `goldfish/repl.scm` — `flush-verbatim` 改发 `utf8:`，`flush-scheme-u8` 删除并改用 `flush-scheme`
- `TeXmacs/plugins/python/bin/python.pex` / `tmpy/protocol.py` — 删除 `flush_scheme_u8`，统一用 `flush_scheme`
- `TeXmacs/plugins/llm/goldfish/tm-llm.scm` — 改用 `flush-scheme`
- `TeXmacs/tests/0801.scm` / `0804.scm` / `tm/66_6.tm` — 更新期望的协议标签
- `TeXmacs/tests/0827.scm` — 新增 UTF-8 适配集成测试

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r 0801
xmake r 0804
xmake r 0827
```

### 3.2 非确定性测试（文档验证）

## 4 What
- 插件 I/O 协议统一为 UTF-8
- 统一 `scheme_flush_u8` 与 `scheme_flush` 支持 UTF-8，删除 `scheme_flush_u8`
- `verbatim:` 走编码自动猜测，统一插件 I/O 为 `utf8:` 走 UTF-8

## 5 How
1. `input.cpp` 中 `verbatim_flush` 与 `file_flush` 错误信息统一按 `"utf-8"` 解析；`scheme_flush` 改为 `tree_utf8_to_herk (scheme_to_tree (buf))`（原 `scheme_flush_u8` 逻辑），删除 `scheme_u8:`、`MODE_SCHEME_UTF8`。
2. `plugin-cmd.scm` 中 `verbatim-serialize` 显式指定 `"utf-8"`，`generic-serialize` 改发 `utf8:` 块。
3. Python、Julia、Goldfish、Maxima、LLM 等插件统一改为发送 `utf8:` / `scheme:`。
4. `0801.scm`、`0804.scm`、`66_6.tm`、Julia `runtests.jl` 更新协议标签期望。
5. 新增 `0827.scm` 覆盖 verbatim 往返、scheme UTF-8 字符串/符号、Herk 转换、`<#XXXX>` 字面量保留等场景。
