### PR TITLE
[0670] TikZ 插件自动检测并引入 arrows.meta 库

### DIFF
--- a/TeXmacs/plugins/tikz/goldfish/tm-tikz.scm
+++ b/TeXmacs/plugins/tikz/goldfish/tm-tikz.scm
@@ -7,143 +7,216 @@
   (liii sys)
   (liii string)
   (liii list)
-)
+) ;import
 
 (define (escape-string str)
-  (string-join
-    (map (lambda (char)
-           (if (char=? char #\")
-               (string #\\ #\")
-               (if (char=? char #\\)
-                   (string #\\ #\\)
-                   (string char))))
-         (string->list str))))
+  (string-join (map (lambda (char)
+                      (if (char=? char #\")
+                        (string #\\ #\")
+                        (if (char=? char #\\) (string #\\ #\\) (string char))
+                      ) ;if
+                    ) ;lambda
+                 (string->list str)
+               ) ;map
+  ) ;string-join
+) ;define
 
 (define (goldfish-quote s)
-  (string-append "\"" (escape-string s) "\""))
+  (string-append "\"" (escape-string s) "\"")
+) ;define
 
 (define (tikz-welcome)
   (flush-prompt "tikz] ")
-  (flush-verbatim "Liii STEM interface to TikZ"))
+  (flush-verbatim "Liii STEM interface to TikZ")
+) ;define
 
 (define (tikz-read-code)
   (define (read-code code)
     (let ((line (read-line)))
       (if (or (eof-object? line) (string=? line "<EOF>\n"))
-          code
-          (read-code (string-append code line)))))
-  (read-code ""))
+        code
+        (read-code (string-append code line))
+      ) ;if
+    ) ;let
+  ) ;define
+  (read-code "")
+) ;define
+
+(define (decode-texmacs-markup code)
+  (let* ((s1 (string-replace code "<less>" "<"))
+         (s2 (string-replace s1 "<gtr>" ">"))
+         (s3 (string-replace s2 "<backslash>" "\\"))
+         (s4 (string-replace s3 "<ast>" "*"))
+        ) ;
+    s4
+  ) ;let*
+) ;define
 
 (define (gen-temp-path)
   (let ((tikz-tmpdir (string-append (os-temp-dir) "/tikz")))
     (when (not (file-exists? tikz-tmpdir))
-      (mkdir tikz-tmpdir))
-    (string-append tikz-tmpdir "/" (uuid4))))
+      (mkdir tikz-tmpdir)
+    ) ;when
+    (string-append tikz-tmpdir "/" (uuid4))
+  ) ;let
+) ;define
 
 (define (wrap-tikz-code code)
   (let ((trimmed (string-trim-left code)))
     (if (or (string-starts? trimmed "\\documentclass")
-            (string-contains? code "\\begin{document}"))
-        code
-        (let* ((lines (string-split code #\newline))
-               (library-lines
-                 (filter (lambda (line)
-                           (string-starts? (string-trim-left line) "\\usetikzlibrary"))
-                         lines))
-               (package-lines
-                 (filter (lambda (line)
-                           (string-starts? (string-trim-left line) "\\usepackage"))
-                         lines))
-             (other-lines
-               (filter (lambda (line)
-                         (let ((trimmed-line (string-trim-left line)))
-                           (and (not (string-starts? trimmed-line "\\usetikzlibrary"))
-                                (not (string-starts? trimmed-line "\\usepackage"))
-                                (not (string-null? trimmed-line)))))
-                       lines))
-               (body (string-join other-lines "\n"))
-               (body-trimmed (string-trim-left body)))
-          (let* ((has-chemfig? (or (string-starts? body-trimmed "\\chem")
-                                  (string-starts? body-trimmed "\\scheme")))
-                 (need-chemfig-package?
-                   (or has-chemfig?
-                       (string-contains? body "\\chem")
-                       (string-contains? body "\\scheme")))
-                 (need-optikz-package?
-                   (or (string-contains? body "\\spectrometer")
-                       (string-contains? body "\\camera")
-                       (string-contains? body "\\diode")
-                       (string-contains? body "\\splitter")
-                       (string-contains? body "\\convexlens")
-                       (string-contains? body "\\concavelens")
-                       (string-contains? body "\\planconvexlens")
-                       (string-contains? body "\\mirror")
-                       (string-contains? body "\\curvedmirror")
-                       (string-contains? body "\\pockelscell")
-                       (string-contains? body "\\laser")
-                       (string-contains? body "\\grating")
-                       (string-contains? body "\\drawrainbow")
-                       (string-contains? body "\\TFP")))
-                 (extra-packages
-                   (let ((pkgs '()))
-                     (when (and need-chemfig-package?
-                                (null? (filter (lambda (line) (string-contains? line "chemfig"))
-                                               package-lines)))
-                       (set! pkgs (cons "\\usepackage{chemfig}" pkgs)))
-                     (when (and need-optikz-package?
-                                (null? (filter (lambda (line) (string-contains? line "optikz"))
-                                               package-lines)))
-                       (set! pkgs (cons "\\usepackage{optikz}" pkgs)))
-                     (when (and need-optikz-package?
-                                (null? (filter (lambda (line) (string-contains? line "calc"))
-                                               package-lines)))
-                       (set! pkgs (cons "\\usepackage{calc}" pkgs)))
-                     (reverse pkgs)))
-                  (inner-code
-                    (if (or (string-null? body-trimmed)
-                            (string-contains? body "\\begin{tikzpicture}")
-                            has-chemfig?)
-                        body
-                        (string-append "\\begin{tikzpicture}\n" body "\n\\end{tikzpicture}"))))
-            (string-append
-              "\\documentclass[tikz,rgb]{standalone}\n"
-              (if (null? package-lines) "" (string-append (string-join package-lines "\n") "\n"))
-              (if (null? extra-packages) "" (string-append (string-join extra-packages "\n") "\n"))
-              "\\begin{document}\n"
-              (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
-              inner-code
-              "\n\\end{document}"))))))
+          (string-contains? code "\\begin{document}")
+        ) ;or
+      code
+      (let* ((lines (string-split code #\newline))
+             (library-lines (filter (lambda (line) (string-starts? (string-trim-left line) "\\usetikzlibrary"))
+                              lines
+                            ) ;filter
+             ) ;library-lines
+             (package-lines (filter (lambda (line) (string-starts? (string-trim-left line) "\\usepackage"))
+                              lines
+                            ) ;filter
+             ) ;package-lines
+             (other-lines (filter (lambda (line)
+                                    (let ((trimmed-line (string-trim-left line)))
+                                      (and (not (string-starts? trimmed-line "\\usetikzlibrary"))
+                                        (not (string-starts? trimmed-line "\\usepackage"))
+                                        (not (string-null? trimmed-line))
+                                      ) ;and
+                                    ) ;let
+                                  ) ;lambda
+                            lines
+                          ) ;filter
+             ) ;other-lines
+             (body (string-join other-lines "\n"))
+             (body-trimmed (string-trim-left body))
+            ) ;
+        (let* ((has-chemfig? (or (string-starts? body-trimmed "\\chem")
+                               (string-starts? body-trimmed "\\scheme")
+                             ) ;or
+               ) ;has-chemfig?
+               (need-chemfig-package? (or has-chemfig?
+                                        (string-contains? body "\\chem")
+                                        (string-contains? body "\\scheme")
+                                      ) ;or
+               ) ;need-chemfig-package?
+               (need-optikz-package? (or (string-contains? body "\\spectrometer")
+                                       (string-contains? body "\\camera")
+                                       (string-contains? body "\\diode")
+                                       (string-contains? body "\\splitter")
+                                       (string-contains? body "\\convexlens")
+                                       (string-contains? body "\\concavelens")
+                                       (string-contains? body "\\planconvexlens")
+                                       (string-contains? body "\\mirror")
+                                       (string-contains? body "\\curvedmirror")
+                                       (string-contains? body "\\pockelscell")
+                                       (string-contains? body "\\laser")
+                                       (string-contains? body "\\grating")
+                                       (string-contains? body "\\drawrainbow")
+                                       (string-contains? body "\\TFP")
+                                     ) ;or
+               ) ;need-optikz-package?
+               (extra-packages (let ((pkgs '()))
+                                 (when (and need-chemfig-package?
+                                         (null? (filter (lambda (line) (string-contains? line "chemfig")) package-lines))
+                                       ) ;and
+                                   (set! pkgs (cons "\\usepackage{chemfig}" pkgs))
+                                 ) ;when
+                                 (when (and need-optikz-package?
+                                         (null? (filter (lambda (line) (string-contains? line "optikz")) package-lines))
+                                       ) ;and
+                                   (set! pkgs (cons "\\usepackage{optikz}" pkgs))
+                                 ) ;when
+                                 (when (and need-optikz-package?
+                                         (null? (filter (lambda (line) (string-contains? line "calc")) package-lines))
+                                       ) ;and
+                                   (set! pkgs (cons "\\usepackage{calc}" pkgs))
+                                 ) ;when
+                                 (reverse pkgs)
+                               ) ;let
+               ) ;extra-packages
+               (need-arrows-meta? (or (string-contains? body "Latex") (string-contains? body "Stealth"))
+               ) ;need-arrows-meta?
+               (extra-libraries (let ((libs '()))
+                                  (when (and need-arrows-meta?
+                                          (null? (filter (lambda (line) (string-contains? line "arrows.meta")) library-lines)
+                                          ) ;null?
+                                        ) ;and
+                                    (set! libs (cons "\\usetikzlibrary{arrows.meta}" libs))
+                                  ) ;when
+                                  (reverse libs)
+                                ) ;let
+               ) ;extra-libraries
+               (inner-code (if (or (string-null? body-trimmed)
+                                 (string-contains? body "\\begin{tikzpicture}")
+                                 has-chemfig?
+                               ) ;or
+                             body
+                             (string-append "\\begin{tikzpicture}\n" body "\n\\end{tikzpicture}")
+                           ) ;if
+               ) ;inner-code
+              ) ;
+          (string-append "\\documentclass[tikz,rgb]{standalone}\n"
+            (if (null? package-lines)
+              ""
+              (string-append (string-join package-lines "\n") "\n")
+            ) ;if
+            (if (null? extra-packages)
+              ""
+              (string-append (string-join extra-packages "\n") "\n")
+            ) ;if
+            "\\begin{document}\n"
+            (if (null? library-lines)
+              ""
+              (string-append (string-join library-lines "\n") "\n")
+            ) ;if
+            (if (null? extra-libraries)
+              ""
+              (string-append (string-join extra-libraries "\n") "\n")
+            ) ;if
+            inner-code
+            "\n\\end{document}"
+          ) ;string-append
+        ) ;let*
+      ) ;let*
+    ) ;if
+  ) ;let
+) ;define
 
 (define (parse-magic-line magic-line)
-  (let ((tokens (filter (lambda (x) (not (string-null? x)))
-                        (string-split magic-line #\space)))
+  (let ((tokens (filter (lambda (x) (not (string-null? x))) (string-split magic-line #\space))
+        ) ;tokens
         (width "0px")
-        (height "0px"))
-    (let loop ((args (cdr tokens)))
-      (cond ((or (null? args) (null? (cdr args)))
-             (list width height))
-            ((string=? (car args) "-width")
-             (set! width (cadr args))
-             (loop (cddr args)))
-            ((string=? (car args) "-height")
-             (set! height (cadr args))
-             (loop (cddr args)))
-            (else (loop (cddr args)))))))
+        (height "0px")
+       ) ;
+    (let loop
+      ((args (cdr tokens)))
+      (cond ((or (null? args) (null? (cdr args))) (list width height))
+            ((string=? (car args) "-width") (set! width (cadr args)) (loop (cddr args)))
+            ((string=? (car args) "-height") (set! height (cadr args)) (loop (cddr args)))
+            (else (loop (cddr args)))
+      ) ;cond
+    ) ;let
+  ) ;let
+) ;define
 
 (define (dump-tex-code code-path code)
-  (with-output-to-file code-path
-    (lambda () (display code))))
+  (with-output-to-file code-path (lambda () (display code)))
+) ;define
 
 (define (tikz-temp-dir)
-  (string-append (os-temp-dir) "/tikz"))
+  (string-append (os-temp-dir) "/tikz")
+) ;define
 
 (define (run-pdflatex tex-path pdflatex-bin)
   (let* ((inner-cmd (string-append (goldfish-quote pdflatex-bin)
-                                   " --interaction=errorstopmode -halt-on-error "
-                                   (goldfish-quote tex-path)
-                                   " > /dev/null 2>&1"))
+                      " --interaction=errorstopmode -halt-on-error "
+                      (goldfish-quote tex-path)
+                      " > /dev/null 2>&1"
+                    ) ;string-append
+         ) ;inner-cmd
          (cmd (string-append "sh -c " (goldfish-quote inner-cmd)))
-         (orig-dir (getcwd)))
+         (orig-dir (getcwd))
+        ) ;
     (unsetenv "DYLD_LIBRARY_PATH")
     (unsetenv "DYLD_FRAMEWORK_PATH")
     (unsetenv "DYLD_FALLBACK_LIBRARY_PATH")
@@ -151,43 +224,62 @@
     (chdir (tikz-temp-dir))
     (let ((result (os-call cmd)))
       (chdir orig-dir)
-      result)))
+      result
+    ) ;let
+  ) ;let*
+) ;define
 
 (define (image-valid? path)
-  (and (file-exists? path) (> (path-getsize path) 10)))
+  (and (file-exists? path) (> (path-getsize path) 10))
+) ;define
 
 (define (get-pdf-page-size log-path)
   (let ((p (open-input-file log-path)))
-    (let loop ()
+    (let loop
+      ()
       (let ((line (read-line p)))
         (if (eof-object? line)
-            (begin (close-input-port p) #f)
-            (if (string-contains? line "papersize=")
-                (let* ((parts (string-split line #\=))
-                       (size-part (cadr parts))
-                       (dims (string-split size-part #\,))
-                       (w-str (string-remove-suffix (car dims) "pt"))
-                       (h-str (string-remove-suffix (cadr dims) "pt"))
-                       (w (string->number w-str))
-                       (h (string->number h-str)))
-                  (close-input-port p)
-                  (if (and w h)
-                      (list w h)
-                      #f))
-                (loop)))))))
+          (begin
+            (close-input-port p)
+            #f
+          ) ;begin
+          (if (string-contains? line "papersize=")
+            (let* ((parts (string-split line #\=))
+                   (size-part (cadr parts))
+                   (dims (string-split size-part #\,))
+                   (w-str (string-remove-suffix (car dims) "pt"))
+                   (h-str (string-remove-suffix (cadr dims) "pt"))
+                   (w (string->number w-str))
+                   (h (string->number h-str))
+                  ) ;
+              (close-input-port p)
+              (if (and w h) (list w h) #f)
+            ) ;let*
+            (loop)
+          ) ;if
+        ) ;if
+      ) ;let
+    ) ;let
+  ) ;let
+) ;define
 
 (define (pdf-page-empty? log-path)
   (let ((size (get-pdf-page-size log-path)))
     (if (not size)
-        #t
-        (let ((w (car size))
-              (h (cadr size)))
-          (and (<= w 0.1) (<= h 0.1))))))
+      #t
+      (let ((w (car size)) (h (cadr size)))
+        (and (<= w 0.1) (<= h 0.1))
+      ) ;let
+    ) ;if
+  ) ;let
+) ;define
 
 (define (flush-image path width height)
   (if (image-valid? path)
-      (flush-file (string-append path "?" "width=" width "&" "height=" height))
-      (flush-verbatim "Failed to generate image")))
+    (flush-file (string-append path "?" "width=" width "&" "height=" height))
+    (flush-verbatim "Failed to generate image")
+  ) ;if
+) ;define
 
 (define (eval-and-print code width height)
   (let* ((temp-path (gen-temp-path))
@@ -195,66 +287,90 @@
          (pdf-path (string-append temp-path ".pdf"))
          (log-path (string-append temp-path ".log"))
          (wrapped-code (wrap-tikz-code code))
-         (pdflatex-bin (fourth (argv))))
+         (pdflatex-bin (fourth (argv)))
+        ) ;
     (dump-tex-code tex-path wrapped-code)
     (if (zero? (run-pdflatex tex-path pdflatex-bin))
-        (let ((size (get-pdf-page-size log-path)))
-          (if (or (not size) (and (<= (car size) 0.1) (<= (cadr size) 0.1)))
-              (flush-verbatim "TikZ produced an empty image (0x0 bounding box)")
-              (let ((final-width width)
-                    (final-height height))
-                (when (and (string=? width "0px") (string=? height "0px"))
-                  (if size
-                      (begin
-                        (set! final-width (string-append (number->string (car size)) "pt"))
-                        (set! final-height (string-append (number->string (cadr size)) "pt")))
-                      (begin
-                        (set! final-width "0.3par")
-                        (set! final-height "0px"))))
-                (flush-image pdf-path final-width final-height))))
-        (begin
-          (flush-verbatim "pdflatex error")
-          (flush-verbatim "")))))
+      (let ((size (get-pdf-page-size log-path)))
+        (if (or (not size) (and (<= (car size) 0.1) (<= (cadr size) 0.1)))
+          (flush-verbatim "TikZ produced an empty image (0x0 bounding box)")
+          (let ((final-width width) (final-height height))
+            (when (and (string=? width "0px") (string=? height "0px"))
+              (if size
+                (begin
+                  (set! final-width (string-append (number->string (car size)) "pt"))
+                  (set! final-height (string-append (number->string (cadr size)) "pt"))
+                ) ;begin
+                (begin
+                  (set! final-width "0.3par")
+                  (set! final-height "0px")
+                ) ;begin
+              ) ;if
+            ) ;when
+            (flush-image pdf-path final-width final-height)
+          ) ;let
+        ) ;if
+      ) ;let
+      (begin
+        (flush-verbatim "pdflatex error")
+        (flush-verbatim "")
+      ) ;begin
+    ) ;if
+  ) ;let*
+) ;define
 
 (define (split-code-and-magic code)
   (if (not (string-starts? code "%"))
-      (list "" code)
-      (let ((i/false (string-index code #\newline)))
-        (if (not i/false)
-            (list code "")
-            (list (substring code 0 i/false)
-                  (substring code (+ i/false 1)))))))
+    (list "" code)
+    (let ((i/false (string-index code #\newline)))
+      (if (not i/false)
+        (list code "")
+        (list (substring code 0 i/false) (substring code (+ i/false 1)))
+      ) ;if
+    ) ;let
+  ) ;if
+) ;define
 
 (define (read-eval-print)
   (let* ((raw-code (tikz-read-code))
-         (l (split-code-and-magic raw-code))
+         (decoded-raw (decode-texmacs-markup raw-code))
+         (l (split-code-and-magic decoded-raw))
          (magic-line (car l))
          (code (cadr l))
-         (parsed (if (string-null? magic-line)
-                     (list "0px" "0px")
-                     (parse-magic-line magic-line)))
+         (parsed (if (string-null? magic-line) (list "0px" "0px") (parse-magic-line magic-line))
+         ) ;parsed
          (width (car parsed))
-         (height (cadr parsed)))
+         (height (cadr parsed))
+        ) ;
     (if (string-null? code)
-        (flush-verbatim "No code provided!")
-        (eval-and-print code width height))))
+      (flush-verbatim "No code provided!")
+      (eval-and-print code width height)
+    ) ;if
+  ) ;let*
+) ;define
 
 (define (safe-read-eval-print)
   (catch #t
     (lambda () (read-eval-print))
     (lambda args
-      (flush-scheme
-        (string-append "(errput (document "
-                       (goldfish-quote (symbol->string (car args)))
-                       " "
-                       (if (and (>= (length args) 2) (not (null? (cadr args))))
-                           (goldfish-quote (object->string (cadr args)))
-                           "")
-                       "))")))))
+      (flush-scheme (string-append "(errput (document "
+                      (goldfish-quote (symbol->string (car args)))
+                      " "
+                      (if (and (>= (length args) 2) (not (null? (cadr args))))
+                        (goldfish-quote (object->string (cadr args)))
+                        ""
+                      ) ;if
+                      "))"
+                    ) ;string-append
+      ) ;flush-scheme
+    ) ;lambda
+  ) ;catch
+) ;define
 
 (define (tikz-repl)
   (safe-read-eval-print)
-  (tikz-repl))
+  (tikz-repl)
+) ;define
 
 (tikz-welcome)
 (tikz-repl)

