### PR TITLE
[0832] 修复椭圆和双曲线在焦点与第三点共线时退化成线

### DIFF
--- a/devel/0832.md
+++ b/devel/0832.md
@@ -11,6 +11,8 @@
 
 ### 3.1 确定性测试（单元测试）
 ```bash
+xmake b curve_test
+xmake r curve_test
 xmake b stem
 xmake r stem
 ```

--- a/devel/0832.md
+++ b/devel/0832.md
@@ -1,0 +1,77 @@
+# [0832] 修复椭圆和双曲线在焦点与第三点共线时退化成线
+
+## 1 相关文档
+- [0831.md](0831.md) - 绘图区增加双曲线和抛物线支持
+
+## 2 任务相关的代码文件
+- `src/Typeset/Concat/concat_graphics.cpp` — 修正椭圆/双曲线的退化判断条件
+- `src/Graphics/Types/curve.cpp` — 三点共线时手动构造正交基，避免 `orthogonalize` 失败后 `i`/`j` 未初始化导致崩溃
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在绘图区插入 `椭圆`，前两点为焦点，第三点位于两焦点之间时，椭圆应退化为线段；位于线段延长线上时，应绘制椭圆
+2. 在绘图区插入 `双曲线`，前两点为焦点，第三点位于两焦点之间时，双曲线应绘制双曲线；位于线段延长线上时，应退化为线段
+
+## 4 What
+0831 中 `typeset_ellipse` 和 `typeset_hyperbola` 只要检测到三点共线就直接调用 `typeset_line` 退化成线。
+
+这过于宽泛：椭圆第三点在焦点连线延长线上时本应画出一个扁平椭圆；双曲线第三点在两焦点之间时也不应直接画线。更合理的做法是根据椭圆/双曲线的几何有解条件来决定是否退化。
+
+## 5 How
+
+### 5.1 退化判断改为几何条件
+
+`src/Typeset/Concat/concat_graphics.cpp` 中：
+
+- **椭圆**：要求 `a > c`，退化条件为共线且 `c >= a`（即 `focal_length >= sum_of_two_dis`，第三点在焦点之间）。
+- **双曲线**：要求 `a < c`，退化条件为共线且 `c <= a`（即 `focal_length <= diff_of_two_dis`，第三点在焦点连线延长线上）。
+
+实现上先把 `n != 3` 的判断提到数组访问之前，避免只点一个点时访问 `a[1]`、`a[2]` 越界崩溃：
+
+```cpp
+if (N (a) == 0 || N (a[0]) == 0) typeset_error (t, ip);
+else if (n != 3) {
+  typeset_line (t, ip, close, true);
+}
+else {
+  double focal_length  = norm (a[1] - a[0]);
+  double sum_of_two_dis= norm (a[2] - a[0]) + norm (a[2] - a[1]);
+  if (linearly_dependent (a[0], a[1], a[2]) &&
+      focal_length >= sum_of_two_dis)
+  {
+    typeset_line (t, ip, close, true);
+  }
+  else {
+    curve c= env->fr (ellipse (a, cip, close));
+    // ...
+  }
+}
+```
+
+双曲线结构相同，只是把 `sum_of_two_dis` 换成 `diff_of_two_dis`，比较方向取反。
+
+### 5.2 共线时手动构造正交基
+
+退化判断放宽后，更多共线配置会进入 `ellipse_rep` / `hyperbola_rep`。而这两个类的 `orthogonalize` 在三点共线时返回 false，若不做兜底，`i`/`j` 就是未初始化的垃圾值，悬浮或点击连线上点会直接 SIGSEGV。
+
+在两个构造函数中加入兜底：
+
+```cpp
+if (orthogonalize (i, j, center, points[0], points[2]))
+  ;
+else {
+  point axis= points[0] - center;
+  if (norm (axis) > 1e-6) i= axis / norm (axis);
+  else i= point (1, 0);
+  j= point (-i[1], i[0]);
+}
+```
+
+双曲线用 `f_close - center` 作为轴向，其余相同。椭圆同时去掉原代码中那个针对 `center`、`points[0]`、`points[1]` 的冗余 `orthogonalize` 调用（三点永远共线，必然失败）。

