### PR TITLE
[0502] 修复 is_community 切换无法控制教程开关的问题

### DIFF
--- a/devel/0502.md
+++ b/devel/0502.md
@@ -1,0 +1,127 @@
+# [0502] 修复 is_community 切换无法控制教程开关的问题
+
+## 1 相关文档
+- [0501.md](0501.md) - 上一任务：将 graphics 目录纳入格式化范围
+- [200_56] PR #3245 - 引入本 bug 的原始改动（教程根据 is_community 自动开关）
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 背景
+
+`is_community` 控制社区版/商业版，命令行切换有效（例如菜单项差异）。但 `tutorial` 开关无法跟随 `is_community` 自动切换：
+
+- 商业版（`is_community=false`）应该启用教程 → ✅ 正常
+- 社区版（`is_community=true`）应该禁用教程 → ❌ 仍然启用
+
+`build/config.h` 里 `USE_TUTORIAL` 永远是 `1`，与 `is_community` 无关。
+
+## 3 任务相关的代码文件
+
+- `xmake/options.lua` - 删除失效的 `tutorial` option 定义及 `enable_tutorial` 局部变量
+- `xmake/targets/libmogan.lua` - `USE_TUTORIAL` 改为直接由 `not has_config("is_community")` 推导
+
+## 4 What
+
+1. 删除 `xmake/options.lua` 中的 `option("tutorial")` 定义、`local enable_tutorial = not has_config("is_community")` 这段局部变量推导
+2. `xmake/targets/libmogan.lua:138` 把 `USE_TUTORIAL = enable_tutorial` 改成 `USE_TUTORIAL = not has_config("is_community")`
+
+## 5 Why
+
+### Bug 链条
+
+[200_56] PR #3245 把教程开关从独立 option 改成"由 is_community 自动推导"：
+
+```lua
+local enable_tutorial = not has_config("is_community")  -- options.lua:51
+
+option("tutorial")
+    set_default(enable_tutorial)                          -- options.lua:54
+```
+
+```lua
+USE_TUTORIAL = enable_tutorial,                           -- libmogan.lua:138
+```
+
+**两个致命问题**：
+
+1. **`has_config` 求值时机错**：`options.lua:51` 在 xmake 加载 option 阶段执行，此时 config 缓存（`xmake.conf`）反映的是**上次** config 的状态，不是当前命令行参数。命令行 `--is_community=true/false` 改的是当前会话的 option 值，但 `has_config` 在 option 注册时已经把 `enable_tutorial` 冻结成上次的缓存值。
+
+2. **`USE_TUTORIAL` 用了局部变量而非 option 值**：`libmogan.lua:138` 用的是 `enable_tutorial`（闭包变量），不是 `has_config("tutorial")`。即使 `option("tutorial")` 的值能正确推导，`config.h` 里 `USE_TUTORIAL` 也读不到——它永远用 `options.lua:51` 冻结的那个值。
+
+实测：`xmake config --is_community=true` 和 `--is_community=false` 切换，`.xmake/linux/x86_64/xmake.conf` 里 `is_community` 跟着变，但 `tutorial` 永远是 `true`，`build/config.h` 里 `USE_TUTORIAL` 永远是 `1`。
+
+### 修复方案
+
+去掉 `tutorial` option 中间层，让 `USE_TUTORIAL` 在 target 配置阶段（所有命令行参数已就位）直接读 `has_config("is_community")`：
+
+```lua
+-- libmogan.lua
+USE_TUTORIAL = not has_config("is_community"),
+```
+
+这样 `has_config` 反映当前命令行的真实值，`USE_TUTORIAL` 跟着 `is_community` 切换。
+
+### 验证
+
+| `xmake config` | `is_community` | `USE_TUTORIAL`（修复前）| `USE_TUTORIAL`（修复后）|
+|---|---|---|---|
+| `--is_community=true` | true | **1** ❌ | **undef** ✅ |
+| `--is_community=false` | false | 1 ✅ | **1** ✅ |
+
+## 6 How
+
+`xmake` 的 option 系统 vs target 配置阶段的求值时机差异：
+
+- **option 注册阶段**（`options.lua` 加载时）：`has_config` 读 xmake.conf 缓存，可能尚未反映本次命令行参数
+- **target 配置阶段**（`libmogan.lua` 加载时）：所有 option 值已稳定，`has_config` 反映当前真实状态
+
+所以 `set_default(expr)` 里若含 `has_config`，会被早期的缓存状态污染；而 target 的 `add_configfiles` variables 块在 target 配置阶段求值，`has_config` 是可靠的。
+
+把推导逻辑移到 target 阶段，绕过 option 默认值的求值时机陷阱。
+
+## 7 如何测试
+
+### 7.1 双向切换验证
+
+```bash
+# 清缓存
+xmake f -c --yes
+
+# 社区版：预期 USE_TUTORIAL undef
+xmake f --is_community=true
+grep "USE_TUTORIAL" build/config.h
+# 应输出: /* #undef USE_TUTORIAL */
+
+# 商业版：预期 USE_TUTORIAL = 1
+xmake f --is_community=false
+grep "USE_TUTORIAL" build/config.h
+# 应输出: #define USE_TUTORIAL 1
+```
+
+### 7.2 编译验证
+
+```bash
+xmake b stem
+```
+
+商业版编译时 `QTMWindow::showEvent` 里 `#if defined(USE_TUTORIAL)` 段被编译进去；社区版该段被预处理器剔除。
+
+## 8 如何提交
+
+按 CLAUDE.md 规范，PR 至少分两个 commit：
+
+1. **第一个 commit**：更新 `devel/0502.md`（本文件）
+2. **后续 commit**：xmake 改动
+
+提交前运行 `gf fmt --changed-since=main`（本任务只涉及 lua 文件，gf fmt 通常不处理 xmake lua，但保持习惯）。
+
+提交信息格式：`[0502] 修复 is_community 切换无法控制教程开关的问题`。
+
+## 9 分支命名
+
+```
+<username>/200_27/0502_fix_tutorial_is_community
+```
+
+## 10 致谢
+
+本 bug 由 [200_56] PR #3245（作者 MoonL79）引入，bug 不影响其原始意图（教程默认跟随 is_community），仅是实现层面有求值时机问题。本次修复保留了 [200_56] 的设计意图。