--- a/TeXmacs/plugins/tikz/tests/tm-tikz-test.scm
+++ b/TeXmacs/plugins/tikz/tests/tm-tikz-test.scm
@@ -10,116 +10,153 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(import (scheme base)
-  (liii check)
-  (liii string)
-  (liii list)
-  (liii path)
-)
+(import (scheme base) (liii check) (liii string) (liii list) (liii path))
 
-; Simulate the wrap-tikz-code logic from tm-tikz.scm
 (define (wrap-tikz-code code)
   (let ((trimmed (string-trim-left code)))
     (if (or (string-starts? trimmed "\\documentclass")
-            (string-contains? code "\\begin{document}"))
+          (string-contains? code "\\begin{document}")
+        ) ;or
       code
       (let* ((lines (string-split code #\newline))
-             (library-lines
-               (filter (lambda (line)
-                         (string-starts? (string-trim-left line) "\\usetikzlibrary"))
-                       lines))
-             (package-lines
-               (filter (lambda (line)
-                         (string-starts? (string-trim-left line) "\\usepackage"))
-                       lines))
-             (other-lines
-               (filter (lambda (line)
-                         (let ((trimmed-line (string-trim-left line)))
-                           (and (not (string-starts? trimmed-line "\\usetikzlibrary"))
-                                (not (string-starts? trimmed-line "\\usepackage"))
-                                (not (string-null? trimmed-line)))))
-                       lines))
+             (library-lines (filter (lambda (line) (string-starts? (string-trim-left line) "\\usetikzlibrary"))
+                              lines
+                            ) ;filter
+             ) ;library-lines
+             (package-lines (filter (lambda (line) (string-starts? (string-trim-left line) "\\usepackage"))
+                              lines
+                            ) ;filter
+             ) ;package-lines
+             (other-lines (filter (lambda (line)
+                                    (let ((trimmed-line (string-trim-left line)))
+                                      (and (not (string-starts? trimmed-line "\\usetikzlibrary"))
+                                        (not (string-starts? trimmed-line "\\usepackage"))
+                                        (not (string-null? trimmed-line))
+                                      ) ;and
+                                    ) ;let
+                                  ) ;lambda
+                            lines
+                          ) ;filter
+             ) ;other-lines
              (body (string-join other-lines "\n"))
-             (body-trimmed (string-trim-left body)))
+             (body-trimmed (string-trim-left body))
+            ) ;
         (let* ((has-chemfig? (or (string-starts? body-trimmed "\\chem")
-                                 (string-starts? body-trimmed "\\scheme")))
-               (need-chemfig-package?
-                 (or has-chemfig?
-                     (string-contains? body "\\chem")
-                     (string-contains? body "\\scheme")))
-               (need-optikz-package?
-                 (or (string-contains? body "\\spectrometer")
-                     (string-contains? body "\\camera")
-                     (string-contains? body "\\diode")
-                     (string-contains? body "\\splitter")
-                     (string-contains? body "\\convexlens")
-                     (string-contains? body "\\concavelens")
-                     (string-contains? body "\\planconvexlens")
-                     (string-contains? body "\\mirror")
-                     (string-contains? body "\\curvedmirror")
-                     (string-contains? body "\\pockelscell")
-                     (string-contains? body "\\laser")
-                     (string-contains? body "\\grating")
-                     (string-contains? body "\\drawrainbow")
-                     (string-contains? body "\\TFP")))
-               (extra-packages
-                 (let ((pkgs '()))
-                   (when (and need-chemfig-package?
-                              (null? (filter (lambda (line) (string-contains? line "chemfig"))
-                                             package-lines)))
-                     (set! pkgs (cons "\\usepackage{chemfig}" pkgs)))
-                   (when (and need-optikz-package?
-                              (null? (filter (lambda (line) (string-contains? line "optikz"))
-                                             package-lines)))
-                     (set! pkgs (cons "\\usepackage{optikz}" pkgs)))
-                   (when (and need-optikz-package?
-                              (null? (filter (lambda (line) (string-contains? line "calc"))
-                                             package-lines)))
-                     (set! pkgs (cons "\\usepackage{calc}" pkgs)))
-                   (reverse pkgs)))
-               (inner-code
-                 (if (or (string-null? body-trimmed)
-                         (string-contains? body "\\begin{tikzpicture}")
-                         has-chemfig?)
-                   body
-                   (string-append "\\begin{tikzpicture}\n" body "\n\\end{tikzpicture}")
-                 ) ;if
+                               (string-starts? body-trimmed "\\scheme")
+                             ) ;or
+               ) ;has-chemfig?
+               (need-chemfig-package? (or has-chemfig?
+                                        (string-contains? body "\\chem")
+                                        (string-contains? body "\\scheme")
+                                      ) ;or
+               ) ;need-chemfig-package?
+               (need-optikz-package? (or (string-contains? body "\\spectrometer")
+                                       (string-contains? body "\\camera")
+                                       (string-contains? body "\\diode")
+                                       (string-contains? body "\\splitter")
+                                       (string-contains? body "\\convexlens")
+                                       (string-contains? body "\\concavelens")
+                                       (string-contains? body "\\planconvexlens")
+                                       (string-contains? body "\\mirror")
+                                       (string-contains? body "\\curvedmirror")
+                                       (string-contains? body "\\pockelscell")
+                                       (string-contains? body "\\laser")
+                                       (string-contains? body "\\grating")
+                                       (string-contains? body "\\drawrainbow")
+                                       (string-contains? body "\\TFP")
+                                     ) ;or
+               ) ;need-optikz-package?
+               (extra-packages (let ((pkgs '()))
+                                 (when (and need-chemfig-package?
+                                         (null? (filter (lambda (line) (string-contains? line "chemfig")) package-lines))
+                                       ) ;and
+                                   (set! pkgs (cons "\\usepackage{chemfig}" pkgs))
+                                 ) ;when
+                                 (when (and need-optikz-package?
+                                         (null? (filter (lambda (line) (string-contains? line "optikz")) package-lines))
+                                       ) ;and
+                                   (set! pkgs (cons "\\usepackage{optikz}" pkgs))
+                                 ) ;when
+                                 (when (and need-optikz-package?
+                                         (null? (filter (lambda (line) (string-contains? line "calc")) package-lines))
+                                       ) ;and
+                                   (set! pkgs (cons "\\usepackage{calc}" pkgs))
+                                 ) ;when
+                                 (reverse pkgs)
+                               ) ;let
+               ) ;extra-packages
+               (need-arrows-meta? (or (string-contains? body "Latex") (string-contains? body "Stealth"))
+               ) ;need-arrows-meta?
+               (extra-libraries (let ((libs '()))
+                                  (when (and need-arrows-meta?
+                                          (null? (filter (lambda (line) (string-contains? line "arrows.meta")) library-lines)
+                                          ) ;null?
+                                        ) ;and
+                                    (set! libs (cons "\\usetikzlibrary{arrows.meta}" libs))
+                                  ) ;when
+                                  (reverse libs)
+                                ) ;let
+               ) ;extra-libraries
+               (inner-code (if (or (string-null? body-trimmed)
+                                 (string-contains? body "\\begin{tikzpicture}")
+                                 has-chemfig?
+                               ) ;or
+                             body
+                             (string-append "\\begin{tikzpicture}\n" body "\n\\end{tikzpicture}")
+                           ) ;if
                ) ;inner-code
               ) ;
-        (string-append
-          "\\documentclass[tikz,rgb]{standalone}\n"
-          (if (null? package-lines) "" (string-append (string-join package-lines "\n") "\n"))
-          (if (null? extra-packages) "" (string-append (string-join extra-packages "\n") "\n"))
-          "\\begin{document}\n"
-          (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
-          inner-code
-          "\n\\end{document}"
-        ) ;string-append
-        ) ;let inner-code
+          (string-append "\\documentclass[tikz,rgb]{standalone}\n"
+            (if (null? package-lines)
+              ""
+              (string-append (string-join package-lines "\n") "\n")
+            ) ;if
+            (if (null? extra-packages)
+              ""
+              (string-append (string-join extra-packages "\n") "\n")
+            ) ;if
+            "\\begin{document}\n"
+            (if (null? library-lines)
+              ""
+              (string-append (string-join library-lines "\n") "\n")
+            ) ;if
+            (if (null? extra-libraries)
+              ""
+              (string-append (string-join extra-libraries "\n") "\n")
+            ) ;if
+            inner-code
+            "\n\\end{document}"
+          ) ;string-append
+        ) ;let*
       ) ;let*
     ) ;if
   ) ;let
 ) ;define
 
-; Simulate the parse-magic-line logic from tm-tikz.scm
+(define (decode-texmacs-markup code)
+  (let* ((s1 (string-replace code "<less>" "<"))
+         (s2 (string-replace s1 "<gtr>" ">"))
+         (s3 (string-replace s2 "<backslash>" "\\"))
+         (s4 (string-replace s3 "<ast>" "*"))
+        ) ;
+    s4
+  ) ;let*
+) ;define
+
 (define (parse-magic-line magic-line)
-  (let ((tokens (filter (lambda (x) (not (string-null? x))) (string-split magic-line #\space)))
+  (let ((tokens (filter (lambda (x) (not (string-null? x))) (string-split magic-line #\space))
+        ) ;tokens
         (width "0px")
         (height "0px")
        ) ;
-    (let loop ((args (cdr tokens)))
+    (let loop
+      ((args (cdr tokens)))
       (cond ((or (null? args) (null? (cdr args))) (list width height))
-            ((string=? (car args) "-width")
-             (set! width (cadr args))
-             (loop (cddr args))
-            ) ;
-            ((string=? (car args) "-height")
-             (set! height (cadr args))
-             (loop (cddr args))
-            ) ;
+            ((string=? (car args) "-width") (set! width (cadr args)) (loop (cddr args)))
+            ((string=? (car args) "-height") (set! height (cadr args)) (loop (cddr args)))
             (else (loop (cddr args)))
       ) ;cond
-    ) ;let loop
+    ) ;let
   ) ;let
 ) ;define
 
@@ -127,125 +164,143 @@
 ;; Tests for wrap-tikz-code
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(check
-  (wrap-tikz-code "\\documentclass{article}\n\\begin{document}\n\\end{document}")
+(check (wrap-tikz-code "\\documentclass{article}\n\\begin{document}\n\\end{document}")
   =>
   "\\documentclass{article}\n\\begin{document}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "% some comment\n\\documentclass[tikz]{standalone}\n\\begin{document}\n\\draw (0,0) -- (1,1);\n\\end{document}")
+(check (wrap-tikz-code "% some comment\n\\documentclass[tikz]{standalone}\n\\begin{document}\n\\draw (0,0) -- (1,1);\n\\end{document}"
+       ) ;wrap-tikz-code
   =>
   "% some comment\n\\documentclass[tikz]{standalone}\n\\begin{document}\n\\draw (0,0) -- (1,1);\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\begin{document}\n\\draw (0,0) -- (1,1);\n\\end{document}")
+(check (wrap-tikz-code "\\begin{document}\n\\draw (0,0) -- (1,1);\n\\end{document}")
   =>
   "\\begin{document}\n\\draw (0,0) -- (1,1);\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "  \\documentclass[tikz]{standalone}")
+(check (wrap-tikz-code "  \\documentclass[tikz]{standalone}")
   =>
   "  \\documentclass[tikz]{standalone}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usetikzlibrary{calc}\n\\draw (0,0) -- (1,1);")
+(check (wrap-tikz-code "\\usetikzlibrary{calc}\n\\draw (0,0) -- (1,1);")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{calc}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}")
+(check (wrap-tikz-code "\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\def\\skala{0.8}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}")
+(check (wrap-tikz-code "\\def\\skala{0.8}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\def\\skala{0.8}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\draw (0,0) -- (1,1);")
+(check (wrap-tikz-code "\\draw (0,0) -- (1,1);")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "  \\draw (0,0) -- (1,1);")
+(check (wrap-tikz-code "  \\draw (0,0) -- (1,1);")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\begin{tikzpicture}\n  \\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usetikzlibrary{shapes.geometric}\n\\node[draw, circle] at (0,0) {A};")
+(check (wrap-tikz-code "\\usetikzlibrary{shapes.geometric}\n\\node[draw, circle] at (0,0) {A};"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{shapes.geometric}\n\\begin{tikzpicture}\n\\node[draw, circle] at (0,0) {A};\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usetikzlibrary{calc}\n\\usetikzlibrary{arrows.meta}\n\\draw (0,0) -- (1,1);")
+(check (wrap-tikz-code "\\usetikzlibrary{calc}\n\\usetikzlibrary{arrows.meta}\n\\draw (0,0) -- (1,1);"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{calc}\n\\usetikzlibrary{arrows.meta}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usetikzlibrary{calc}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}")
+(check (wrap-tikz-code "\\usetikzlibrary{calc}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{calc}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usetikzlibrary{shapes.geometric}")
+(check (wrap-tikz-code "\\usetikzlibrary{shapes.geometric}")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{shapes.geometric}\n\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usepackage{chemfig}\n\\chemfig{*6(=-=-=-)}")
+(check (wrap-tikz-code "\\usepackage{chemfig}\n\\chemfig{*6(=-=-=-)}")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{chemfig}\n\\begin{document}\n\\chemfig{*6(=-=-=-)}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\chemfig{*6(=-=-=-)}")
+(check (wrap-tikz-code "\\chemfig{*6(=-=-=-)}")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{chemfig}\n\\begin{document}\n\\chemfig{*6(=-=-=-)}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usepackage{chemfig}\n\\draw (0,0) -- (1,1);")
+(check (wrap-tikz-code "\\usepackage{chemfig}\n\\draw (0,0) -- (1,1);")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{chemfig}\n\\begin{document}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\node (molecule) at (0,0) {\\chemfig{*6(--=--)}};\n\\draw[->, red] (molecule) -- (2,1);")
+(check (wrap-tikz-code "\\node (molecule) at (0,0) {\\chemfig{*6(--=--)}};\n\\draw[->, red] (molecule) -- (2,1);"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{chemfig}\n\\begin{document}\n\\begin{tikzpicture}\n\\node (molecule) at (0,0) {\\chemfig{*6(--=--)}};\n\\draw[->, red] (molecule) -- (2,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usepackage{pgfplots}\n\\draw (0,0) -- (1,1);")
+(check (wrap-tikz-code "\\usepackage{pgfplots}\n\\draw (0,0) -- (1,1);")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{pgfplots}\n\\begin{document}\n\\begin{tikzpicture}\n\\draw (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\def\\skala{0.8}\n\\spectrometer[angle=0] at (5.5,4);")
+(check (wrap-tikz-code "\\def\\skala{0.8}\n\\spectrometer[angle=0] at (5.5,4);")
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{optikz}\n\\usepackage{calc}\n\\begin{document}\n\\begin{tikzpicture}\n\\def\\skala{0.8}\n\\spectrometer[angle=0] at (5.5,4);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
 
-(check
-  (wrap-tikz-code "\\usepackage{optikz}\n\\usepackage{calc}\n\\def\\skala{0.8}\n\\spectrometer[angle=0] at (5.5,4);")
+(check (wrap-tikz-code "\\usepackage{optikz}\n\\usepackage{calc}\n\\def\\skala{0.8}\n\\spectrometer[angle=0] at (5.5,4);"
+       ) ;wrap-tikz-code
   =>
   "\\documentclass[tikz,rgb]{standalone}\n\\usepackage{optikz}\n\\usepackage{calc}\n\\begin{document}\n\\begin{tikzpicture}\n\\def\\skala{0.8}\n\\spectrometer[angle=0] at (5.5,4);\n\\end{tikzpicture}\n\\end{document}"
-)
+) ;check
+
+(check (wrap-tikz-code "\\draw[-{Latex}] (0,0) -- (1,1);")
+  =>
+  "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{arrows.meta}\n\\begin{tikzpicture}\n\\draw[-{Latex}] (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
+) ;check
+
+(check (wrap-tikz-code "\\usetikzlibrary{arrows.meta}\n\\draw[-{Latex}] (0,0) -- (1,1);"
+       ) ;wrap-tikz-code
+  =>
+  "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{arrows.meta}\n\\begin{tikzpicture}\n\\draw[-{Latex}] (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
+) ;check
+
+(check (wrap-tikz-code "\\usetikzlibrary{calc}\n\\draw[-{Latex}] (0,0) -- (1,1);")
+  =>
+  "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{calc}\n\\usetikzlibrary{arrows.meta}\n\\begin{tikzpicture}\n\\draw[-{Latex}] (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
+) ;check
+
+(check (wrap-tikz-code "\\draw[-Stealth] (0,0) -- (1,1);")
+  =>
+  "\\documentclass[tikz,rgb]{standalone}\n\\begin{document}\n\\usetikzlibrary{arrows.meta}\n\\begin{tikzpicture}\n\\draw[-Stealth] (0,0) -- (1,1);\n\\end{tikzpicture}\n\\end{document}"
+) ;check
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for decode-texmacs-markup
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(check (decode-texmacs-markup "draw[-<gtr>]") => "draw[->]")
+(check (decode-texmacs-markup "draw[-<less>]") => "draw[-<]")
+(check (decode-texmacs-markup "draw[<backslash>draw]") => "draw[\\draw]")
+(check (decode-texmacs-markup "draw[<ast>]") => "draw[*]")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests for parse-magic-line
@@ -257,11 +312,20 @@
 
 (check (parse-magic-line "% -height 100px") => (list "0px" "100px"))
 
-(check (parse-magic-line "% -width 0.8par -height 100px") => (list "0.8par" "100px"))
+(check (parse-magic-line "% -width 0.8par -height 100px")
+  =>
+  (list "0.8par" "100px")
+) ;check
 
-(check (parse-magic-line "% -height 100px -width 0.8par") => (list "0.8par" "100px"))
+(check (parse-magic-line "% -height 100px -width 0.8par")
+  =>
+  (list "0.8par" "100px")
+) ;check
 
-(check (parse-magic-line "% -foo bar -width 0.5par -baz qux -height 50px") => (list "0.5par" "50px"))
+(check (parse-magic-line "% -foo bar -width 0.5par -baz qux -height 50px")
+  =>
+  (list "0.5par" "50px")
+) ;check
 
 (check (parse-magic-line "% -width 0.8par -height") => (list "0.8par" "0px"))
 
@@ -270,7 +334,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (image-valid? path)
-  (and (file-exists? path) (> (path-getsize path) 10)))
+  (and (file-exists? path) (> (path-getsize path) 10))
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests for image-valid?
@@ -278,9 +343,7 @@
 
 (define test-empty-path "/tmp/tikz-test-empty.txt")
 
-(with-output-to-file test-empty-path
-  (lambda ()
-    (display "")))
+(with-output-to-file test-empty-path (lambda () (display "")))
 
 (check (image-valid? "/tmp/nonexistent-file-12345.txt") => #f)
 (check (image-valid? test-empty-path) => #f)
@@ -291,61 +354,78 @@
 
 (define (get-pdf-page-size log-path)
   (let ((p (open-input-file log-path)))
-    (let loop ()
+    (let loop
+      ()
       (let ((line (read-line p)))
         (if (eof-object? line)
-            (begin (close-input-port p) #f)
-            (if (string-contains? line "papersize=")
-                (let* ((parts (string-split line #\=))
-                       (size-part (cadr parts))
-                       (dims (string-split size-part #\,))
-                       (w-str (string-remove-suffix (car dims) "pt"))
-                       (h-str (string-remove-suffix (cadr dims) "pt"))
-                       (w (string->number w-str))
-                       (h (string->number h-str)))
-                  (close-input-port p)
-                  (if (and w h)
-                      (list w h)
-                      #f))
-                (loop)))))))
+          (begin
+            (close-input-port p)
+            #f
+          ) ;begin
+          (if (string-contains? line "papersize=")
+            (let* ((parts (string-split line #\=))
+                   (size-part (cadr parts))
+                   (dims (string-split size-part #\,))
+                   (w-str (string-remove-suffix (car dims) "pt"))
+                   (h-str (string-remove-suffix (cadr dims) "pt"))
+                   (w (string->number w-str))
+                   (h (string->number h-str))
+                  ) ;
+              (close-input-port p)
+              (if (and w h) (list w h) #f)
+            ) ;let*
+            (loop)
+          ) ;if
+        ) ;if
+      ) ;let
+    ) ;let
+  ) ;let
+) ;define
 
 (define (pdf-page-empty? log-path)
   (let ((size (get-pdf-page-size log-path)))
     (if (not size)
-        #t
-        (let ((w (car size))
-              (h (cadr size)))
-          (and (<= w 0.1) (<= h 0.1))))))
+      #t
+      (let ((w (car size)) (h (cadr size)))
+        (and (<= w 0.1) (<= h 0.1))
+      ) ;let
+    ) ;if
+  ) ;let
+) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests for pdf-page-empty?
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define test-log-empty-path "/tmp/tikz-test-log-empty.log")
+
 (define test-log-valid-path "/tmp/tikz-test-log-valid.log")
+
 (define test-log-vertical-path "/tmp/tikz-test-log-vertical.log")
+
 (define test-log-horizontal-path "/tmp/tikz-test-log-horizontal.log")
+
 (define test-log-point-path "/tmp/tikz-test-log-point.log")
 
 (with-output-to-file test-log-empty-path
-  (lambda ()
-    (display "<special> papersize=0.0pt,0.0pt\n")))
+  (lambda () (display "<special> papersize=0.0pt,0.0pt\n"))
+) ;with-output-to-file
 
 (with-output-to-file test-log-valid-path
-  (lambda ()
-    (display "<special> papersize=28.85274pt,28.85274pt\n")))
+  (lambda () (display "<special> papersize=28.85274pt,28.85274pt\n"))
+) ;with-output-to-file
 
 (with-output-to-file test-log-vertical-path
-  (lambda ()
-    (display "<special> papersize=0.4pt,28.85274pt\n")))
+  (lambda () (display "<special> papersize=0.4pt,28.85274pt\n"))
+) ;with-output-to-file
 
 (with-output-to-file test-log-horizontal-path
-  (lambda ()
-    (display "<special> papersize=28.85274pt,0.4pt\n")))
+  (lambda () (display "<special> papersize=28.85274pt,0.4pt\n"))
+) ;with-output-to-file
 
 (with-output-to-file test-log-point-path
-  (lambda ()
-    (display "<special> papersize=0.4pt,0.4pt\n")))
+  (lambda () (display "<special> papersize=0.4pt,0.4pt\n"))
+) ;with-output-to-file
 
 (check (get-pdf-page-size test-log-empty-path) => (list 0.0 0.0))
 (check (get-pdf-page-size test-log-valid-path) => (list 28.85274 28.85274))

--- a/TeXmacs/tests/tmu/0670.tmu
+++ b/TeXmacs/tests/tmu/0670.tmu
@@ -1,0 +1,66 @@
+<TMU|<tuple|1.1.0|2026.2.9>>
+
+<style|<tuple|generic|number-europe|preview-ref|framed-session|tikz>>
+
+<\body>
+  <\session|tikz|default>
+    <\output>
+      Liii STEM interface to TikZ
+    </output>
+
+    <\unfolded-io>
+      tikz]\ 
+    <|unfolded-io>
+      \\usetikzlibrary{calc, angles, quotes}
+
+      \;
+
+      % 1. 定义三角形的三个物理顶点坐标
+
+      \\coordinate (A) at (0,0);
+
+      \\coordinate (B) at (3.2,0);
+
+      \\coordinate (C) at (1.0,2.2);
+
+      \;
+
+      % 2. 绘制闭合多边形三角形主体
+
+      \\draw[thick] (A) -- (B) -- (C) -- cycle;
+
+      \;
+
+      % 3. 标注顶点的文本标签
+
+      \\node[below left] at (A) {$A$};
+
+      \\node[below right] at (B) {$B$};
+
+      \\node[above] at (C) {$C$};
+
+      \;
+
+      % 4. 使用 pic 自动计算并标记内角（由三点确定角，逆时针方向）
+
+      \\pic [draw, -\<gtr\>, "$\\alpha$", angle radius=15pt, angle eccentricity=1.2] {angle = B--A--C};
+
+      \\pic [draw, -{Latex}, "$\\beta$", angle radius=18pt, angle eccentricity=1.2] {angle = C--B--A};
+    <|unfolded-io>
+      pdflatex error
+    </unfolded-io>
+
+    <\input>
+      tikz]\ 
+    <|input>
+      \;
+    </input>
+  </session>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|DED45977-2271-4C10-88B8-68108A834040>
+  </collection>
+</initial>

--- a/devel/0670.md
+++ b/devel/0670.md
@@ -1,4 +1,4 @@
-# [0670] TikZ 插件自动检测并引入 arrows.meta 库
+# [0670] TikZ 插件自动检测并引入 arrows.meta 库与 TeXmacs 实体字符还原
 
 ## 1 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
@@ -40,24 +40,34 @@ gf fmt --changed-since=main
 ## 5 What
 1. 在 `tm-tikz.scm` 的 `wrap-tikz-code` 函数中增加了对 `Latex` 和 `Stealth` 箭头关键字的自动匹配与检测。
 2. 匹配成功时，若用户没有显式声明 `\usetikzlibrary{arrows.meta}`，会自动向生成的 LaTeX 文档引入 `\usetikzlibrary{arrows.meta}`。
-3. 仿照 package 的 `extra-packages` 机制，优雅地为 TikZ 库引入设计了 `extra-libraries` 机制。
-4. 补充了 4 个单元测试用例，覆盖无预声明自动引入、已有相同或不同预声明、不同箭头提示类型的处理，并全面通过测试。
-5. 将用户准备好的 `0670.tmu` 集成测试文档复制到 `TeXmacs/tests/tmu/0670.tmu`。
+3. 增加 `decode-texmacs-markup` 实体解析函数，专门处理并还原 TeXmacs 从 `.tmu` 重算会话时发送给插件 stdin 的 `<less>`（变为 `<`）、`<gtr>`（变为 `>`）、`<backslash>`（变为 `\`）以及 `<ast>`（变为 `*`）特殊 HTML/XML-like 实体字符串，防止 pdflatex 因接收到未转义实体字符而崩。
+4. 仿照 package 的 `extra-packages` 机制，优雅地为 TikZ 库引入设计了 `extra-libraries` 机制。
+5. 补充了相应的单元测试用例，覆盖无预声明自动引入、已有相同或不同预声明、不同箭头提示类型的处理，并全面通过测试。
+6. 将用户准备好的 `0670.tmu` 集成测试文档复制到 `TeXmacs/tests/tmu/0670.tmu`。
 
 ## 6 Why
 在 TikZ 绘图中使用现代箭头提示类型（如 `Latex` 或 `Stealth`）时，pgf 必须加载 `arrows.meta` 库。如果用户在代码中直接使用 `-{Latex}` 或 `-Stealth` 而忘记了在头部声明 `\usetikzlibrary{arrows.meta}`，则 `pdflatex` 会编译报错 `! Package pgf Error: Unknown arrow tip kind 'Latex'`。
 
-为了提高易用性，减少用户的心智负担，TikZ 插件应当能够智能地感知用户对这些常见箭头库的依赖，并在后台编译打包前自动加载必要的 TikZ 库。
+另外，从现有 `.tmu` 文档中重新执行会话时，TeXmacs 内部会将保存的 `\<less\>`、`\<gtr\>` 转换为 `<less>`、`<gtr>` 实体字符串输入给插件进程 stdin，导致生成 LaTeX 模板含有 `-<gtr>` 这类非法代码而引起 pdflatex 编译失败。所以必须由插件的 Scheme 解释器在接收到代码的第一时间进行转义和实体字符还原。
 
 ## 7 How
 在 `wrap-tikz-code` 处理 LaTeX 模板生成的过程中：
-1. 识别代码中是否含有现代箭头标识符：
+1. 识别代码中是否含有现代箭头标识符并进行字符解码还原：
+   ```scheme
+   (define (decode-texmacs-markup code)
+     (let* ((s1 (string-replace code "<less>" "<"))
+            (s2 (string-replace s1 "<gtr>" ">"))
+            (s3 (string-replace s2 "<backslash>" "\\"))
+            (s4 (string-replace s3 "<ast>" "*")))
+       s4))
+   ```
+2. 识别代码中是否含有现代箭头标识符：
    ```scheme
    (need-arrows-meta?
      (or (string-contains? body "Latex")
          (string-contains? body "Stealth")))
    ```
-2. 提取需要补充导入的 TikZ 库并去重：
+3. 提取需要补充导入的 TikZ 库并去重：
    ```scheme
    (extra-libraries
      (let ((libs '()))
@@ -67,7 +77,7 @@ gf fmt --changed-since=main
          (set! libs (cons "\\usetikzlibrary{arrows.meta}" libs)))
        (reverse libs)))
    ```
-3. 在 `\begin{document}` 之后，与原有的 `library-lines` 并列输出 `extra-libraries`：
+4. 在 `\begin{document}` 之后，与原有的 `library-lines` 并列输出 `extra-libraries`：
    ```scheme
    (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
    (if (null? extra-libraries) "" (string-append (string-join extra-libraries "\n") "\n"))

--- a/devel/0670.md
+++ b/devel/0670.md
@@ -1,0 +1,75 @@
+# [0670] TikZ 插件自动检测并引入 arrows.meta 库
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0612.md](0612.md) - TikZ 插件重构文档
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/tikz/goldfish/tm-tikz.scm`
+- `TeXmacs/plugins/tikz/tests/tm-tikz-test.scm`
+- `TeXmacs/tests/tmu/0670.tmu` — 包含使用 arrows.meta 的 TikZ 代码的测试文档
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+1. 构建 Goldfish Scheme 解释器：
+   ```bash
+   xmake b goldfish
+   ```
+2. 运行 TikZ 插件单元测试：
+   ```bash
+   TeXmacs/plugins/goldfish/bin/goldfish load TeXmacs/plugins/tikz/tests/tm-tikz-test.scm
+   ```
+
+### 3.2 非确定性测试（文档验证）
+1. 构建并运行 Mogan STEM：
+   ```bash
+   xmake b stem
+   xmake r stem
+   ```
+2. 打开 `TeXmacs/tests/tmu/0670.tmu`，按回车键重新计算会话。验证原本报错 `pdflatex error` 的 TikZ 图像能够顺利通过 pdflatex 编译并由 MuPDF 完美渲染，不再产生未知箭头类型 `Latex` 的编译错误。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+1. 在 `tm-tikz.scm` 的 `wrap-tikz-code` 函数中增加了对 `Latex` 和 `Stealth` 箭头关键字的自动匹配与检测。
+2. 匹配成功时，若用户没有显式声明 `\usetikzlibrary{arrows.meta}`，会自动向生成的 LaTeX 文档引入 `\usetikzlibrary{arrows.meta}`。
+3. 仿照 package 的 `extra-packages` 机制，优雅地为 TikZ 库引入设计了 `extra-libraries` 机制。
+4. 补充了 4 个单元测试用例，覆盖无预声明自动引入、已有相同或不同预声明、不同箭头提示类型的处理，并全面通过测试。
+5. 将用户准备好的 `0670.tmu` 集成测试文档复制到 `TeXmacs/tests/tmu/0670.tmu`。
+
+## 6 Why
+在 TikZ 绘图中使用现代箭头提示类型（如 `Latex` 或 `Stealth`）时，pgf 必须加载 `arrows.meta` 库。如果用户在代码中直接使用 `-{Latex}` 或 `-Stealth` 而忘记了在头部声明 `\usetikzlibrary{arrows.meta}`，则 `pdflatex` 会编译报错 `! Package pgf Error: Unknown arrow tip kind 'Latex'`。
+
+为了提高易用性，减少用户的心智负担，TikZ 插件应当能够智能地感知用户对这些常见箭头库的依赖，并在后台编译打包前自动加载必要的 TikZ 库。
+
+## 7 How
+在 `wrap-tikz-code` 处理 LaTeX 模板生成的过程中：
+1. 识别代码中是否含有现代箭头标识符：
+   ```scheme
+   (need-arrows-meta?
+     (or (string-contains? body "Latex")
+         (string-contains? body "Stealth")))
+   ```
+2. 提取需要补充导入的 TikZ 库并去重：
+   ```scheme
+   (extra-libraries
+     (let ((libs '()))
+       (when (and need-arrows-meta?
+                  (null? (filter (lambda (line) (string-contains? line "arrows.meta"))
+                                 library-lines)))
+         (set! libs (cons "\\usetikzlibrary{arrows.meta}" libs)))
+       (reverse libs)))
+   ```
+3. 在 `\begin{document}` 之后，与原有的 `library-lines` 并列输出 `extra-libraries`：
+   ```scheme
+   (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
+   (if (null? extra-libraries) "" (string-append (string-join extra-libraries "\n") "\n"))
+   ```
+该机制不仅优雅地解决了 `arrows.meta` 的缺失问题，也为将来自动检测引入其他 TikZ 库提供了可拓展的良好设计模式。


### PR DESCRIPTION
### 如何测试

1. 编译并运行 Mogan STEM：
   ```bash
   xmake b stem && xmake r stem
   ```
2. 打开 `TeXmacs/tests/tmu/0670.tmu` 示例文件（已合入项目），运行里面的 TikZ 会话，观察在不包含 `\usetikzlibrary{arrows.meta}` 声明且重置会话执行时，带有 `-{Latex}` 箭头的 Pic 能否成功编译并完美渲染。
3. 单元测试运行：
   ```bash
   xmake b goldfish
   TeXmacs/plugins/goldfish/bin/goldfish load TeXmacs/plugins/tikz/tests/tm-tikz-test.scm
   ```

---

### What
1. 在 `tm-tikz.scm` 的 `wrap-tikz-code` 函数中增加了对 `Latex` 和 `Stealth` 箭头关键字的自动匹配与检测。
2. 匹配成功时，若用户没有显式声明 `\usetikzlibrary{arrows.meta}`，会自动向生成的 LaTeX 文档引入 `\usetikzlibrary{arrows.meta}`。
3. 增加 `decode-texmacs-markup` 实体解析函数，专门处理并还原 TeXmacs 从 `.tmu` 重算会话时发送给插件 stdin 的 `<less>`（变为 `<`）、`<gtr>`（变为 `>`）、`<backslash>`（变为 `\`）以及 `<ast>`（变为 `*`）特殊 HTML/XML-like 实体字符串，防止 pdflatex 因接收到未转义实体字符而崩。
4. 仿照 package 的 `extra-packages` 机制，优雅地为 TikZ 库引入设计了 `extra-libraries` 机制。
5. 补充了 8 个单元测试用例，覆盖无预声明自动引入、已有相同或不同预声明、不同箭头提示类型的处理，以及 TeXmacs 实体字符还原，并全面通过测试。
6. 将用户准备好的 `0670.tmu` 集成测试文档复制到 `TeXmacs/tests/tmu/0670.tmu`。

### Why
在 TikZ 绘图中使用现代箭头提示类型（如 `Latex` 或 `Stealth`）时，pgf 必须加载 `arrows.meta` 库。如果用户在代码中直接使用 `-{Latex}` 或 `-Stealth` 而忘记了在头部声明 `\usetikzlibrary{arrows.meta}`，则 `pdflatex` 会编译报错 `! Package pgf Error: Unknown arrow tip kind 'Latex'`。

另外，从现有 `.tmu` 文档中重新执行会话时，TeXmacs 内部会将保存的 `\<less\>`、`\<gtr\>` 转换为 `<less>`、`<gtr>` 实体字符串输入给插件进程 stdin，导致生成 LaTeX 模板含有 `-<gtr>` 这类非法代码而引起 pdflatex 编译失败。所以必须由插件的 Scheme 解释器在接收到代码的第一时间进行转义和实体字符还原。

### How
在 `wrap-tikz-code` 处理 LaTeX 模板生成的过程中：
1. 识别代码中是否含有现代箭头标识符并进行字符解码还原：
   ```scheme
   (define (decode-texmacs-markup code)
     (let* ((s1 (string-replace code "<less>" "<"))
            (s2 (string-replace s1 "<gtr>" ">"))
            (s3 (string-replace s2 "<backslash>" "\\"))
            (s4 (string-replace s3 "<ast>" "*")))
       s4))
   ```
2. 识别代码中是否含有现代箭头标识符：
   ```scheme
   (need-arrows-meta?
     (or (string-contains? body "Latex")
         (string-contains? body "Stealth")))
   ```
3. 提取需要补充导入的 TikZ 库并去重：
   ```scheme
   (extra-libraries
     (let ((libs '()))
       (when (and need-arrows-meta?
                  (null? (filter (lambda (line) (string-contains? line "arrows.meta"))
                                 library-lines)))
         (set! libs (cons "\\usetikzlibrary{arrows.meta}" libs)))
       (reverse libs)))
   ```
4. 在 `\begin{document}` 之后，与原有的 `library-lines` 并列输出 `extra-libraries`：
   ```scheme
   (if (null? library-lines) "" (string-append (string-join library-lines "\n") "\n"))
   (if (null? extra-libraries) "" (string-append (string-join extra-libraries "\n") "\n"))
   ```
