### PR TITLE
[1138] HEART_BEAT, TUTORIAL, LOGIN, OAUTH，STARTUP 事件

### DIFF
--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -82,7 +82,6 @@
           (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
           (if (or (string=? event-type "HEART_BEAT")
                 (string=? event-type "LOGIN")
-                (string=? event-type "OAUTH")
                 (string=? event-type "TUTORIAL")
                 (string=? event-type "INVITE_CLICK")
                 (string=? event-type "VIP_CLICK")

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -51,6 +51,7 @@
 
 (define-public (important-event? event-type)
   (or (string=? event-type "HEART_BEAT")
+    (string=? event-type "STARTUP")
     (string=? event-type "TUTORIAL")
     (string=? event-type "INVITE_CLICK")
     (string=? event-type "VIP_CLICK")

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -80,7 +80,8 @@
             ) ;begin
           ) ;if
           (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
-          (if (or (string=? event-type "LOGIN")
+          (if (or (string=? event-type "HEART_BEAT")
+                (string=? event-type "LOGIN")
                 (string=? event-type "INVITE_CLICK")
                 (string=? event-type "VIP_CLICK")
               ) ;or

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -82,6 +82,8 @@
           (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
           (if (or (string=? event-type "HEART_BEAT")
                 (string=? event-type "LOGIN")
+                (string=? event-type "OAUTH")
+                (string=? event-type "TUTORIAL")
                 (string=? event-type "INVITE_CLICK")
                 (string=? event-type "VIP_CLICK")
               ) ;or

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -49,6 +49,15 @@
   ) ;if
 ) ;define-public
 
+(define-public (important-event? event-type)
+  (or (string=? event-type "HEART_BEAT")
+    (string=? event-type "LOGIN")
+    (string=? event-type "TUTORIAL")
+    (string=? event-type "INVITE_CLICK")
+    (string=? event-type "VIP_CLICK")
+  ) ;or
+) ;define-public
+
 (define-public (track-event event-type properties)
   (if (not (telemetry-enabled?))
     #f
@@ -79,15 +88,13 @@
               ) ;display
             ) ;begin
           ) ;if
-          (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
-          (if (or (string=? event-type "HEART_BEAT")
-                (string=? event-type "LOGIN")
-                (string=? event-type "TUTORIAL")
-                (string=? event-type "INVITE_CLICK")
-                (string=? event-type "VIP_CLICK")
-              ) ;or
-            (upload-events event-type)
+          (if (important-event? event-type)
+            (begin
+              (telemetry-flush)
+              (upload-events event-type)
+            ) ;begin
           ) ;if
+          (if (>= len (telemetry-get-buffer-size)) (telemetry-flush))
         ) ;let
         #t
       ) ;begin

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -51,7 +51,6 @@
 
 (define-public (important-event? event-type)
   (or (string=? event-type "HEART_BEAT")
-    (string=? event-type "LOGIN")
     (string=? event-type "TUTORIAL")
     (string=? event-type "INVITE_CLICK")
     (string=? event-type "VIP_CLICK")

--- a/TeXmacs/progs/telemetry/telemetry-utils.scm
+++ b/TeXmacs/progs/telemetry/telemetry-utils.scm
@@ -24,7 +24,7 @@
 
 (import (only (srfi srfi-19) current-date date->string date-zone-offset))
 
-(define telemetry-buffer-size 300)
+(define telemetry-buffer-size 20)
 
 (define telemetry-flush-interval-ms 300000)
 (define-public telemetry-max-queue-size 1000)

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -1,0 +1,84 @@
+# [1138] 登录刷新令牌后新增 HEART_BEAT 埋点事件并触发上传
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+- [1137.md](1137.md) - 登录完成后新增 LOGIN 埋点事件
+
+## 2 任务相关的代码文件
+
+- `src/Plugins/Qt/QTMOAuth.cpp`
+- `TeXmacs/progs/telemetry/telemetry-track.scm`
+
+## 3 如何测试
+
+### 3.1 单元/局部验证
+
+在 headless 模式下直接触发 `HEART_BEAT` 事件，检查终端输出：
+
+```bash
+xmake b stem
+TEXMACS_PATH=$(pwd)/TeXmacs \
+  build/.../MoganSTEM -headless -x "(import-from (telemetry telemetry-track)) (track-event \"HEART_BEAT\" '())"
+```
+
+预期输出包含：
+
+- `[telemetry] track: HEART_BEAT (queue: ...)`
+- `[telemetry] upload triggered by HEART_BEAT (ts=...)`
+
+### 3.2 集成验证
+
+1. 启动 Mogan 商业版，完成 OAuth 登录后，等待自动刷新令牌（或触发刷新令牌流程）。
+2. 刷新成功后，`$TEXMACS_HOME_PATH/telemetry/log/` 下的 jsonl 文件或内存队列中应出现 `HEART_BEAT` 事件。
+3. telemetry 假插件应收到上传触发，日志中可见 `HEART_BEAT` 对应的上传记录。
+
+## 4 如何提交
+
+提交前执行：
+
+```bash
+gf fmt --changed-since=main
+git diff
+```
+
+## 5 What
+
+1. 在 `QTMOAuth::refreshToken` 的刷新成功路径中新增 `telemetry_track("HEART_BEAT")`，记录登录令牌刷新事件。
+2. 在 `telemetry-track.scm` 的 `track-event` 中把 `"HEART_BEAT"` 加入立即触发 `upload-events` 的事件类型列表（与 `"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）。
+3. 新增 `devel/1138.md` 任务文档。
+
+## 6 Why
+
+登录刷新令牌是活跃用户在线的重要信号，需要在 telemetry 中记录并立即触发上传，便于服务端实时感知用户活跃状态。
+
+## 7 How
+
+### 7.1 C++ 侧埋点
+
+- 文件：`src/Plugins/Qt/QTMOAuth.cpp`
+- 在 `refreshToken` 成功获取并保存新的 `access_token` 后、确保登录状态之前，同步调用：
+
+  ```cpp
+  telemetry_track ("HEART_BEAT");
+  ```
+
+- `telemetry.hpp` 已在该文件引入，无需再次添加。
+- `telemetry_track` 在 `IS_COMMUNITY` 构建下为空操作，因此不需要额外的宏保护。
+
+### 7.2 Scheme 侧触发 upload-events
+
+- 文件：`TeXmacs/progs/telemetry/telemetry-track.scm`
+- 在 `track-event` 函数中，把判断立即上传的条件扩展为：
+
+  ```scheme
+  (if (or (string=? event-type "HEART_BEAT")
+          (string=? event-type "LOGIN")
+          (string=? event-type "INVITE_CLICK")
+          (string=? event-type "VIP_CLICK")
+        ) ;or
+    (upload-events event-type)
+  ) ;if
+  ```
+
+- 复用已有的 `upload-events` 函数，payload 包含触发时间和事件名。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -50,7 +50,7 @@ git diff
 2. 将 `LOGIN` 事件的触发从 `QTMOAuth` 移到 `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数内，并在初始登录态直接检查时同步处理，使登录状态变化信号与埋点一一对应。
 3. 在 `FirstLaunchTutorialController` 的引导完成回调中，当完成原因为 `Completed` 时记录 `telemetry_track("TUTORIAL")`。
 4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）；`"OAUTH"` 仅入队，不立即上传。
-5. 将 `telemetry-utils.scm` 中的 `telemetry-buffer-size` 从 `300` 调整为 `20`，使普通事件更快落盘。
+6. 将 `QTMOAuth` 构造函数中的 `loadExistingToken()` 移除，改在 `qt_tm_widget.cpp` 的 `checkLocalTokenAndLogin()`（点击个人信息页/登录按钮入口）中调用，实现 token 的懒加载。
 
 ## 6 Why
 
@@ -157,4 +157,27 @@ git diff
   (define telemetry-buffer-size 20)
   ```
 
-- 该阈值由 `track-event` 中 `(>= len (telemetry-get-buffer-size))` 判断使用，达到后会调用 `telemetry-flush` 将内存队列写入 jsonl 文件。
+### 7.5 token 懒加载
+
+- 文件：`src/Plugins/Qt/QTMOAuth.cpp`、`src/Plugins/Qt/qt_tm_widget.cpp`
+- 将 `QTMOAuth` 构造函数末尾的 `loadExistingToken()` 调用移除，避免启动时立即加载本地 token：
+
+  ```cpp
+  // 原构造函数中的调用已删除
+  // loadExistingToken ();
+  ```
+
+- 在 `qt_tm_widget_rep::checkLocalTokenAndLogin()`（用户点击个人信息页/登录按钮时触发）中，先调用 `QTMOAuth::loadExistingToken()` 加载本地 token，再执行后续登录态判断与用户信息获取：
+
+  ```cpp
+  if (is_server_started ()) {
+    tm_server_rep* server=
+        dynamic_cast<tm_server_rep*> (get_server ().operator->());
+    if (server && server->getAccount ()) {
+      QTMOAuth* account= server->getAccount ();
+      account->loadExistingToken ();
+    }
+  }
+  ```
+
+- 这样 token 只在用户主动打开个人信息相关入口时才加载，减少启动时的不必要网络/文件操作。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -124,17 +124,28 @@ git diff
 ### 7.3 Scheme 侧触发 upload-events
 
 - 文件：`TeXmacs/progs/telemetry/telemetry-track.scm`
-- 在 `track-event` 函数中，把判断立即上传的条件扩展为：
+- 新增 `important-event?` 判断函数，当前包含 `"HEART_BEAT"`、`"LOGIN"`、`"TUTORIAL"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 五个事件（`"OAUTH"` 不入列）：
 
   ```scheme
-  (if (or (string=? event-type "HEART_BEAT")
-          (string=? event-type "LOGIN")
-          (string=? event-type "TUTORIAL")
-          (string=? event-type "INVITE_CLICK")
-          (string=? event-type "VIP_CLICK")
-        ) ;or
-    (upload-events event-type)
+  (define-public (important-event? event-type)
+    (or (string=? event-type "HEART_BEAT")
+        (string=? event-type "LOGIN")
+        (string=? event-type "TUTORIAL")
+        (string=? event-type "INVITE_CLICK")
+        (string=? event-type "VIP_CLICK")
+    ) ;or
+  ) ;define-public
+  ```
+
+- 在 `track-event` 中，若事件为 `important-event?`，则先执行 `(telemetry-flush)` 落盘内存队列中的已有事件，再调用 `(upload-events event-type)` 触发本次重要事件的上传：
+
+  ```scheme
+  (if (important-event? event-type)
+    (begin
+      (telemetry-flush)
+      (upload-events event-type)
+    ) ;begin
   ) ;if
   ```
 
-- `OAUTH` 事件仅加入事件队列，不触发立即上传；`TUTORIAL` 事件与 `LOGIN`、`HEART_BEAT` 等一样立即触发上传。
+- 复用已有的 `upload-events` 函数，payload 包含触发时间和事件名。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -50,7 +50,7 @@ git diff
 2. 将 `LOGIN` 事件的触发从 `QTMOAuth` 移到 `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数内，并在初始登录态直接检查时同步处理，使登录状态变化信号与埋点一一对应。
 3. 在 `FirstLaunchTutorialController` 的引导完成回调中，当完成原因为 `Completed` 时记录 `telemetry_track("TUTORIAL")`。
 4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）；`"OAUTH"` 仅入队，不立即上传。
-5. 已在 `refreshToken` 成功路径中新增 `telemetry_track("HEART_BEAT")`，记录登录令牌刷新事件。
+5. 将 `telemetry-utils.scm` 中的 `telemetry-buffer-size` 从 `300` 调整为 `20`，使普通事件更快落盘。
 
 ## 6 Why
 
@@ -148,4 +148,13 @@ git diff
   ) ;if
   ```
 
-- 复用已有的 `upload-events` 函数，payload 包含触发时间和事件名。
+### 7.4 调整内存队列触发落盘的阈值
+
+- 文件：`TeXmacs/progs/telemetry/telemetry-utils.scm`
+- 将 `telemetry-buffer-size` 从 `300` 改为 `20`，降低批量落盘的等待事件数：
+
+  ```scheme
+  (define telemetry-buffer-size 20)
+  ```
+
+- 该阈值由 `track-event` 中 `(>= len (telemetry-get-buffer-size))` 判断使用，达到后会调用 `telemetry-flush` 将内存队列写入 jsonl 文件。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -49,7 +49,7 @@ git diff
 1. 在 `QTMOAuth::handleAuthorizationCode` 的 OAuth 登录成功路径中，把原来的 `telemetry_track("LOGIN")` 改为 `telemetry_track("OAUTH")`，用于区分 OAuth 授权登录方式。
 2. 将 `LOGIN` 事件的触发从 `QTMOAuth` 移到 `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数内，并在初始登录态直接检查时同步处理，使登录状态变化信号与埋点一一对应。
 3. 在 `FirstLaunchTutorialController` 的引导完成回调中，当完成原因为 `Completed` 时记录 `telemetry_track("TUTORIAL")`。
-4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"OAUTH"` 与 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）。
+4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）；`"OAUTH"` 仅入队，不立即上传。
 5. 已在 `refreshToken` 成功路径中新增 `telemetry_track("HEART_BEAT")`，记录登录令牌刷新事件。
 
 ## 6 Why
@@ -129,7 +129,6 @@ git diff
   ```scheme
   (if (or (string=? event-type "HEART_BEAT")
           (string=? event-type "LOGIN")
-          (string=? event-type "OAUTH")
           (string=? event-type "TUTORIAL")
           (string=? event-type "INVITE_CLICK")
           (string=? event-type "VIP_CLICK")
@@ -138,4 +137,4 @@ git diff
   ) ;if
   ```
 
-- 复用已有的 `upload-events` 函数，payload 包含触发时间和事件名。
+- `OAUTH` 事件仅加入事件队列，不触发立即上传；`TUTORIAL` 事件与 `LOGIN`、`HEART_BEAT` 等一样立即触发上传。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -77,32 +77,39 @@ git diff
 
 #### LOGIN
 
-- 文件：`src/Plugins/Qt/qt_tm_widget.cpp`
-- 在连接 `loginStateChanged` 的槽函数中，登录态为 `true` 时记录：
+- 文件：`src/Plugins/Qt/QTMOAuth.cpp`
+- 在 `m_isLoggedIn` 被设置为 `true` 之后直接记录，确保 LOGIN 事件与登录状态切换严格对应。涉及以下三处：
 
-  ```cpp
-  QObject::connect (account, &QTMOAuth::loginStateChanged,
-                    [this] (bool loggedIn) {
-                      if (loggedIn) {
-                        telemetry_track ("LOGIN");
-                        syncScmGuestNotification (false);
-                        refreshMembershipInfoInBackground ();
-                      }
-                      else {
-                        syncScmMembershipNotification (false);
-                        checkNetworkAvailable ();
-                      }
-                    });
-  ```
+  1. `handleAuthorizationCode` 成功获取并保存 token 后：
 
-- 在窗口初始化时，若账号已经处于登录态，同步补记一次：
+     ```cpp
+     m_isLoggedIn= true;
+     telemetry_track ("LOGIN");
+     telemetry_track ("OAUTH");
+     emit loginStateChanged (true);
+     ```
 
-  ```cpp
-  if (account->isLoggedIn ()) {
-    telemetry_track ("LOGIN");
-    refreshMembershipInfoInBackground ();
-  }
-  ```
+  2. `refreshToken` 刷新后发现此前未登录时：
+
+     ```cpp
+     if (!m_isLoggedIn) {
+       m_isLoggedIn= true;
+       telemetry_track ("LOGIN");
+       emit loginStateChanged (true);
+     }
+     ```
+
+  3. `checkTokenStatus` 检查到 token 有效且未过期、此前未登录时：
+
+     ```cpp
+     if (!m_isLoggedIn) {
+       m_isLoggedIn= true;
+       telemetry_track ("LOGIN");
+       emit loginStateChanged (true);
+     }
+     ```
+
+- `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数不再记录 `LOGIN`，避免重复。
 
 #### TUTORIAL
 
@@ -124,12 +131,11 @@ git diff
 ### 7.3 Scheme 侧触发 upload-events
 
 - 文件：`TeXmacs/progs/telemetry/telemetry-track.scm`
-- 新增 `important-event?` 判断函数，当前包含 `"HEART_BEAT"`、`"LOGIN"`、`"TUTORIAL"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 五个事件（`"OAUTH"` 不入列）：
+- 新增 `important-event?` 判断函数，当前包含 `"HEART_BEAT"`、`"TUTORIAL"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 四个事件（`"LOGIN"`、`"OAUTH"` 不入列）：
 
   ```scheme
   (define-public (important-event? event-type)
     (or (string=? event-type "HEART_BEAT")
-        (string=? event-type "LOGIN")
         (string=? event-type "TUTORIAL")
         (string=? event-type "INVITE_CLICK")
         (string=? event-type "VIP_CLICK")
@@ -158,3 +164,10 @@ git diff
   ```
 
 - 该阈值由 `track-event` 中 `(>= len (telemetry-get-buffer-size))` 判断使用，达到后会调用 `telemetry-flush` 将内存队列写入 jsonl 文件。
+
+## 8 变更记录
+
+### 2026-07-17
+
+- 将 `"LOGIN"` 从 `important-event?` 列表中移除，使其不再作为立即触发上传的重要事件；`LOGIN` 仍会被正常入队，由队列阈值或心跳等其它事件触发落盘上传。
+- 将 `LOGIN` 事件的记录位置从 `qt_tm_widget.cpp` 的 `loginStateChanged` 槽函数调整到 `QTMOAuth.cpp` 中所有 `m_isLoggedIn= true` 之后直接触发，保证埋点与状态切换一一对应。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -8,6 +8,8 @@
 ## 2 任务相关的代码文件
 
 - `src/Plugins/Qt/QTMOAuth.cpp`
+- `src/Plugins/Qt/qt_tm_widget.cpp`
+- `src/Plugins/Qt/qt_tutorial.cpp`
 - `TeXmacs/progs/telemetry/telemetry-track.scm`
 
 ## 3 如何测试
@@ -44,9 +46,11 @@ git diff
 
 ## 5 What
 
-1. 在 `QTMOAuth::refreshToken` 的刷新成功路径中新增 `telemetry_track("HEART_BEAT")`，记录登录令牌刷新事件。
-2. 在 `telemetry-track.scm` 的 `track-event` 中把 `"HEART_BEAT"` 加入立即触发 `upload-events` 的事件类型列表（与 `"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）。
-3. 新增 `devel/1138.md` 任务文档。
+1. 在 `QTMOAuth::handleAuthorizationCode` 的 OAuth 登录成功路径中，把原来的 `telemetry_track("LOGIN")` 改为 `telemetry_track("OAUTH")`，用于区分 OAuth 授权登录方式。
+2. 将 `LOGIN` 事件的触发从 `QTMOAuth` 移到 `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数内，并在初始登录态直接检查时同步处理，使登录状态变化信号与埋点一一对应。
+3. 在 `FirstLaunchTutorialController` 的引导完成回调中，当完成原因为 `Completed` 时记录 `telemetry_track("TUTORIAL")`。
+4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"OAUTH"` 与 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）。
+5. 已在 `refreshToken` 成功路径中新增 `telemetry_track("HEART_BEAT")`，记录登录令牌刷新事件。
 
 ## 6 Why
 
@@ -54,19 +58,70 @@ git diff
 
 ## 7 How
 
-### 7.1 C++ 侧埋点
+### 7.1 区分 OAUTH、LOGIN 与 TUTORIAL 事件
+
+- `OAUTH` 只在用户通过 OAuth 授权码流程完成登录时记录，表示本次登录采用的授权方式。
+- `LOGIN` 在登录状态由 `false` 切换为 `true` 时记录。通过把埋点放在 `loginStateChanged` 信号的槽函数内，保证与状态变化信号一一对应。
+- `TUTORIAL` 在新用户引导教程完成（`TutorialFinishReason::Completed`）时记录。
+
+### 7.2 C++ 侧埋点
+
+#### OAUTH
 
 - 文件：`src/Plugins/Qt/QTMOAuth.cpp`
-- 在 `refreshToken` 成功获取并保存新的 `access_token` 后、确保登录状态之前，同步调用：
+- 在 `handleAuthorizationCode` 成功获取并保存 token 后，把原 `LOGIN` 改为：
 
   ```cpp
-  telemetry_track ("HEART_BEAT");
+  telemetry_track ("OAUTH");
   ```
 
-- `telemetry.hpp` 已在该文件引入，无需再次添加。
+#### LOGIN
+
+- 文件：`src/Plugins/Qt/qt_tm_widget.cpp`
+- 在连接 `loginStateChanged` 的槽函数中，登录态为 `true` 时记录：
+
+  ```cpp
+  QObject::connect (account, &QTMOAuth::loginStateChanged,
+                    [this] (bool loggedIn) {
+                      if (loggedIn) {
+                        telemetry_track ("LOGIN");
+                        syncScmGuestNotification (false);
+                        refreshMembershipInfoInBackground ();
+                      }
+                      else {
+                        syncScmMembershipNotification (false);
+                        checkNetworkAvailable ();
+                      }
+                    });
+  ```
+
+- 在窗口初始化时，若账号已经处于登录态，同步补记一次：
+
+  ```cpp
+  if (account->isLoggedIn ()) {
+    telemetry_track ("LOGIN");
+    refreshMembershipInfoInBackground ();
+  }
+  ```
+
+#### TUTORIAL
+
+- 文件：`src/Plugins/Qt/qt_tutorial.cpp`
+- 引入 `telemetry.hpp`。
+- 在 `FirstLaunchTutorialController` 完成回调中，当用户完成教程时记录：
+
+  ```cpp
+  [this] (TutorialFinishReason reason) {
+    if (reason == TutorialFinishReason::Completed) {
+      telemetry_track ("TUTORIAL");
+    }
+    // ... 原 Completed/Skipped 处理逻辑
+  }
+  ```
+
 - `telemetry_track` 在 `IS_COMMUNITY` 构建下为空操作，因此不需要额外的宏保护。
 
-### 7.2 Scheme 侧触发 upload-events
+### 7.3 Scheme 侧触发 upload-events
 
 - 文件：`TeXmacs/progs/telemetry/telemetry-track.scm`
 - 在 `track-event` 函数中，把判断立即上传的条件扩展为：
@@ -74,6 +129,8 @@ git diff
   ```scheme
   (if (or (string=? event-type "HEART_BEAT")
           (string=? event-type "LOGIN")
+          (string=? event-type "OAUTH")
+          (string=? event-type "TUTORIAL")
           (string=? event-type "INVITE_CLICK")
           (string=? event-type "VIP_CLICK")
         ) ;or

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -46,11 +46,12 @@ git diff
 
 ## 5 What
 
-1. 在 `QTMOAuth::handleAuthorizationCode` 的 OAuth 登录成功路径中，把原来的 `telemetry_track("LOGIN")` 改为 `telemetry_track("OAUTH")`，用于区分 OAuth 授权登录方式。
-2. 将 `LOGIN` 事件的触发从 `QTMOAuth` 移到 `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数内，并在初始登录态直接检查时同步处理，使登录状态变化信号与埋点一一对应。
+1. 在 `QTMOAuth::handleAuthorizationCode` 的 OAuth 登录成功路径中记录 `telemetry_track("OAUTH")`，用于区分 OAuth 授权登录方式。
+2. 将 `LOGIN` 事件的触发放在 `QTMOAuth.cpp` 中所有 `m_isLoggedIn= true` 之后直接记录，保证与登录状态切换一一对应；`qt_tm_widget.cpp` 的 `loginStateChanged` 槽函数不再记录 `LOGIN`。
 3. 在 `FirstLaunchTutorialController` 的引导完成回调中，当完成原因为 `Completed` 时记录 `telemetry_track("TUTORIAL")`。
-4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）；`"OAUTH"` 仅入队，不立即上传。
-5. 将 `telemetry-utils.scm` 中的 `telemetry-buffer-size` 从 `300` 调整为 `20`，使普通事件更快落盘。
+4. 在 `QTMStartupTabWidget` 首次 `showEvent` 时记录 `telemetry_track("STARTUP")`，标记用户实际看到软件首页。
+5. 在 `telemetry-track.scm` 的 `important-event?` 中加入 `"STARTUP"`，与 `"HEART_BEAT"`、`"TUTORIAL"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 一起作为立即触发 `upload-events` 的重要事件；`"LOGIN"`、`"OAUTH"` 仅入队，不立即上传。
+6. 将 `telemetry-utils.scm` 中的 `telemetry-buffer-size` 从 `300` 调整为 `20`，使普通事件更快落盘。
 
 ## 6 Why
 
@@ -61,8 +62,9 @@ git diff
 ### 7.1 区分 OAUTH、LOGIN 与 TUTORIAL 事件
 
 - `OAUTH` 只在用户通过 OAuth 授权码流程完成登录时记录，表示本次登录采用的授权方式。
-- `LOGIN` 在登录状态由 `false` 切换为 `true` 时记录。通过把埋点放在 `loginStateChanged` 信号的槽函数内，保证与状态变化信号一一对应。
+- `LOGIN` 在 `QTMOAuth` 中登录状态由 `false` 切换为 `true` 时直接记录，保证与状态变化一一对应。
 - `TUTORIAL` 在新用户引导教程完成（`TutorialFinishReason::Completed`）时记录。
+- `STARTUP` 在用户首次看到软件首页（`QTMStartupTabWidget` 首次 `showEvent`）时记录。
 
 ### 7.2 C++ 侧埋点
 
@@ -111,6 +113,35 @@ git diff
 
 - `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数不再记录 `LOGIN`，避免重复。
 
+#### STARTUP
+
+- 文件：`src/Plugins/Qt/QTMStartupTabWidget.cpp`
+- 引入 `telemetry.hpp`。
+- 在类声明中新增 `showEvent` 重写和一个 `startupTracked_` 标记：
+
+  ```cpp
+  protected:
+    void showEvent (QShowEvent* event) override;
+    // ...
+  private:
+    bool startupTracked_= false;
+  ```
+
+- 在 `showEvent` 中首次显示时记录 `STARTUP`：
+
+  ```cpp
+  void
+  QTMStartupTabWidget::showEvent (QShowEvent* event) {
+    QWidget::showEvent (event);
+    if (!startupTracked_) {
+      startupTracked_= true;
+      telemetry_track ("STARTUP");
+    }
+  }
+  ```
+
+- 该事件在用户体验层面表示“打开软件首页”，因此放在 `showEvent` 而非构造函数中，确保用户实际看到首页才触发。
+
 #### TUTORIAL
 
 - 文件：`src/Plugins/Qt/qt_tutorial.cpp`
@@ -131,11 +162,12 @@ git diff
 ### 7.3 Scheme 侧触发 upload-events
 
 - 文件：`TeXmacs/progs/telemetry/telemetry-track.scm`
-- 新增 `important-event?` 判断函数，当前包含 `"HEART_BEAT"`、`"TUTORIAL"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 四个事件（`"LOGIN"`、`"OAUTH"` 不入列）：
+- 新增 `important-event?` 判断函数，当前包含 `"HEART_BEAT"`、`"STARTUP"`、`"TUTORIAL"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 五个事件（`"LOGIN"`、`"OAUTH"` 不入列）：
 
   ```scheme
   (define-public (important-event? event-type)
     (or (string=? event-type "HEART_BEAT")
+        (string=? event-type "STARTUP")
         (string=? event-type "TUTORIAL")
         (string=? event-type "INVITE_CLICK")
         (string=? event-type "VIP_CLICK")
@@ -171,3 +203,4 @@ git diff
 
 - 将 `"LOGIN"` 从 `important-event?` 列表中移除，使其不再作为立即触发上传的重要事件；`LOGIN` 仍会被正常入队，由队列阈值或心跳等其它事件触发落盘上传。
 - 将 `LOGIN` 事件的记录位置从 `qt_tm_widget.cpp` 的 `loginStateChanged` 槽函数调整到 `QTMOAuth.cpp` 中所有 `m_isLoggedIn= true` 之后直接触发，保证埋点与状态切换一一对应。
+- 新增 `"STARTUP"` 事件，在 `QTMStartupTabWidget` 首次 `showEvent` 时记录，并加入 `important-event?`，作为重要事件立即触发上传。

--- a/devel/1138.md
+++ b/devel/1138.md
@@ -50,7 +50,7 @@ git diff
 2. 将 `LOGIN` 事件的触发从 `QTMOAuth` 移到 `qt_tm_widget.cpp` 中 `loginStateChanged` 信号的槽函数内，并在初始登录态直接检查时同步处理，使登录状态变化信号与埋点一一对应。
 3. 在 `FirstLaunchTutorialController` 的引导完成回调中，当完成原因为 `Completed` 时记录 `telemetry_track("TUTORIAL")`。
 4. 在 `telemetry-track.scm` 的 `track-event` 中把 `"TUTORIAL"` 加入立即触发 `upload-events` 的事件类型列表（与 `"HEART_BEAT"`、`"LOGIN"`、`"INVITE_CLICK"`、`"VIP_CLICK"` 并列）；`"OAUTH"` 仅入队，不立即上传。
-6. 将 `QTMOAuth` 构造函数中的 `loadExistingToken()` 移除，改在 `qt_tm_widget.cpp` 的 `checkLocalTokenAndLogin()`（点击个人信息页/登录按钮入口）中调用，实现 token 的懒加载。
+5. 将 `telemetry-utils.scm` 中的 `telemetry-buffer-size` 从 `300` 调整为 `20`，使普通事件更快落盘。
 
 ## 6 Why
 
@@ -157,27 +157,4 @@ git diff
   (define telemetry-buffer-size 20)
   ```
 
-### 7.5 token 懒加载
-
-- 文件：`src/Plugins/Qt/QTMOAuth.cpp`、`src/Plugins/Qt/qt_tm_widget.cpp`
-- 将 `QTMOAuth` 构造函数末尾的 `loadExistingToken()` 调用移除，避免启动时立即加载本地 token：
-
-  ```cpp
-  // 原构造函数中的调用已删除
-  // loadExistingToken ();
-  ```
-
-- 在 `qt_tm_widget_rep::checkLocalTokenAndLogin()`（用户点击个人信息页/登录按钮时触发）中，先调用 `QTMOAuth::loadExistingToken()` 加载本地 token，再执行后续登录态判断与用户信息获取：
-
-  ```cpp
-  if (is_server_started ()) {
-    tm_server_rep* server=
-        dynamic_cast<tm_server_rep*> (get_server ().operator->());
-    if (server && server->getAccount ()) {
-      QTMOAuth* account= server->getAccount ();
-      account->loadExistingToken ();
-    }
-  }
-  ```
-
-- 这样 token 只在用户主动打开个人信息相关入口时才加载，减少启动时的不必要网络/文件操作。
+- 该阈值由 `track-event` 中 `(>= len (telemetry-get-buffer-size))` 判断使用，达到后会调用 `telemetry-flush` 将内存队列写入 jsonl 文件。

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -300,12 +300,12 @@ QTMOAuth::refreshToken () {
         call ("account-save-token-expiry",
               from_qstring (QString::number (m_tokenExpiryTime)));
 
-
         // 确保登录状态为true
         if (!m_isLoggedIn) {
           m_isLoggedIn= true;
           emit loginStateChanged (true);
-        } else {
+        }
+        else {
           // 记录 HEART_BEAT 事件
           telemetry_track ("HEART_BEAT");
         }

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -128,6 +128,9 @@ QTMOAuth::QTMOAuth (QObject* parent) {
   connect (m_tokenCheckTimer, &QTimer::timeout, this,
            &QTMOAuth::checkTokenStatus);
   m_tokenCheckTimer->start (90000); // 每一分半检查一次
+
+  // 加载现有的token信息
+  loadExistingToken ();
 }
 
 void

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -128,9 +128,6 @@ QTMOAuth::QTMOAuth (QObject* parent) {
   connect (m_tokenCheckTimer, &QTimer::timeout, this,
            &QTMOAuth::checkTokenStatus);
   m_tokenCheckTimer->start (90000); // 每一分半检查一次
-
-  // 加载现有的token信息
-  loadExistingToken ();
 }
 
 void

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -206,6 +206,9 @@ QTMOAuth::handleAuthorizationCode (const QString& code) {
         // 设置登录状态
         m_isLoggedIn= true;
 
+        // 记录 LOGIN 事件
+        telemetry_track ("LOGIN");
+
         // 记录 OAUTH 事件
         telemetry_track ("OAUTH");
 
@@ -303,6 +306,7 @@ QTMOAuth::refreshToken () {
         // 确保登录状态为true
         if (!m_isLoggedIn) {
           m_isLoggedIn= true;
+          telemetry_track ("LOGIN");
           emit loginStateChanged (true);
         }
         else {
@@ -350,6 +354,7 @@ QTMOAuth::checkTokenStatus () {
   // Token有效且未过期
   if (!m_isLoggedIn) {
     m_isLoggedIn= true;
+    telemetry_track ("LOGIN");
     emit loginStateChanged (true);
   }
 

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -300,6 +300,9 @@ QTMOAuth::refreshToken () {
         call ("account-save-token-expiry",
               from_qstring (QString::number (m_tokenExpiryTime)));
 
+        // 记录 HEART_BEAT 事件
+        telemetry_track ("HEART_BEAT");
+
         // 确保登录状态为true
         if (!m_isLoggedIn) {
           m_isLoggedIn= true;

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -300,13 +300,14 @@ QTMOAuth::refreshToken () {
         call ("account-save-token-expiry",
               from_qstring (QString::number (m_tokenExpiryTime)));
 
-        // 记录 HEART_BEAT 事件
-        telemetry_track ("HEART_BEAT");
 
         // 确保登录状态为true
         if (!m_isLoggedIn) {
           m_isLoggedIn= true;
           emit loginStateChanged (true);
+        } else {
+          // 记录 HEART_BEAT 事件
+          telemetry_track ("HEART_BEAT");
         }
       }
       else {

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -206,8 +206,8 @@ QTMOAuth::handleAuthorizationCode (const QString& code) {
         // 设置登录状态
         m_isLoggedIn= true;
 
-        // 记录 LOGIN 事件
-        telemetry_track ("LOGIN");
+        // 记录 OAUTH 事件
+        telemetry_track ("OAUTH");
 
         if (!refreshToken.isEmpty ()) {
           m_refreshToken= refreshToken;

--- a/src/Plugins/Qt/QTMStartupTabWidget.cpp
+++ b/src/Plugins/Qt/QTMStartupTabWidget.cpp
@@ -14,6 +14,7 @@
 #include "QTMTemplatePage.hpp"
 #include "qt_dpi_utils.hpp"
 #include "qt_utilities.hpp"
+#include "telemetry.hpp"
 #include "template_manager.hpp"
 
 #include <QButtonGroup>
@@ -93,6 +94,15 @@ QTMStartupTabWidget::QTMStartupTabWidget (QWidget* parent)
   stackedWidget->setObjectName ("startup-tab-content"); // 样式在主题CSS中定义
   setup_right_content (stackedWidget);
   mainLayout->addWidget (stackedWidget, 1);
+}
+
+void
+QTMStartupTabWidget::showEvent (QShowEvent* event) {
+  QWidget::showEvent (event);
+  if (!startupTracked_) {
+    startupTracked_= true;
+    telemetry_track ("STARTUP");
+  }
 }
 
 QTMStartupTabWidget::Entry

--- a/src/Plugins/Qt/QTMStartupTabWidget.hpp
+++ b/src/Plugins/Qt/QTMStartupTabWidget.hpp
@@ -47,6 +47,7 @@ private slots:
   void onCategoriesLoaded ();
 
 protected:
+  void showEvent (QShowEvent* event) override;
   void keyPressEvent (QKeyEvent* event) override;
   void keyReleaseEvent (QKeyEvent* event) override;
 
@@ -69,6 +70,7 @@ private:
 private:
   Entry   currentEntry_;
   QString currentCategory_;
+  bool    startupTracked_= false;
 
   // Navigation buttons
   QPushButton*        navHomeBtn_;

--- a/src/Plugins/Qt/QTMStartupTabWidget.hpp
+++ b/src/Plugins/Qt/QTMStartupTabWidget.hpp
@@ -17,6 +17,7 @@
 
 class QKeyEvent;
 class QLabel;
+class QShowEvent;
 class QVBoxLayout;
 class QPushButton;
 class QStackedWidget;

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -933,6 +933,7 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
         QObject::connect (account, &QTMOAuth::loginStateChanged,
                           [this] (bool loggedIn) {
                             if (loggedIn) {
+                              telemetry_track ("LOGIN");
                               syncScmGuestNotification (false);
                               refreshMembershipInfoInBackground ();
                             }
@@ -942,6 +943,7 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
                             }
                           });
         if (account->isLoggedIn ()) {
+          telemetry_track ("LOGIN");
           refreshMembershipInfoInBackground ();
         }
       }

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -2932,16 +2932,6 @@ qt_tm_widget_rep::checkLocalTokenAndLogin () {
   // 根据当前更新状态同步更新区显隐和弹窗几何
   setLoginDialogUpdateSectionVisible (shouldShowLoginDialogUpdateSection ());
 
-  // 点击个人信息页时，让 QTMOAuth 重新加载本地 token
-  if (is_server_started ()) {
-    tm_server_rep* server=
-        dynamic_cast<tm_server_rep*> (get_server ().operator->());
-    if (server && server->getAccount ()) {
-      QTMOAuth* account= server->getAccount ();
-      account->loadExistingToken ();
-    }
-  }
-
   // 使用scheme代码获取本地token缓存
   eval ("(use-modules (liii account))");
   string  token  = as_string (call ("account-load-token"));

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -933,7 +933,6 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
         QObject::connect (account, &QTMOAuth::loginStateChanged,
                           [this] (bool loggedIn) {
                             if (loggedIn) {
-                              telemetry_track ("LOGIN");
                               syncScmGuestNotification (false);
                               refreshMembershipInfoInBackground ();
                             }

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -2932,6 +2932,16 @@ qt_tm_widget_rep::checkLocalTokenAndLogin () {
   // 根据当前更新状态同步更新区显隐和弹窗几何
   setLoginDialogUpdateSectionVisible (shouldShowLoginDialogUpdateSection ());
 
+  // 点击个人信息页时，让 QTMOAuth 重新加载本地 token
+  if (is_server_started ()) {
+    tm_server_rep* server=
+        dynamic_cast<tm_server_rep*> (get_server ().operator->());
+    if (server && server->getAccount ()) {
+      QTMOAuth* account= server->getAccount ();
+      account->loadExistingToken ();
+    }
+  }
+
   // 使用scheme代码获取本地token缓存
   eval ("(use-modules (liii account))");
   string  token  = as_string (call ("account-load-token"));

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -943,7 +943,6 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
                             }
                           });
         if (account->isLoggedIn ()) {
-          telemetry_track ("LOGIN");
           refreshMembershipInfoInBackground ();
         }
       }

--- a/src/Plugins/Qt/qt_tutorial.cpp
+++ b/src/Plugins/Qt/qt_tutorial.cpp
@@ -16,6 +16,7 @@
 #include "qt_gui.hpp"
 #include "qt_utilities.hpp"
 #include "scheme.hpp"
+#include "telemetry.hpp"
 #include "tm_file.hpp"
 
 #include <QApplication>
@@ -1358,6 +1359,10 @@ FirstLaunchTutorialController::FirstLaunchTutorialController (QObject* parent)
       m_startedThisSession (false) {
   connect (m_engine, &TutorialEngine::finished, this,
            [this] (TutorialFinishReason reason) {
+             if (reason == TutorialFinishReason::Completed) {
+               telemetry_track ("TUTORIAL");
+             }
+
              if (reason != TutorialFinishReason::Completed &&
                  reason != TutorialFinishReason::Skipped) {
                return;


### PR DESCRIPTION
## Summary

- 在 `QTMOAuth::refreshToken` 成功刷新并保存 token 后调用 `telemetry_track(\"HEART_BEAT\")`，记录登录令牌刷新事件。
- 在 `telemetry-track.scm` 的 `track-event` 中将 `\"HEART_BEAT\"` 加入立即触发 `upload-events` 的事件类型列表。
- 新增 `devel/1138.md` 任务文档。

## Test plan

- [ ] 本地执行 `xmake b stem` 通过。
- [ ] headless 模式下触发 `(track-event \"HEART_BEAT\" '())` 可看到 `[telemetry] upload triggered by HEART_BEAT` 输出。
- [ ] 商业版集成验证：已登录状态下打开软件，若 token 过期或临近过期则刷新成功后会生成 `HEART_BEAT` 事件并触发上传。

🤖 Generated with [Claude Code](https://claude.com/claude-code)