--- a/xmake/options.lua
+++ b/xmake/options.lua
@@ -48,13 +48,6 @@ option("is_community")
     set_description("Adjust community or commercial version")
 option_end()
 
-local enable_tutorial = not has_config("is_community")
-
-option("tutorial")
-    set_default(enable_tutorial)
-    set_description("Enable tutorial infrastructure and first-launch tutorial; derived from is_community")
-option_end()
-
 option("debug_with_timestamp")
     set_default(true)
     set_description("Enable timestamps in debug messages")

--- a/xmake/targets/libmogan.lua
+++ b/xmake/targets/libmogan.lua
@@ -135,7 +135,7 @@ target("libmogan") do
                 USE_MUPDF_RENDERER = has_config("mupdf"),
                 USE_STARTUP_TAB = has_config("startup_tab"),
                 USE_TEXT_TOOLBAR = has_config("text_toolbar"),
-                USE_TUTORIAL = enable_tutorial,
+                USE_TUTORIAL = not has_config("is_community"),
                 IS_COMMUNITY = has_config("is_community"),
                 DEBUG_WITH_TIMESTAMP = has_config("debug_with_timestamp"),
                 }})


### PR DESCRIPTION
[200_56] PR #3245 把 tutorial option 的默认值改成由 is_community 推导， 但 enable_tutorial 局部变量在 option 注册阶段被冻结，has_config 读的是 陈旧缓存，导致 USE_TUTORIAL 永远为 1，社区版也无法关闭教程。

去掉 tutorial option 中间层，让 USE_TUTORIAL 在 target 配置阶段直接由 not has_config("is_community") 推导，命令行 --is_community=true/false 能正确控制教程开关。