### PR TITLE
[1141] 修复 AI 聊天输入框回车键误触发发送的问题

### DIFF
--- a/devel/1141.md
+++ b/devel/1141.md
@@ -1,0 +1,211 @@
+# [1141] 修复 AI 聊天输入框回车键误触发发送的问题
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+
+```bash
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
+
+### 3.2 非确定性测试（文档验证）
+
+1. 启动 Mogan STEM 并打开 AI 聊天侧边栏。
+2. 在输入框中输入 `\alpha`（此时会出现一个 hybrid 节点）。
+3. 按回车键，确认 `α` 被正确插入，而不是直接发送消息。
+4. 再次按回车键，确认消息被发送。
+5. 同时验证普通回车仍然可以发送消息；Shift+Enter 仍然可以换行；补全弹窗出现时回车仍然用于确认补全。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
+
+## 5 What
+
+修复 AI 聊天输入框中，按下回车键一定会触发消息发送的问题。具体表现为：在输入框中输入 TeXmacs 混合命令（如 `\alpha`）后，用户需要按回车键将其转换为希腊字母，但当前实现会直接把这条未完成的命令发送出去。
+
+## 6 Why
+
+AI 聊天输入框本质上是一个内嵌的 TeXmacs 编辑器（`texmacs_input_widget`）。用户在其中输入数学符号、LaTeX 命令时，依赖 TeXmacs 的 hybrid 节点机制：输入 `\` 后生成一个 hybrid 节点，再按回车键调用 `activate-hybrid` 完成转换（如 `\alpha` → `α`）。
+
+当前 `ChatConversationPanel::eventFilter` 在 Qt 事件分发层就拦截了回车键，直接触发 `sendRequested`，导致底层 `QTMWidget::keyPressEvent` 永远不会收到这个回车事件，因此 hybrid 无法被激活。
+
+## 7 How
+
+### 7.1 根因定位
+
+在 `src/Plugins/Qt/qt_chat_tab_widget.cpp` 中，`ChatConversationPanel::eventFilter` 对输入框的 `QTMWidget` 安装了事件过滤器：
+
+```cpp
+editor->installEventFilter (this);
+```
+
+当收到 `KeyPress` 事件时，`should_send_on_keypress` 判断是否需要发送：
+
+```cpp
+bool
+ChatConversationPanel::should_send_on_keypress (int key,
+                                                Qt::KeyboardModifiers mods,
+                                                bool hasActiveCompletionPopup) {
+  bool isEnterKey= (key == Qt::Key_Return || key == Qt::Key_Enter);
+  if (!isEnterKey) return false;
+  if (mods & Qt::ShiftModifier) return false;
+  if (hasActiveCompletionPopup) return false;
+  return true;
+}
+```
+
+当前只有三种情况会放行回车键：
+
+1. 不是回车键；
+2. 按下了 Shift（用于换行）；
+3. 存在数学补全弹窗（`has_active_math_completion_popup` 返回 true）。
+
+但 `α` 这类符号的完成走的是 **hybrid 节点激活** 路径，不依赖补全弹窗。因此回车键被错误地判定为“发送”。
+
+### 7.2 修复思路
+
+与“存在补全弹窗时放行回车”类似，增加一条规则：
+
+> 当光标位于 hybrid 节点内部时，放行回车键，让 TeXmacs 处理 `activate-hybrid`。
+
+TeXmacs 已经在 `editor_rep` 中提供了 `inside(tree_label)` 方法，可以直接判断当前光标是否位于某种标签的节点内。`qt_chat_tab_widget.cpp` 已经包含 `new_view.hpp` 并处于 `moebius` 命名空间，因此可以写成：
+
+```cpp
+editor ed= get_current_editor ();
+bool isInHybrid= ed->inside (HYBRID);
+```
+
+### 7.3 具体改动
+
+#### 方案 A（推荐）：扩展 `should_send_on_keypress` 的判定参数
+
+保持决策逻辑集中，同时让单元测试可以覆盖新分支。
+
+1. 在 `qt_chat_tab_widget.hpp` 中修改声明：
+
+```cpp
+static bool should_send_on_keypress (int key, Qt::KeyboardModifiers mods,
+                                     bool hasActiveCompletionPopup,
+                                     bool isInHybrid= false);
+```
+
+2. 在 `qt_chat_tab_widget.cpp` 中修改实现：
+
+```cpp
+bool
+ChatConversationPanel::should_send_on_keypress (int key,
+                                                Qt::KeyboardModifiers mods,
+                                                bool hasActiveCompletionPopup,
+                                                bool isInHybrid) {
+  bool isEnterKey= (key == Qt::Key_Return || key == Qt::Key_Enter);
+  if (!isEnterKey) return false;
+  if (mods & Qt::ShiftModifier) return false;
+  if (hasActiveCompletionPopup) return false;
+  if (isInHybrid) return false;
+  return true;
+}
+```
+
+3. 在 `eventFilter` 中传入 hybrid 状态：
+
+```cpp
+bool hasActiveCompletionPopup= has_active_math_completion_popup (watched);
+editor ed= get_current_editor ();
+bool isInHybrid= ed->inside (HYBRID);
+if (should_send_on_keypress (keyEvent->key (), keyEvent->modifiers (),
+                             hasActiveCompletionPopup, isInHybrid)) {
+  void* ptr= watched->property ("chat_panel").value<void*> ();
+  if (ptr == this) {
+    emit sendRequested (sessionId_);
+    return true;
+  }
+}
+```
+
+默认参数保证已有调用（如单元测试）无需修改即可编译通过。
+
+#### 方案 B：在 `eventFilter` 中单独判断 hybrid
+
+如果希望保持 `should_send_on_keypress` 的签名不变，也可以在 `eventFilter` 中前置判断：
+
+```cpp
+editor ed= get_current_editor ();
+if (ed->inside (HYBRID)) return false; // 让 TeXmacs 处理回车
+```
+
+但这样会把发送决策拆分到两个地方，不推荐。
+
+### 7.4 单元测试补充
+
+在 `qt_chat_tab_widget_test.cpp` 中增加一个测试用例：
+
+```cpp
+void test_not_send_on_plain_enter_when_in_hybrid () {
+  QVERIFY (!ChatConversationPanel::should_send_on_keypress (
+      Qt::Key_Return, Qt::NoModifier, false, true));
+}
+```
+
+### 7.5 边界情况
+
+- 普通文本输入：光标不在 hybrid 内，`isInHybrid` 为 false，回车正常发送。
+- `\alpha` + 回车：光标在 hybrid 内，第一次回车被放行，`α` 被插入；第二次回车时光标已不在 hybrid 内，正常发送。
+- Shift+Enter：原有逻辑继续放行，用于换行。
+- 数学补全弹窗：原有逻辑继续放行，用于确认补全；此时通常光标也在 hybrid 内，两条规则一致。
+- 无当前编辑器：`eventFilter` 运行时输入框必然持有焦点，正常情况下不会发生；如为保险起见，可先判断 `ed.rep != nullptr`。
+
+### 7.6 参考路径
+
+- hybrid 节点创建：`src/Edit/Modify/edit_dynamic.cpp` 中的 `make_hybrid`
+- hybrid 激活：`src/Edit/Modify/edit_dynamic.cpp` 中的 `activate_latex`
+- 回车键绑定：`TeXmacs/progs/generic/generic-kbd.scm`、`TeXmacs/progs/source/source-edit.scm`
+- 事件过滤：`src/Plugins/Qt/qt_chat_tab_widget.cpp` 中的 `ChatConversationPanel::eventFilter`
+
+## 8 本次改动
+
+### 8.1 涉及文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp`
+- `devel/1141.md`
+
+### 8.2 代码改动摘要
+
+1. 在 `qt_chat_tab_widget.hpp` 中为 `should_send_on_keypress` 增加 `isInHybrid` 参数（默认值为 `false`），保持既有调用和单元测试不变。
+2. 在 `qt_chat_tab_widget.cpp` 中：
+   - `should_send_on_keypress` 增加 `isInHybrid` 分支，光标在 hybrid 节点内时不触发发送。
+   - `eventFilter` 中通过 `get_current_editor()->inside(HYBRID)` 获取当前 hybrid 状态，并传入 `should_send_on_keypress`。
+3. 在 `qt_chat_tab_widget_test.cpp` 中增加 `test_not_send_on_plain_enter_when_in_hybrid` 测试用例。
+
+### 8.3 提交前检查
+
+已执行：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+xmake b qt_chat_tab_widget_test
+xmake r qt_chat_tab_widget_test
+```
+
+测试结果：`111 passed, 0 failed`。

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -527,11 +527,13 @@ ChatConversationPanel::should_block_readonly_event (QObject* watched,
 bool
 ChatConversationPanel::should_send_on_keypress (int                   key,
                                                 Qt::KeyboardModifiers mods,
-                                                bool hasActiveCompletionPopup) {
+                                                bool hasActiveCompletionPopup,
+                                                bool isInHybrid) {
   bool isEnterKey= (key == Qt::Key_Return || key == Qt::Key_Enter);
   if (!isEnterKey) return false;
   if (mods & Qt::ShiftModifier) return false;
   if (hasActiveCompletionPopup) return false;
+  if (isInHybrid) return false;
   return true;
 }
 
@@ -548,9 +550,11 @@ ChatConversationPanel::eventFilter (QObject* watched, QEvent* event) {
       emit closeSidebarInDockModeRequested ();
       return true;
     }
-    bool hasActiveCompletionPopup= has_active_math_completion_popup (watched);
+    bool   hasActiveCompletionPopup= has_active_math_completion_popup (watched);
+    editor ed                      = get_current_editor ();
+    bool   isInHybrid              = (!is_nil (ed)) && ed->inside (HYBRID);
     if (should_send_on_keypress (keyEvent->key (), keyEvent->modifiers (),
-                                 hasActiveCompletionPopup)) {
+                                 hasActiveCompletionPopup, isInHybrid)) {
       void* ptr= watched->property ("chat_panel").value<void*> ();
       if (ptr == this) {
         emit sendRequested (sessionId_);

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -115,10 +115,12 @@ public:
    * @param key 按键值
    * @param mods 修饰键状态
    * @param hasActiveCompletionPopup 是否存在待确认的补全/Tab cycle 弹窗
+   * @param isInHybrid 光标是否位于 hybrid 节点内（如 \alpha 未完成输入）
    * @return 应触发发送时返回 true
    */
   static bool should_send_on_keypress (int key, Qt::KeyboardModifiers mods,
-                                       bool hasActiveCompletionPopup);
+                                       bool hasActiveCompletionPopup,
+                                       bool isInHybrid= false);
 
 signals:
   void sendRequested (const string& sessionId);

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -678,7 +678,12 @@ private slots:
 
   void test_not_send_on_plain_enter_with_completion_popup () {
     QVERIFY (!ChatConversationPanel::should_send_on_keypress (
-        Qt::Key_Return, Qt::NoModifier, true));
+        Qt::Key_Return, Qt::NoModifier, true, false));
+  }
+
+  void test_not_send_on_plain_enter_when_in_hybrid () {
+    QVERIFY (!ChatConversationPanel::should_send_on_keypress (
+        Qt::Key_Return, Qt::NoModifier, false, true));
   }
 
   void test_not_send_on_non_enter_key () {


### PR DESCRIPTION
## 摘要

修复 AI 聊天输入框中，按下回车键一定会触发消息发送的问题。当用户输入 TeXmacs 混合命令（如 `\\alpha`）后，第一次回车应完成符号转换，而不是直接发送消息。

## 改动

- `src/Plugins/Qt/qt_chat_tab_widget.hpp`：为 `should_send_on_keypress` 增加 `isInHybrid` 参数（默认 `false`）。
- `src/Plugins/Qt/qt_chat_tab_widget.cpp`：
  - `should_send_on_keypress` 增加 hybrid 分支。
  - `eventFilter` 中通过 `get_current_editor()->inside(HYBRID)` 判断当前是否处于 hybrid 节点内。
- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp`：新增 `test_not_send_on_plain_enter_when_in_hybrid` 测试。
- `devel/1141.md`：任务文档。

## 测试

- [x] `xmake b stem` 通过
- [x] `xmake b qt_chat_tab_widget_test` 通过
- [x] `xmake r qt_chat_tab_widget_test`：111 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)