### PR TITLE
[0833] 绘图区进入时背景不填充为淡蓝色

### DIFF
--- a/devel/0833.md
+++ b/devel/0833.md
@@ -1,0 +1,30 @@
+# [0833] 绘图区进入时背景不填充为淡蓝色
+
+## 1 相关文档
+- [213_22.md](213_22.md) - Replace focus border with translucent background
+
+## 2 任务相关的代码文件
+- `src/Edit/Interface/edit_interface.cpp` — 聚焦矩形 `foc_rects` 计算时增加 `!inside_graphics(false)` 特判
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 打开软件，插入一个绘图区（graphics）并把光标置于绘图区中。
+2. 观察绘图区背景，应当保持默认底色，**不应被填充为淡蓝色**。
+3. 退出绘图区后，聚焦在表格或数学公式等聚焦环境时，其背景仍应正确高亮显示为半透明淡蓝色。
+
+## 4 What
+在之前的任务（PR #2888 / `213_22.md`）中，聚焦指示由高亮边框改为了半透明淡蓝色背景填充。
+
+这导致在进入绘图区（graphics）时，整个画布区域被识别为聚焦环境，导致整个绘图画布全部变成淡蓝色。
+
+## 5 How
+在 `edit_interface.cpp` 的 `apply_changes` 函数计算 `foc_rects` 中，追加 `!inside_graphics(false)` 判定条件：
+
+当位于绘图区内部时，跳过 `foc_rects` 的计算（使其保持为空矩形），从而避免整个绘图画布在重绘时被填充聚焦色。

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -1108,7 +1108,9 @@ edit_interface_rep::apply_changes () {
       ;
     else pp= path_up (pp);
     if (full_context || table_cells) compute_env_rects (pp, env_rects, true);
-    if (show_focus && (!semantic_flag || !semantic_only))
+    // 在绘图区中不计算 foc_rects，即不会产生淡蓝色背景高亮
+    if (show_focus && (!semantic_flag || !semantic_only) &&
+        !inside_graphics (false))
       compute_env_rects (pp, foc_rects, false);
     if (env_rects != old_env_rects) {
       invalidate (old_env_rects);


### PR DESCRIPTION
# [0833] 绘图区进入时背景不填充为淡蓝色

## 1 相关文档
- [213_22.md](213_22.md) - Replace focus border with translucent background

## 2 任务相关的代码文件
- `src/Edit/Interface/edit_interface.cpp` — 聚焦矩形 `foc_rects` 计算时增加 `!inside_graphics(false)` 特判

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 打开软件，插入一个绘图区（graphics）并把光标置于绘图区中。
2. 观察绘图区背景，应当保持默认底色，**不应被填充为淡蓝色**。
3. 退出绘图区后，聚焦在表格或数学公式等聚焦环境时，其背景仍应正确高亮显示为半透明淡蓝色。

## 4 What
在之前的任务（PR #2888 / `213_22.md`）中，聚焦指示由高亮边框改为了半透明淡蓝色背景填充。

这导致在进入绘图区（graphics）时，整个画布区域被识别为聚焦环境，导致整个绘图画布全部变成淡蓝色。

## 5 How
在 `edit_interface.cpp` 的 `apply_changes` 函数计算 `foc_rects` 中，追加 `!inside_graphics(false)` 判定条件：

当位于绘图区内部时，跳过 `foc_rects` 的计算（使其保持为空矩形），从而避免整个绘图画布在重绘时被填充聚焦色。
