### PR TITLE
[0842] 修复数学模式下 `Ctrl+I` 无法斜体

### DIFF
--- a/TeXmacs/progs/generic/format-edit.scm
+++ b/TeXmacs/progs/generic/format-edit.scm
@@ -565,7 +565,9 @@
 (tm-define (toggle-bold) (toggle-with-like '(with "font-series" "bold" "") #f))
 
 (tm-define (toggle-italic)
-  (toggle-with-like '(with "font-shape" "italic" "") #f)
+  (if (in-math?)
+      (make 'math-it)
+      (toggle-with-like '(with "font-shape" "italic" "") #f))
 ) ;tm-define
 
 (tm-define (toggle-small-caps)

--- a/TeXmacs/progs/generic/format-edit.scm
+++ b/TeXmacs/progs/generic/format-edit.scm
@@ -566,8 +566,9 @@
 
 (tm-define (toggle-italic)
   (if (in-math?)
-      (make 'math-it)
-      (toggle-with-like '(with "font-shape" "italic" "") #f))
+    (make 'math-it)
+    (toggle-with-like '(with "font-shape" "italic" "") #f)
+  ) ;if
 ) ;tm-define
 
 (tm-define (toggle-small-caps)

--- a/devel/0842.md
+++ b/devel/0842.md
@@ -1,0 +1,35 @@
+# [0842] 修复数学模式下 `Ctrl+I` 无法斜体
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/format-edit.scm` — 优化 `toggle-italic`，在数学模式下使用 `math-it`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在普通文本模式下按下 `Ctrl+I`，应正常产生斜体
+2. 在数学模式下按下 `Ctrl+I`，也应正常产生斜体
+
+## 4 What
+解决在数学公式中按 `Ctrl+I` 无法直观显示斜体的问题，通过在数学模式下智能注入 `math-it` 来优化斜体快捷键。
+
+## 5 Why
+在文本模式下字形由 `font-shape` 控制，而在数学模式下由 `math-font-shape` 决定。数学排版具有严格的语义约束（如数字直立、变量斜体），为避免外界普通文本样式污染数学公式，排版引擎有意隔离了 `font-shape` 向数学模式的继承。相反，字重属性 `font-series` 是继承的，因而加粗可以直接生效。
+
+## 6 How
+修改 `format-edit.scm` 中的 `toggle-italic` 函数：
+```scheme
+(tm-define (toggle-italic)
+  (if (in-math?)
+      (make 'math-it)
+      (toggle-with-like '(with "font-shape" "italic" "") #f))
+) ;tm-define
+```


### PR DESCRIPTION
# [0842] 修复数学模式下 `Ctrl+I` 无法斜体

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/format-edit.scm` — 优化 `toggle-italic`，在数学模式下使用 `math-it`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在普通文本模式下按下 `Ctrl+I`，应正常产生斜体
2. 在数学模式下按下 `Ctrl+I`，也应正常产生斜体

## 4 What
解决在数学公式中按 `Ctrl+I` 无法直观显示斜体的问题，通过在数学模式下智能注入 `math-it` 来优化斜体快捷键。

## 5 Why
在文本模式下字形由 `font-shape` 控制，而在数学模式下由 `math-font-shape` 决定。数学排版具有严格的语义约束（如数字直立、变量斜体），为避免外界普通文本样式污染数学公式，排版引擎有意隔离了 `font-shape` 向数学模式的继承。相反，字重属性 `font-series` 是继承的，因而加粗可以直接生效。

## 6 How
修改 `format-edit.scm` 中的 `toggle-italic` 函数：
```scheme
(tm-define (toggle-italic)
  (if (in-math?)
      (make 'math-it)
      (toggle-with-like '(with "font-shape" "italic" "") #f))
) ;tm-define
```
