### PR TITLE
[1135] 实现 telemetry 假插件

### DIFF
--- a/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
@@ -25,7 +25,10 @@
 
 (import (texmacs protocol))
 
-(define telemetry-log-path "/tmp/telemetry.log")
+(define telemetry-log-path
+  (path->string (path-join (path-temp-dir) "telemetry.log"))
+) ;define
+
 
 ;; 插件进程与主进程的握手：启动时必须 flush 插件名 "telemetry"，
 ;; 否则主进程不会进入 DATA_COMMAND 状态、无法投递后续负载。

--- a/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
@@ -1,0 +1,93 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-telemetry.scm
+;; DESCRIPTION : Fake telemetry plugin entry for goldfish
+;; COPYRIGHT   : (C) 2026 Mogan Developers
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii base) (liii path))
+(set! *load-path*
+  (cons (path->string (path-parent (port-filename))) *load-path*)
+) ;set!
+
+(import (texmacs protocol))
+
+(define telemetry-log-path "/tmp/telemetry.log")
+
+;; 插件进程与主进程的握手：启动时必须 flush 插件名 "telemetry"，
+;; 否则主进程不会进入 DATA_COMMAND 状态、无法投递后续负载。
+
+(define (welcome)
+  (flush-verbatim "telemetry")
+) ;define
+
+;; 主进程发送的 payload 可能是 (document "...") 或直接字符串，
+;; 统一提取为字符串；无法识别时返回空字符串。
+
+(define (document->string doc)
+  (cond ((and (pair? doc) (eq? (car doc) 'document) (= (length doc) 2)) (cadr doc))
+        ((string? doc) doc)
+        (else "")
+  ) ;cond
+) ;define
+
+(define (telemetry-log message)
+  (catch #t
+    (lambda () (path-append-text telemetry-log-path (string-append message "\n")))
+    (lambda args
+      (flush-verbatim (string-append "telemetry error: " (object->string args)))
+    ) ;lambda
+  ) ;catch
+) ;define
+
+(define (handle-telemetry payload)
+  (catch #t
+    (lambda ()
+      (let ((s (document->string payload)))
+        (if (string=? s "")
+          (flush-verbatim "telemetry skipped: empty payload")
+          (begin
+            (telemetry-log s)
+            (flush-verbatim "telemetry logged")
+          ) ;begin
+        ) ;if
+      ) ;let
+    ) ;lambda
+    (lambda args
+      (flush-verbatim (string-append "telemetry exception: " (object->string args)))
+    ) ;lambda
+  ) ;catch
+) ;define
+
+(define (read-eval-print)
+  (catch #t
+    (lambda ()
+      (let ((code (read-paragraph-by-visible-eof)))
+        (if (or (eof-object? code) (string=? code ""))
+          #t
+          (begin
+            (handle-telemetry code)
+            (read-eval-print)
+          ) ;begin
+        ) ;if
+      ) ;let
+    ) ;lambda
+    (lambda args #t)
+  ) ;catch
+) ;define
+
+(welcome)
+(read-eval-print)

--- a/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
@@ -25,10 +25,13 @@
 
 (import (texmacs protocol))
 
-(define telemetry-log-path
-  (path->string (path-join (path-temp-dir) "telemetry.log"))
+(define (telemetry-home)
+  (path-from-env "TEXMACS_HOME_PATH")
 ) ;define
 
+(define telemetry-log-path
+  (path->string (path-join (telemetry-home) "telemetry.log"))
+) ;define
 
 ;; 插件进程与主进程的握手：启动时必须 flush 插件名 "telemetry"，
 ;; 否则主进程不会进入 DATA_COMMAND 状态、无法投递后续负载。

--- a/TeXmacs/plugins/telemetry/progs/init-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/progs/init-telemetry.scm
@@ -1,0 +1,46 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-telemetry.scm
+;; DESCRIPTION : Initialize the fake 'telemetry' plugin
+;; COPYRIGHT   : (C) 2026 Mogan Developers
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (binary goldfish))
+(import (liii path))
+
+(define (telemetry-serialize lan t)
+  (with u
+    (pre-serialize lan t)
+    (with s (texmacs->utf8raw (stree->tree u)) (string-append s "\n<EOF>\n"))
+  ) ;with
+) ;define
+
+(define (launcher)
+  (let* ((home (path-from-env "TEXMACS_HOME_PATH"))
+         (sys (path-from-env "TEXMACS_PATH"))
+         (user (path-join home "plugins" "telemetry" "goldfish" "tm-telemetry.scm"))
+         (sys-path (path-join sys "plugins" "telemetry" "goldfish" "tm-telemetry.scm"))
+         (entry (if (url-exists? (path->string user))
+                  (path->string user)
+                  (path->string sys-path)
+                ) ;if
+         ) ;entry
+        ) ;
+    (string-append (string-quote (url->system (find-binary-goldfish)))
+      " "
+      (string-quote (url->system entry))
+    ) ;string-append
+  ) ;let*
+) ;define
+
+(plugin-configure telemetry
+  (:require (has-binary-goldfish?))
+  (:launch ,(launcher))
+  (:serializer ,telemetry-serialize)
+) ;plugin-configure

--- a/devel/1135.md
+++ b/devel/1135.md
@@ -18,7 +18,7 @@
 
 ### 3.2 非确定性测试（集成验证）
 
-构建 Mogan 并启动后，通过 `silent-feed*` 向 telemetry 插件发送 JSON，检查 `/tmp/telemetry.log` 是否按预期追加内容：
+构建 Mogan 并启动后，通过 `silent-feed*` 向 telemetry 插件发送 JSON，检查系统临时目录下的 `telemetry.log` 是否按预期追加内容：
 
 ```scheme
 (silent-feed* "telemetry"
@@ -37,7 +37,7 @@ TEXMACS_PATH=$(pwd)/TeXmacs \
   build/.../MoganSTEM -headless -x "(silent-feed* 'telemetry \"\" '(document \"{\\\"event\\\":\\\"test\\\"}\") (lambda (r) (noop)) '())"
 ```
 
-最终效果：`/tmp/telemetry.log` 会追加收到的 JSON 字符串。
+最终效果：系统临时目录下的 `telemetry.log` 会追加收到的 JSON 字符串。
 
 ## 4 如何提交
 
@@ -50,7 +50,7 @@ git diff
 
 ## 5 What
 
-实现一个 fake telemetry 插件，仅用于接收 Mogan 主进程传入的 JSON 数据，并将 JSON 字符串追加写入 `/tmp/telemetry.log`。
+实现一个 fake telemetry 插件，仅用于接收 Mogan 主进程传入的 JSON 数据，并将 JSON 字符串追加写入系统临时目录下的 `telemetry.log`。
 
 1. 新增 `init-telemetry.scm`，完成插件注册、启动命令和序列化函数。
 2. 新增 `tm-telemetry.scm`，在 Goldfish 子进程中读取主进程发送的 JSON 并写日志。
@@ -66,6 +66,6 @@ git diff
 
 - `progs/init-telemetry.scm` 使用 `plugin-configure` 注册插件名 `telemetry`，并通过 `(has-binary-goldfish?)` 检查 Goldfish 解释器是否存在。`:launch` 指定启动命令，`:serializer` 指定把待发送内容转换为以 `\n<EOF>\n` 结尾的可见 EOF 格式，供 Goldfish 端的 `read-paragraph-by-visible-eof` 读取。
 
-- `goldfish/tm-telemetry.scm` 启动时先 `flush-verbatim "telemetry"` 完成握手；随后循环调用 `read-paragraph-by-visible-eof` 读取主进程发来的段落。读到的内容可能是 `(document "...")` 或直接字符串，统一用 `document->string` 提取。提取结果追加到 `/tmp/telemetry.log`，写完后回显确认消息，等待下一次通信。
+- `goldfish/tm-telemetry.scm` 启动时先 `flush-verbatim "telemetry"` 完成握手；随后循环调用 `read-paragraph-by-visible-eof` 读取主进程发来的段落。读到的内容可能是 `(document "...")` 或直接字符串，统一用 `document->string` 提取。日志路径通过 `(path-join (path-temp-dir) "telemetry.log")` 获取，自动适配 Windows/Linux/macOS，提取结果追加到该临时日志文件，写完后回显确认消息，等待下一次通信。
 
 - 为保持简单，不单独拆出 `(liii telemetry)` 库；写日志与数据提取逻辑直接放在 `tm-telemetry.scm` 中。所有写操作被 `catch` 包裹，避免非法输入导致子进程崩溃。

--- a/devel/1135.md
+++ b/devel/1135.md
@@ -1,0 +1,71 @@
+# [1135] 实现 telemetry 假插件
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+- [autosave 插件](../TeXmacs/plugins/autosave) - 参考实现
+
+## 2 任务相关的代码文件
+
+- `TeXmacs/plugins/telemetry/progs/init-telemetry.scm`
+- `TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+
+`tm-telemetry.scm` 是纯 Goldfish Scheme 脚本，可在加载 `(texmacs protocol)` 与相关 liii 库后，用 `gf eval` 或 Goldfish REPL 手动验证 `document->string`、`telemetry-log` 等辅助函数。
+
+### 3.2 非确定性测试（集成验证）
+
+构建 Mogan 并启动后，通过 `silent-feed*` 向 telemetry 插件发送 JSON，检查 `/tmp/telemetry.log` 是否按预期追加内容：
+
+```scheme
+(silent-feed* "telemetry"
+  ""
+  `(document "{key:value}")
+  (lambda (r) (noop))
+  '()
+) ;silent-feed*
+```
+
+也可在 headless 模式下用命令行触发：
+
+```bash
+xmake b stem
+TEXMACS_PATH=$(pwd)/TeXmacs \
+  build/.../MoganSTEM -headless -x "(silent-feed* 'telemetry \"\" '(document \"{\\\"event\\\":\\\"test\\\"}\") (lambda (r) (noop)) '())"
+```
+
+最终效果：`/tmp/telemetry.log` 会追加收到的 JSON 字符串。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+git diff
+```
+
+## 5 What
+
+实现一个 fake telemetry 插件，仅用于接收 Mogan 主进程传入的 JSON 数据，并将 JSON 字符串追加写入 `/tmp/telemetry.log`。
+
+1. 新增 `init-telemetry.scm`，完成插件注册、启动命令和序列化函数。
+2. 新增 `tm-telemetry.scm`，在 Goldfish 子进程中读取主进程发送的 JSON 并写日志。
+3. 子进程保持插件协议握手与循环读取，确保 Mogan 主进程能正常投递后续负载。
+
+## 6 Why
+
+需要一个轻量的占位插件来验证 Mogan 的插件通信链路、序列化/反序列化流程，以及外部 Goldfish 进程接收并处理 JSON 负载的能力。telemetry 插件本身不做真实的数据上报，仅把收到的内容写到本地日志，便于调试和集成测试。
+
+## 7 How
+
+参考 autosave 插件的两层结构：
+
+- `progs/init-telemetry.scm` 使用 `plugin-configure` 注册插件名 `telemetry`，并通过 `(has-binary-goldfish?)` 检查 Goldfish 解释器是否存在。`:launch` 指定启动命令，`:serializer` 指定把待发送内容转换为以 `\n<EOF>\n` 结尾的可见 EOF 格式，供 Goldfish 端的 `read-paragraph-by-visible-eof` 读取。
+
+- `goldfish/tm-telemetry.scm` 启动时先 `flush-verbatim "telemetry"` 完成握手；随后循环调用 `read-paragraph-by-visible-eof` 读取主进程发来的段落。读到的内容可能是 `(document "...")` 或直接字符串，统一用 `document->string` 提取。提取结果追加到 `/tmp/telemetry.log`，写完后回显确认消息，等待下一次通信。
+
+- 为保持简单，不单独拆出 `(liii telemetry)` 库；写日志与数据提取逻辑直接放在 `tm-telemetry.scm` 中。所有写操作被 `catch` 包裹，避免非法输入导致子进程崩溃。


### PR DESCRIPTION
## 摘要

参考 autosave 插件结构实现一个 fake telemetry 插件：
- 接收 Mogan 主进程传入的 JSON
- 将 JSON 字符串追加写入 `/tmp/telemetry.log`

## 变更内容

- `TeXmacs/plugins/telemetry/progs/init-telemetry.scm`
  - 注册 `telemetry` 插件
  - 配置 Goldfish 启动命令和 serializer
- `TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm`
  - 子进程入口，完成握手后循环读取 JSON
  - 使用 `path-append-text` 追加写入 `/tmp/telemetry.log`
  - 空输入和 EOF 均优雅处理
- `devel/1135.md`
  - 按任务文档模板记录实现细节和测试方式

## 测试方式

```scheme
(silent-feed* "telemetry"
  ""
  `(document "{key:value}")
  (lambda (r) (noop))
  '()
) ;silent-feed*
```

效果：`/tmp/telemetry.log` 追加收到 JSON。

🤖 Generated with [Claude Code](https://claude.com/claude-code)