### PR TITLE
[1136] 新增 telemetry upload-events 触发与假插件日志

### DIFF
--- a/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
@@ -18,7 +18,7 @@
 ;; limitations under the License.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(import (liii base) (liii path))
+(import (scheme base) (liii base) (liii path) (liii json) (srfi srfi-19))
 
 (import (texmacs protocol))
 
@@ -51,12 +51,34 @@
   (path-append-text telemetry-log-path (string-append message "\n"))
 ) ;define
 
+;; 把 payload 中的 Unix 时间戳转换成本地可读时间，方便日志排查。
+;; 如果解析失败或没有时间戳，则按原样记录。
+
+(define (format-payload s)
+  (catch #t
+    (lambda ()
+      (let* ((json (string->json s)) (ts (json-ref json "time")))
+        (if (number? ts)
+          (let* ((sec (inexact->exact (truncate ts)))
+                 (date (time-utc->date (make-time TIME-UTC 0 sec)))
+                 (date-str (date->string date "~Y-~m-~d ~H:~M:~S"))
+                ) ;
+            (json->string (json-push (json-drop json "time") "time" date-str))
+          ) ;let*
+          (json->string json)
+        ) ;if
+      ) ;let*
+    ) ;lambda
+    (lambda args s)
+  ) ;catch
+) ;define
+
 (define (handle-telemetry payload)
   (let ((s (document->string payload)))
     (if (string=? s "")
       (flush-verbatim "telemetry skipped: empty payload")
       (begin
-        (telemetry-log s)
+        (telemetry-log (format-payload s))
         (flush-verbatim "telemetry logged")
       ) ;begin
     ) ;if

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -80,7 +80,9 @@
             ) ;begin
           ) ;if
           (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
-          (if (string=? event-type "CLOSE") (upload-events event-type))
+          (if (or (string=? event-type "INVITE_CLICK") (string=? event-type "VIP_CLICK"))
+            (upload-events event-type)
+          ) ;if
         ) ;let
         #t
       ) ;begin

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -11,7 +11,9 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (telemetry telemetry-track) (:use (telemetry telemetry-utils)))
+(texmacs-module (telemetry telemetry-track)
+  (:use (telemetry telemetry-utils) (utils plugins plugin-eval))
+) ;texmacs-module
 
 (import (scheme base)
   (liii base)
@@ -22,6 +24,30 @@
 ) ;import
 
 (define-public *telemetry-event-queue* '())
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Upload trigger: notify the telemetry plugin that an upload should start
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (upload-events event)
+  (if (not (telemetry-enabled?))
+    #f
+    (let* ((ts (telemetry-now))
+           (payload (list (cons "time" ts) (cons "event" event)))
+           (json (telemetry->json payload))
+          ) ;
+      (silent-feed* "telemetry" "" `(document ,json) (lambda (r) (noop)) '())
+      (display (string-append "[telemetry] upload triggered by "
+                 event
+                 " (ts="
+                 (number->string ts)
+                 ")\n"
+               ) ;string-append
+      ) ;display
+      #t
+    ) ;let*
+  ) ;if
+) ;define-public
 
 (define-public (track-event event-type properties)
   (if (not (telemetry-enabled?))
@@ -54,6 +80,7 @@
             ) ;begin
           ) ;if
           (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
+          (if (string=? event-type "CLOSE") (upload-events event-type))
         ) ;let
         #t
       ) ;begin

--- a/devel/1136.md
+++ b/devel/1136.md
@@ -1,0 +1,96 @@
+# [1136] telemetry-track 新增 upload-events 并优化假插件日志
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+- [1135.md](1135.md) - telemetry 假插件实现
+
+## 2 任务相关的代码文件
+
+- `TeXmacs/progs/telemetry/telemetry-track.scm`
+- `TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试/局部验证）
+
+Goldfish 侧的时间戳转换和 JSON 处理是独立逻辑，可在 gf eval 中快速验证：
+
+```scheme
+(import (srfi srfi-19) (liii json))
+(define ts (inexact->exact (truncate (current-second))))
+(define date-str
+  (date->string (time-utc->date (make-time TIME-UTC 0 ts)) "~Y-~m-~d ~H:~M:~S"))
+(display date-str) (newline)
+```
+
+### 3.2 非确定性测试（集成验证）
+
+构建并启动 Mogan 后：
+
+1. 触发埋点事件，例如关闭窗口时 `track-event` 会自动触发 `upload-events`。
+2. 检查 `$TEXMACS_HOME_PATH/telemetry.log`：
+   - 应包含 `time` 字段的人类可读时间戳。
+   - 应包含上传的事件列表。
+
+也可在 headless 模式下手动触发：
+
+```bash
+xmake b stem
+TEXMACS_PATH=$(pwd)/TeXmacs \
+  build/.../MoganSTEM -headless -x "(import-from (telemetry telemetry-track)) (track-event \"CLOSE\" '())"
+```
+
+## 4 如何提交
+
+提交前执行：
+
+```bash
+gf fmt --changed-since=main
+git diff
+```
+
+## 5 What
+
+在 `telemetry-track.scm` 中新增 `upload-events`：
+
+1. `upload-events` 接收一个参数：触发本次上传的 event name。
+2. payload 包含触发上传的 Unix 时间戳和触发上传的 event name。
+3. 参考 autosave 的 `silent-feed*` 调用方式，通过 telemetry 假插件投递 payload。
+4. `track-event` 收到 `"CLOSE"` 事件时立即调用 `(upload-events "CLOSE")`。
+
+在 `tm-telemetry.scm` 中：
+
+1. 解析收到的 JSON payload。
+2. 将 `time` 字段从 Unix 时间戳转换为本地人类可读时间。
+3. 转换后再写入 `telemetry.log`，便于排查问题。
+
+## 6 Why
+
+之前 telemetry 数据仅通过 `telemetry-flush` 写入本地 jsonl 文件，缺少一个向外部插件触发的上传入口。新增 `upload-events` 后，可以在关键事件（如关闭应用）时立即把埋点数据发送给 telemetry 插件，方便后续实现真正的上传工作流。
+
+在假插件侧把时间戳转换为可读格式，可以直接在日志中看到上传发生的具体时间，降低调试成本。
+
+## 7 How
+
+### 7.1 upload-events
+
+- 位于 `telemetry-track.scm`。
+- 与 `telemetry-utils` 共用事件序列化函数 `telemetry->json`。
+- payload 结构：
+
+```json
+{
+  "time": 1752850000,
+  "event": "CLOSE"
+}
+```
+
+- 使用 `silent-feed*` 向 `telemetry` 插件发送 `(document ,json)`。
+
+### 7.2 假插件日志格式化
+
+- 在 `tm-telemetry.scm` 中引入 `(liii json)` 和 `(srfi srfi-19)`。
+- `format-payload` 先尝试 `string->json`，若失败则按原样记录。
+- 对 `time` 字段使用 `make-time`、`time-utc->date`、`date->string` 转换为 `"~Y-~m-~d ~H:~M:~S"` 格式。
+- 转换后通过 `json->string` 写回日志。

--- a/devel/1136.md
+++ b/devel/1136.md
@@ -28,17 +28,17 @@ Goldfish 侧的时间戳转换和 JSON 处理是独立逻辑，可在 gf eval �
 
 构建并启动 Mogan 后：
 
-1. 触发埋点事件，例如关闭窗口时 `track-event` 会自动触发 `upload-events`。
+1. 触发 `INVITE_CLICK` 或 `VIP_CLICK` 埋点事件，例如 `(track-event "VIP_CLICK" '())`，`track-event` 会自动调用 `upload-events`。
 2. 检查 `$TEXMACS_HOME_PATH/telemetry.log`：
    - 应包含 `time` 字段的人类可读时间戳。
-   - 应包含上传的事件列表。
+   - 应包含触发上传的 `event` 字段。
 
 也可在 headless 模式下手动触发：
 
 ```bash
 xmake b stem
 TEXMACS_PATH=$(pwd)/TeXmacs \
-  build/.../MoganSTEM -headless -x "(import-from (telemetry telemetry-track)) (track-event \"CLOSE\" '())"
+  build/.../MoganSTEM -headless -x "(import-from (telemetry telemetry-track)) (track-event \"VIP_CLICK\" '())"
 ```
 
 ## 4 如何提交
@@ -57,7 +57,7 @@ git diff
 1. `upload-events` 接收一个参数：触发本次上传的 event name。
 2. payload 包含触发上传的 Unix 时间戳和触发上传的 event name。
 3. 参考 autosave 的 `silent-feed*` 调用方式，通过 telemetry 假插件投递 payload。
-4. `track-event` 收到 `"CLOSE"` 事件时立即调用 `(upload-events "CLOSE")`。
+4. `track-event` 收到 `"INVITE_CLICK"` 或 `"VIP_CLICK"` 事件时自动调用 `upload-events`。
 
 在 `tm-telemetry.scm` 中：
 
@@ -67,7 +67,7 @@ git diff
 
 ## 6 Why
 
-之前 telemetry 数据仅通过 `telemetry-flush` 写入本地 jsonl 文件，缺少一个向外部插件触发的上传入口。新增 `upload-events` 后，可以在关键事件（如关闭应用）时立即把埋点数据发送给 telemetry 插件，方便后续实现真正的上传工作流。
+之前 telemetry 数据仅通过 `telemetry-flush` 写入本地 jsonl 文件，缺少一个向外部插件触发的上传入口。新增 `upload-events` 后，可以在需要时（例如由调度器或外部事件）向 telemetry 插件发送上传触发指令，方便后续实现真正的上传工作流。
 
 在假插件侧把时间戳转换为可读格式，可以直接在日志中看到上传发生的具体时间，降低调试成本。
 
@@ -82,7 +82,7 @@ git diff
 ```json
 {
   "time": 1752850000,
-  "event": "CLOSE"
+  "event": "INVITE_CLICK"
 }
 ```
 


### PR DESCRIPTION
## Summary

- 在 `TeXmacs/progs/telemetry/telemetry-track.scm` 中新增 `upload-events`：
  - 接收触发上传的 event name，通过 `silent-feed*` 向 telemetry 假插件发送 payload。
  - payload 包含 Unix 时间戳和 event name：`{\"time\": <ts>, \"event\": \"<name>\"}`。
  - `track-event` 在 `"INVITE_CLICK"` 和 `"VIP_CLICK"` 时自动触发上传。
- 在 `TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm` 中解析 payload，将 `time` 字段转换为本地可读时间后写入日志。
- 新增/更新 `devel/1136.md` 任务文档。

## Test plan

- [ ] 构建 `xmake b stem`。
- [ ] headless 触发 `(track-event \"INVITE_CLICK\" '())` 或 `(track-event \"VIP_CLICK\" '())`，检查 `$TEXMACS_HOME_PATH/telemetry.log` 中 `time` 已转换为可读格式。
- [ ] 确认 `upload-events` 收到 payload 后插件返回 `telemetry logged`。