### PR TITLE
[0503] 修复教程 OCR 按钮触发后文本插入位置

### DIFF
--- a/TeXmacs/plugins/tutorial/progs/init-tutorial.scm
+++ b/TeXmacs/plugins/tutorial/progs/init-tutorial.scm
@@ -73,6 +73,8 @@
 ) ;tm-define
 
 (tm-define (tutorial-trigger-ocr)
+  (go-end)
+  (kbd-return)
   (ocr-paste)
   (when (defined? 'tutorial-notify-action)
     (tutorial-notify-action "ocr-paste")

--- a/devel/0503.md
+++ b/devel/0503.md
@@ -206,3 +206,33 @@ cms/0503/tutorial
 本任务依赖 [0502](0502.md)（xmake 修复）。0502 修复了 `is_community` 切换无法控制教程开关的问题——在 0502 合并前，社区版编译产物里教程代码可能被预处理器剔除（`USE_TUTORIAL` undef），无法验证按钮功能。
 
 商业版（`is_community=false`）不受此限制，0503 的按钮功能可以独立验证。
+
+---
+
+## 11 后续修复：OCR 按钮触发后识别文本插入到图像上方
+
+### 11.1 What
+修复点击第 3 步「立即体验 OCR」按钮后，OCR 识别结果插入到示例图像上方的问题，改为插入到图像下方。
+
+### 11.2 Why
+`tutorial-trigger-ocr` 内部调用通用 `(ocr-paste)`，而 `ocr-paste` 只在当前光标处插入 OCR 结果。`ocr-demo.tmu` 加载后光标默认位于图像之前，导致识别内容出现在图像上方。图片悬浮菜单的 OCR 按钮直接调用 `ocr-to-latex-by-image`，本无此问题，因此不能改动通用 `ocr-paste`。
+
+### 11.3 How
+在 `TeXmacs/plugins/tutorial/progs/init-tutorial.scm` 的 `(tutorial-trigger-ocr)` 中，先移动光标到文档末尾、插入换行，再执行 `ocr-paste`：
+
+```scheme
+(tm-define (tutorial-trigger-ocr)
+  (go-end)
+  (kbd-return)
+  (ocr-paste)
+  ...)
+```
+
+这样 `ocr-paste` 插入的 OCR 结果始终位于文档最末尾（即示例图像之后），且不影响图片悬浮菜单 OCR 与通用 `ocr-paste`。
+
+### 11.4 涉及文件
+- `TeXmacs/plugins/tutorial/progs/init-tutorial.scm`
+- `devel/0503.md`（本文件）
+
+### 11.5 测试
+同第 3 步 GUI 集成测试：点击「立即体验 OCR」后，识别出的文本应出现在示例图像下方。


### PR DESCRIPTION
## Summary
修复新用户引导教程第 3 步（OCR）点击「立即体验 OCR」按钮后，OCR 识别结果插入到示例图像上方的问题。改为在文档末尾插入换行后再执行 `ocr-paste`，使识别结果位于图像之后。

## 改动范围
- `TeXmacs/plugins/tutorial/progs/init-tutorial.scm`：在 `tutorial-trigger-ocr` 中先 `(go-end)` 移动到文档末尾，再 `(kbd-return)` 换行，最后执行 `ocr-paste`
- `devel/0503.md`：追加本次修复的说明

## 测试
- 本地 `xmake b stem` 构建通过
- 新用户引导教程第 3 步点击按钮后，OCR 结果应出现在示例图像之后

🤖 Generated with [Claude Code](https://claude.com/claude-code)