### PR TITLE
[0839] 坐标设置弹窗预填入当前坐标

### DIFF
--- a/TeXmacs/progs/graphics/graphics-menu.scm
+++ b/TeXmacs/progs/graphics/graphics-menu.scm
@@ -535,7 +535,13 @@
 ) ;menu-bind
 
 (menu-bind graphics-control-point-pos-menu
- ("Set position" (interactive graphics-set-control-point-position))
+  ("Set position"
+   (interactive
+     (lambda (x y) (graphics-set-control-point-position x y))
+     (list "X coordinate" "string" (get-control-point-x (stree-radical (car (sketch-get1))) selected-point-no))
+     (list "Y coordinate" "string" (get-control-point-y (stree-radical (car (sketch-get1))) selected-point-no))
+   ) ;interactive
+  ) ;"Set position"
 ) ;menu-bind
 
 (menu-bind graphics-line-width-menu

--- a/TeXmacs/progs/graphics/graphics-menu.scm
+++ b/TeXmacs/progs/graphics/graphics-menu.scm
@@ -535,13 +535,18 @@
 ) ;menu-bind
 
 (menu-bind graphics-control-point-pos-menu
-  ("Set position"
-   (interactive
-     (lambda (x y) (graphics-set-control-point-position x y))
-     (list "X coordinate" "string" (get-control-point-x (stree-radical (car (sketch-get1))) selected-point-no))
-     (list "Y coordinate" "string" (get-control-point-y (stree-radical (car (sketch-get1))) selected-point-no))
+ ("Set position"
+   (interactive (lambda (x y) (graphics-set-control-point-position x y))
+     (list "X coordinate"
+       "string"
+       (get-control-point-x (stree-radical (car (sketch-get1))) selected-point-no)
+     ) ;list
+     (list "Y coordinate"
+       "string"
+       (get-control-point-y (stree-radical (car (sketch-get1))) selected-point-no)
+     ) ;list
    ) ;interactive
-  ) ;"Set position"
+ ) ;
 ) ;menu-bind
 
 (menu-bind graphics-line-width-menu

--- a/devel/0839.md
+++ b/devel/0839.md
@@ -1,0 +1,36 @@
+# [0839] 坐标设置弹窗预填入当前坐标
+
+## 1 相关文档
+- [0838.md](0838.md) - 支持控制点编辑与拖拽
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-menu.scm` — 重构 `graphics-control-point-pos-menu`，将静态参数注入重构为包含动态默认值的交互规格列表。
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在绘图区对绘制任意图形，右键单击该图形的控制点
+2. 属性栏显示 `位置` 组件，点击后弹窗内应该写入了当前的坐标
+3. 修改后确定，应该会更新图形
+
+## 4 What
+目前在通过属性工具栏的 `"Position:"` 复合坐标组件弹窗微调控制点位置时，弹出的两个连续输入框（X 坐标与 Y 坐标）是完全空白的，无法直观地展示并基于当前控制点的物理数值进行微调。
+
+本次修改为该弹出输入框增加了坐标默认值预填入功能，自动加载当前极点的实际位置作为输入框的默认初始值。
+
+## 5 How
+- 动态参数求值：在 `graphics-menu.scm` 的位置设置菜单 `graphics-control-point-pos-menu` 中，不再直接绑定单纯的函数名，而是将其改写为携带动态参数的 lambda：
+  ```scheme
+  (interactive
+    (lambda (x y) (graphics-set-control-point-position x y))
+    (list "X coordinate" "string" (get-control-point-x (stree-radical (car (sketch-get1))) selected-point-no))
+    (list "Y coordinate" "string" (get-control-point-y (stree-radical (car (sketch-get1))) selected-point-no))
+  )
+  ```
+- 当用户触发 `"Set position"` 命令时，渲染菜单首先执行求值，实时拉取选中极点的当前实际 X, Y 轴数值并作为第 3 个参数注入到交互参数规格列表中，由 Mogan 物理输入对话框展示为默认预填内容。


### PR DESCRIPTION
# [0839] 坐标设置弹窗预填入当前坐标

## 1 相关文档
- [0838.md](0838.md) - 支持控制点编辑与拖拽

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-menu.scm` — 重构 `graphics-control-point-pos-menu`，将静态参数注入重构为包含动态默认值的交互规格列表。

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在绘图区对绘制任意图形，右键单击该图形的控制点
2. 属性栏显示 `位置` 组件，点击后弹窗内应该写入了当前的坐标
3. 修改后确定，应该会更新图形

## 4 What
目前在通过属性工具栏的 `"Position:"` 复合坐标组件弹窗微调控制点位置时，弹出的两个连续输入框（X 坐标与 Y 坐标）是完全空白的，无法直观地展示并基于当前控制点的物理数值进行微调。

本次修改为该弹出输入框增加了坐标默认值预填入功能，自动加载当前极点的实际位置作为输入框的默认初始值。

## 5 How
- 动态参数求值：在 `graphics-menu.scm` 的位置设置菜单 `graphics-control-point-pos-menu` 中，不再直接绑定单纯的函数名，而是将其改写为携带动态参数的 lambda：
  ```scheme
  (interactive
    (lambda (x y) (graphics-set-control-point-position x y))
    (list "X coordinate" "string" (get-control-point-x (stree-radical (car (sketch-get1))) selected-point-no))
    (list "Y coordinate" "string" (get-control-point-y (stree-radical (car (sketch-get1))) selected-point-no))
  )
  ```
- 当用户触发 `"Set position"` 命令时，渲染菜单首先执行求值，实时拉取选中极点的当前实际 X, Y 轴数值并作为第 3 个参数注入到交互参数规格列表中，由 Mogan 物理输入对话框展示为默认预填内容。
