### PR TITLE
[0711] 修复商业版 AI 聊天标签页未默认显示的问题

### DIFF
--- a/devel/0711.md
+++ b/devel/0711.md
@@ -18,3 +18,19 @@ Qt 解耦
 xmake b stem
 xmake r stem
 ```
+
+## 修复记录
+
+### 问题
+
+2026-07-08 提交 `07e738d17` 在 `src/Texmacs/Data/new_window.cpp` 中为 Chat 标签页添加 `QTTEXMACS` 条件时，误将原来的 `#ifndef IS_COMMUNITY` 写成了 `#if defined(QTTEXMACS) && defined(IS_COMMUNITY)`，导致商业版（`community=false`）不再创建 AI 聊天标签页，与注释及其他商业版 AI 逻辑矛盾。
+
+### 改动
+
+- `src/Texmacs/Data/new_window.cpp`：将 Chat 标签页创建条件修正为 `#if defined(QTTEXMACS) && !defined(IS_COMMUNITY)`，恢复商业版默认创建 Chat 标签页的行为。
+
+### 验证
+
+1. 以 `community=false` 构建并启动，确认启动页后第二个标签页为 Chat。
+2. 以 `community=true` 构建并启动，确认默认没有 Chat 标签页。
+

--- a/src/Texmacs/Data/new_window.cpp
+++ b/src/Texmacs/Data/new_window.cpp
@@ -312,7 +312,7 @@ ensure_window (tree geom) {
     url win = new_buffer_in_new_window (name, tree (DOCUMENT), geom);
 #endif
 
-#if defined(QTTEXMACS) && defined(IS_COMMUNITY)
+#if defined(QTTEXMACS) && !defined(IS_COMMUNITY)
     // 商业版默认创建 AI 聊天标签页，固定在第二个位置
     url chat_name= "tmfs://chat-tab";
     if (is_nil (concrete_buffer (chat_name))) {


### PR DESCRIPTION
## Summary

- 修复 `src/Texmacs/Data/new_window.cpp` 中 Chat 标签页创建条件被 `07e738d17` 误改的问题：将 `#if defined(QTTEXMACS) && defined(IS_COMMUNITY)` 恢复为 `#if defined(QTTEXMACS) && !defined(IS_COMMUNITY)`，使商业版（`community=false`）启动时再次在启动页之后固定创建 Chat 标签页。
- 更新 `devel/0711.md` 任务文档，追加修复记录与验证步骤。

## Test plan

- [ ] 以 `community=false` 构建并启动，确认启动页后第二个标签页为 Chat。
- [ ] 以 `community=true` 构建并启动，确认默认没有 Chat 标签页。

🤖 Generated with [Claude Code](https://claude.com/claude-code)