### PR TITLE
[0845] 图形对象删除magnify属性

### DIFF
--- a/TeXmacs/progs/graphics/graphics-group.scm
+++ b/TeXmacs/progs/graphics/graphics-group.scm
@@ -133,9 +133,7 @@
                                                                 ,group-bary-y))
       ) ;point-norm
     ) ;/
-    (lambda (o)
-      (traverse-transform o (zoom-point group-bary-x group-bary-y h))
-    ) ;lambda
+    (lambda (o) (traverse-transform o (zoom-point group-bary-x group-bary-y h)))
   ) ;with
 ) ;define
 

--- a/TeXmacs/progs/graphics/graphics-group.scm
+++ b/TeXmacs/progs/graphics/graphics-group.scm
@@ -134,17 +134,7 @@
       ) ;point-norm
     ) ;/
     (lambda (o)
-      (let* ((res (traverse-transform o (zoom-point group-bary-x group-bary-y h)))
-             (curmag #f)
-            ) ;
-        (if (eq? (car res) 'with)
-          (with curmag
-            (s2f (find-prop res "magnify" "1.0"))
-            (list-find&set-prop res "magnify" (f2s (* curmag h)))
-          ) ;with
-          `(with ,"magnify" ,(f2s h) ,res)
-        ) ;if
-      ) ;let*
+      (traverse-transform o (zoom-point group-bary-x group-bary-y h))
     ) ;lambda
   ) ;with
 ) ;define
@@ -365,7 +355,7 @@
   ) ;:require
   (with v
     (if (string-starts? var "gr-") (string-drop var 3) var)
-    (if (graphics-mode-attribute? (graphics-mode) v)
+    (if (and (!= v "magnify") (graphics-mode-attribute? (graphics-mode) v))
       (with l (map (cut property-get <> v 0) (sketch-get)) (properties-and l))
       (former var)
     ) ;if
@@ -412,7 +402,7 @@
   ) ;:require
   (with v
     (if (string-starts? var "gr-") (string-drop var 3) var)
-    (if (graphics-mode-attribute? (graphics-mode) v)
+    (if (and (!= v "magnify") (graphics-mode-attribute? (graphics-mode) v))
       (with r (map (cut property-set <> v val) (sketch-get)) (sketch-set! r))
       (former var val)
     ) ;if

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -542,6 +542,7 @@
 (tm-define (graphics-enrich-bis t id tab)
   (set! tab (list->ahash-table (ahash-table->list tab)))
   (ahash-remove! tab "gid")
+  (ahash-remove! tab "magnify")
   (let* ((attrs (graphical-relevant-attributes t))
          (sel (ahash-table-select tab attrs))
          (l1 (cons (cons "gid" id) (ahash-table->list sel)))

--- a/devel/0845.md
+++ b/devel/0845.md
@@ -1,0 +1,31 @@
+# [0845] 图形对象删除magnify属性
+
+## 1 相关文档
+- [0837](0837.md) - 绘图区默认缩放与子单位格线步数自适应
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-utils.scm`
+  - `graphics-enrich-bis`：在属性过滤时新增 `(ahash-remove! tab "magnify")`，防止新创建或提交的图形对象在包装属性时写入局部 `magnify` 键值。
+- `TeXmacs/progs/graphics/graphics-group.scm`
+  - `graphics-get-property` / `graphics-set-property`：在选区属性读写拦截条件中增加 `(!= v "magnify")` 排除检查，防止在选中对象时拦截并误操作画布级的 `magnify` 视图缩放。
+  - `group-zoom`：重构并简化 zoom 缩放工具的行为，不再对图形对象套用局部 `magnify` 属性或包装 `with` wrapper，而是纯粹对顶点执行三维/二维坐标变换。
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+图形在坐标系缩放、zoom 工具缩放、以及对象属性读写时，源码不在出现 magnify 属性
+
+## 4 What
+- 从图形对象的属性包装（Enrichment/Commit）、选中状态的属性读写拦截（Get/Set Property）、以及缩放工具（Group Zoom）中彻底清理 `magnify` 属性的使用。
+- 确保画布视图比例缩放只操作坐标系/网格本身；选中对象的缩放工具也只直接转换顶点坐标，不再为个别图形对象注入或套用 `magnify`。
+
+## 5 How
+- 在 `graphics-utils.scm` 的 `graphics-enrich-bis` 函数内新增 `(ahash-remove! tab "magnify")`，彻底清除向对象包装局部 `magnify` 的可能。
+- 在 `graphics-group.scm` 的选区级 `graphics-get-property` 和 `graphics-set-property` 的拦截条件中，追加 `(!= v "magnify")`。让画布级别视图缩放的 `"magnify"` 属性直接穿透到 `former` 进行全局画布操作。
+- 在 `graphics-group.scm` 的 `group-zoom` 过程中，舍弃对 `with` 及局部 `magnify` 计算与嵌套修改的分支，简化为单一的 `(traverse-transform o (zoom-point group-bary-x group-bary-y h))`，仅对所有 `point` 的顶点坐标作缩放映射。


### PR DESCRIPTION
# [0845] 图形对象删除magnify属性

## 1 相关文档
- [0837](0837.md) - 绘图区默认缩放与子单位格线步数自适应

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-utils.scm`
  - `graphics-enrich-bis`：在属性过滤时新增 `(ahash-remove! tab "magnify")`，防止新创建或提交的图形对象在包装属性时写入局部 `magnify` 键值。
- `TeXmacs/progs/graphics/graphics-group.scm`
  - `graphics-get-property` / `graphics-set-property`：在选区属性读写拦截条件中增加 `(!= v "magnify")` 排除检查，防止在选中对象时拦截并误操作画布级的 `magnify` 视图缩放。
  - `group-zoom`：重构并简化 zoom 缩放工具的行为，不再对图形对象套用局部 `magnify` 属性或包装 `with` wrapper，而是纯粹对顶点执行三维/二维坐标变换。

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
图形在坐标系缩放、zoom 工具缩放、以及对象属性读写时，源码不在出现 magnify 属性

## 4 What
- 从图形对象的属性包装（Enrichment/Commit）、选中状态的属性读写拦截（Get/Set Property）、以及缩放工具（Group Zoom）中彻底清理 `magnify` 属性的使用。
- 确保画布视图比例缩放只操作坐标系/网格本身；选中对象的缩放工具也只直接转换顶点坐标，不再为个别图形对象注入或套用 `magnify`。

## 5 How
- 在 `graphics-utils.scm` 的 `graphics-enrich-bis` 函数内新增 `(ahash-remove! tab "magnify")`，彻底清除向对象包装局部 `magnify` 的可能。
- 在 `graphics-group.scm` 的选区级 `graphics-get-property` 和 `graphics-set-property` 的拦截条件中，追加 `(!= v "magnify")`。让画布级别视图缩放的 `"magnify"` 属性直接穿透到 `former` 进行全局画布操作。
- 在 `graphics-group.scm` 的 `group-zoom` 过程中，舍弃对 `with` 及局部 `magnify` 计算与嵌套修改的分支，简化为单一的 `(traverse-transform o (zoom-point group-bary-x group-bary-y h))`，仅对所有 `point` 的顶点坐标作缩放映射。