--- a/src/Graphics/Types/curve.cpp
+++ b/src/Graphics/Types/curve.cpp
@@ -1031,9 +1031,15 @@ ellipse_rep::ellipse_rep (array<point> a2, array<path> cip2, bool close)
     r2= 1e-4;
   }
 
-  if (orthogonalize (i, j, center, points[0], points[1]))
+  if (orthogonalize (i, j, center, points[0], points[2]))
     ;
-  else orthogonalize (i, j, center, points[0], points[2]);
+  else {
+    // 三点共线，手动构造正交基
+    point axis= points[0] - center;
+    if (norm (axis) > 1e-6) i= axis / norm (axis);
+    else i= point (1, 0);
+    j= point (-i[1], i[0]);
+  }
 }
 
 point
@@ -1126,7 +1132,13 @@ hyperbola_rep::hyperbola_rep (array<point> a2, array<path> cip2, bool close)
   point f_close= (norm (points[2] - f2) < norm (points[2] - f1)) ? f2 : f1;
   if (orthogonalize (i, j, center, f_close, points[2]))
     ;
-  else orthogonalize (i, j, center, f_close, f_close + point (0, 1));
+  else {
+    // 三点共线，手动构造正交基
+    point axis= f_close - center;
+    if (norm (axis) > 1e-6) i= axis / norm (axis);
+    else i= point (1, 0);
+    j= point (-i[1], i[0]);
+  }
 
   double ratio= norm (points[2] - center) / (r1 + 1e-6);
   u_max       = max (6.0, my_acosh (ratio) * 1.5);

