### PR TITLE
[1133] 页脚表格启用 cell-hyphen 让中间单元格自动伸缩

### DIFF
--- a/TeXmacs/packages/header/header-generic.ts
+++ b/TeXmacs/packages/header/header-generic.ts
@@ -20,9 +20,9 @@
     </src-license>
   </src-title>>
 
-  <assign|page-odd-footer|<tabular*|<tformat|<twith|table-width|1par>|<twith|table-hmode|exact>|<cwith|1|1|1|1|cell-width|0.3par>|<cwith|1|1|1|1|cell-hmode|exact>|<cwith|1|1|3|3|cell-width|0.3par>|<cwith|1|1|3|3|cell-hmode|exact>|<cwith|1|1|2|2|cell-width|0.4par>|<cwith|1|1|2|2|cell-hmode|exact>|<cwith|1|1|1|1|cell-halign|l>|<cwith|1|1|3|3|cell-halign|r>|<table|<row|<cell|>|<cell|<page-number>>|<cell|>>>>>>
+  <assign|page-odd-footer|<tabular*|<tformat|<twith|table-width|1par>|<twith|table-hmode|exact>|<cwith|1|1|1|1|cell-width|0.3par>|<cwith|1|1|1|1|cell-hmode|exact>|<cwith|1|1|3|3|cell-width|0.3par>|<cwith|1|1|3|3|cell-hmode|exact>|<cwith|1|1|2|2|cell-width|0.4par>|<cwith|1|1|2|2|cell-hmode|exact>|<cwith|1|1|1|1|cell-halign|l>|<cwith|1|1|3|3|cell-halign|r>|<cwith|1|-1|1|-1|cell-hyphen|t>|<table|<row|<cell|>|<cell|<page-number>>|<cell|>>>>>>
 
-  <assign|page-even-footer|<tabular*|<tformat|<twith|table-width|1par>|<twith|table-hmode|exact>|<cwith|1|1|1|1|cell-width|0.3par>|<cwith|1|1|1|1|cell-hmode|exact>|<cwith|1|1|3|3|cell-width|0.3par>|<cwith|1|1|3|3|cell-hmode|exact>|<cwith|1|1|2|2|cell-width|0.4par>|<cwith|1|1|2|2|cell-hmode|exact>|<cwith|1|1|1|1|cell-halign|l>|<cwith|1|1|3|3|cell-halign|r>|<table|<row|<cell|>|<cell|<page-number>>|<cell|>>>>>>
+  <assign|page-even-footer|<tabular*|<tformat|<twith|table-width|1par>|<twith|table-hmode|exact>|<cwith|1|1|1|1|cell-width|0.3par>|<cwith|1|1|1|1|cell-hmode|exact>|<cwith|1|1|3|3|cell-width|0.3par>|<cwith|1|1|3|3|cell-hmode|exact>|<cwith|1|1|2|2|cell-width|0.4par>|<cwith|1|1|2|2|cell-hmode|exact>|<cwith|1|1|1|1|cell-halign|l>|<cwith|1|1|3|3|cell-halign|r>|<cwith|1|-1|1|-1|cell-hyphen|t>|<table|<row|<cell|>|<cell|<page-number>>|<cell|>>>>>>
 
   \;
 

--- a/devel/1133.md
+++ b/devel/1133.md
@@ -1,0 +1,32 @@
+# 1133 页脚表格启用 cell-hyphen 允许中间单元格自动伸缩
+
+## What
+
+在 `header-generic.ts` 的 `page-odd-footer` 和 `page-even-footer` 表格 `tformat`
+中新增 `<cwith|1|-1|1|-1|cell-hyphen|t>`，让单元格启用自动换行/伸缩，使中间
+单元格（页码 `<page-number>` 所在列）能根据内容自动撑开。
+
+## Why
+
+原先页脚是 1×3 的 `tabular*`，三列宽度固定为 `0.3par` / `0.4par` / `0.3par`
+（`cell-hmode|exact`），中间列宽度被锁死。当页码或后续填充内容超出固定宽度时
+无法自动伸缩，导致排版不灵活。启用 `cell-hyphen` 后，单元格内容可按需换行
+/伸缩。
+
+## How
+
+在两个 `assign` 的 `tformat` 内部，紧贴现有 `cwith` 链尾、`<table|...>` 之前
+插入：
+
+```
+<cwith|1|-1|1|-1|cell-hyphen|t>
+```
+
+作用域 `1|-1|1|-1` 覆盖整张表所有单元格。当前左右两列为空，启用 hyphen 无
+副作用。
+
+## 涉及文件
+
+- `TeXmacs/packages/header/header-generic.ts`
+  - `page-odd-footer`（第 23 行）
+  - `page-even-footer`（第 25 行）


### PR DESCRIPTION
## Summary

- 在 `header-generic.ts` 的 `page-odd-footer` 和 `page-even-footer` 表格 `tformat` 中新增 `<cwith|1|-1|1|-1|cell-hyphen|t>`，让单元格启用自动换行/伸缩
- 中间单元格（页码 `<page-number>` 所在列）原本宽度锁死为 `0.4par`（`cell-hmode|exact`），启用后可随内容自动撑开

## Why

原先页脚是 1×3 `tabular*`，三列宽度固定（`0.3par` / `0.4par` / `0.3par`），中间列宽度被锁死，内容超出固定宽度时无法自动伸缩，排版不灵活。

## Test plan

- [ ] `xmake b stem` 构建通过
- [ ] 打开一篇 generic 样式文档，确认页脚页码渲染正常
- [ ] 在页脚左右列填充内容验证伸缩行为