### PR TITLE
[0503] 初次启动引导教程：为魔法粘贴和 OCR 步骤提供一键触发按钮

### DIFF
--- a/TeXmacs/plugins/tutorial/data/first-launch-tutorial.json
+++ b/TeXmacs/plugins/tutorial/data/first-launch-tutorial.json
@@ -20,33 +20,41 @@
     {
       "id": "magic-paste",
       "title": "魔法粘贴",
-      "top-text": "魔法粘贴可以自动识别剪贴板中的内容类型，并尽可能保留网页内容的结构、标题层级、列表样式和公式表达，让外部内容进入文档后依然便于继续编辑与排版。",
-      "bubble-size": "large",
-      "offset-x": 500,
+      "top-text": "",
+      "bubble-size": "huge",
+      "offset-x": 200,
       "offset-y": 0,
       "media-path": ":/tutorial/magic-paste-tutorial.gif",
-      "bottom-text": "<b>系统已经为您打开了一个新的空白文档，并将一段网页内容复制到了剪贴板。</b>请在编辑区中使用 <b>Ctrl+V</b>（Windows / Linux）或 <b>Command+V</b>（macOS）进行粘贴。完成本步操作后，才可以进入下一步。",
+      "bottom-text": "尝试<b>魔法粘贴</b>功能，<b>无损</b>粘贴<a href=\"https://www.zhihu.com/question/437858614/answer/2027388910074957914\">请问该对称行列式该如何计算最简便呢？ - 知乎</a>的内容！",
       "target-id": "editorArea",
       "placement": "top",
       "highlight-padding": 12,
       "require-action": "paste",
       "on-enter": "(tutorial-prepare-magic-paste-demo)",
+      "action-button": {
+        "label": "立即体验魔法粘贴",
+        "command": "(tutorial-trigger-magic-paste)"
+      },
       "skip-if-missing": true
     },
     {
       "id": "ocr",
       "title": "OCR 文字识别",
-      "top-text": "如果您的剪贴板中包含图片内容，软件可以通过快捷键触发 OCR ，提取其中的文字，让您快速将截图转换为可编辑文本；您也可以在插入图片后，通过图片悬浮菜单上的 OCR 按钮发起识别。",
-      "bubble-size": "large",
-      "offset-x": 500,
+      "top-text": "",
+      "bubble-size": "huge",
+      "offset-x": 200,
       "offset-y": 0,
       "media-path": ":/tutorial/ocr-tutorial.gif",
-      "bottom-text": "系统已经为您打开了一个包含图片的文档，且将一张图片放入了您的剪贴板，您可以在编辑区中使用 <b>Ctrl+Shift+V</b>（Windows / Linux）或 <b>Command+Shift+V</b>（macOS）触发 OCR 识别，也可以用鼠标点击悬浮菜单中的按钮触发 OCR 识别，图片中的文字将被快速提取为文档中的可编辑文本。完成本步操作后，才可以进入下一步。",
+      "bottom-text": "让<b>OCR</b>识别这张包含公式的图片！",
       "target-id": "editorArea",
       "placement": "top",
       "highlight-padding": 12,
       "require-action": "ocr-paste",
       "on-enter": "(tutorial-prepare-ocr-demo)",
+      "action-button": {
+        "label": "立即体验 OCR",
+        "command": "(tutorial-trigger-ocr)"
+      },
       "skip-if-missing": true
     }
   ]