--- a/src/Typeset/Concat/concat_graphics.cpp
+++ b/src/Typeset/Concat/concat_graphics.cpp
@@ -487,17 +487,20 @@ concater_rep::typeset_ellipse (tree t, path ip, bool close) {
   for (i= 0; i < n; i++)
     cip[i]= descend (ip, i);
   if (N (a) == 0 || N (a[0]) == 0) typeset_error (t, ip);
+  else if (n != 3) {
+    typeset_line (t, ip, close, true);
+  }
   else {
-    if (n != 3 || linearly_dependent (a[0], a[1], a[2])) {
+    double focal_length  = norm (a[1] - a[0]);
+    double sum_of_two_dis= norm (a[2] - a[0]) + norm (a[2] - a[1]);
+    // 椭圆要求 a > c；共线且 c >= a（即第三点在焦点之间）时退化为线段
+    if (linearly_dependent (a[0], a[1], a[2]) &&
+        focal_length >= sum_of_two_dis) {
       // cout << "typeset_ellipse: linearly dependent points "<< "\n";
       typeset_line (t, ip, close, true);
     }
     else {
-      double focal_length, sum_of_two_dis;
-      point  f1= a[0], f2= a[1], o3= a[2];
-      focal_length  = norm (f2 - f1);
-      sum_of_two_dis= norm (o3 - f1) + norm (o3 - f2);
-      curve c       = env->fr (ellipse (a, cip, close));
+      curve c= env->fr (ellipse (a, cip, close));
       adjust_extremities (c, env->white_zones);
       print (curve_box (ip, c, env->line_portion, env->pen, env->dash_style,
                         env->dash_motif, env->dash_style_unit, env->fill_brush,
@@ -518,8 +521,15 @@ concater_rep::typeset_hyperbola (tree t, path ip, bool close) {
   for (i= 0; i < n; i++)
     cip[i]= descend (ip, i);
   if (N (a) == 0 || N (a[0]) == 0) typeset_error (t, ip);
+  else if (n != 3) {
+    typeset_line (t, ip, close, true);
+  }
   else {
-    if (n != 3 || linearly_dependent (a[0], a[1], a[2])) {
+    double focal_length   = norm (a[1] - a[0]);
+    double diff_of_two_dis= abs (norm (a[2] - a[0]) - norm (a[2] - a[1]));
+    // 双曲线要求 a < c；共线且 c <= a（即第三点在焦点连线延长线上）时退化
+    if (linearly_dependent (a[0], a[1], a[2]) &&
+        focal_length <= diff_of_two_dis) {
       // cout << "typeset_hyperbola: linearly dependent points "<< "\n";
       typeset_line (t, ip, close, true);
     }

--- a/tests/Graphics/Types/curve_test.cpp
+++ b/tests/Graphics/Types/curve_test.cpp
@@ -168,11 +168,9 @@ TestCurveConic::test_ellipse_non_collinear () {
   QVERIFY (e.center == mkp (1, 0));
 
   // 椭圆上任意一点到两焦点距离之和应为常数
-  double sum= norm (e.evaluate (0.0) - e.f1) +
-              norm (e.evaluate (0.0) - e.f2);
+  double sum= norm (e.evaluate (0.0) - e.f1) + norm (e.evaluate (0.0) - e.f2);
   for (double t= 0.25; t <= 1.0; t+= 0.25) {
-    double s= norm (e.evaluate (t) - e.f1) +
-              norm (e.evaluate (t) - e.f2);
+    double s= norm (e.evaluate (t) - e.f1) + norm (e.evaluate (t) - e.f2);
     QVERIFY (fuzzy_eq (s, sum, 1e-6));
   }
 }
@@ -293,8 +291,8 @@ TestCurveConic::test_hyperbola_non_collinear () {
   QVERIFY (h.center == mkp (1, 0));
 
   // 双曲线上任意一点到两焦点距离之差的绝对值应为常数
-  double d1= norm (h.evaluate (0.0) - h.f1);
-  double d2= norm (h.evaluate (0.0) - h.f2);
+  double d1  = norm (h.evaluate (0.0) - h.f1);
+  double d2  = norm (h.evaluate (0.0) - h.f2);
   double diff= d1 > d2 ? d1 - d2 : d2 - d1;
   for (double t= 0.1; t < 1.0; t+= 0.1) {
     double dt1= norm (h.evaluate (t) - h.f1);

--- a/tests/Graphics/Types/curve_test.cpp
+++ b/tests/Graphics/Types/curve_test.cpp
@@ -1,0 +1,491 @@
+
+/******************************************************************************
+ * MODULE     : curve_test.cpp
+ * DESCRIPTION: Unit tests for ellipse/hyperbola conic curves
+ * COPYRIGHT  : (C) 2026 AcceleratorX
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "base.hpp"
+#include "curve.hpp"
+#include "point.hpp"
+#include <QtTest/QtTest>
+
+static point
+mkp (double x, double y) {
+  point p (2);
+  p[0]= x;
+  p[1]= y;
+  return p;
+}
+
+static bool
+fuzzy_eq (double a, double b, double eps= 1e-9) {
+  return a - b < eps && b - a < eps;
+}
+
+static bool
+is_nan (double x) {
+  return x != x;
+}
+
+static bool
+is_unit_vector (point v) {
+  return fuzzy_eq (norm (v), 1.0, 1e-9);
+}
+
+static bool
+is_orthogonal (point u, point v) {
+  return fuzzy_eq (inner (u, v), 0.0, 1e-9);
+}
+
+class TestCurveConic : public QObject {
+  Q_OBJECT
+
+private slots:
+  // 退化判断：覆盖共线/非共线、焦点重合、三点重合、延长线等所有情况
+  void test_ellipse_degeneration_criteria ();
+  void test_ellipse_degeneration_boundary ();
+  // 共线且第三点在焦点之间：椭圆应退化为线段，构造函数兜底不应崩溃
+  void test_ellipse_collinear_between_foci ();
+  // 共线且第三点在焦点延长线上：应构造扁平椭圆
+  void test_ellipse_collinear_outside_foci ();
+  // 共线但轴线为垂直方向：验证正交基兜底对任意方向都有效
+  void test_ellipse_collinear_vertical ();
+  // 非共线标准椭圆：验证焦点、中心、半径和几何定义
+  void test_ellipse_non_collinear ();
+  // 两焦点重合：椭圆退化为圆，不应触发退化判断
+  void test_ellipse_coincident_foci ();
+  // 三点完全重合：边界情况，构造函数兜底不应崩溃
+  void test_ellipse_three_identical_points ();
+  // 椭圆上任意参数 t 的采样点都不应出现 NaN
+  void test_ellipse_evaluate_all_parameters ();
+
+  // 退化判断：覆盖共线/非共线、焦点重合、三点重合、延长线等所有情况
+  void test_hyperbola_degeneration_criteria ();
+  void test_hyperbola_degeneration_boundary ();
+  // 共线且第三点在焦点之间：双曲线可正常构造
+  void test_hyperbola_collinear_between_foci ();
+  // 共线且第三点在焦点延长线上：双曲线应退化为线段
+  void test_hyperbola_collinear_outside_foci ();
+  // 共线但轴线为垂直方向：验证正交基兜底对任意方向都有效
+  void test_hyperbola_collinear_vertical ();
+  // 非共线标准双曲线：验证焦点、中心、半径和几何定义
+  void test_hyperbola_non_collinear ();
+  // 两焦点重合：双曲线退化为线段
+  void test_hyperbola_coincident_foci ();
+  // 三点完全重合：边界情况，构造函数兜底不应崩溃
+  void test_hyperbola_three_identical_points ();
+  // 双曲线上任意参数 t 的采样点都不应出现 NaN
+  void test_hyperbola_evaluate_all_parameters ();
+
+  // 正交基兜底：共线时手动构造的 i/j 必须是单位正交向量
+  void test_orthogonal_basis_after_fallback ();
+  // 不同方向共线时，轴向都应正确对齐到焦点连线
+  void test_orthogonal_basis_multiple_directions ();
+};
+
+/*
+ * 退化判断：椭圆要求 a > c（两焦点距离之和小于焦距时无法构成椭圆）。
+ * 当三点共线且 focal_length >= sum_of_two_dis（即第三点在两个焦点之间）
+ * 时应退化为线段。
+ */
+static bool
+ellipse_should_degenerate (point f1, point f2, point p) {
+  if (!linearly_dependent (f1, f2, p)) return false;
+  double focal_length  = norm (f2 - f1);
+  double sum_of_two_dis= norm (p - f1) + norm (p - f2);
+  return focal_length >= sum_of_two_dis;
+}
+
+void
+TestCurveConic::test_ellipse_degeneration_criteria () {
+  // 覆盖非共线、焦点之间、延长线、焦点重合、三点重合等全部情况
+  QVERIFY (!ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (1, 1)));
+  QVERIFY (ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (1, 0)));
+  QVERIFY (!ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (-1, 0)));
+  QVERIFY (!ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (3, 0)));
+  QVERIFY (ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (0, 0)));
+  QVERIFY (ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (2, 0)));
+  QVERIFY (!ellipse_should_degenerate (mkp (0, 0), mkp (0, 0), mkp (1, 0)));
+  QVERIFY (ellipse_should_degenerate (mkp (0, 0), mkp (0, 0), mkp (0, 0)));
+}
+
+// 共线且第三点在焦点之间：椭圆应退化为线段，构造函数兜底不应崩溃。
+void
+TestCurveConic::test_ellipse_collinear_between_foci () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (2, 0);
+  a[2]= mkp (1, 0);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+
+  QVERIFY (is_unit_vector (e.i));
+  QVERIFY (is_unit_vector (e.j));
+  QVERIFY (is_orthogonal (e.i, e.j));
+  QVERIFY (e.center == mkp (1, 0));
+  QVERIFY (!is_nan (e.evaluate (0.0)[0]));
+  QVERIFY (!is_nan (e.evaluate (0.5)[0]));
+}
+
+// 共线且第三点在焦点延长线上：应构造扁平椭圆。
+void
+TestCurveConic::test_ellipse_collinear_outside_foci () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (2, 0);
+  a[2]= mkp (3, 0);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+
+  QVERIFY (is_unit_vector (e.i));
+  QVERIFY (is_unit_vector (e.j));
+  QVERIFY (is_orthogonal (e.i, e.j));
+  QVERIFY (e.center == mkp (1, 0));
+  QVERIFY (e.r1 > e.focal_length / 2);
+}
+
+// 非共线标准椭圆：验证焦点、中心、半径和几何定义。
+void
+TestCurveConic::test_ellipse_non_collinear () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (2, 0);
+  a[2]= mkp (1, 1);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+
+  QVERIFY (is_unit_vector (e.i));
+  QVERIFY (is_unit_vector (e.j));
+  QVERIFY (is_orthogonal (e.i, e.j));
+  QVERIFY (e.center == mkp (1, 0));
+
+  // 椭圆上任意一点到两焦点距离之和应为常数
+  double sum= norm (e.evaluate (0.0) - e.f1) +
+              norm (e.evaluate (0.0) - e.f2);
+  for (double t= 0.25; t <= 1.0; t+= 0.25) {
+    double s= norm (e.evaluate (t) - e.f1) +
+              norm (e.evaluate (t) - e.f2);
+    QVERIFY (fuzzy_eq (s, sum, 1e-6));
+  }
+}
+
+// 两焦点重合：椭圆退化为圆，不应触发退化判断。
+void
+TestCurveConic::test_ellipse_coincident_foci () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (0, 0);
+  a[2]= mkp (1, 0);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+
+  QVERIFY (is_unit_vector (e.i));
+  QVERIFY (is_unit_vector (e.j));
+  QVERIFY (is_orthogonal (e.i, e.j));
+  QVERIFY (e.center == mkp (0, 0));
+}
+
+// 三点完全重合：边界情况，构造函数兜底不应崩溃。
+void
+TestCurveConic::test_ellipse_three_identical_points () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (0, 0);
+  a[2]= mkp (0, 0);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+
+  QVERIFY (is_unit_vector (e.i));
+  QVERIFY (is_unit_vector (e.j));
+  QVERIFY (is_orthogonal (e.i, e.j));
+  QVERIFY (e.center == mkp (0, 0));
+}
+
+/*
+ * 退化判断：双曲线要求 a < c（到两焦点距离之差大于焦距时无法构成双曲线）。
+ * 当三点共线且 focal_length <= diff_of_two_dis（即第三点在焦点连线延长线上）
+ * 时应退化为线段。
+ */
+static bool
+hyperbola_should_degenerate (point f1, point f2, point p) {
+  if (!linearly_dependent (f1, f2, p)) return false;
+  double focal_length   = norm (f2 - f1);
+  double d1             = norm (p - f1);
+  double d2             = norm (p - f2);
+  double diff_of_two_dis= d1 > d2 ? d1 - d2 : d2 - d1;
+  return focal_length <= diff_of_two_dis;
+}
+
+void
+TestCurveConic::test_hyperbola_degeneration_criteria () {
+  // 覆盖非共线、焦点之间、延长线、焦点重合、三点重合等全部情况
+  QVERIFY (!hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (1, 1)));
+  QVERIFY (!hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (1, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (-1, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (3, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (0, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (2, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (0, 0), mkp (1, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (0, 0), mkp (0, 0)));
+}
+
+// 共线且第三点在焦点之间：双曲线可正常构造。
+void
+TestCurveConic::test_hyperbola_collinear_between_foci () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (2, 0);
+  a[2]= mkp (1, 0);
+  array<path> cip;
+
+  hyperbola_rep h (a, cip, false);
+
+  QVERIFY (is_unit_vector (h.i));
+  QVERIFY (is_unit_vector (h.j));
+  QVERIFY (is_orthogonal (h.i, h.j));
+  QVERIFY (h.center == mkp (1, 0));
+  QVERIFY (!is_nan (h.evaluate (0.0)[0]));
+  QVERIFY (!is_nan (h.evaluate (0.5)[0]));
+}
+
+// 共线且第三点在焦点延长线上：双曲线应退化为线段。
+void
+TestCurveConic::test_hyperbola_collinear_outside_foci () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (2, 0);
+  a[2]= mkp (3, 0);
+  array<path> cip;
+
+  hyperbola_rep h (a, cip, false);
+
+  QVERIFY (is_unit_vector (h.i));
+  QVERIFY (is_unit_vector (h.j));
+  QVERIFY (is_orthogonal (h.i, h.j));
+  QVERIFY (h.center == mkp (1, 0));
+  QVERIFY (h.r1 < h.focal_length / 2);
+}
+
+// 非共线标准双曲线：验证焦点、中心、半径和几何定义。
+void
+TestCurveConic::test_hyperbola_non_collinear () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (2, 0);
+  a[2]= mkp (1, 1);
+  array<path> cip;
+
+  hyperbola_rep h (a, cip, false);
+
+  QVERIFY (is_unit_vector (h.i));
+  QVERIFY (is_unit_vector (h.j));
+  QVERIFY (is_orthogonal (h.i, h.j));
+  QVERIFY (h.center == mkp (1, 0));
+
+  // 双曲线上任意一点到两焦点距离之差的绝对值应为常数
+  double d1= norm (h.evaluate (0.0) - h.f1);
+  double d2= norm (h.evaluate (0.0) - h.f2);
+  double diff= d1 > d2 ? d1 - d2 : d2 - d1;
+  for (double t= 0.1; t < 1.0; t+= 0.1) {
+    double dt1= norm (h.evaluate (t) - h.f1);
+    double dt2= norm (h.evaluate (t) - h.f2);
+    double d  = dt1 > dt2 ? dt1 - dt2 : dt2 - dt1;
+    QVERIFY (fuzzy_eq (d, diff, 1e-6));
+  }
+}
+
+// 两焦点重合：双曲线退化为线段。
+void
+TestCurveConic::test_hyperbola_coincident_foci () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (0, 0);
+  a[2]= mkp (1, 0);
+  array<path> cip;
+
+  hyperbola_rep h (a, cip, false);
+
+  QVERIFY (is_unit_vector (h.i));
+  QVERIFY (is_unit_vector (h.j));
+  QVERIFY (is_orthogonal (h.i, h.j));
+  QVERIFY (h.center == mkp (0, 0));
+}
+
+// 三点完全重合：边界情况，构造函数兜底不应崩溃。
+void
+TestCurveConic::test_hyperbola_three_identical_points () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (0, 0);
+  a[2]= mkp (0, 0);
+  array<path> cip;
+
+  hyperbola_rep h (a, cip, false);
+
+  QVERIFY (is_unit_vector (h.i));
+  QVERIFY (is_unit_vector (h.j));
+  QVERIFY (is_orthogonal (h.i, h.j));
+  QVERIFY (h.center == mkp (0, 0));
+}
+
+/*
+ * 显式验证三点共线时正交基兜底路径：轴向应与焦点方向一致，j 为 i 逆时针
+ * 旋转 90 度所得。
+ */
+void
+TestCurveConic::test_orthogonal_basis_after_fallback () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (4, 0);
+  a[2]= mkp (2, 0);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+  QVERIFY (e.i == mkp (1, 0) || e.i == mkp (-1, 0));
+  QVERIFY (e.j == mkp (0, 1) || e.j == mkp (0, -1));
+
+  hyperbola_rep h (a, cip, false);
+  QVERIFY (h.i == mkp (1, 0) || h.i == mkp (-1, 0));
+  QVERIFY (h.j == mkp (0, 1) || h.j == mkp (0, -1));
+}
+
+/*
+ * 退化边界：第三点正好落在某一焦点上时，sum_of_two_dis == focal_length，
+ * 满足退化条件。
+ */
+void
+TestCurveConic::test_ellipse_degeneration_boundary () {
+  QVERIFY (ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (0, 0)));
+  QVERIFY (ellipse_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (2, 0)));
+}
+
+// 垂直方向共线：验证兜底正交基不依赖水平轴。
+void
+TestCurveConic::test_ellipse_collinear_vertical () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (0, 2);
+  a[2]= mkp (0, 1);
+  array<path> cip;
+
+  ellipse_rep e (a, cip, false);
+
+  QVERIFY (is_unit_vector (e.i));
+  QVERIFY (is_unit_vector (e.j));
+  QVERIFY (is_orthogonal (e.i, e.j));
+  QVERIFY (e.center == mkp (0, 1));
+  QVERIFY (!is_nan (e.evaluate (0.0)[0]));
+  QVERIFY (!is_nan (e.evaluate (0.5)[0]));
+}
+
+// 验证椭圆在 [0,1] 全参数范围内 evaluate 不返回 NaN。
+void
+TestCurveConic::test_ellipse_evaluate_all_parameters () {
+  array<point> cases[3]= {
+      array<point> (mkp (0, 0), mkp (2, 0), mkp (1, 0)),
+      array<point> (mkp (0, 0), mkp (2, 0), mkp (3, 0)),
+      array<point> (mkp (0, 0), mkp (2, 0), mkp (1, 1)),
+  };
+  array<path> cip;
+
+  for (int k= 0; k < 3; k++) {
+    ellipse_rep e (cases[k], cip, false);
+    for (double t= 0.0; t <= 1.0; t+= 0.05) {
+      point p= e.evaluate (t);
+      QVERIFY (!is_nan (p[0]));
+      QVERIFY (!is_nan (p[1]));
+    }
+  }
+}
+
+/*
+ * 退化边界：第三点正好落在某一焦点上时，diff_of_two_dis == focal_length，
+ * 满足退化条件。
+ */
+void
+TestCurveConic::test_hyperbola_degeneration_boundary () {
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (0, 0)));
+  QVERIFY (hyperbola_should_degenerate (mkp (0, 0), mkp (2, 0), mkp (2, 0)));
+}
+
+// 垂直方向共线：验证兜底正交基不依赖水平轴。
+void
+TestCurveConic::test_hyperbola_collinear_vertical () {
+  array<point> a (3);
+  a[0]= mkp (0, 0);
+  a[1]= mkp (0, 2);
+  a[2]= mkp (0, 3);
+  array<path> cip;
+
+  hyperbola_rep h (a, cip, false);
+
+  QVERIFY (is_unit_vector (h.i));
+  QVERIFY (is_unit_vector (h.j));
+  QVERIFY (is_orthogonal (h.i, h.j));
+  QVERIFY (h.center == mkp (0, 1));
+  QVERIFY (!is_nan (h.evaluate (0.0)[0]));
+  QVERIFY (!is_nan (h.evaluate (0.5)[0]));
+}
+
+// 验证双曲线在 [0,1] 全参数范围内 evaluate 不返回 NaN。
+void
+TestCurveConic::test_hyperbola_evaluate_all_parameters () {
+  array<point> cases[3]= {
+      array<point> (mkp (0, 0), mkp (2, 0), mkp (1, 0)),
+      array<point> (mkp (0, 0), mkp (2, 0), mkp (3, 0)),
+      array<point> (mkp (0, 0), mkp (2, 0), mkp (1, 1)),
+  };
+  array<path> cip;
+
+  for (int k= 0; k < 3; k++) {
+    hyperbola_rep h (cases[k], cip, false);
+    for (double t= 0.0; t <= 1.0; t+= 0.05) {
+      point p= h.evaluate (t);
+      QVERIFY (!is_nan (p[0]));
+      QVERIFY (!is_nan (p[1]));
+    }
+  }
+}
+
+// 多方向共线时，兜底构造的轴向都应沿焦点连线，j 为其正交方向。
+void
+TestCurveConic::test_orthogonal_basis_multiple_directions () {
+  array<path> cip;
+
+  // 45 度方向
+  {
+    array<point> a (3);
+    a[0]= mkp (0, 0);
+    a[1]= mkp (2, 2);
+    a[2]= mkp (1, 1);
+    ellipse_rep e (a, cip, false);
+    QVERIFY (is_unit_vector (e.i));
+    QVERIFY (is_unit_vector (e.j));
+    QVERIFY (is_orthogonal (e.i, e.j));
+  }
+
+  // 垂直方向
+  {
+    array<point> a (3);
+    a[0]= mkp (0, 0);
+    a[1]= mkp (0, 4);
+    a[2]= mkp (0, 2);
+    hyperbola_rep h (a, cip, false);
+    QVERIFY (is_unit_vector (h.i));
+    QVERIFY (is_unit_vector (h.j));
+    QVERIFY (is_orthogonal (h.i, h.j));
+  }
+}
+
+QTEST_MAIN (TestCurveConic)
+#include "curve_test.moc"


