### PR TITLE
[0835] 绘图区右下角显示鼠标坐标

### DIFF
--- a/devel/0835.md
+++ b/devel/0835.md
@@ -1,0 +1,34 @@
+# [0835] 绘图区右下角显示鼠标坐标
+
+## 1 相关文档
+- [222_65.md](222_65.md) - 修复右侧 footer 快捷键显示错误，并补齐 operation footer 的快捷键提示
+
+## 2 任务相关的代码文件
+- `src/Edit/Interface/edit_graphics.cpp`
+  - `mouse_graphics`：高频鼠标事件处理完后，获取 `edit_interface_rep` 并立即同步调用无参的 `set_right_footer`。
+- `src/Edit/Interface/edit_footer.cpp`
+  - `set_right_footer`（无参重载）：当光标位于绘图区（`inside_graphics`）时进行拦截，提取并显示精度为 4 位的鼠标当前坐标 `(x, y)` 并返回。
+  - `set_footer`：在处于绘图区时自动重定向调用无参的 `set_right_footer`。
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 新建绘图区，且焦点进入绘图区
+2. 移动鼠标，右下角应实时更新鼠标所在的坐标，不应有明显延迟
+3. 当鼠标停止移动，不会变回 `Graphics` 文本
+
+## 4 What
+- 鼠标在绘图区中移动或拖拽时，右下角应显示高精度的平面坐标，精度为 4 位小数（如 `(x.xxxx, y.yyyy)`）
+- 要求坐标显示极其灵敏和即时，与鼠标移动、画布顶点刷新保持同步且没有延迟
+- 在绘图区环境内，鼠标停止后，空闲菜单不被临时消息覆盖
+
+## 5 How
+- 在 `edit_graphics.cpp` 的 `mouse_graphics` 尾部，对 `THE_CURSOR` 发起通知后，通过 `dynamic_cast<edit_interface_rep*>` 动态获取接口实例，并立即同步触发 `edit_if->set_right_footer()` 以绕过空闲更新限流。
+- 在 `edit_footer.cpp` 的默认右页脚生成器 `set_right_footer()` 头部，通过 `inside_graphics(false)` 检测当前是否处于绘图区，若在绘图区则使用 `round (get_x() * 1e4) / 1e4` 取得 4 位精确坐标值，封装成 `(x, y)` 字符串，绕过其他 compound path 的生成逻辑直接进行渲染。
+- 在 `edit_footer.cpp` 的 `set_footer()` 定时事件更新中，将 `if (message_r == "") set_right_footer (); else set_right_footer (message_r);` 修改为 `if (message_r == "" || inside_graphics (false)) set_right_footer (); else set_right_footer (message_r);`。使定时器执行时，如果发现仍在绘图区，直接拦截 `message_r` 消息，走无参 `set_right_footer()`，保留在原位不消失的最新坐标显示。

--- a/src/Edit/Interface/edit_footer.cpp
+++ b/src/Edit/Interface/edit_footer.cpp
@@ -548,6 +548,14 @@ edit_interface_rep::compute_compound_footer (tree t, path p) {
 
 void
 edit_interface_rep::set_right_footer () {
+  if (inside_graphics (false)) {
+    // 绘图区拦截，显示坐标
+    double rx    = round (get_x () * 1e4) / 1e4;
+    double ry    = round (get_y () * 1e4) / 1e4;
+    string coords= string ("(") * as_string (rx) * ", " * as_string (ry) * ")";
+    set_right_footer (tree (coords));
+    return;
+  }
   tree cf= compute_compound_footer (et, path_up (tp));
   tree st= subtree (et, path_up (tp));
   tree lf;
@@ -677,7 +685,7 @@ edit_interface_rep::set_footer () {
     if (message_l == "") set_left_footer ();
     else set_left_footer (message_l);
     set_middle_footer ();
-    if (message_r == "") set_right_footer ();
+    if (message_r == "" || inside_graphics (false)) set_right_footer ();
     else set_right_footer (message_r);
     message_l= message_r= "";
   }

--- a/src/Edit/Interface/edit_graphics.cpp
+++ b/src/Edit/Interface/edit_graphics.cpp
@@ -540,6 +540,9 @@ edit_graphics_rep::mouse_graphics (string type, SI x, SI y, int mods, time_t t,
     else if (type == "drop-object") call ("graphics-drop-object", sx, sy);
     invalidate_graphical_object ();
     notify_change (THE_CURSOR);
+    // 及时 call set_right_footer()，使坐标显示实时更新
+    edit_interface_rep* edit_if= dynamic_cast<edit_interface_rep*> (this);
+    if (edit_if != nullptr) edit_if->set_right_footer ();
     return true;
   }
   // cout << "No frame " << tp << ", " << subtree (et, path_up (tp)) << "\n";


### PR DESCRIPTION
# [0835] 绘图区右下角显示鼠标坐标

## 1 相关文档
- [222_65.md](222_65.md) - 修复右侧 footer 快捷键显示错误，并补齐 operation footer 的快捷键提示

## 2 任务相关的代码文件
- `src/Edit/Interface/edit_graphics.cpp`
  - `mouse_graphics`：高频鼠标事件处理完后，获取 `edit_interface_rep` 并立即同步调用无参的 `set_right_footer`。
- `src/Edit/Interface/edit_footer.cpp`
  - `set_right_footer`（无参重载）：当光标位于绘图区（`inside_graphics`）时进行拦截，提取并显示精度为 4 位的鼠标当前坐标 `(x, y)` 并返回。
  - `set_footer`：在处于绘图区时自动重定向调用无参的 `set_right_footer`。

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 新建绘图区，且焦点进入绘图区
2. 移动鼠标，右下角应实时更新鼠标所在的坐标，不应有明显延迟
3. 当鼠标停止移动，不会变回 `Graphics` 文本

## 4 What
- 鼠标在绘图区中移动或拖拽时，右下角应显示高精度的平面坐标，精度为 4 位小数（如 `(x.xxxx, y.yyyy)`）
- 要求坐标显示极其灵敏和即时，与鼠标移动、画布顶点刷新保持同步且没有延迟
- 在绘图区环境内，鼠标停止后，空闲菜单不被临时消息覆盖

## 5 How
- 在 `edit_graphics.cpp` 的 `mouse_graphics` 尾部，对 `THE_CURSOR` 发起通知后，通过 `dynamic_cast<edit_interface_rep*>` 动态获取接口实例，并立即同步触发 `edit_if->set_right_footer()` 以绕过空闲更新限流。
- 在 `edit_footer.cpp` 的默认右页脚生成器 `set_right_footer()` 头部，通过 `inside_graphics(false)` 检测当前是否处于绘图区，若在绘图区则使用 `round (get_x() * 1e4) / 1e4` 取得 4 位精确坐标值，封装成 `(x, y)` 字符串，绕过其他 compound path 的生成逻辑直接进行渲染。
- 在 `edit_footer.cpp` 的 `set_footer()` 定时事件更新中，将 `if (message_r == "") set_right_footer (); else set_right_footer (message_r);` 修改为 `if (message_r == "" || inside_graphics (false)) set_right_footer (); else set_right_footer (message_r);`。使定时器执行时，如果发现仍在绘图区，直接拦截 `message_r` 消息，走无参 `set_right_footer()`，保留在原位不消失的最新坐标显示。
