### PR TITLE
[0846] 绘图区缩放精度与极值锁死问题

### DIFF
--- a/TeXmacs/progs/graphics/graphics-drd.scm
+++ b/TeXmacs/progs/graphics/graphics-drd.scm
@@ -221,7 +221,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (graphics-common-attributes)
-  '("gid" "anim-id" "proviso" "magnify" "color" "opacity")
+  '("gid" "anim-id" "proviso" "color" "opacity")
 ) ;tm-define
 
 (tm-define (graphics-all-attributes)

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -47,8 +47,9 @@
 ;; Extra abbreviations
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(tm-define (graphics-zoom-in) (graphics-zoom 1.189207115))
-(tm-define (graphics-zoom-out) (graphics-zoom 0.840896415))
+(define graphics-zoom-factor 1.189207115002721)
+(tm-define (graphics-zoom-in) (graphics-zoom graphics-zoom-factor))
+(tm-define (graphics-zoom-out) (graphics-zoom (/ 1.0 graphics-zoom-factor)))
 
 (tm-define (graphics-move-origin-left) (graphics-move-origin "+0.01gw" "0gh"))
 (tm-define (graphics-move-origin-right) (graphics-move-origin "-0.01gw" "0gh"))

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -259,10 +259,7 @@
 
 (define (graphics-zoom-unit u magn)
   (let ((base-u (string-append "1" (length-extract-unit u))))
-    (if (== magn "default")
-      base-u
-      (length-mult (magnify->number magn) base-u)
-    ) ;if
+    (if (== magn "default") base-u (length-mult (magnify->number magn) base-u))
   ) ;let
 ) ;define
 

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -257,10 +257,20 @@
   ) ;let*
 ) ;define
 
+(define (graphics-zoom-unit u magn)
+  (let ((base-u (string-append "1" (length-extract-unit u))))
+    (if (== magn "default")
+      base-u
+      (length-mult (magnify->number magn) base-u)
+    ) ;if
+  ) ;let
+) ;define
+
 (tm-define (graphics-zoom e)
   (let* ((fr (graphics-cartesian-frame))
          (u (caddr fr))
-         (newu (length-mult e u))
+         (magn (multiply-magnify (graphics-get-property "magnify") e))
+         (newu (graphics-zoom-unit u magn))
          (newud (length-decode newu))
          (x1 (cadr (cadddr fr)))
          (y1 (caddr (cadddr fr)))
@@ -279,15 +289,14 @@
     ;; (display* "old u = " u "\n")
     ;; (display* "new u = " newu "\n")
     (if (and (> newud 100) (< newud 10000000))
-      (with magn
-        (multiply-magnify (graphics-get-property "magnify") e)
+      (begin
         (graphics-decorations-reset)
         (graphics-set-property "gr-frame" newfr)
         (graphics-set-property "magnify" magn)
         ;; 根据缩放自动调整子格线数量
         (graphics-grid-aspect-autoupdate)
         (graphics-decorations-update)
-      ) ;with
+      ) ;begin
     ) ;if
   ) ;let*
 ) ;tm-define

--- a/devel/0846.md
+++ b/devel/0846.md
@@ -1,0 +1,30 @@
+# [0846] 绘图区缩放精度与极值锁死问题
+
+## 1 相关文档
+- [0845.md](0845.md) - 图形对象删除magnify属性
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-kbd.scm`
+  - `graphics-zoom-in` / `graphics-zoom-out`：定义双精度精确放大系数 `graphics-zoom-factor`，其对应的缩小因子定义为其浮点精确倒数 `(/ 1.0 graphics-zoom-factor)`，实现双向对冲消项。
+- `TeXmacs/progs/graphics/graphics-main.scm`
+  - `graphics-zoom-unit`：新增该私有辅助函数，由 `u` 提取基础物理单位（如 `"1cm"` 或 `"1in"`），然后用 `length-mult` 将数字形式的高精度 `magnify` 投影乘算输出。
+  - `graphics-zoom`：不再迭代累加物理长度，而是通过调用 `graphics-zoom-unit` 从而实现以常数基础单位为基准的无状态高精度缩放转换。
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 交互验证
+多次按 `+` / `-` 进行画布放大和缩小到极限，再拉回来，自动格线和图形线宽都不应该有问题
+
+## 4 What
+- 解决手动缩放 `+` / `-` 中由于缩放因子非精确互逆在反复操作中累积产生的浮点数漂移。
+- 解决在超小或超长周期的缩放过程中，由于连续进行“格式化舍入”导致的长有效位数衰减与锁死问题。
+
+## 5 How
+- 在 `graphics-kbd.scm` 中，将硬编码单精度因子 `1.189207115` 和 `0.840896415` 替换为以 `graphics-zoom-factor = 2^(1/4)` 与其浮点精确倒数 `(/ 1.0 graphics-zoom-factor)` 组合，确保累乘结果始终恒等于 `1.0` 从而完美触发系统的容差归零机制。
+- 在 `graphics-main.scm` 中定义 `graphics-zoom-unit` 辅助函数。在 `graphics-zoom` 中用 `(length-mult (magnify->number magn) base-u)` 替换旧式的 `(length-mult e u)`。通过直接乘算不变的常数基础物理单位，将格式化处理安全交付 C++ 原生引擎，保障绝对排版安全与最佳性能。


### PR DESCRIPTION
# [0846] 绘图区缩放精度与极值锁死问题

## 1 相关文档
- [0845.md](0845.md) - 图形对象删除magnify属性

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-kbd.scm`
  - `graphics-zoom-in` / `graphics-zoom-out`：定义双精度精确放大系数 `graphics-zoom-factor`，其对应的缩小因子定义为其浮点精确倒数 `(/ 1.0 graphics-zoom-factor)`，实现双向对冲消项。
- `TeXmacs/progs/graphics/graphics-main.scm`
  - `graphics-zoom-unit`：新增该私有辅助函数，由 `u` 提取基础物理单位（如 `"1cm"` 或 `"1in"`），然后用 `length-mult` 将数字形式的高精度 `magnify` 投影乘算输出。
  - `graphics-zoom`：不再迭代累加物理长度，而是通过调用 `graphics-zoom-unit` 从而实现以常数基础单位为基准的无状态高精度缩放转换。

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 交互验证
多次按 `+` / `-` 进行画布放大和缩小到极限，再拉回来，自动格线和图形线宽都不应该有问题

## 4 What
- 解决手动缩放 `+` / `-` 中由于缩放因子非精确互逆在反复操作中累积产生的浮点数漂移。
- 解决在超小或超长周期的缩放过程中，由于连续进行“格式化舍入”导致的长有效位数衰减与锁死问题。

## 5 How
- 在 `graphics-kbd.scm` 中，将硬编码单精度因子 `1.189207115` 和 `0.840896415` 替换为以 `graphics-zoom-factor = 2^(1/4)` 与其浮点精确倒数 `(/ 1.0 graphics-zoom-factor)` 组合，确保累乘结果始终恒等于 `1.0` 从而完美触发系统的容差归零机制。
- 在 `graphics-main.scm` 中定义 `graphics-zoom-unit` 辅助函数。在 `graphics-zoom` 中用 `(length-mult (magnify->number magn) base-u)` 替换旧式的 `(length-mult e u)`。通过直接乘算不变的常数基础物理单位，将格式化处理安全交付 C++ 原生引擎，保障绝对排版安全与最佳性能。