### PR DESCRIPTION
# [0832] 修复椭圆和双曲线在焦点与第三点共线时退化成线

## 1 相关文档
- [0831.md](0831.md) - 绘图区增加双曲线和抛物线支持

## 2 任务相关的代码文件
- `src/Typeset/Concat/concat_graphics.cpp` — 修正椭圆/双曲线的退化判断条件
- `src/Graphics/Types/curve.cpp` — 三点共线时手动构造正交基，避免 `orthogonalize` 失败后 `i`/`j` 未初始化导致崩溃

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在绘图区插入 `椭圆`，前两点为焦点，第三点位于两焦点之间时，椭圆应退化为线段；位于线段延长线上时，应绘制椭圆
2. 在绘图区插入 `双曲线`，前两点为焦点，第三点位于两焦点之间时，双曲线应绘制双曲线；位于线段延长线上时，应退化为线段

## 4 What
0831 中 `typeset_ellipse` 和 `typeset_hyperbola` 只要检测到三点共线就直接调用 `typeset_line` 退化成线。

这过于宽泛：椭圆第三点在焦点连线延长线上时本应画出一个扁平椭圆；双曲线第三点在两焦点之间时也不应直接画线。更合理的做法是根据椭圆/双曲线的几何有解条件来决定是否退化。

