### PR TITLE
[1137] 登录成功后新增 LOGIN 事件并触发 upload-events

### DIFF
--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -80,7 +80,10 @@
             ) ;begin
           ) ;if
           (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
-          (if (or (string=? event-type "INVITE_CLICK") (string=? event-type "VIP_CLICK"))
+          (if (or (string=? event-type "LOGIN")
+                (string=? event-type "INVITE_CLICK")
+                (string=? event-type "VIP_CLICK")
+              ) ;or
             (upload-events event-type)
           ) ;if
         ) ;let

--- a/devel/1137.md
+++ b/devel/1137.md
@@ -1,0 +1,90 @@
+# [1137] 登录完成后新增 LOGIN 埋点事件并触发上传
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+- [1136.md](1136.md) - telemetry upload-events 触发
+
+## 2 任务相关的代码文件
+
+- `src/Plugins/Qt/QTMOAuth.cpp`
+- `TeXmacs/progs/telemetry/telemetry-track.scm`
+
+## 3 如何测试
+
+### 3.1 单元/局部验证
+
+在 headless 模式下直接触发 `LOGIN` 事件，检查终端输出：
+
+```bash
+xmake b stem
+TEXMACS_PATH=$(pwd)/TeXmacs \
+  build/.../MoganSTEM -headless -x "(import-from (telemetry telemetry-track)) (track-event \"LOGIN\" '())"
+```
+
+预期输出包含：
+
+- `[telemetry] track: LOGIN (queue: ...)`
+- `[telemetry] upload triggered by LOGIN (ts=...)`
+
+并检查 `$TEXMACS_HOME_PATH/telemetry.log` 包含格式化的上传日志（含人类可读时间戳和 event 字段）。
+
+### 3.2 集成验证
+
+1. 启动 Mogan 商业版，完成 OAuth 登录。
+2. 登录成功后，`$TEXMACS_HOME_PATH/telemetry/log/` 下的 jsonl 文件或内存队列中应出现 `LOGIN` 事件。
+3. 同时 telemetry 假插件应收到上传触发，日志中可见 `LOGIN` 对应的上传记录。
+
+## 4 如何提交
+
+提交前执行：
+
+```bash
+gf fmt --changed-since=main
+git diff
+```
+
+## 5 What
+
+1. 在 `QTMOAuth::handleAuthorizationCode` 的 token 交换成功路径中新增 `telemetry_track("LOGIN")`，记录登录完成事件。
+2. 在 `telemetry-track.scm` 的 `track-event` 中把 `"LOGIN"` 加入立即触发 `upload-events` 的事件类型列表（与 `"INVITE_CLICK"`、`"VIP_CLICK"` 并列）。
+3. 新增 `devel/1137.md` 任务文档。
+
+## 6 Why
+
+登录是用户生命周期的关键节点，需要在 telemetry 中记录。由于登录完成后回调页面会立即重定向到 growth-url，产品侧希望该事件能立刻触发上传，便于实时感知登录行为，而不是等待定时 flush。
+
+## 7 How
+
+### 7.1 C++ 侧埋点
+
+- 文件：`src/Plugins/Qt/QTMOAuth.cpp`
+- 在成功获取并保存 `access_token` 后，设置 `m_isLoggedIn= true` 时同步调用：
+
+  ```cpp
+  telemetry_track ("LOGIN");
+  ```
+
+- 新增 `#include "telemetry.hpp"`。
+- `telemetry_track` 在 `IS_COMMUNITY` 构建下为空操作，因此不需要额外的宏保护。
+
+### 7.2 Scheme 侧触发 upload-events
+
+- 文件：`TeXmacs/progs/telemetry/telemetry-track.scm`
+- 在 `track-event` 函数中，把判断立即上传的条件从：
+
+  ```scheme
+  (if (or (string=? event-type "INVITE_CLICK") (string=? event-type "VIP_CLICK"))
+    (upload-events event-type)
+  ```
+
+  扩展为：
+
+  ```scheme
+  (if (or (string=? event-type "LOGIN")
+          (string=? event-type "INVITE_CLICK")
+          (string=? event-type "VIP_CLICK"))
+    (upload-events event-type)
+  ```
+
+- 复用已有的 `upload-events` 函数，payload 包含触发时间和事件名。

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -12,6 +12,7 @@
 #include "QTMOAuth.hpp"
 #include "qt_utilities.hpp"
 #include "scheme.hpp"
+#include "telemetry.hpp"
 #include "tm_sys_utils.hpp"
 
 #include <QtGui/qdesktopservices.h>
@@ -204,6 +205,9 @@ QTMOAuth::handleAuthorizationCode (const QString& code) {
 
         // 设置登录状态
         m_isLoggedIn= true;
+
+        // 记录 LOGIN 事件
+        telemetry_track ("LOGIN");
 
         if (!refreshToken.isEmpty ()) {
           m_refreshToken= refreshToken;


### PR DESCRIPTION
## Summary

- 在 `QTMOAuth::handleAuthorizationCode` 的 token 交换成功路径中新增 `telemetry_track("LOGIN")`。
- 在 `telemetry-track.scm` 的 `track-event` 中将 `"LOGIN"` 加入立即触发 `upload-events` 的事件类型列表（与 `"INVITE_CLICK"`、`"VIP_CLICK"` 并列）。
- 新增 `devel/1137.md` 任务文档。

## Test plan

- [ ] 构建通过 `xmake b stem`
- [ ] headless 模式下执行 `(track-event "LOGIN" '())`，终端出现 `[telemetry] track: LOGIN ...` 与 `[telemetry] upload triggered by LOGIN ...`
- [ ] 检查 `$TEXMACS_HOME_PATH/telemetry.log` 包含格式化的 LOGIN 上传日志
- [ ] 完成一次真实 OAuth 登录，确认 LOGIN 事件被记录并触发上传

🤖 Generated with [Claude Code](https://claude.com/claude-code)