--- a/TeXmacs/plugins/tutorial/progs/init-tutorial.scm
+++ b/TeXmacs/plugins/tutorial/progs/init-tutorial.scm
@@ -11,38 +11,70 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (tutorial-magic-paste-demo-path)
-  (unix->url "$TEXMACS_PATH/plugins/tutorial/data/zhihu-magic-paste-demo.html"))
+  (unix->url "$TEXMACS_PATH/plugins/tutorial/data/zhihu-magic-paste-demo.html")
+) ;define
 
 (define tutorial-magic-paste-demo-opened? #f)
+
 (define tutorial-ocr-demo-opened? #f)
 
 (define (tutorial-ocr-demo-document-path)
-  (unix->url "$TEXMACS_PATH/plugins/tutorial/data/ocr-demo.tmu"))
+  (unix->url "$TEXMACS_PATH/plugins/tutorial/data/ocr-demo.tmu")
+) ;define
 
 (define (tutorial-ocr-demo-image-path)
-  (unix->url "$TEXMACS_PATH/misc/images/tutorial/stem-image.png"))
+  (unix->url "$TEXMACS_PATH/misc/images/tutorial/stem-image.png")
+) ;define
 
 (tm-define (tutorial-notify-action action)
-  (cpp-set-preference "tutorial:last-action" action))
+  (cpp-set-preference "tutorial:last-action" action)
+) ;tm-define
 
 (tm-define (tutorial-prepare-magic-paste-demo)
   (let* ((html-path (tutorial-magic-paste-demo-path))
-         (html      (string-load html-path))
-         (old-export (clipboard-get-export)))
+         (html (string-load html-path))
+         (old-export (clipboard-get-export))
+        ) ;
     (if (not tutorial-magic-paste-demo-opened?)
-        (begin
-          (new-document)
-          (set! tutorial-magic-paste-demo-opened? #t)))
+      (begin
+        (new-document)
+        (set! tutorial-magic-paste-demo-opened? #t)
+      ) ;begin
+    ) ;if
     (if (defined? 'qt-clipboard-set-html)
-        (qt-clipboard-set-html html)
-        (begin
-          (clipboard-set-export "verbatim")
-          (clipboard-set "primary" html)
-          (clipboard-set-export old-export)))))
+      (qt-clipboard-set-html html)
+      (begin
+        (clipboard-set-export "verbatim")
+        (clipboard-set "primary" html)
+        (clipboard-set-export old-export)
+      ) ;begin
+    ) ;if
+  ) ;let*
+) ;tm-define
 
 (tm-define (tutorial-prepare-ocr-demo)
   (if (not tutorial-ocr-demo-opened?)
-      (begin
-        (load-document (tutorial-ocr-demo-document-path))
-        (set! tutorial-ocr-demo-opened? #t)))
-  (graphics-file-to-clipboard (tutorial-ocr-demo-image-path)))
+    (begin
+      (load-document (tutorial-ocr-demo-document-path))
+      (set! tutorial-ocr-demo-opened? #t)
+    ) ;begin
+  ) ;if
+  (graphics-file-to-clipboard (tutorial-ocr-demo-image-path))
+) ;tm-define
+
+;; Why: 直接调 kbd-magic-paste 会触发登录/额度校验弹窗，不适合教程演示；
+;;      且其 notify-action 写死为 "ocr-paste"，无法匹配魔法粘贴步骤的 "paste"。
+;;      这里直接走核心解析逻辑 smart-format-paste，再显式发 "paste" 完成信号。
+(tm-define (tutorial-trigger-magic-paste)
+  (smart-format-paste)
+  (when (defined? 'tutorial-notify-action)
+    (tutorial-notify-action "paste")
+  ) ;when
+) ;tm-define
+
+(tm-define (tutorial-trigger-ocr)
+  (ocr-paste)
+  (when (defined? 'tutorial-notify-action)
+    (tutorial-notify-action "ocr-paste")
+  ) ;when
+) ;tm-define

--- a/devel/0503.md
+++ b/devel/0503.md
@@ -1,0 +1,208 @@
+# [0503] 初次启动引导教程：为魔法粘贴和 OCR 步骤提供一键触发按钮
+
+## 1 相关文档
+- [0501.md](0501.md) - 上一任务：将 graphics 目录纳入格式化范围
+- [0502.md](0502.md) - 修复 is_community 切换无法控制教程开关的问题（前置依赖）
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 背景
+
+初次启动引导教程（`first-launch` flow）共有三步：
+
+1. **welcome** - 介绍主工作区
+2. **magic-paste** - 体验魔法粘贴：进入步骤时把 HTML 灌入剪贴板，要求用户手动按 `Ctrl+V` 粘贴
+3. **ocr** - 体验 OCR：进入步骤时把图片放入剪贴板，要求用户手动按 `Ctrl+Shift+V`
+
+需求：在第 2、3 步的气泡里放一个**明显的按钮**，按下直接触发对应功能，免去用户找快捷键。按钮与"下一步"按钮**合二为一**——单钮多状态：action 模式触发功能，action 完成后自动切换为"下一步"。
+
+## 3 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_tutorial.hpp` - `TutorialStepConfig` 增加 `actionButtonLabel` / `actionButtonCommand`；`TutorialBubble` 增加 `NextButtonMode` 状态机、`m_actionButton` 删除（合并到 `m_nextButton`）、`appendBottomNotice` / `clearBottomNotice` / `applyNextButtonAppearance` / `emitNextButtonAction` 接口；`TutorialOverlay` 透传 `actionRequested` / `appendBottomNotice` 等
+- `src/Plugins/Qt/qt_tutorial.cpp` - JSON loader 解析 `action-button`；`m_nextButton` 一钮双态（NormalNext/ActionTrigger）；气泡加 `Huge` 宽度档位（1160px）；`m_bottomTextLabel` 富文本+巨大字号+链接可点击；`appendBottomNotice` 追加完成提示；`pollRequiredAction` 识别完成时切换按钮模式并追加"恭喜您！..."
+- `TeXmacs/plugins/tutorial/progs/init-tutorial.scm` - 新增 `tutorial-trigger-magic-paste`、`tutorial-trigger-ocr`
+- `TeXmacs/plugins/tutorial/data/first-launch-tutorial.json` - 第 2/3 步增加 `action-button`，文案精简，bubble-size=huge，offset-x=200
+
+## 4 What
+
+### 4.1 数据结构
+
+- `TutorialStepConfig` 新增 `actionButtonLabel`、`actionButtonCommand` 两个 `QString` 字段
+- `TutorialBubbleSize` 枚举新增 `Huge` 档位（宽度 1160px）
+- `TutorialConfigLoader` 解析 JSON 的 `action-button: { label, command }` 对象
+
+### 4.2 单钮双态按钮
+
+`TutorialBubble::m_nextButton` 一个按钮承担两种职责，由 `m_nextMode` 状态机控制：
+
+| 模式 | 按钮文案 | enabled | 点击行为 |
+|---|---|---|---|
+| `ActionTrigger` | 步骤配置的 label（如"立即体验魔法粘贴"）| 始终 true | 发 `actionRequested(command)` |
+| `NormalNext` | "下一步"或"完成"（最后一步）| 跟随 `setNextEnabled` | 发 `nextRequested` 或 `finishRequested` |
+
+状态转换：
+- `setActionButton(label, cmd)` 有非空 label/cmd → `ActionTrigger`
+- `setNextEnabled(true)` 时若当前是 `ActionTrigger` → 自动切回 `NormalNext`
+- `ActionTrigger` 模式下 `setNextEnabled(false)` **不禁用**按钮（让用户能点 action 触发）
+
+### 4.3 完成提示
+
+`pollRequiredAction` 识别到 `require-action` 完成时：
+1. 调 `setNextEnabled(true)` 触发按钮模式切换（`ActionTrigger` → `NormalNext`）
+2. 调 `appendBottomNotice` 在 `m_bottomTextLabel` 追加 HTML 提示：
+   - 非最后一步：<span style="color:#0f766e">恭喜您！可以进入下一步教程了！</span>
+   - 最后一步：<span style="color:#0f766e">恭喜您！教程已完成！</span>
+
+### 4.4 富文本支持
+
+`m_bottomTextLabel` 配置：
+- `setTextFormat(Qt::RichText)` - 支持 `<b>`、`<a>`、`<span>` 等
+- `setOpenExternalLinks(false)` + `linkActivated` 信号 → `QDesktopServices::openUrl` - 自定义点击行为，避免被 overlay 鼠标事件拦截
+- `setTextInteractionFlags(Qt::LinksAccessibleByMouse)` - 仅允许鼠标访问链接（不做文本选择，避免影响布局）
+- 字号 `kBubbleHugeFontPx = 22`（比标题 20 还大，突出主引导文案）
+
+### 4.5 气泡宽度档位
+
+新增 `Huge` 档（1160px），用于承载巨大字号 + 较长文案。`bubble-size: "huge"` 在 JSON 里配置。
+
+### 4.6 JSON 配置
+
+第 2 步 magic-paste：
+- `bubble-size: "huge"`，`offset-x: 200`
+- `top-text: ""`（清空）
+- `bottom-text` 改为 HTML：`尝试<b>魔法粘贴</b>功能，<b>无损</b>粘贴<a href="https://www.zhihu.com/question/437858614/answer/2027388910074957914">请问该对称行列式该如何计算最简便呢？ - 知乎</a>的内容！`
+- `action-button: { label: "立即体验魔法粘贴", command: "(tutorial-trigger-magic-paste)" }`
+
+第 3 步 ocr：
+- `bubble-size: "huge"`，`offset-x: 200`
+- `top-text: ""`，`bottom-text: "让<b>OCR</b>识别这张包含公式的图片！"`
+- `action-button: { label: "立即体验 OCR", command: "(tutorial-trigger-ocr)" }`
+
+### 4.7 Scheme 触发函数
+
+`init-tutorial.scm` 新增：
+- `tutorial-trigger-magic-paste` → 调 `smart-format-paste` + `(tutorial-notify-action "paste")`
+- `tutorial-trigger-ocr` → 调 `ocr-paste` + `(tutorial-notify-action "ocr-paste")`
+
+## 5 Why
+
+### 为什么按钮要和"下一步"合二为一
+
+- **视觉聚焦**：单钮引导用户清晰执行"先触发 action，再进入下一步"的流程，避免两个按钮（action button + next button）让用户困惑先点哪个
+- **状态机自然**：按钮文案随状态变化本身就是反馈——用户看到按钮从"立即体验"变成"下一步"就知道可以前进了
+- **代码简化**：不需要再维护独立的 `m_actionButton` widget、布局位置、信号链路
+
+### 为什么不用 `kbd-magic-paste`
+
+`kbd-magic-paste` 看似一步到位，但有两个问题：
+
+1. **会触发登录/额度校验弹窗**：内部走 `with-magic-paste-check`，调远程接口 `check-magic-paste`，未登录或超额时弹出登录/升级对话框。教程第一次启动就让用户面对登录墙不合适。
+2. **`notify-action` 写死成 `"ocr-paste"`**（`generic-edit.scm:1464-1466`），与第 2 步 JSON 的 `"require-action": "paste"` 不匹配，第 2 步永远解锁不了。
+
+因此第 2 步的包装函数直接调核心解析逻辑 `smart-format-paste`（跳过登录校验），再显式发 `"paste"` 信号。
+
+### 为什么不用 `kbd-paste`
+
+`kbd-paste` 末尾发的是 `"paste"`（与第 2 步 JSON 匹配），但它不走魔法解析（`smart-format-paste`），用户感受不到"魔法粘贴"的智能 HTML 结构识别效果，违背教程演示目的。
+
+### 为什么第 3 步直接调 `ocr-paste` 而不是 `kbd-magic-paste`
+
+剪贴板确定是图片，没必要再走 `kbd-magic-paste` 的格式判断分支；直接 `ocr-paste` 更直白，通知信号也由包装函数显式发出，与 JSON 的 `"ocr-paste"` 精确对齐。
+
+### 为什么完成提示分两套文案
+
+最后一步完成后用户没有"下一步"，应该提示教程结束；非最后一步要引导用户继续。通过 `m_currentIndex == steps.size() - 1` 区分。
+
+### 为什么追加提示后必须 `adjustSize` + `repositionBubble`
+
+否则气泡 widget 的 geometry 还是原来的高度，但 layout 已经把 footer 按钮往下推到边界外，被裁切不可见。**这是 0503 开发中实际遇到的 bug**——OCR 完成追加提示后 footer 消失，用户无法点"完成"。修复在 `TutorialBubble::appendBottomNotice/clearBottomNotice` 调 `adjustSize()`，`TutorialOverlay::appendBottomNotice/clearBottomNotice` 调 `repositionBubble()`。
+
+## 6 How（关键实现细节）
+
+### 数据流
+
+```
+JSON action-button
+  → TutorialConfigLoader 解析进 TutorialStepConfig.actionButtonLabel/Command
+  → TutorialOverlay::setStep → TutorialBubble::setStep
+  → setActionButton(label, command) 设置 ActionTrigger 模式
+用户点击按钮
+  → TutorialBubble::emitNextButtonAction
+  → ActionTrigger 模式 → emit actionRequested(command)
+  → TutorialOverlay::actionRequested 信号透传
+  → TutorialEngine lambda: exec_delayed(scheme_cmd(command))
+  → Scheme 执行 (tutorial-trigger-magic-paste / tutorial-trigger-ocr)
+    → smart-format-paste / ocr-paste（实际功能）
+    → (tutorial-notify-action "paste" / "ocr-paste")
+    → preference "tutorial:last-action" 被写入
+TutorialEngine::pollRequiredAction 每 150ms 轮询
+  → 匹配 step.requiredAction
+  → setNextEnabled(true) 触发 ActionTrigger → NormalNext 切换
+  → appendBottomNotice 追加"恭喜您！..."
+  → 按钮文案变"下一步"/"完成"
+```
+
+### 状态机关键点
+
+```cpp
+void setNextEnabled(bool enabled, const QString& toolTip) {
+    m_nextGateEnabled = enabled;
+    m_nextButton->setToolTip(toolTip);
+    if (enabled && m_nextMode == NextButtonMode::ActionTrigger)
+        m_nextMode = NextButtonMode::NormalNext;  // 完成识别驱动切换
+    applyNextButtonAppearance();
+}
+```
+
+`ActionTrigger` 模式下 `applyNextButtonAppearance` 强制 `setEnabled(true)`，让用户随时可点 action 触发（允许多次演示）。
+
+## 7 如何测试
+
+### 7.1 构建验证
+
+```bash
+xmake b stem
+```
+
+### 7.2 GUI 集成测试（headless 跑不了）
+
+按 CLAUDE.md GUI 集成测试规范：
+
+```bash
+MOGAN_TEST_GUI=1 xmake r <对应教程测试>
+```
+
+或手动用全新 preference 的 mogan 启动，确认：
+
+1. **第 2 步**：按钮文案"立即体验魔法粘贴"，可点
+   - 点击后 HTML 被智能粘贴进文档（保留标题层级、列表、公式等结构）
+   - 轮询识别后按钮文案切到"下一步"，bottom-text 追加绿色"恭喜您！可以进入下一步教程了！"
+   - 底部超链接"请问该对称行列式该如何计算最简便呢？ - 知乎"可点击调用系统浏览器
+   - "魔法粘贴"、"无损"加粗显示，文案整体字号巨大
+2. **第 3 步**：按钮文案"立即体验 OCR"，可点
+   - 点击后图片被识别成可编辑文本
+   - 识别完成后按钮文案切到"完成"，bottom-text 追加绿色"恭喜您！教程已完成！"
+   - footer 按钮（"完成"）必须可见且可点（验证 adjustSize + repositionBubble 修复）
+3. **welcome 步骤**：无 action-button，按钮显示"下一步"
+
+## 8 如何提交
+
+按 CLAUDE.md 规范，PR 至少分两个 commit：
+
+1. **第一个 commit**：更新 `devel/0503.md`（本文件）
+2. **后续 commit**：代码改动
+
+提交前运行 `gf fmt --changed-since=main`（已执行，`init-tutorial.scm` 已被重排）。
+
+提交信息格式：`[0503] 简述`。
+
+## 9 分支命名
+
+```
+cms/0503/tutorial
+```
+
+## 10 依赖
+
+本任务依赖 [0502](0502.md)（xmake 修复）。0502 修复了 `is_community` 切换无法控制教程开关的问题——在 0502 合并前，社区版编译产物里教程代码可能被预处理器剔除（`USE_TUTORIAL` undef），无法验证按钮功能。
+
+商业版（`is_community=false`）不受此限制，0503 的按钮功能可以独立验证。

--- a/src/Plugins/Qt/qt_tutorial.cpp
+++ b/src/Plugins/Qt/qt_tutorial.cpp
@@ -291,8 +291,10 @@ parseStepEntry (const json& stepJson, QWK::TutorialStepConfig& step,
                            .arg (step.id);
       return false;
     }
-    step.actionButtonLabel  = QString::fromStdString (labelIt->get<std::string> ());
-    step.actionButtonCommand= QString::fromStdString (cmdIt->get<std::string> ());
+    step.actionButtonLabel=
+        QString::fromStdString (labelIt->get<std::string> ());
+    step.actionButtonCommand=
+        QString::fromStdString (cmdIt->get<std::string> ());
   }
 
   if (!hasTopTextField && step.mediaPath.isEmpty () &&
@@ -560,10 +562,9 @@ TutorialBubble::TutorialBubble (QWidget* parent)
   m_bottomTextLabel->setTextFormat (Qt::RichText);
   m_bottomTextLabel->setOpenExternalLinks (false);
   m_bottomTextLabel->setTextInteractionFlags (Qt::LinksAccessibleByMouse);
-  QObject::connect (m_bottomTextLabel,
-                    &QLabel::linkActivated, [] (const QString& link) {
-                      QDesktopServices::openUrl (QUrl (link));
-                    });
+  QObject::connect (
+      m_bottomTextLabel, &QLabel::linkActivated,
+      [] (const QString& link) { QDesktopServices::openUrl (QUrl (link)); });
   m_mediaContainer->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Fixed);
   m_mediaContainer->setVisible (false);
   m_mediaContainer->setFixedSize (0, 0);
@@ -765,7 +766,7 @@ TutorialBubble::setLastStep (bool last) {
 
 void
 TutorialBubble::setNextEnabled (bool enabled, const QString& toolTip) {
-  m_nextGateEnabled = enabled;
+  m_nextGateEnabled= enabled;
   m_nextButton->setToolTip (toolTip);
   if (enabled && m_nextMode == NextButtonMode::ActionTrigger)
     m_nextMode= NextButtonMode::NormalNext;
@@ -774,11 +775,11 @@ TutorialBubble::setNextEnabled (bool enabled, const QString& toolTip) {
 
 void
 TutorialBubble::setActionButton (const QString& label, const QString& command) {
-  m_actionLabel  = label;
-  m_actionCommand= command;
+  m_actionLabel       = label;
+  m_actionCommand     = command;
   const bool hasAction= !label.isEmpty () && !command.isEmpty ();
-  m_nextMode= hasAction ? NextButtonMode::ActionTrigger
-                        : NextButtonMode::NormalNext;
+  m_nextMode=
+      hasAction ? NextButtonMode::ActionTrigger : NextButtonMode::NormalNext;
   applyNextButtonAppearance ();
 }
 
@@ -1214,10 +1215,14 @@ TutorialEngine::pollRequiredAction () {
 
   m_completedActionSteps.insert (step.id);
   reset_user_preference (kTutorialLastActionPreference);
-  const bool isLastStep= (m_currentIndex == m_config.steps.size () - 1);
-  const QString notice= isLastStep
-      ? QStringLiteral ("<span style=\"color:#0f766e\">恭喜您！教程已完成！</span>")
-      : QStringLiteral ("<span style=\"color:#0f766e\">恭喜您！可以进入下一步教程了！</span>");
+  const bool    isLastStep= (m_currentIndex == m_config.steps.size () - 1);
+  const QString notice=
+      isLastStep
+          ? QStringLiteral (
+                "<span style=\"color:#0f766e\">恭喜您！教程已完成！</span>")
+          : QStringLiteral ("<span "
+                            "style=\"color:#0f766e\">"
+                            "恭喜您！可以进入下一步教程了！</span>");
   m_overlay->appendBottomNotice (notice);
   updateCurrentStepGate ();
 }

--- a/src/Plugins/Qt/qt_tutorial.cpp
+++ b/src/Plugins/Qt/qt_tutorial.cpp
@@ -19,6 +19,7 @@
 #include "tm_file.hpp"
 
 #include <QApplication>
+#include <QDesktopServices>
 #include <QDir>
 #include <QEvent>
 #include <QFileInfo>
@@ -53,11 +54,13 @@ constexpr int kBubbleButtonPadXPx       = 14;
 constexpr int kBubbleButtonMinWidthPx   = 72;
 constexpr int kBubbleTitleFontPx        = 20;
 constexpr int kBubbleBodyFontPx         = 16;
+constexpr int kBubbleHugeFontPx         = 22;
 constexpr int kBubbleProgressFontPx     = 13;
 constexpr int kBubbleButtonFontPx       = 12;
 constexpr int kBubbleWidthSmallPx       = 300;
 constexpr int kBubbleWidthMediumPx      = 360;
 constexpr int kBubbleWidthLargePx       = 440;
+constexpr int kBubbleWidthHugePx        = 1160;
 constexpr int kBubbleMediaSmallWidthPx  = 240;
 constexpr int kBubbleMediaSmallHeightPx = 144;
 constexpr int kBubbleMediaMediumWidthPx = 300;
@@ -142,6 +145,7 @@ parseBubbleSize (const QString& value, QWK::TutorialBubbleSize& bubbleSize) {
   if (normalized == "small") bubbleSize= QWK::TutorialBubbleSize::Small;
   else if (normalized == "medium") bubbleSize= QWK::TutorialBubbleSize::Medium;
   else if (normalized == "large") bubbleSize= QWK::TutorialBubbleSize::Large;
+  else if (normalized == "huge") bubbleSize= QWK::TutorialBubbleSize::Huge;
   else return false;
 
   return true;
@@ -260,6 +264,35 @@ parseStepEntry (const json& stepJson, QWK::TutorialStepConfig& step,
           QString ("Tutorial step %1 require-action must be a string")
               .arg (step.id);
     return false;
+  }
+
+  const auto actionBtnIt= stepJson.find ("action-button");
+  if (actionBtnIt != stepJson.end () && !actionBtnIt->is_null ()) {
+    if (!actionBtnIt->is_object ()) {
+      if (errorMessage != nullptr)
+        *errorMessage=
+            QString ("Tutorial step %1 action-button must be an object")
+                .arg (step.id);
+      return false;
+    }
+    const auto labelIt= actionBtnIt->find ("label");
+    const auto cmdIt  = actionBtnIt->find ("command");
+    if (labelIt == actionBtnIt->end () || cmdIt == actionBtnIt->end ()) {
+      if (errorMessage != nullptr)
+        *errorMessage= QString ("Tutorial step %1 action-button needs label "
+                                "and command")
+                           .arg (step.id);
+      return false;
+    }
+    if (!labelIt->is_string () || !cmdIt->is_string ()) {
+      if (errorMessage != nullptr)
+        *errorMessage= QString ("Tutorial step %1 action-button label/command "
+                                "must be strings")
+                           .arg (step.id);
+      return false;
+    }
+    step.actionButtonLabel  = QString::fromStdString (labelIt->get<std::string> ());
+    step.actionButtonCommand= QString::fromStdString (cmdIt->get<std::string> ());
   }
 
   if (!hasTopTextField && step.mediaPath.isEmpty () &&
@@ -510,7 +543,7 @@ TutorialBubble::TutorialBubble (QWidget* parent)
       m_progressLabel (new QLabel (this)),
       m_previousButton (new QPushButton (this)),
       m_nextButton (new QPushButton (this)), m_mediaMovie (nullptr),
-      m_currentMediaPath () {
+      m_currentMediaPath (), m_actionCommand () {
   setObjectName ("tutorialBubble");
   setAttribute (Qt::WA_StyledBackground, true);
   setSizePolicy (QSizePolicy::Fixed, QSizePolicy::Preferred);
@@ -524,6 +557,13 @@ TutorialBubble::TutorialBubble (QWidget* parent)
   m_titleLabel->setWordWrap (true);
   m_topTextLabel->setWordWrap (true);
   m_bottomTextLabel->setWordWrap (true);
+  m_bottomTextLabel->setTextFormat (Qt::RichText);
+  m_bottomTextLabel->setOpenExternalLinks (false);
+  m_bottomTextLabel->setTextInteractionFlags (Qt::LinksAccessibleByMouse);
+  QObject::connect (m_bottomTextLabel,
+                    &QLabel::linkActivated, [] (const QString& link) {
+                      QDesktopServices::openUrl (QUrl (link));
+                    });
   m_mediaContainer->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Fixed);
   m_mediaContainer->setVisible (false);
   m_mediaContainer->setFixedSize (0, 0);
@@ -562,7 +602,7 @@ TutorialBubble::TutorialBubble (QWidget* parent)
   setFixedWidth (DpiUtils::scaled (kBubbleWidthMediumPx));
   DpiUtils::applyScaledFont (m_titleLabel, kBubbleTitleFontPx);
   DpiUtils::applyScaledFont (m_topTextLabel, kBubbleBodyFontPx);
-  DpiUtils::applyScaledFont (m_bottomTextLabel, kBubbleBodyFontPx);
+  DpiUtils::applyScaledFont (m_bottomTextLabel, kBubbleHugeFontPx);
   DpiUtils::applyScaledFont (m_progressLabel, kBubbleProgressFontPx);
   DpiUtils::applyScaledFont (m_previousButton, kBubbleButtonFontPx);
   DpiUtils::applyScaledFont (m_nextButton, kBubbleButtonFontPx);
@@ -579,10 +619,8 @@ TutorialBubble::TutorialBubble (QWidget* parent)
 
   connect (m_previousButton, &QPushButton::clicked, this,
            &TutorialBubble::previousRequested);
-  connect (m_nextButton, &QPushButton::clicked, this, [this] () {
-    if (m_nextButton->text () == qt_translate ("完成")) emit finishRequested ();
-    else emit nextRequested ();
-  });
+  connect (m_nextButton, &QPushButton::clicked, this,
+           &TutorialBubble::emitNextButtonAction);
 }
 
 void
@@ -607,7 +645,7 @@ TutorialBubble::setStep (const TutorialStepConfig& step, int index, int total) {
 
   DpiUtils::applyScaledFont (m_titleLabel, kBubbleTitleFontPx);
   DpiUtils::applyScaledFont (m_topTextLabel, kBubbleBodyFontPx);
-  DpiUtils::applyScaledFont (m_bottomTextLabel, kBubbleBodyFontPx);
+  DpiUtils::applyScaledFont (m_bottomTextLabel, kBubbleHugeFontPx);
   DpiUtils::applyScaledFont (m_progressLabel, kBubbleProgressFontPx);
   DpiUtils::applyScaledFont (m_previousButton, kBubbleButtonFontPx);
   DpiUtils::applyScaledFont (m_nextButton, kBubbleButtonFontPx);
@@ -629,13 +667,22 @@ TutorialBubble::setStep (const TutorialStepConfig& step, int index, int total) {
     mediaSize= QSize (DpiUtils::scaled (kBubbleMediaLargeWidthPx),
                       DpiUtils::scaled (kBubbleMediaLargeHeightPx));
     break;
+  case TutorialBubbleSize::Huge:
+    setFixedWidth (DpiUtils::scaled (kBubbleWidthHugePx));
+    mediaSize= QSize (DpiUtils::scaled (kBubbleMediaLargeWidthPx),
+                      DpiUtils::scaled (kBubbleMediaLargeHeightPx));
+    break;
   }
 
   m_titleLabel->setText (step.title);
   m_topTextLabel->setText (step.topText);
   m_topTextLabel->setVisible (!step.topText.isEmpty ());
-  m_bottomTextLabel->setText (step.bottomText);
+  m_originalBottomText= step.bottomText;
+  m_bottomNoticeHtml.clear ();
+  refreshBottomText ();
   m_bottomTextLabel->setVisible (!step.bottomText.isEmpty ());
+
+  setActionButton (step.actionButtonLabel, step.actionButtonCommand);
 
   if (mediaPath != m_currentMediaPath) {
     if (m_mediaMovie != nullptr) {
@@ -712,14 +759,73 @@ TutorialBubble::setFirstStep (bool first) {
 
 void
 TutorialBubble::setLastStep (bool last) {
-  m_nextButton->setText (last ? qt_translate ("完成")
-                              : qt_translate ("下一步"));
+  m_isLastStep= last;
+  applyNextButtonAppearance ();
 }
 
 void
 TutorialBubble::setNextEnabled (bool enabled, const QString& toolTip) {
-  m_nextButton->setEnabled (enabled);
+  m_nextGateEnabled = enabled;
   m_nextButton->setToolTip (toolTip);
+  if (enabled && m_nextMode == NextButtonMode::ActionTrigger)
+    m_nextMode= NextButtonMode::NormalNext;
+  applyNextButtonAppearance ();
+}
+
+void
+TutorialBubble::setActionButton (const QString& label, const QString& command) {
+  m_actionLabel  = label;
+  m_actionCommand= command;
+  const bool hasAction= !label.isEmpty () && !command.isEmpty ();
+  m_nextMode= hasAction ? NextButtonMode::ActionTrigger
+                        : NextButtonMode::NormalNext;
+  applyNextButtonAppearance ();
+}
+
+void
+TutorialBubble::applyNextButtonAppearance () {
+  if (m_nextMode == NextButtonMode::ActionTrigger) {
+    m_nextButton->setText (m_actionLabel);
+    m_nextButton->setEnabled (true);
+    return;
+  }
+  m_nextButton->setText (m_isLastStep ? qt_translate ("完成")
+                                      : qt_translate ("下一步"));
+  m_nextButton->setEnabled (m_nextGateEnabled);
+}
+
+void
+TutorialBubble::emitNextButtonAction () {
+  if (m_nextMode == NextButtonMode::ActionTrigger &&
+      !m_actionCommand.isEmpty ()) {
+    emit actionRequested (m_actionCommand);
+    return;
+  }
+  if (m_nextButton->text () == qt_translate ("完成")) emit finishRequested ();
+  else emit nextRequested ();
+}
+
+void
+TutorialBubble::refreshBottomText () {
+  QString html= m_originalBottomText;
+  if (!m_bottomNoticeHtml.isEmpty ()) {
+    html+= QStringLiteral ("<br><br>") + m_bottomNoticeHtml;
+  }
+  m_bottomTextLabel->setText (html);
+}
+
+void
+TutorialBubble::appendBottomNotice (const QString& noticeHtml) {
+  m_bottomNoticeHtml= noticeHtml;
+  refreshBottomText ();
+  adjustSize ();
+}
+
+void
+TutorialBubble::clearBottomNotice () {
+  m_bottomNoticeHtml.clear ();
+  refreshBottomText ();
+  adjustSize ();
 }
 
 TutorialOverlay::TutorialOverlay (QMainWindow* parentWindow)
@@ -737,6 +843,8 @@ TutorialOverlay::TutorialOverlay (QMainWindow* parentWindow)
            &TutorialOverlay::nextRequested);
   connect (m_bubble, &TutorialBubble::finishRequested, this,
            &TutorialOverlay::finishRequested);
+  connect (m_bubble, &TutorialBubble::actionRequested, this,
+           &TutorialOverlay::actionRequested);
 }
 
 void
@@ -894,6 +1002,18 @@ TutorialOverlay::setNextEnabled (bool enabled, const QString& toolTip) {
 }
 
 void
+TutorialOverlay::appendBottomNotice (const QString& noticeHtml) {
+  m_bubble->appendBottomNotice (noticeHtml);
+  repositionBubble (m_currentStep.placement);
+}
+
+void
+TutorialOverlay::clearBottomNotice () {
+  m_bubble->clearBottomNotice ();
+  repositionBubble (m_currentStep.placement);
+}
+
+void
 TutorialOverlay::paintEvent (QPaintEvent* event) {
   (void) event;
 
@@ -967,6 +1087,11 @@ TutorialEngine::start (QMainWindow*                  hostWindow,
            &TutorialEngine::next);
   connect (m_overlay, &TutorialOverlay::finishRequested, this,
            [this] () { stop (TutorialFinishReason::Completed); });
+  connect (m_overlay, &TutorialOverlay::actionRequested, this,
+           [this] (const QString& command) {
+             if (command.trimmed ().isEmpty ()) return;
+             exec_delayed (scheme_cmd (from_qstring (command)));
+           });
 
   m_hostWindow->installEventFilter (this);
   updateOverlayGeometry ();
@@ -1089,6 +1214,11 @@ TutorialEngine::pollRequiredAction () {
 
   m_completedActionSteps.insert (step.id);
   reset_user_preference (kTutorialLastActionPreference);
+  const bool isLastStep= (m_currentIndex == m_config.steps.size () - 1);
+  const QString notice= isLastStep
+      ? QStringLiteral ("<span style=\"color:#0f766e\">恭喜您！教程已完成！</span>")
+      : QStringLiteral ("<span style=\"color:#0f766e\">恭喜您！可以进入下一步教程了！</span>");
+  m_overlay->appendBottomNotice (notice);
   updateCurrentStepGate ();
 }
 
@@ -1242,8 +1372,8 @@ TutorialFlowConfig
 FirstLaunchTutorialController::loadFirstLaunchFlow () const {
   TutorialFlowConfig flow;
   QString            errorMessage;
-  if (TutorialConfigLoader::loadFlow (firstLaunchTutorialConfigPath (), flow,
-                                      &errorMessage)) {
+  const url          cfgPath= firstLaunchTutorialConfigPath ();
+  if (TutorialConfigLoader::loadFlow (cfgPath, flow, &errorMessage)) {
     return flow;
   }
 

--- a/src/Plugins/Qt/qt_tutorial.cpp
+++ b/src/Plugins/Qt/qt_tutorial.cpp
@@ -1215,14 +1215,18 @@ TutorialEngine::pollRequiredAction () {
 
   m_completedActionSteps.insert (step.id);
   reset_user_preference (kTutorialLastActionPreference);
-  const bool    isLastStep= (m_currentIndex == m_config.steps.size () - 1);
-  const QString notice=
-      isLastStep
-          ? QStringLiteral (
-                "<span style=\"color:#0f766e\">恭喜您！教程已完成！</span>")
-          : QStringLiteral ("<span "
-                            "style=\"color:#0f766e\">"
-                            "恭喜您！可以进入下一步教程了！</span>");
+  QString notice;
+  if (step.requiredAction == QStringLiteral ("ocr-paste")) {
+    notice= QStringLiteral (
+        "<span style=\"color:#0f766e\">恭喜您！您也可以使用快捷键 "
+        "Ctrl+Shift+v/Command+Shift+v 或图片悬浮菜单触发 "
+        "OCR！所有教程已完成！</span>");
+  }
+  else {
+    notice= QStringLiteral (
+        "<span style=\"color:#0f766e\">恭喜您！您也可以使用快捷键 "
+        "Ctrl+Shift+v/Command+Shift+v 触发！现在可以进行下一步了</span>");
+  }
   m_overlay->appendBottomNotice (notice);
   updateCurrentStepGate ();
 }

--- a/src/Plugins/Qt/qt_tutorial.hpp
+++ b/src/Plugins/Qt/qt_tutorial.hpp
@@ -27,7 +27,7 @@ class QWheelEvent;
 namespace QWK {
 
 enum class TutorialPlacement { Auto, Top, Bottom, Left, Right };
-enum class TutorialBubbleSize { Small, Medium, Large };
+enum class TutorialBubbleSize { Small, Medium, Large, Huge };
 
 enum class TutorialFinishReason { Completed, Skipped, Cancelled, HostClosed };
 
@@ -43,6 +43,8 @@ struct TutorialStepConfig {
   QString            bottomText;
   QString            onEnterCommand;
   QString            requiredAction;
+  QString            actionButtonLabel;
+  QString            actionButtonCommand;
   TutorialBubbleSize bubbleSize= TutorialBubbleSize::Medium;
   int                offsetX   = 0;
   int                offsetY   = 0;
@@ -85,23 +87,41 @@ public:
   void setFirstStep (bool first);
   void setLastStep (bool last);
   void setNextEnabled (bool enabled, const QString& toolTip= QString ());
+  void setActionButton (const QString& label, const QString& command);
+  void appendBottomNotice (const QString& noticeHtml);
+  void clearBottomNotice ();
+
+private:
+  void refreshBottomText ();
+  void applyNextButtonAppearance ();
+  void emitNextButtonAction ();
+
+  enum class NextButtonMode { NormalNext, ActionTrigger };
 
 signals:
   void previousRequested ();
   void nextRequested ();
   void finishRequested ();
+  void actionRequested (const QString& command);
 
 private:
-  QLabel*      m_titleLabel;
-  QLabel*      m_topTextLabel;
-  QWidget*     m_mediaContainer;
-  QLabel*      m_mediaLabel;
-  QLabel*      m_bottomTextLabel;
-  QLabel*      m_progressLabel;
-  QPushButton* m_previousButton;
-  QPushButton* m_nextButton;
-  QMovie*      m_mediaMovie;
-  QString      m_currentMediaPath;
+  QLabel*         m_titleLabel;
+  QLabel*         m_topTextLabel;
+  QWidget*        m_mediaContainer;
+  QLabel*         m_mediaLabel;
+  QLabel*         m_bottomTextLabel;
+  QLabel*         m_progressLabel;
+  QPushButton*    m_previousButton;
+  QPushButton*    m_nextButton;
+  QMovie*         m_mediaMovie;
+  QString         m_currentMediaPath;
+  QString         m_actionCommand;
+  QString         m_originalBottomText;
+  QString         m_bottomNoticeHtml;
+  NextButtonMode  m_nextMode        = NextButtonMode::NormalNext;
+  bool            m_nextGateEnabled = false;
+  bool            m_isLastStep      = false;
+  QString         m_actionLabel;
 };
 
 class TutorialOverlay : public QWidget {
@@ -115,11 +135,14 @@ public:
   void clearHighlight ();
   void repositionBubble (TutorialPlacement placement);
   void setNextEnabled (bool enabled, const QString& toolTip= QString ());
+  void appendBottomNotice (const QString& noticeHtml);
+  void clearBottomNotice ();
 
 signals:
   void previousRequested ();
   void nextRequested ();
   void finishRequested ();
+  void actionRequested (const QString& command);
 
 protected:
   void paintEvent (QPaintEvent* event) override;

--- a/src/Plugins/Qt/qt_tutorial.hpp
+++ b/src/Plugins/Qt/qt_tutorial.hpp
@@ -105,23 +105,23 @@ signals:
   void actionRequested (const QString& command);
 
 private:
-  QLabel*         m_titleLabel;
-  QLabel*         m_topTextLabel;
-  QWidget*        m_mediaContainer;
-  QLabel*         m_mediaLabel;
-  QLabel*         m_bottomTextLabel;
-  QLabel*         m_progressLabel;
-  QPushButton*    m_previousButton;
-  QPushButton*    m_nextButton;
-  QMovie*         m_mediaMovie;
-  QString         m_currentMediaPath;
-  QString         m_actionCommand;
-  QString         m_originalBottomText;
-  QString         m_bottomNoticeHtml;
-  NextButtonMode  m_nextMode        = NextButtonMode::NormalNext;
-  bool            m_nextGateEnabled = false;
-  bool            m_isLastStep      = false;
-  QString         m_actionLabel;
+  QLabel*        m_titleLabel;
+  QLabel*        m_topTextLabel;
+  QWidget*       m_mediaContainer;
+  QLabel*        m_mediaLabel;
+  QLabel*        m_bottomTextLabel;
+  QLabel*        m_progressLabel;
+  QPushButton*   m_previousButton;
+  QPushButton*   m_nextButton;
+  QMovie*        m_mediaMovie;
+  QString        m_currentMediaPath;
+  QString        m_actionCommand;
+  QString        m_originalBottomText;
+  QString        m_bottomNoticeHtml;
+  NextButtonMode m_nextMode       = NextButtonMode::NormalNext;
+  bool           m_nextGateEnabled= false;
+  bool           m_isLastStep     = false;
+  QString        m_actionLabel;
 };
 
 class TutorialOverlay : public QWidget {


### PR DESCRIPTION
教程第 2/3 步原本要求用户手动按 Ctrl+V / Ctrl+Shift+V，现在把按钮和
"下一步"合二为一：进入步骤时按钮显示"立即体验魔法粘贴"/"立即体验 OCR"，
点击直接触发对应 Scheme 命令（绕过 kbd-magic-paste 的登录校验）；
轮询识别到 require-action 完成后，按钮自动切回"下一步"/"完成"，
并在气泡底部追加"恭喜您！..."提示。

气泡加 Huge 宽度档（1160px），bottom-text 富文本+巨大字号，第 2 步的
知乎链接可直接点击调用系统浏览器。

依赖 [0502] 的 xmake 修复才能在社区版编译产物里启用教程代码。