## 5 How

### 5.1 退化判断改为几何条件

`src/Typeset/Concat/concat_graphics.cpp` 中：

- **椭圆**：要求 `a > c`，退化条件为共线且 `c >= a`（即 `focal_length >= sum_of_two_dis`，第三点在焦点之间）。
- **双曲线**：要求 `a < c`，退化条件为共线且 `c <= a`（即 `focal_length <= diff_of_two_dis`，第三点在焦点连线延长线上）。

实现上先把 `n != 3` 的判断提到数组访问之前，避免只点一个点时访问 `a[1]`、`a[2]` 越界崩溃：

```cpp
if (N (a) == 0 || N (a[0]) == 0) typeset_error (t, ip);
else if (n != 3) {
  typeset_line (t, ip, close, true);
}
else {
  double focal_length  = norm (a[1] - a[0]);
  double sum_of_two_dis= norm (a[2] - a[0]) + norm (a[2] - a[1]);
  if (linearly_dependent (a[0], a[1], a[2]) &&
      focal_length >= sum_of_two_dis)
  {
    typeset_line (t, ip, close, true);
  }
  else {
    curve c= env->fr (ellipse (a, cip, close));
    // ...
  }
}
```

双曲线结构相同，只是把 `sum_of_two_dis` 换成 `diff_of_two_dis`，比较方向取反。

### 5.2 共线时手动构造正交基

退化判断放宽后，更多共线配置会进入 `ellipse_rep` / `hyperbola_rep`。而这两个类的 `orthogonalize` 在三点共线时返回 false，若不做兜底，`i`/`j` 就是未初始化的垃圾值，悬浮或点击连线上点会直接 SIGSEGV。

在两个构造函数中加入兜底：

```cpp
if (orthogonalize (i, j, center, points[0], points[2]))
  ;
else {
  point axis= points[0] - center;
  if (norm (axis) > 1e-6) i= axis / norm (axis);
  else i= point (1, 0);
  j= point (-i[1], i[0]);
}
```

双曲线用 `f_close - center` 作为轴向，其余相同。椭圆同时去掉原代码中那个针对 `center`、`points[0]`、`points[1]` 的冗余 `orthogonalize` 调用（三点永远共线，必然失败）。
