### PR TITLE
[1134] 用 ascii-downcase 修复 HTML 识别器对损坏 UTF-8 的崩溃

### DIFF
--- a/TeXmacs/plugins/html/progs/data/html.scm
+++ b/TeXmacs/plugins/html/progs/data/html.scm
@@ -13,9 +13,17 @@
 
 (texmacs-module (data html))
 
+(import (liii ascii))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Html
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; ASCII-only 大小写折叠：仅折叠 A-Z，非 ASCII 原样保留。
+;; HTML 标签/属性名都是 ASCII，用此替代 string-downcase 可避免
+;; 对含损坏 UTF-8 字节的输入触发 string->utf8 整段校验而崩溃。
+(define (html-ascii-downcase s)
+  (string-map (lambda (c) (ascii-downcase c)) s))
 
 (define html-detected-limit 1000)
 
@@ -79,7 +87,7 @@
         (let* ((len (string-length s))
                (limit (if (>= len html-detected-limit) html-detected-limit len))
                (substr (substring s 0 limit))
-               (lc-substr (string-downcase substr)))
+               (lc-substr (html-ascii-downcase substr)))
           (let ((count (+ (html-string-count-substring lc-substr "<div")
                          (html-string-count-substring lc-substr "<span")
                          (html-string-count-substring lc-substr "<p")
@@ -131,7 +139,7 @@
 
 ;; 这一行文本是否包含html标签
 (define (html-line-contains-features? line)
-    (let ((lc-line (string-downcase line)))
+    (let ((lc-line (html-ascii-downcase line)))
       (or
        (> (html-string-count-substring lc-line "<div") 0)
        (> (html-string-count-substring lc-line "<span") 0)
@@ -176,7 +184,7 @@
 
 ;; 计算div标签的平衡性
 (define (html-structure-balanced? s)
-    (let* ((lc-s (string-downcase s))
+    (let* ((lc-s (html-ascii-downcase s))
            (open-tags (html-string-count-substring lc-s "<div"))
            (close-tags (html-string-count-substring lc-s "</div")))
       ;; div 的开标签与闭标签数量差小于2
@@ -190,11 +198,11 @@
           (and (> (character-from-string s #\<) 0)
                (> (character-from-string s #\>) 0)
                (> (html-string-count-substring s "</") 0))
-          (> (html-string-count-substring (string-downcase s) "class=") 0)
-          (> (html-string-count-substring (string-downcase s) "id=") 0)
-          (> (html-string-count-substring (string-downcase s) "style=") 0)
-          (> (html-string-count-substring (string-downcase s) "href=") 0)
-          (> (html-string-count-substring (string-downcase s) "src=") 0))
+          (> (html-string-count-substring (html-ascii-downcase s) "class=") 0)
+          (> (html-string-count-substring (html-ascii-downcase s) "id=") 0)
+          (> (html-string-count-substring (html-ascii-downcase s) "style=") 0)
+          (> (html-string-count-substring (html-ascii-downcase s) "href=") 0)
+          (> (html-string-count-substring (html-ascii-downcase s) "src=") 0))
          #t)
         ((>= (html-angle-bracket-density s) 0.03) #t)
         (else #f))))

--- a/TeXmacs/plugins/html/progs/data/html.scm
+++ b/TeXmacs/plugins/html/progs/data/html.scm
@@ -13,233 +13,271 @@
 
 (texmacs-module (data html))
 
-(import (liii ascii))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Html
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; ASCII-only 大小写折叠：仅折叠 A-Z，非 ASCII 原样保留。
-;; HTML 标签/属性名都是 ASCII，用此替代 string-downcase 可避免
-;; 对含损坏 UTF-8 字节的输入触发 string->utf8 整段校验而崩溃。
-(define (html-ascii-downcase s)
-  (string-map (lambda (c) (ascii-downcase c)) s))
+;; HTML 标签/属性名都是 ASCII，用 safe-ascii-string-downcase 做 ASCII-only
+;; 大小写折叠可避免对含损坏 UTF-8 字节的输入触发 string->utf8 整段校验而崩溃。
 
 (define html-detected-limit 1000)
 
 ;; 按行分割文本
+
 (define (html-string-split-lines s)
-  (let ((len (if (>= (string-length s) html-detected-limit) html-detected-limit (string-length s))))
-    (let loop ((i 0)
-              (start 0)
-              (result '()))
-      (cond ((>= i len)
-             (reverse (cons (substring s start i) result)))
+  (let ((len (if (>= (string-length s) html-detected-limit)
+               html-detected-limit
+               (string-length s)
+             ) ;if
+        ) ;len
+       ) ;
+    (let loop
+      ((i 0) (start 0) (result '()))
+      (cond ((>= i len) (reverse (cons (substring s start i) result)))
             ((char=? (string-ref s i) #\newline)
-             (loop (+ i 1)
-                   (+ i 1)
-                   (cons (substring s start i) result)))
-            (else (loop (+ i 1) start result))))))
+             (loop (+ i 1) (+ i 1) (cons (substring s start i) result))
+            ) ;
+            (else (loop (+ i 1) start result))
+      ) ;cond
+    ) ;let
+  ) ;let
+) ;define
 
 ;; 某个字符在文本中的含量
+
 (define (character-from-string s ch)
-  (if (not (string-null? s)) 
-      (let* ((len (string-length s))
-             (limit (if (>= len html-detected-limit) html-detected-limit len)))
-        (let loop ((ref 0)
-                   (count 0))
-          (if (>= ref limit)
-              (/ count len)
-              (loop (+ ref 1)
-                    (if (char=? (string-ref s ref) ch)
-                        (+ count 1)
-                        count)))))
-      #f))
+  (if (not (string-null? s))
+    (let* ((len (string-length s))
+           (limit (if (>= len html-detected-limit) html-detected-limit len))
+          ) ;
+      (let loop
+        ((ref 0) (count 0))
+        (if (>= ref limit)
+          (/ count len)
+          (loop (+ ref 1) (if (char=? (string-ref s ref) ch) (+ count 1) count))
+        ) ;if
+      ) ;let
+    ) ;let*
+    #f
+  ) ;if
+) ;define
 
 ;; 计算一个子串在文本中的含量，计算的是子串的字符数，而不是个数
+
 (define (html-string-count-substring s sub)
-    (let ((sub-len (string-length sub)))
-      (if (zero? sub-len)
-          0
-          (let loop ((i 0)
-                     (count 0))
-            (if (>= i (- (string-length s) sub-len -1))
-                count
-                (if (string=? (substring s i (+ i sub-len)) sub)
-                    (loop (+ i sub-len) (+ count 1))
-                    (loop (+ i 1) count)))))))
+  (let ((sub-len (string-length sub)))
+    (if (zero? sub-len)
+      0
+      (let loop
+        ((i 0) (count 0))
+        (if (>= i (- (string-length s) sub-len -1))
+          count
+          (if (string=? (substring s i (+ i sub-len)) sub)
+            (loop (+ i sub-len) (+ count 1))
+            (loop (+ i 1) count)
+          ) ;if
+        ) ;if
+      ) ;let
+    ) ;if
+  ) ;let
+) ;define
 
 ;; < 和 > 的含量
+
 (define (html-angle-bracket-density s)
-    (if (string-null? s)
-        0
-        (let* ((len (string-length s))
-               (limit (if (>= len html-detected-limit) html-detected-limit len))
-               (substr (substring s 0 limit)))
-          (/ (+ (character-from-string substr #\<)
-                (character-from-string substr #\>))
-             len))))
+  (if (string-null? s)
+    0
+    (let* ((len (string-length s))
+           (limit (if (>= len html-detected-limit) html-detected-limit len))
+           (substr (substring s 0 limit))
+          ) ;
+      (/ (+ (character-from-string substr #\<) (character-from-string substr #\>))
+        len
+      ) ;/
+    ) ;let*
+  ) ;if
+) ;define
 
 ;; 完整的tag子串在文本中的字符含量
+
 (define (html-tag-density s)
-    (if (string-null? s)
-        0
-        (let* ((len (string-length s))
-               (limit (if (>= len html-detected-limit) html-detected-limit len))
-               (substr (substring s 0 limit))
-               (lc-substr (html-ascii-downcase substr)))
-          (let ((count (+ (html-string-count-substring lc-substr "<div")
-                         (html-string-count-substring lc-substr "<span")
-                         (html-string-count-substring lc-substr "<p")
-                         (html-string-count-substring lc-substr "<a")
-                         (html-string-count-substring lc-substr "<img")
-                         (html-string-count-substring lc-substr "<ul")
-                         (html-string-count-substring lc-substr "<ol")
-                         (html-string-count-substring lc-substr "<li")
-                         (html-string-count-substring lc-substr "<table")
-                         (html-string-count-substring lc-substr "<tr")
-                         (html-string-count-substring lc-substr "<td")
-                         (html-string-count-substring lc-substr "<th")
-                         (html-string-count-substring lc-substr "<h1")
-                         (html-string-count-substring lc-substr "<h2")
-                         (html-string-count-substring lc-substr "<h3")
-                         (html-string-count-substring lc-substr "<h4")
-                         (html-string-count-substring lc-substr "<h5")
-                         (html-string-count-substring lc-substr "<h6")
-                         (html-string-count-substring lc-substr "<form")
-                         (html-string-count-substring lc-substr "<input")
-                         (html-string-count-substring lc-substr "<button")
-                         (html-string-count-substring lc-substr "<textarea")
-                         (html-string-count-substring lc-substr "<select")
-                         (html-string-count-substring lc-substr "<option")
-                         (html-string-count-substring lc-substr "<style")
-                         (html-string-count-substring lc-substr "<script")
-                         (html-string-count-substring lc-substr "<meta")
-                         (html-string-count-substring lc-substr "<link")
-                         (html-string-count-substring lc-substr "</div")
-                         (html-string-count-substring lc-substr "</ul")
-                         (html-string-count-substring lc-substr "</ol")
-                         (html-string-count-substring lc-substr "</table")
-                         (html-string-count-substring lc-substr "</tr")
-                         (html-string-count-substring lc-substr "</form")
-                         (html-string-count-substring lc-substr "</style")
-                         (html-string-count-substring lc-substr "</script"))))
-            (/ count len)))))
+  (if (string-null? s)
+    0
+    (let* ((len (string-length s))
+           (limit (if (>= len html-detected-limit) html-detected-limit len))
+           (substr (substring s 0 limit))
+           (lc-substr (safe-ascii-string-downcase substr))
+          ) ;
+      (let ((count (+ (html-string-count-substring lc-substr "<div")
+                     (html-string-count-substring lc-substr "<span")
+                     (html-string-count-substring lc-substr "<p")
+                     (html-string-count-substring lc-substr "<a")
+                     (html-string-count-substring lc-substr "<img")
+                     (html-string-count-substring lc-substr "<ul")
+                     (html-string-count-substring lc-substr "<ol")
+                     (html-string-count-substring lc-substr "<li")
+                     (html-string-count-substring lc-substr "<table")
+                     (html-string-count-substring lc-substr "<tr")
+                     (html-string-count-substring lc-substr "<td")
+                     (html-string-count-substring lc-substr "<th")
+                     (html-string-count-substring lc-substr "<h1")
+                     (html-string-count-substring lc-substr "<h2")
+                     (html-string-count-substring lc-substr "<h3")
+                     (html-string-count-substring lc-substr "<h4")
+                     (html-string-count-substring lc-substr "<h5")
+                     (html-string-count-substring lc-substr "<h6")
+                     (html-string-count-substring lc-substr "<form")
+                     (html-string-count-substring lc-substr "<input")
+                     (html-string-count-substring lc-substr "<button")
+                     (html-string-count-substring lc-substr "<textarea")
+                     (html-string-count-substring lc-substr "<select")
+                     (html-string-count-substring lc-substr "<option")
+                     (html-string-count-substring lc-substr "<style")
+                     (html-string-count-substring lc-substr "<script")
+                     (html-string-count-substring lc-substr "<meta")
+                     (html-string-count-substring lc-substr "<link")
+                     (html-string-count-substring lc-substr "</div")
+                     (html-string-count-substring lc-substr "</ul")
+                     (html-string-count-substring lc-substr "</ol")
+                     (html-string-count-substring lc-substr "</table")
+                     (html-string-count-substring lc-substr "</tr")
+                     (html-string-count-substring lc-substr "</form")
+                     (html-string-count-substring lc-substr "</style")
+                     (html-string-count-substring lc-substr "</script")
+                   ) ;+
+            ) ;count
+           ) ;
+        (/ count len)
+      ) ;let
+    ) ;let*
+  ) ;if
+) ;define
 
 ;; = 和 " 的含量
+
 (define (html-attribute-density s)
-    (if (string-null? s)
-        0
-        (let* ((len (string-length s))
-               (limit (if (>= len html-detected-limit) html-detected-limit len))
-               (substr (substring s 0 limit)))
-          (/ (+ (character-from-string substr #\=)
-                (character-from-string substr #\"))
-             len))))
+  (if (string-null? s)
+    0
+    (let* ((len (string-length s))
+           (limit (if (>= len html-detected-limit) html-detected-limit len))
+           (substr (substring s 0 limit))
+          ) ;
+      (/ (+ (character-from-string substr #\=) (character-from-string substr #\"))
+        len
+      ) ;/
+    ) ;let*
+  ) ;if
+) ;define
 
-;; 这一行文本是否包含html标签
 (define (html-line-contains-features? line)
-    (let ((lc-line (html-ascii-downcase line)))
-      (or
-       (> (html-string-count-substring lc-line "<div") 0)
-       (> (html-string-count-substring lc-line "<span") 0)
-       (> (html-string-count-substring lc-line "<p") 0)
-       (> (html-string-count-substring lc-line "<a") 0)
-       (> (html-string-count-substring lc-line "<img") 0)
-       (> (html-string-count-substring lc-line "<ul") 0)
-       (> (html-string-count-substring lc-line "<ol") 0)
-       (> (html-string-count-substring lc-line "<li") 0)
-       (> (html-string-count-substring lc-line "<table") 0)
-       (> (html-string-count-substring lc-line "<tr") 0)
-       (> (html-string-count-substring lc-line "<td") 0)
-       (> (html-string-count-substring lc-line "<th") 0)
-       (> (html-string-count-substring lc-line "<h1") 0)
-       (> (html-string-count-substring lc-line "<h2") 0)
-       (> (html-string-count-substring lc-line "<h3") 0)
-       (> (html-string-count-substring lc-line "<h4") 0)
-       (> (html-string-count-substring lc-line "<h5") 0)
-       (> (html-string-count-substring lc-line "<h6") 0)
-       (> (html-string-count-substring lc-line "</div") 0)
-       (> (html-string-count-substring lc-line "</span") 0)
-       (> (html-string-count-substring lc-line "</p") 0)
-       (> (html-string-count-substring lc-line "</a") 0)
-       (> (html-string-count-substring lc-line "/>") 0)
-       (> (html-string-count-substring lc-line "<!doctype") 0)
-       (> (html-string-count-substring lc-line "<?xml") 0))))
+  (let ((lc-line (safe-ascii-string-downcase line)))
+    (or (> (html-string-count-substring lc-line "<div") 0)
+      (> (html-string-count-substring lc-line "<span") 0)
+      (> (html-string-count-substring lc-line "<p") 0)
+      (> (html-string-count-substring lc-line "<a") 0)
+      (> (html-string-count-substring lc-line "<img") 0)
+      (> (html-string-count-substring lc-line "<ul") 0)
+      (> (html-string-count-substring lc-line "<ol") 0)
+      (> (html-string-count-substring lc-line "<li") 0)
+      (> (html-string-count-substring lc-line "<table") 0)
+      (> (html-string-count-substring lc-line "<tr") 0)
+      (> (html-string-count-substring lc-line "<td") 0)
+      (> (html-string-count-substring lc-line "<th") 0)
+      (> (html-string-count-substring lc-line "<h1") 0)
+      (> (html-string-count-substring lc-line "<h2") 0)
+      (> (html-string-count-substring lc-line "<h3") 0)
+      (> (html-string-count-substring lc-line "<h4") 0)
+      (> (html-string-count-substring lc-line "<h5") 0)
+      (> (html-string-count-substring lc-line "<h6") 0)
+      (> (html-string-count-substring lc-line "</div") 0)
+      (> (html-string-count-substring lc-line "</span") 0)
+      (> (html-string-count-substring lc-line "</p") 0)
+      (> (html-string-count-substring lc-line "</a") 0)
+      (> (html-string-count-substring lc-line "/>") 0)
+      (> (html-string-count-substring lc-line "<!doctype") 0)
+      (> (html-string-count-substring lc-line "<?xml") 0)
+    ) ;or
+  ) ;let
+) ;define
 
-;; 计算存在html特征的行的含量
 (define (html-feature-line-density s)
-    (let ((lines (html-string-split-lines s)))
-      (if (null? lines)
-          0
-          (let loop ((remaining lines)
-                     (count 0)
-                     (total 0))
-            (if (null? remaining)
-                (if (> total 0) (/ count total) 0)
-                (let ((line (car remaining)))
-                  (loop (cdr remaining)
-                        (if (html-line-contains-features? line) (+ count 1) count)
-                        (+ total 1))))))))
+  (let ((lines (html-string-split-lines s)))
+    (if (null? lines)
+      0
+      (let loop
+        ((remaining lines) (count 0) (total 0))
+        (if (null? remaining)
+          (if (> total 0) (/ count total) 0)
+          (let ((line (car remaining)))
+            (loop (cdr remaining)
+              (if (html-line-contains-features? line) (+ count 1) count)
+              (+ total 1)
+            ) ;loop
+          ) ;let
+        ) ;if
+      ) ;let
+    ) ;if
+  ) ;let
+) ;define
 
-;; 计算div标签的平衡性
 (define (html-structure-balanced? s)
-    (let* ((lc-s (html-ascii-downcase s))
-           (open-tags (html-string-count-substring lc-s "<div"))
-           (close-tags (html-string-count-substring lc-s "</div")))
-      ;; div 的开标签与闭标签数量差小于2
-      (and (> open-tags 0) (> close-tags 0) (<= (abs (- open-tags close-tags)) 2))))
+  (let* ((lc-s (safe-ascii-string-downcase s))
+         (open-tags (html-string-count-substring lc-s "<div"))
+         (close-tags (html-string-count-substring lc-s "</div"))
+        ) ;
+    (and (> open-tags 0) (> close-tags 0) (<= (abs (- open-tags close-tags)) 2))
+  ) ;let*
+) ;define
 
-;; 短字符串的特殊检测
 (define (determine-short-html-string s)
-    (let* ((len (string-length s)))
-      (cond
-        ((or
-          (and (> (character-from-string s #\<) 0)
-               (> (character-from-string s #\>) 0)
-               (> (html-string-count-substring s "</") 0))
-          (> (html-string-count-substring (html-ascii-downcase s) "class=") 0)
-          (> (html-string-count-substring (html-ascii-downcase s) "id=") 0)
-          (> (html-string-count-substring (html-ascii-downcase s) "style=") 0)
-          (> (html-string-count-substring (html-ascii-downcase s) "href=") 0)
-          (> (html-string-count-substring (html-ascii-downcase s) "src=") 0))
-         #t)
-        ((>= (html-angle-bracket-density s) 0.03) #t)
-        (else #f))))
+  (let* ((len (string-length s)))
+    (cond ((or (and (> (character-from-string s #\<) 0)
+                 (> (character-from-string s #\>) 0)
+                 (> (html-string-count-substring s "</") 0)
+               ) ;and
+             (> (html-string-count-substring (safe-ascii-string-downcase s) "class=") 0)
+             (> (html-string-count-substring (safe-ascii-string-downcase s) "id=") 0)
+             (> (html-string-count-substring (safe-ascii-string-downcase s) "style=") 0)
+             (> (html-string-count-substring (safe-ascii-string-downcase s) "href=") 0)
+             (> (html-string-count-substring (safe-ascii-string-downcase s) "src=") 0)
+           ) ;or
+           #t
+          ) ;
+          ((>= (html-angle-bracket-density s) 0.03) #t)
+          (else #f)
+    ) ;cond
+  ) ;let*
+) ;define
 
 (define (is-short-html-string? s)
-  (if (<= (string-length s) 100)
-      (determine-short-html-string s)
-      #f))
+  (if (<= (string-length s) 100) (determine-short-html-string s) #f)
+) ;define
 
- (define (is-html-string? s)
-    (let* ((angle-density (html-angle-bracket-density s))
-           (tag-density (html-tag-density s))
-           (attr-density (html-attribute-density s))
-           (feature-line-density (html-feature-line-density s))
-           (balanced? (html-structure-balanced? s)))
-      (cond
-        ;; High confidence: clear HTML structure
-        ;; < > 含量，标签含量，特征行含量
-        ((and (>= angle-density 0.02)
-              (>= tag-density 0.01)
-              (>= feature-line-density 0.25))
-         #t)
-        ;; Medium confidence: good angle bracket density with either tags or attributes
-        ;; 
-        ((and (>= angle-density 0.015)
-              (or (>= tag-density 0.005)
-                  (>= attr-density 0.01))
-              (>= feature-line-density 0.15))
-         #t)
-        ;; Lower confidence: balanced structure with some HTML features
-        ((and balanced?
-              (>= angle-density 0.01)
-              (>= feature-line-density 0.10))
-         #t)
-        ;; Very high angle bracket density (likely HTML/XML)
-        ((>= angle-density 0.03) #t)
-        (else #f))))
+(define (is-html-string? s)
+  (let* ((angle-density (html-angle-bracket-density s))
+         (tag-density (html-tag-density s))
+         (attr-density (html-attribute-density s))
+         (feature-line-density (html-feature-line-density s))
+         (balanced? (html-structure-balanced? s))
+        ) ;
+    (cond ((and (>= angle-density 0.02)
+             (>= tag-density 0.01)
+             (>= feature-line-density 0.25)
+           ) ;and
+           #t
+          ) ;
+          ((and (>= angle-density 0.015)
+             (or (>= tag-density 0.005) (>= attr-density 0.01))
+             (>= feature-line-density 0.15)
+           ) ;and
+           #t
+          ) ;
+          ((and balanced? (>= angle-density 0.01) (>= feature-line-density 0.1)) #t)
+          ((>= angle-density 0.03) #t)
+          (else #f)
+    ) ;cond
+  ) ;let*
+) ;define
 
 (define (html-recognizes-at? s pos)
   (set! pos (format-skip-spaces s pos))
@@ -275,48 +313,41 @@
         ((format-test? s pos "<meta") #t)
         ((format-test? s pos "<link") #t)
         ((format-test? s pos "<!--") #t)
-        ((format-test? s pos "<?xml ")
-         (html-recognizes-at? s (format-skip-line s pos)))
+        ((format-test? s pos "<?xml ") (html-recognizes-at? s (format-skip-line s pos)))
         ((format-test? s pos "<!doctype ")
-         (html-recognizes-at? s (format-skip-line s pos)))
+         (html-recognizes-at? s (format-skip-line s pos))
+        ) ;
         ((is-short-html-string? s) #t)
         ((is-html-string? s) #t)
-        (else #f)))
+        (else #f)
+  ) ;cond
+) ;define
 
 (define (html-recognizes? s)
-  (and (string? s) (html-recognizes-at? s 0)))
-
+  (and (string? s) (html-recognizes-at? s 0))
+) ;define
 (define-format html
   (:name "Html")
   (:suffix "html" "xhtml" "htm")
   (:recognize html-recognizes?)
-  (:option "mathml->texmacs:latex-annotations" "off"))
-
+  (:option "mathml->texmacs:latex-annotations" "off")
+) ;define-format
 (lazy-define (convert html htmltm) parse-html-snippet)
 (lazy-define (convert html htmltm) parse-html-document)
 (lazy-define (convert html htmltm) html->texmacs)
 (lazy-define (convert html htmlout) serialize-html)
 (lazy-define (convert html tmhtml) texmacs->html)
-
-(converter html-document html-stree
-  (:function parse-html-document))
-
-(converter html-stree html-document
-  (:function serialize-html))
-
-(converter html-snippet html-stree
-  (:function parse-html-snippet))
-
-(converter html-stree html-snippet
-  (:function serialize-html))
-
-(converter html-stree texmacs-stree
-  (:function html->texmacs))
-
-(converter texmacs-stree html-stree
+(converter html-document html-stree (:function parse-html-document))
+(converter html-stree html-document (:function serialize-html))
+(converter html-snippet html-stree (:function parse-html-snippet))
+(converter html-stree html-snippet (:function serialize-html))
+(converter html-stree texmacs-stree (:function html->texmacs))
+(converter texmacs-stree
+  html-stree
   (:function-with-options texmacs->html)
   (:option "texmacs->html:css" "on")
   (:option "texmacs->html:mathjax" "off")
   (:option "texmacs->html:mathml" "on")
   (:option "texmacs->html:images" "off")
-  (:option "texmacs->html:css-stylesheet" "---"))
+  (:option "texmacs->html:css-stylesheet" "---")
+) ;converter

--- a/TeXmacs/progs/kernel/library/base.scm
+++ b/TeXmacs/progs/kernel/library/base.scm
@@ -47,6 +47,19 @@
   (list->string (list c))
 ) ;define-public
 
+;; 仅折叠 ASCII A-Z，非 ASCII 字符（含损坏 UTF-8 字节）原样保留。
+;; 与 string-downcase 不同：不触发 string->utf8 整段校验，
+;; 因此可安全用于含损坏 UTF-8 的输入做大小写不敏感的 ASCII 标签/关键字匹配。
+(define-public (safe-ascii-string-downcase s)
+  (string-map (lambda (c)
+                (let ((n (char->integer c)))
+                  (if (and (>= n 65) (<= n 90)) (integer->char (+ n 32)) c)
+                ) ;let
+              ) ;lambda
+    s
+  ) ;string-map
+) ;define-public
+
 (define-public (tm-char-whitespace? c)
   "Is @c a whitespace character?"
   ;; NOTE: this routine is implemented in an incorrect way in certain

--- a/TeXmacs/progs/kernel/texmacs/tm-convert-test.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-convert-test.scm
@@ -1,0 +1,85 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-convert-test.scm
+;; DESCRIPTION : Test suite for tm-convert
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (kernel texmacs tm-convert-test)
+  (:use (kernel texmacs tm-convert))
+) ;texmacs-module
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for format-test?
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-format-test-basic)
+  ;; 大小写不敏感的 ASCII 关键字匹配
+  (check (format-test? "<HTMLxxx" 0 "<html") => #t)
+  (check (format-test? "<Htmlxxx" 0 "<html") => #t)
+  (check (format-test? "<htmlxxx" 0 "<html") => #t)
+  ;; 不匹配
+  (check (format-test? "<bodyxxx" 0 "<html") => #f)
+  ;; 子串长度不足时不越界（应返回 #f）
+  (check (format-test? "<htm" 0 "<html") => #f)
+  (check (format-test? "" 0 "<html") => #f)
+  ;; pos 越界（输入比 pos 短）
+  (check (format-test? "ab" 5 "<html") => #f)
+) ;define
+
+(define (test-format-test-pos)
+  ;; pos 不为零：从中间位置匹配
+  (check (format-test? "xxx<HTML" 3 "<html") => #t)
+  (check (format-test? "xxx<htm" 3 "<html") => #f)
+  ;; LaTeX 反斜杠关键字
+  (check (format-test? "xxx\\DocumentClass" 3 "\\documentclass") => #t)
+) ;define
+
+(define (test-format-test-non-ascii)
+  ;; 非 ASCII 字符原样保留：子串不等于 ASCII 关键字
+  (check (format-test? "<hätml" 0 "<html") => #f)
+  ;; 非 ASCII 出现在 what 之前的位置不影响匹配
+  (check (format-test? "中文<HTML" 6 "<html") => #t)
+  ;; 合法 UTF-8 多字节字符（中文）作为整体不匹配 ASCII 关键字
+  (check (format-test? "中文" 0 "<html") => #f)
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for safe-ascii-string-downcase
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-safe-ascii-string-downcase)
+  ;; 纯 ASCII 大写折叠
+  (check (safe-ascii-string-downcase "HELLO") => "hello")
+  (check (safe-ascii-string-downcase "Hello World") => "hello world")
+  (check (safe-ascii-string-downcase "<HTML>") => "<html>")
+  ;; 无可折叠字符时原样返回
+  (check (safe-ascii-string-downcase "abc123") => "abc123")
+  (check (safe-ascii-string-downcase "") => "")
+  ;; 非 ASCII 字符原样保留（中文 UTF-8 字节序列不参与折叠，也不触发崩溃）
+  (check (safe-ascii-string-downcase "好A好B") => "好a好b")
+  ;; 混合：ASCII 折叠 + 非 ASCII 保留
+  (check (safe-ascii-string-downcase "测试<P>") => "测试<p>")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-tm-convert)
+  (test-format-test-basic)
+  (test-format-test-pos)
+  (test-format-test-non-ascii)
+  (test-safe-ascii-string-downcase)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/texmacs/tm-convert.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-convert.scm
@@ -601,7 +601,9 @@
   (with end
     (+ pos (string-length what))
     (and (>= (string-length s) end)
-      (== (string-downcase (substring s pos end)) what)
+      ;; 用 ASCII-only 折叠：避免对含损坏 UTF-8 的输入触发 string-downcase
+      ;; 内部的 string->utf8 整段校验而崩溃（HTML/LaTeX 关键字都是 ASCII）。
+      (== (safe-ascii-string-downcase (substring s pos end)) what)
     ) ;and
   ) ;with
 ) ;define-public

--- a/devel/1134.md
+++ b/devel/1134.md
@@ -18,7 +18,17 @@ gf eval '(import (liii ascii)) (display (string-map (lambda (c) (ascii-downcase 
 ```
 xmake b stem
 ```
-构造含损坏 UTF-8 字节的剪贴板内容（如 `"好\xef\xbf"`，半个 U+FFFD 序列），粘贴进编辑器触发 format auto-detect，验证不再抛 `string->utf8: Invalid UTF-8 sequence`。
+**复现步骤**：
+1. 复制下方中文文本（含「考虑」等字）：
+```
+好的，这里有几段包含"考虑"二字的文字内容，供你参考使用：
+1. 在启动这个新项目之前，我们需要审慎**考虑**其长期的市场风险和潜在的技术瓶颈。
+2. 这份报告综合**考虑**了用户反馈、市场数据和竞品分析，最终得出了产品迭代的方向。
+```
+2. 在 mogan 编辑器里 `Ctrl+Shift+V`（魔法粘贴）。
+
+**修复前**：抛 `string->utf8: Invalid UTF-8 sequence`，堆栈顶 `html-recognizes-at?` → `string-downcase` → `utf8-string-map` → `string->utf8`。
+**修复后**：正常粘贴，不再崩溃。
 
 ## 4 如何提交
 

--- a/devel/1134.md
+++ b/devel/1134.md
@@ -57,3 +57,31 @@ HTML 标签和属性名本就是 ASCII，Unicode 大小写折叠在这里是过�
 关键点：直接用 `(ascii-downcase s)`（字符串版）行不通——SRFI-175 的字符串分支在 `TeXmacs/plugins/goldfish/goldfish/srfi/srfi-175.scm:200-201` 有 `(unless (ascii-string? x) (error ...))` 预检，遇到任何非 ASCII 字符照样报错。
 
 正确用法是 `ascii-downcase` 的字符版本（line 198–199：`(char? x)` 分支只调 `ascii-upper-case-value` 对 A–Z 加 32，其它字符原样返回），通过 `string-map` 逐字符调用。`string-map` 按字符迭代，不会触发 `string->utf8` 的整段校验，从根本上避开崩溃路径。
+
+## 8 扩展：抽出公共工具 `safe-ascii-string-downcase` 并修复 `format-test?`
+
+### 8.1 What
+1. 在 `TeXmacs/progs/kernel/library/base.scm` 的 Strings 章节新增公共工具 `safe-ascii-string-downcase`：仅折叠 ASCII A–Z，非 ASCII 字符（含损坏 UTF-8 字节）原样保留，不触发 `string->utf8` 整段校验。
+2. `TeXmacs/progs/kernel/texmacs/tm-convert.scm` 的 `format-test?` 把 `string-downcase` 换成 `safe-ascii-string-downcase`。`format-test?` 是所有格式识别器（HTML/LaTeX/...）共享的前缀匹配函数，同样存在「对损坏 UTF-8 输入先崩在大小写折叠副作用」的问题。
+3. `TeXmacs/plugins/html/progs/data/html.scm` 删掉局部的 `html-ascii-downcase` 包装，删除 `(import (liii ascii))`，7 处调用点直接用 `safe-ascii-string-downcase`。
+4. 新增 `TeXmacs/progs/kernel/texmacs/tm-convert-test.scm`，覆盖：`format-test?` 基本/位置/非 ASCII/越界场景，以及 `safe-ascii-string-downcase` 自身的纯 ASCII、空串、中文混排等用例。共 20 个 check。
+
+### 8.2 Why
+- `format-test?` 在所有 `html-recognizes-at?`/`latex-recognizes?` 等格式识别路径上都会被调用，与 `html-recognizes?` 共享同一份崩溃风险。HTML 那次只修了 `html-recognizes?` 内部的 `string-downcase`，但 `format-test?` 仍走老路径——只要走前缀匹配，损坏 UTF-8 输入依然会崩。
+- 把 ASCII 折叠抽到 `kernel/library/base.scm`（最底层公共库）后，HTML 和 `format-test?` 共享同一实现，避免两份代码重复（之前 `html-ascii-downcase` 与新需求会再造一份）。
+- `format-test?` 没有 scheme 单元测试，本次顺带补上 `tm-convert-test.scm`，未来回归可直接 `xmake r tm-convert-test`。
+
+### 8.3 How
+- `safe-ascii-string-downcase` 用 base.scm 自带的 `string-map`（line 167：`(list->string (map proc (string->list s)))`）逐字符迭代。`string->list` 按字符拆分，不会触发 `string->utf8` 整段校验。每个字符只对 65–90（A–Z）加 32，其它原样返回。
+- `format-test?` 的 `what` 参数全部为 ASCII 小写字面量（`"<html"`、`"\\document"` 等），所以「子串做 ASCII 折叠后与 `what` 比较」的语义保持不变。
+- HTML 那边删掉 `html-ascii-downcase` 包装后，7 处调用直接用 `safe-ascii-string-downcase`；`import (liii ascii)` 因为不再被使用一并删除。
+
+### 8.4 涉及文件
+- `TeXmacs/progs/kernel/library/base.scm`：新增 `safe-ascii-string-downcase`。
+- `TeXmacs/progs/kernel/texmacs/tm-convert.scm`：`format-test?` 用新工具替换 `string-downcase`。
+- `TeXmacs/plugins/html/progs/data/html.scm`：删 `html-ascii-downcase`、删 `import`、7 处调用改名。
+- `TeXmacs/progs/kernel/texmacs/tm-convert-test.scm`：新增测试文件，入口 `(regtest-tm-convert)`，20 个 check。
+
+### 8.5 测试
+- `xmake r tm-convert-test`：20 correct, 0 failed。
+- `gf eval` 验证 `string-downcase "<HT\xffM"` 抛 `value-error`，而 `safe-ascii-string-downcase "<HT\xffM"` 返回 `"<ht\xffm"`，行为对比确认。

--- a/devel/1134.md
+++ b/devel/1134.md
@@ -1,0 +1,49 @@
+# [1134] 用 ascii-downcase 修复 HTML 识别器对损坏 UTF-8 的崩溃
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/html/progs/data/html.scm` — 新增 `html-ascii-downcase` helper（用 `(liii ascii)` 的 `ascii-downcase` 字符版 + `string-map` 逐字符折叠，非 ASCII 字符原样保留，不触发 `string->utf8` 整段校验）；将 7 处用于 HTML 标签/属性匹配的 `string-downcase` 替换为 `html-ascii-downcase`（line 82、134、179、193、194、195、196、197）
+
+## 3 如何测试
+
+### 3.1 确定性测试（Goldfish 解释器）
+```
+gf eval '(import (liii ascii)) (display (string-map (lambda (c) (ascii-downcase c)) "好A好B")) (newline)'
+```
+预期输出 `好a好b`（非 ASCII 原样保留，ASCII 折叠为小写）。
+
+### 3.2 非确定性测试（mogan 集成）
+```
+xmake b stem
+```
+构造含损坏 UTF-8 字节的剪贴板内容（如 `"好\xef\xbf"`，半个 U+FFFD 序列），粘贴进编辑器触发 format auto-detect，验证不再抛 `string->utf8: Invalid UTF-8 sequence`。
+
+## 4 如何提交
+
+提交前执行：
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+1. 在 `TeXmacs/plugins/html/progs/data/html.scm` 顶部 `(import (liii ascii))`。
+2. 新增 `html-ascii-downcase`：用 `(string-map (lambda (c) (ascii-downcase c)) s)`，对每个字符调 `ascii-downcase` 的字符分支（`(char? x)` 路径，只对 A–Z 加 32，其它字符原样返回），绕开 `ascii-downcase` 字符串版对非 ASCII 的拒收（`ascii-string?` 预检）。
+3. 替换 7 处 `string-downcase` 调用为 `html-ascii-downcase`。
+
+## 6 Why
+HTML 格式识别器 `html-recognizes?` 在判断输入串是否 HTML 时，会通过 `string-downcase` 做大小写不敏感的标签/属性匹配（`<div`、`class=`、`href=` 等）。
+
+`string-downcase`（`TeXmacs/plugins/goldfish/goldfish/scheme/char.scm:5875`）走 `utf8-string-map`，其第一行 `(string->utf8 str)` 会整段校验 UTF-8 合法性（`TeXmacs/plugins/goldfish/src/scheme_base.cpp:100-104`：`utf8_count_and_locate` 返回负值即抛 `value-error "string->utf8: Invalid UTF-8 sequence"`）。
+
+当输入含损坏 UTF-8 字节（常见于 PDF 复制、OCR、跨编码转换、网络截断），识别器在「这不是 HTML」的判断过程中就先崩在大小写折叠的副作用上——识别器比被识别数据还脆弱。
+
+HTML 标签和属性名本就是 ASCII，Unicode 大小写折叠在这里是过度的。改用 ASCII-only 折叠后：
+- ASCII（标签/属性名）正常小写化；
+- 非 ASCII（文本内容、损坏字节）原样保留，不进入 `string->utf8` 校验路径。
+
+## 7 How
+关键点：直接用 `(ascii-downcase s)`（字符串版）行不通——SRFI-175 的字符串分支在 `TeXmacs/plugins/goldfish/goldfish/srfi/srfi-175.scm:200-201` 有 `(unless (ascii-string? x) (error ...))` 预检，遇到任何非 ASCII 字符照样报错。
+
+正确用法是 `ascii-downcase` 的字符版本（line 198–199：`(char? x)` 分支只调 `ascii-upper-case-value` 对 A–Z 加 32，其它字符原样返回），通过 `string-map` 逐字符调用。`string-map` 按字符迭代，不会触发 `string->utf8` 的整段校验，从根本上避开崩溃路径。


### PR DESCRIPTION
## Summary
- HTML 格式识别器 `html-recognizes?` 在判断输入是否 HTML 时，通过 `string-downcase` 做大小写不敏感的标签/属性匹配（`<div`、`class=`、`href=` 等）。
- `string-downcase` 走 `utf8-string-map`，其第一行 `(string->utf8 str)` 会整段校验 UTF-8 合法性（`scheme_base.cpp:100-104`：`utf8_count_and_locate` 返回负值即抛 `value-error`）。当输入含损坏 UTF-8 字节（PDF 复制、OCR、跨编码转换、网络截断等常见来源），识别器在「这不是 HTML」的判断过程中就先崩在大小写折叠的副作用上。
- HTML 标签和属性名本就是 ASCII，Unicode 大小写折叠在这里是过度的。改用 `(liii ascii)` 的 `ascii-downcase` 字符版 + `string-map` 逐字符折叠：ASCII 正常小写化，非 ASCII 原样保留，不进入 `string->utf8` 校验路径。

## 复现
1. 复制下方中文文本：
```
好的，这里有几段包含"考虑"二字的文字内容，供你参考使用：
1. 在启动这个新项目之前，我们需要审慎**考虑**其长期的市场风险和潜在的技术瓶颈。
2. 这份报告综合**考虑**了用户反馈、市场数据和竞品分析，最终得出了产品迭代的方向。
```
2. 在 mogan 编辑器里 `Ctrl+Shift+V`（魔法粘贴）。
3. **修复前**：抛 `string->utf8: Invalid UTF-8 sequence`，堆栈顶 `html-recognizes-at?` → `string-downcase` → `utf8-string-map` → `string->utf8`。
4. **修复后**：正常粘贴。

## 改动
- `TeXmacs/plugins/html/progs/data/html.scm`：
  - 新增 `(import (liii ascii))`
  - 新增 `html-ascii-downcase` helper（用 `ascii-downcase` 字符版 + `string-map`，绕开 `ascii-downcase` 字符串版对非 ASCII 的拒收预检）
  - 替换 7 处用于 HTML 标签/属性匹配的 `string-downcase` 调用

## Test plan
- [ ] `gf eval` 验证 helper：`(html-ascii-downcase "<DIV CLASS=\"X\">")` → `<div class="x">`
- [ ] `gf eval` 验证非 ASCII：`(html-ascii-downcase "好A好B")` → `好a好b`
- [ ] `xmake b stem` 构建通过
- [ ] 按上述复现步骤验证魔法粘贴不再崩溃
- [ ] 验证正常 HTML 文档的识别/导入不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)