### PR TITLE
[0829] LLM 插件协议重构

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -27,6 +27,18 @@
 
 (import (liii njson))
 
+;;; ---------- Record Type ----------
+
+(define-record-type <chat-input>
+  (make-chat-input input session-id model thinking search)
+  chat-input?
+  (input       chat-input-input)
+  (session-id  chat-input-session-id)
+  (model       chat-input-model)
+  (thinking    chat-input-thinking)
+  (search      chat-input-search)
+) ;define-record-type
+
 ;;; ---------- 全局常量 ----------
 
 (define chat-tab-session-name "llm")
@@ -358,10 +370,15 @@
   ) ;cond
 ) ;define
 
-(define (chat-tab-build-context-input input session-id model thinking search)
+(define (chat-tab-build-context-input ctx)
   ;; 单轮：只编码当前用户输入 + per-round 参数
   ;; 线格式：%chat <json>\n<EOF>\n
-  (let* ((content (chat-tab-tree->plain-text input))
+  (let* ((input (chat-input-input ctx))
+         (session-id (chat-input-session-id ctx))
+         (model (chat-input-model ctx))
+         (thinking (chat-input-thinking ctx))
+         (search (chat-input-search ctx))
+         (content (chat-tab-tree->plain-text input))
          (obj (string->njson "{}"))
          (params (string->njson "{}"))
          (stree-input (if (tree? input) (tree->stree input) input))
@@ -393,30 +410,28 @@
     (let ((json-str (njson->string obj)))
       (njson-free params)
       (njson-free obj)
-      (let ((cork-json (utf8->cork json-str)))
-        (stree->tree `(document ,(string-append "%chat " cork-json)))
-      ) ;let
+      (stree->tree `(document ,(string-append "%chat " json-str)))
     ) ;let
   ) ;let*
 ) ;define
 
 ;;; ---------- Feed ----------
 
-(define (chat-tab-session-feed lan ses input session-id out opts model thinking search)
+(define (chat-tab-session-feed lan ses ctx out opts)
   ;; 用单轮输入替换原始输入
-  (set! input
-    (chat-tab-build-context-input input session-id model thinking search)
-  ) ;set!
-  (set! input (plugin-preprocess lan ses input opts))
-  (with-buffer (chat-tab-session->message-buffer session-id)
-    (tree-assign! out '(document (script-busy)))
-  ) ;with-buffer
-  ;; 通知 C++ 进入 Generating 状态，切换按钮为 Stop
-  (chat-tab-notify-state session-id "generating")
-  (with x
-    (chat-tab-session-encode input session-id out opts)
-    (apply plugin-feed `(,lan ,ses ,@(car x) ,(cdr x)))
-  ) ;with
+  (let ((input (chat-tab-build-context-input ctx))
+        (session-id (chat-input-session-id ctx)))
+    (set! input (plugin-preprocess lan ses input opts))
+    (with-buffer (chat-tab-session->message-buffer session-id)
+      (tree-assign! out '(document (script-busy)))
+    ) ;with-buffer
+    ;; 通知 C++ 进入 Generating 状态，切换按钮为 Stop
+    (chat-tab-notify-state session-id "generating")
+    (with x
+      (chat-tab-session-encode input session-id out opts)
+      (apply plugin-feed `(,lan ,ses ,@(car x) ,(cdr x)))
+    ) ;with
+  ) ;let
 ) ;define
 
 ;;; ---------- 发送 ----------
@@ -460,16 +475,9 @@
                     #t
                   ) ;begin
                   (begin
-                    (chat-tab-session-feed chat-tab-session-name
-                      plugin-ses
-                      input
-                      session-id
-                      out
-                      '()
-                      model
-                      thinking
-                      search
-                    ) ;chat-tab-session-feed
+                    (let ((ctx (make-chat-input input session-id model thinking search)))
+                      (chat-tab-session-feed chat-tab-session-name plugin-ses ctx out '())
+                    ) ;let
                     #t
                   ) ;begin
                 ) ;if

--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -32,11 +32,11 @@
 (define-record-type <chat-input>
   (make-chat-input input session-id model thinking search)
   chat-input?
-  (input       chat-input-input)
-  (session-id  chat-input-session-id)
-  (model       chat-input-model)
-  (thinking    chat-input-thinking)
-  (search      chat-input-search)
+  (input chat-input-input)
+  (session-id chat-input-session-id)
+  (model chat-input-model)
+  (thinking chat-input-thinking)
+  (search chat-input-search)
 ) ;define-record-type
 
 ;;; ---------- 全局常量 ----------
@@ -420,7 +420,8 @@
 (define (chat-tab-session-feed lan ses ctx out opts)
   ;; 用单轮输入替换原始输入
   (let ((input (chat-tab-build-context-input ctx))
-        (session-id (chat-input-session-id ctx)))
+        (session-id (chat-input-session-id ctx))
+       ) ;
     (set! input (plugin-preprocess lan ses input opts))
     (with-buffer (chat-tab-session->message-buffer session-id)
       (tree-assign! out '(document (script-busy)))

--- a/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
@@ -218,8 +218,8 @@
                   (let* ((doc (tree-ref body j)) (content (if (tree? text) (tree->stree text) text)))
                     ;; 按 \n 拆分：首段追加到 doc 末尾，后续段落新增
                     (when (and (string? content) (not (string-null? content)))
-                      (let* ((cork-parts (string-split (cork->utf8 content) #\newline))
-                             (parts (map utf8->cork cork-parts))
+                      (let* ((herk-parts (string-split (herk->utf8 content) #\newline))
+                             (parts (map utf8->herk herk-parts))
                             ) ;
                         (when (nnull? parts)
                           ;; 追加第一段到 doc 最后一个子节点

--- a/devel/0829.md
+++ b/devel/0829.md
@@ -1,0 +1,33 @@
+# [0829] LLM 插件协议重构
+
+## 1 相关文档
+- [0827.md](0827.md) - 插件 I/O 协议统一为 UTF-8
+- [0828.md](0828.md) - 插件 I/O 序列化器迁移到 UTF-8 raw
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 引入 `<chat-input>` 记录类型，精简参数，并移除 `utf8->cork` 转换
+- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 将 `chat-tab-append-reasoning!` 中的 cork 转换替换为 herk 转换
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake r 0239
+xmake r 0251
+xmake r 0828
+```
+
+### 3.2 非确定性测试（文档验证）
+
+## 5 What
+1. 定义 `<chat-input>` 记录类型收拢参数，面向对象精简接口设计。
+2. 彻底移除 `chat-tab-build-context-input` 内部冗余的 `utf8->cork` 转换，协议数据直发纯净 UTF-8。
+3. 将 `chat-tab-append-reasoning!` 内部残留的 `cork` 转换改为 `herk` 转换。
+
+## 7 How
+1. 在 `chat-protocol.scm` 中，声明记录类型 `<chat-input>`，包含字段 `input`, `session-id`, `model`, `thinking`, `search`（在 Guile/Mogan 核心环境中，`define-record-type` 默认全局可用，无需显式 `import`）。
+2. 重构 `chat-tab-build-context-input(ctx)`：仅接收单一参数 `ctx`。移除 `utf8->cork`，直接将 `json-str` 嵌入 `%chat ` 命令中。
+3. 重构 `chat-tab-session-feed`，其接口精简为 `(chat-tab-session-feed lan ses ctx out opts)`。
+4. 调整 `chat-tab-session-send`：使用 `make-chat-input` 构造记录对象并传入。
+5. 重构 `chat-tree-ops.scm` 的 `chat-tab-append-reasoning!`：将思考段落分行时调用的 `cork->utf8` / `utf8->cork` 替换为 `herk->utf8` / `utf8->herk`。**原因**：该追加操作属于编辑器内部文档树渲染（**不属于对外 I/O 协议**）。由于主程序内部排版引擎底层依靠 Herk 编码来识别并渲染字符，不能直接写入 `utf8-raw` 原始串。升级为 `herk` 既满足了内部排版要求，又避免了老旧 `cork` 转换丢弃非 ASCII 字符（如 Emoji）的缺陷。


### PR DESCRIPTION
# [0829] LLM 插件协议重构

## 1 相关文档
- [0827.md](0827.md) - 插件 I/O 协议统一为 UTF-8
- [0828.md](0828.md) - 插件 I/O 序列化器迁移到 UTF-8 raw
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 引入 `<chat-input>` 记录类型，精简参数，并移除 `utf8->cork` 转换
- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 将 `chat-tab-append-reasoning!` 中的 cork 转换替换为 herk 转换

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake r 0239
xmake r 0251
xmake r 0828
```

### 3.2 非确定性测试（文档验证）

## 5 What
1. 定义 `<chat-input>` 记录类型收拢参数，面向对象精简接口设计。
2. 彻底移除 `chat-tab-build-context-input` 内部冗余的 `utf8->cork` 转换，协议数据直发纯净 UTF-8。
3. 将 `chat-tab-append-reasoning!` 内部残留的 `cork` 转换改为 `herk` 转换。

## 7 How
1. 在 `chat-protocol.scm` 中，声明记录类型 `<chat-input>`，包含字段 `input`, `session-id`, `model`, `thinking`, `search`（在 Guile/Mogan 核心环境中，`define-record-type` 默认全局可用，无需显式 `import`）。
2. 重构 `chat-tab-build-context-input(ctx)`：仅接收单一参数 `ctx`。移除 `utf8->cork`，直接将 `json-str` 嵌入 `%chat ` 命令中。
3. 重构 `chat-tab-session-feed`，其接口精简为 `(chat-tab-session-feed lan ses ctx out opts)`。
4. 调整 `chat-tab-session-send`：使用 `make-chat-input` 构造记录对象并传入。
5. 重构 `chat-tree-ops.scm` 的 `chat-tab-append-reasoning!`：将思考段落分行时调用的 `cork->utf8` / `utf8->cork` 替换为 `herk->utf8` / `utf8->herk`。**原因**：该追加操作属于编辑器内部文档树渲染（**不属于对外 I/O 协议**）。由于主程序内部排版引擎底层依靠 Herk 编码来识别并渲染字符，不能直接写入 `utf8-raw` 原始串。升级为 `herk` 既满足了内部排版要求，又避免了老旧 `cork` 转换丢弃非 ASCII 字符（如 Emoji）的缺陷。
