### PR TITLE
[1139] 修复 path-exists? 收到非法参数时崩溃

### DIFF
--- a/TeXmacs/tests/1139.scm
+++ b/TeXmacs/tests/1139.scm
@@ -1,0 +1,58 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1139.scm
+;; DESCRIPTION : Integration test for path-exists? crash fix
+;; COPYRIGHT   : (C) 2026  Da Shen
+;;
+;; 验证编辑器 `path-exists?`（C++ 粘合函数 `tmg_path_existsP`）在收到
+;; boolean、string、number 等非法参数时不会 abort，而是抛出可被捕获的
+;; Scheme 类型错误。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(define (path-exists?-raises-error? arg)
+  "Call editor path-exists? with ARG and return #t if it raises an error
+   instead of returning normally or crashing."
+  (catch #t
+    (lambda () (path-exists? arg) #f)
+    (lambda args #t)))
+
+(define (test-path-exists?-boolean)
+  (display "Testing path-exists? with boolean arguments...\n")
+  ;; 修复前：#t/#f 会进入 tmscm_is_path 的 tmscm_car，触发 s7 abort
+  ;; 修复后：应抛出 Scheme 类型错误
+  (check (path-exists?-raises-error? #t) => #t)
+  (check (path-exists?-raises-error? #f) => #t)
+  (display "boolean arguments tests passed!\n"))
+
+(define (test-path-exists?-other-invalid)
+  (display "Testing path-exists? with other invalid arguments...\n")
+  (check (path-exists?-raises-error? "foo") => #t)
+  (check (path-exists?-raises-error? 42) => #t)
+  (check (path-exists?-raises-error? 'sym) => #t)
+  ;; 列表中只要有一个元素不是整数，就不是合法 path
+  (check (path-exists?-raises-error? '(1 #t)) => #t)
+  (display "other invalid arguments tests passed!\n"))
+
+(define (test-path-exists?-valid)
+  (display "Testing path-exists? with valid arguments...\n")
+  ;; 空路径 (list) 是合法的 path，不应报错；结果应为 boolean
+  (check (boolean? (path-exists? (list))) => #t)
+  ;; 单元素整数路径也是合法 path
+  (check (boolean? (path-exists? '(0))) => #t)
+  (display "valid arguments tests passed!\n"))
+
+(tm-define (test_1139)
+  (display "Running test_1139...\n")
+  (test-path-exists?-boolean)
+  (test-path-exists?-other-invalid)
+  (test-path-exists?-valid)
+  (check-report))

--- a/devel/1139.md
+++ b/devel/1139.md
@@ -1,0 +1,127 @@
+# 1139 修复 `path-exists?` 收到非 path 参数时崩溃
+
+## 问题现象
+
+运行过程中触发崩溃，终端关键日志：
+
+```text
+s7_car[26403]: not a pair, but boolean (type: 7)
+Process terminated by signal: SIGABRT (abort) (6)
+```
+
+`SIGABRT` 由 s7 解释器在类型检查失败时抛出：某个地方把 `boolean` 传给了期望 pair/list 的 `car`。
+
+## 用 addr2line 定位崩溃源
+
+### 关键：PIE 二进制要用偏移量
+
+`moganstem` 是 PIE 可执行文件，backtrace 里打印的地址是运行时的虚拟地址。`addr2line`
+直接使用这些绝对地址会失败（输出 `??:0`），必须传入 `+` 后面的**文件偏移量**。
+
+原始 backtrace 片段：
+
+```text
+build/linux/x86_64/debug/moganstem(+0x1de264) [0x55bf37565264]
+build/linux/x86_64/debug/moganstem(+0x13aebba) [0x55bf38735bba]
+build/linux/x86_64/debug/moganstem(+0x39d013) [0x55bf37724013]
+build/linux/x86_64/debug/moganstem(+0xf5e2a5) [0x55bf382e52a5]
+build/linux/x86_64/debug/moganstem(+0x3b85f8) [0x55bf3773f5f8]
+build/linux/x86_64/debug/moganstem(+0x3d12b4) [0x55bf377582b4]
+```
+
+正确调用方式（取 `+0x...` 部分）：
+
+```bash
+addr2line -e build/linux/x86_64/debug/moganstem -f -C \
+  0x1de264 0x13aebba 0x39d013 0xf5e2a5 0x3b85f8 0x3d12b4
+```
+
+解析结果（关键帧）：
+
+| 偏移量 | 函数 | 文件 |
+|--------|------|------|
+| `0x1de264` | `clean_exit_on_signal` | `src/System/Boot/init_texmacs.cpp:142` |
+| `0x13aebba` | `check_ref_one` | `TeXmacs/plugins/goldfish/src/s7.c:4938` |
+| `0x39d013` | `s7_car` | `TeXmacs/plugins/goldfish/src/s7.c:26403` |
+| `0xf5e2a5` | `tmscm_car` | `moebius/Scheme/S7/s7_tm.hpp:96` |
+| `0x3b85f8` | `tmscm_is_path` | `moebius/Scheme/L1/object_l1.cpp:220` |
+| `0x3d12b4` | `tmg_path_existsP` | `build/.gens/libmogan/linux/x86_64/debug/glue/glue_editor.cpp:86` |
+
+### 调用链解读
+
+崩溃发生在 Scheme 函数 `path-exists?` 的 C++ 粘合层：
+
+```text
+tmg_path_existsP (path-exists?)
+  -> TMSCM_ASSERT_PATH
+    -> tmscm_is_path
+      -> tmscm_car
+        -> s7_car
+          -> abort (not a pair)
+```
+
+`TMSCM_ASSERT_PATH` 先用 `tmscm_is_path` 校验参数，但 `tmscm_is_path` 在递归时直接对非 null 参数调用 `tmscm_car`；当参数是 `#t`/`#f` 这类 boolean 时，`s7_car` 触发类型错误并 abort。
+
+## 根因
+
+`moebius/Scheme/L1/object_l1.cpp` 中的 `tmscm_is_path` 未先判断是否为 pair：
+
+```cpp
+bool
+tmscm_is_path (tmscm p) {
+  if (tmscm_is_null (p)) return true;
+  else return tmscm_is_int (tmscm_car (p)) && tmscm_is_path (tmscm_cdr (p));
+}
+```
+
+同类函数如 `tmscm_is_list_string`、`tmscm_is_list_tree`、`tmscm_is_array_int` 等都先检查了 `tmscm_is_pair(p)`，只有 `tmscm_is_path` 缺少这层防护。
+
+## 修复
+
+在 `tmscm_is_path` 中增加 pair 判断：
+
+```cpp
+bool
+tmscm_is_path (tmscm p) {
+  if (tmscm_is_null (p)) return true;
+  if (!tmscm_is_pair (p)) return false;
+  return tmscm_is_int (tmscm_car (p)) && tmscm_is_path (tmscm_cdr (p));
+}
+```
+
+这样当 `path-exists?` 收到 boolean 等非法参数时，`tmscm_is_path` 会返回 `#f`，`TMSCM_ASSERT_PATH` 再按照正常路径抛出 Scheme 错误（而非 C++ abort）。
+
+## 涉及文件
+
+- `moebius/Scheme/L1/object_l1.cpp`
+- `TeXmacs/tests/1139.scm`
+
+## 集成测试
+
+新增 `TeXmacs/tests/1139.scm`，在 headless Mogan 进程中调用编辑器 `path-exists?`，
+验证以下非法参数均抛出 Scheme 错误而不是 abort：
+
+- `#t`、`#f`
+- `"foo"`
+- `42`
+- `'sym`
+- `'(1 #t)`
+
+同时验证合法 path（`(list)`、`'(0)`）正常返回 boolean。
+
+执行：
+
+```bash
+xmake b 1139
+xmake r 1139
+```
+
+结果：`8 correct, 0 failed`。
+
+## 构建验证
+
+```bash
+xmake b stem
+```
+
+构建通过。

--- a/moebius/Scheme/L1/object_l1.cpp
+++ b/moebius/Scheme/L1/object_l1.cpp
@@ -217,7 +217,8 @@ tmscm_to_list_tree (tmscm p) {
 bool
 tmscm_is_path (tmscm p) {
   if (tmscm_is_null (p)) return true;
-  else return tmscm_is_int (tmscm_car (p)) && tmscm_is_path (tmscm_cdr (p));
+  if (!tmscm_is_pair (p)) return false;
+  return tmscm_is_int (tmscm_car (p)) && tmscm_is_path (tmscm_cdr (p));
 }
 
 tmscm


### PR DESCRIPTION
## 问题

编辑器 `path-exists?`（C++ `tmg_path_existsP`）在收到 boolean 等非法参数时，
`tmscm_is_path` 会直接对非 pair 值调用 `tmscm_car`，导致 s7 抛出
`not a pair, but boolean` 并 abort 整个进程。

## 修复

- 在 `moebius/Scheme/L1/object_l1.cpp` 的 `tmscm_is_path` 中增加
  `tmscm_is_pair` 判断，与同类函数保持一致。
- 非法参数现在会正常触发 `TMSCM_ASSERT_PATH`，抛出 Scheme 类型错误，
  而不是 C++ abort。

## 测试

- 新增集成测试 `TeXmacs/tests/1139.scm`，覆盖 `#t`、`#f`、字符串、数字、
  符号、含非整数元素的列表等非法参数。
- 验证合法 path（`(list)`、`'(0)`）仍正常返回 boolean。
- 本地执行 `xmake b 1139 && xmake r 1139` 通过：8 correct, 0 failed。

## 任务文档

详见 `devel/1139.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)