### PR TITLE
[1142] 将 telemetry 与启动日志改为 debug-message

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -60,16 +60,21 @@
 
 
 (let ()
-  (display "Benchmark 1\n")
-  (define start (texmacs-time))
   (define (fib n)
     (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2))))
   ) ;define
-  (display (fib 30))
-  (newline)
-  (display "Time: ")
-  (display (- (texmacs-time) start))
-  (newline)
+  (define start (texmacs-time))
+  (define result (fib 30))
+  (define elapsed (- (texmacs-time) start))
+  (debug-message "debug-std"
+    (string-append "Benchmark 1\n"
+      (number->string result)
+      "\n"
+      "Time: "
+      (number->string elapsed)
+      "\n"
+    ) ;string-append
+  ) ;debug-message
 ) ;let
 
 (define developer-mode? #f)
@@ -78,7 +83,7 @@
 
 (define remote-client-list (list))
 
-(display "Booting TeXmacs kernel functionality\n")
+(debug-message "debug-std" "Booting TeXmacs kernel functionality\n")
 (load (url-concretize "$TEXMACS_PATH/progs/kernel/boot/boot-s7.scm"))
 
 (inherit-modules (kernel boot compat-s7)
@@ -534,7 +539,12 @@
   export-selection-as-graphics
   clipboard-copy-image
 ) ;lazy-define
-(lazy-define (convert rewrite init-rewrite) texmacs->code texmacs->verbatim texmacs->utf8raw utf8raw->texmacs)
+(lazy-define (convert rewrite init-rewrite)
+  texmacs->code
+  texmacs->verbatim
+  texmacs->utf8raw
+  utf8raw->texmacs
+) ;lazy-define
 (lazy-define (convert html tmhtml) ext-tmhtml-eqnarray*)
 (define-secure-symbols ext-tmhtml-eqnarray*)
 (lazy-define (convert html tmhtml-expand) tmhtml-env-patch)
@@ -668,10 +678,16 @@
   (use-modules (utils misc updater))
   (delayed (:idle 2000) (updater-initialize))
 ) ;when
-(display* "time: " (- (texmacs-time) boot-start) "\n")
-(display* "memory: " (texmacs-memory) " bytes\n")
-
-(display "------------------------------------------------------\n")
+(debug-message "debug-std"
+  (string-append "time: "
+    (number->string (- (texmacs-time) boot-start))
+    "\n"
+    "memory: "
+    (number->string (texmacs-memory))
+    " bytes\n"
+    "------------------------------------------------------\n"
+  ) ;string-append
+) ;debug-message
 (delayed (:pause 120000) (autosave-delayed))
 (catch #t
   (lambda ()
@@ -691,42 +707,61 @@
   ) ;lambda
 ) ;catch
 (texmacs-banner)
-(display "Initialization done\n")
+(debug-message "debug-std" "Initialization done\n")
 
 (let ()
-  (display "------------------------------------------------------\n")
-  (display "Benchmark 2\n")
   (define start (texmacs-time))
   (tm-define (tm-fib n) (if (< n 2) n (+ (tm-fib (- n 1)) (tm-fib (- n 2)))))
-  (display (tm-fib 30))
-  (newline)
-  (display "Time: ")
-  (display (- (texmacs-time) start))
-  (newline)
-  (display "------------------------------------------------------\n")
+  (define result (tm-fib 30))
+  (define elapsed (- (texmacs-time) start))
+  (debug-message "debug-std"
+    (string-append "------------------------------------------------------\n"
+      "Benchmark 2\n"
+      (number->string result)
+      "\n"
+      "Time: "
+      (number->string elapsed)
+      "\n"
+      "------------------------------------------------------\n"
+    ) ;string-append
+  ) ;debug-message
 ) ;let
 
-(display "------------------------------------------------------\n")
-(display "Forcing delayed loads\n")
-
+(debug-message "debug-std"
+  "------------------------------------------------------\n"
+) ;debug-message
+(debug-message "debug-std" "Forcing delayed loads\n")
 (lazy-keyboard-force #t)
-(display* "time: " (- (texmacs-time) boot-start) "\n")
-(display* "memory: " (texmacs-memory) " bytes\n")
-(display "------------------------------------------------------\n")
+(debug-message "debug-std"
+  (string-append "time: "
+    (number->string (- (texmacs-time) boot-start))
+    "\n"
+    "memory: "
+    (number->string (texmacs-memory))
+    " bytes\n"
+    "------------------------------------------------------\n"
+  ) ;string-append
+) ;debug-message
 
 
 
 (tm-define (benchmark-menu-expand)
-  (display "------------------------------------------------------\n")
-  (display "Benchmark menu-expand\n")
-  (let ((start (texmacs-time)))
-    (display (menu-expand '(horizontal (link texmacs-main-icons))))
-    (newline)
-    (display "Time: ")
-    (display (- (texmacs-time) start))
-    (newline)
-  ) ;let
-  (display "------------------------------------------------------\n")
+  (let* ((start (texmacs-time))
+         (result (menu-expand '(horizontal (link texmacs-main-icons))))
+         (elapsed (- (texmacs-time) start))
+        ) ;
+    (debug-message "debug-std"
+      (string-append "------------------------------------------------------\n"
+        "Benchmark menu-expand\n"
+        (object->string result)
+        "\n"
+        "Time: "
+        (number->string elapsed)
+        "\n"
+        "------------------------------------------------------\n"
+      ) ;string-append
+    ) ;debug-message
+  ) ;let*
 ) ;tm-define
 
 ;; (delayed (:idle 1000) (benchmark-menu-expand))
@@ -748,9 +783,9 @@
                                               (update (lambda ()
                                                         (update (lambda ()
                                                                   (buffer-pretend-saved (current-buffer))
-                                                                  (display "Timing:")
-                                                                  (display (- (texmacs-time) start-time))
-                                                                  (newline)
+                                                                  (debug-message "debug-std"
+                                                                    (string-append "Timing:" (number->string (- (texmacs-time) start-time)) "\n")
+                                                                  ) ;debug-message
                                                                 ) ;lambda
                                                         ) ;update
                                                       ) ;lambda

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -59,6 +59,24 @@
 ) ;let
 
 
+(let ()
+  (define (fib n)
+    (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2))))
+  ) ;define
+  (define start (texmacs-time))
+  (define result (fib 30))
+  (define elapsed (- (texmacs-time) start))
+  (debug-message "debug-std"
+    (string-append "Benchmark 1\n"
+      (number->string result)
+      "\n"
+      "Time: "
+      (number->string elapsed)
+      "\n"
+    ) ;string-append
+  ) ;debug-message
+) ;let
+
 (define developer-mode? #f)
 
 (define boot-start (texmacs-time))

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -59,24 +59,6 @@
 ) ;let
 
 
-(let ()
-  (define (fib n)
-    (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2))))
-  ) ;define
-  (define start (texmacs-time))
-  (define result (fib 30))
-  (define elapsed (- (texmacs-time) start))
-  (debug-message "debug-std"
-    (string-append "Benchmark 1\n"
-      (number->string result)
-      "\n"
-      "Time: "
-      (number->string elapsed)
-      "\n"
-    ) ;string-append
-  ) ;debug-message
-) ;let
-
 (define developer-mode? #f)
 
 (define boot-start (texmacs-time))

--- a/TeXmacs/progs/telemetry/init-telemetry.scm
+++ b/TeXmacs/progs/telemetry/init-telemetry.scm
@@ -54,32 +54,34 @@
 
 (define-public (init-telemetry)
   (if telemetry-scheduled?
-    (display "[telemetry] init: already initialized\n")
+    (debug-message "debug-events" "[telemetry] init: already initialized\n")
     (if (telemetry-enabled?)
       (begin
         (telemetry-clean-orphans)
         (set! telemetry-scheduled? #t)
-        (display (string-append "[telemetry] init: enabled, buffer="
-                   (number->string (telemetry-get-buffer-size))
-                   ", interval="
-                   (number->string (telemetry-get-flush-interval))
-                   "ms\n"
-                 ) ;string-append
-        ) ;display
+        (debug-message "debug-events"
+          (string-append "[telemetry] init: enabled, buffer="
+            (number->string (telemetry-get-buffer-size))
+            ", interval="
+            (number->string (telemetry-get-flush-interval))
+            "ms\n"
+          ) ;string-append
+        ) ;debug-message
         (on-exit (catch #t
                    (lambda () (track-event "CLOSE" '()) (telemetry-flush-if-needed))
                    (lambda args
-                     (display (string-append "[telemetry] error: exit flush failed: "
-                                (object->string args)
-                                "\n"
-                              ) ;string-append
-                     ) ;display
+                     (debug-message "debug-events"
+                       (string-append "[telemetry] error: exit flush failed: "
+                         (object->string args)
+                         "\n"
+                       ) ;string-append
+                     ) ;debug-message
                    ) ;lambda
                  ) ;catch
         ) ;on-exit
         (telemetry-delayed)
       ) ;begin
-      (display "[telemetry] init: disabled\n")
+      (debug-message "debug-events" "[telemetry] init: disabled\n")
     ) ;if
   ) ;if
 ) ;define-public

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -66,13 +66,14 @@
     #f
     (let* ((ts (telemetry-now)) (json (build-upload-payload event)))
       (silent-feed* "telemetry" "" `(document ,json) (lambda (r) (noop)) '())
-      (display (string-append "[telemetry] upload triggered by "
-                 event
-                 " (ts="
-                 (number->string ts)
-                 ")\n"
-               ) ;string-append
-      ) ;display
+      (debug-message "debug-events"
+        (string-append "[telemetry] upload triggered by "
+          event
+          " (ts="
+          (number->string ts)
+          ")\n"
+        ) ;string-append
+      ) ;debug-message
       #t
     ) ;let*
   ) ;if
@@ -96,25 +97,27 @@
           (cons (telemetry-make-event event-type properties) *telemetry-event-queue*)
         ) ;set!
         (let ((len (length *telemetry-event-queue*)))
-          (display (string-append "[telemetry] track: "
-                     event-type
-                     " (queue: "
-                     (number->string len)
-                     "/"
-                     (number->string (telemetry-get-buffer-size))
-                     ")\n"
-                   ) ;string-append
-          ) ;display
+          (debug-message "debug-events"
+            (string-append "[telemetry] track: "
+              event-type
+              " (queue: "
+              (number->string len)
+              "/"
+              (number->string (telemetry-get-buffer-size))
+              ")\n"
+            ) ;string-append
+          ) ;debug-message
           (if (> len telemetry-max-queue-size)
             (begin
               (set! *telemetry-event-queue*
                 (list-head *telemetry-event-queue* telemetry-max-queue-size)
               ) ;set!
-              (display (string-append "[telemetry] warn: queue truncated to "
-                         (number->string telemetry-max-queue-size)
-                         "\n"
-                       ) ;string-append
-              ) ;display
+              (debug-message "debug-events"
+                (string-append "[telemetry] warn: queue truncated to "
+                  (number->string telemetry-max-queue-size)
+                  "\n"
+                ) ;string-append
+              ) ;debug-message
             ) ;begin
           ) ;if
           (if (important-event? event-type)
@@ -158,26 +161,29 @@
             (string-save text (system->url filepath))
             (if (telemetry-meta-add-entry filename)
               (begin
-                (display (string-append "[telemetry] flush: "
-                           (number->string (length events))
-                           " events -> "
-                           filename
-                           "\n"
-                         ) ;string-append
-                ) ;display
+                (debug-message "debug-events"
+                  (string-append "[telemetry] flush: "
+                    (number->string (length events))
+                    " events -> "
+                    filename
+                    "\n"
+                  ) ;string-append
+                ) ;debug-message
                 #t
               ) ;begin
               (begin
-                (display (string-append "[telemetry] error: meta update failed for " filename "\n")
-                ) ;display
+                (debug-message "debug-events"
+                  (string-append "[telemetry] error: meta update failed for " filename "\n")
+                ) ;debug-message
                 #f
               ) ;begin
             ) ;if
           ) ;let
         ) ;lambda
         (lambda args
-          (display (string-append "[telemetry] error: write failed: " (object->string args) "\n")
-          ) ;display
+          (debug-message "debug-events"
+            (string-append "[telemetry] error: write failed: " (object->string args) "\n")
+          ) ;debug-message
           #f
         ) ;lambda
       ) ;catch
@@ -195,11 +201,12 @@
           #t
         ) ;begin
         (begin
-          (display (string-append "[telemetry] error: flush failed, keeping "
-                     (number->string (length *telemetry-event-queue*))
-                     " events in memory queue\n"
-                   ) ;string-append
-          ) ;display
+          (debug-message "debug-events"
+            (string-append "[telemetry] error: flush failed, keeping "
+              (number->string (length *telemetry-event-queue*))
+              " events in memory queue\n"
+            ) ;string-append
+          ) ;debug-message
           #f
         ) ;begin
       ) ;if

--- a/TeXmacs/progs/telemetry/telemetry-utils.scm
+++ b/TeXmacs/progs/telemetry/telemetry-utils.scm
@@ -249,11 +249,12 @@
         (catch #t
           (lambda () (try-write))
           (lambda args2
-            (display (string-append "[telemetry] error: meta write failed after retry: "
-                       (object->string args2)
-                       "\n"
-                     ) ;string-append
-            ) ;display
+            (debug-message "debug-events"
+              (string-append "[telemetry] error: meta write failed after retry: "
+                (object->string args2)
+                "\n"
+              ) ;string-append
+            ) ;debug-message
             (when (path-exists? tmp-path)
               (path-unlink tmp-path)
             ) ;when

--- a/devel/1142.md
+++ b/devel/1142.md
@@ -2,9 +2,11 @@
 
 ## What
 
-将 Scheme 层面的 telemetry 调试日志和 `init-research.scm` 中的启动阶段日志，
-从原生的 `(display ...)` 改为 `(debug-message channel msg)`，统一走项目的
-`debug-std` / `debug-events` 调试频道。
+将 Scheme 层面的 telemetry 调试日志、`init-research.scm` 中的启动阶段日志、
+模板中心（TemplateCenter）/缩略图缓存（ThumbnailCache）的 C++ 日志，
+以及启动和 OAuth 阶段直接输出到 `cout` 的日志，
+从原生的 `(display ...)` / `qDebug()/qWarning()` / `cout` 改为项目调试体系中的
+`debug-message` / `debug_std` / `debug_io` / `debug_boot`，统一由调试开关控制。
 
 ## Why
 
@@ -25,6 +27,20 @@
   `Forcing delayed loads`、菜单展开 benchmark 等日志从 `(display ...)` /
   `(display* ...)` 改为 `(debug-message "debug-std" ...)`；
   同时移除无意义的 `Benchmark 1` fib(30) 计算；
+- 模板中心与缩略图缓存的 C++ 日志从 `qDebug()/qWarning()` 改为项目调试流：
+  - 本地缓存操作（`[Template]`、`[ThumbnailCache]`）使用 `DEBUG_STD` + `debug_std`；
+  - 网络相关操作（`[TemplateAPI]`、`[ThumbnailLoader]`、`[VersionUpdate]`、远程分类/模板加载失败）使用
+    `DEBUG_IO` + `debug_io`；
+  - Qt 字符串通过 `qPrintable()` 传给 `tm_ostream`。
+- 启动阶段的进度日志统一改为 `DEBUG_STD` + `debug_std`（`debug_boot` 不带时间戳）：
+  - `src/System/Boot/init_texmacs.cpp` 中的 `Installing internal plug-ins...`、
+    `Opening display...`、`Starting server...`、`Loading ...`、`Starting event loop...`、
+    `Stopping server...`、`Closing display...`、`Good bye...`；
+  - `src/System/Link/texmacs_server.cpp` 中的 `Starting server...`；
+  - `src/Plugins/Qt/qt_gui.cpp` 中的 `Mac Screen scaleFfactor:`、`Setting up HiDPI mode`、
+    `Screen extents:`。
+- `src/Plugins/Qt/QTMOAuth.cpp` 中的端口日志改为 `DEBUG_IO` + `debug_io`（OAuth 属于网络流程）。
+- 保留 `Welcome to Mogan STEM`、`Installation completed` 等启动欢迎信息为 `debug_boot`。
 - 保留 telemetry 初始化失败时写到 `current-error-port` 的错误输出。
 
 ## 涉及文件
@@ -33,4 +49,14 @@
 - `TeXmacs/progs/telemetry/telemetry-track.scm`
 - `TeXmacs/progs/telemetry/telemetry-utils.scm`
 - `TeXmacs/progs/init-research.scm`
+- `src/Mogan/TemplateCenter/template_cache.cpp`
+- `src/Mogan/TemplateCenter/template_api.cpp`
+- `src/Mogan/TemplateCenter/template_manager.cpp`
+- `src/Mogan/Cache/thumbnail_cache.cpp`
+- `src/Mogan/Cache/thumbnail_loader.cpp`
+- `src/Plugins/Qt/qt_tm_widget.cpp`
+- `src/Plugins/Qt/QTMOAuth.cpp`
+- `src/Plugins/Qt/qt_gui.cpp`
+- `src/System/Boot/init_texmacs.cpp`
+- `src/System/Link/texmacs_server.cpp`
 - `devel/1142.md`

--- a/devel/1142.md
+++ b/devel/1142.md
@@ -1,0 +1,35 @@
+# 1142: telemetry 与启动日志改为 debug-message
+
+## What
+
+将 Scheme 层面的 telemetry 调试日志和 `init-research.scm` 中的启动阶段日志，
+从原生的 `(display ...)` 改为 `(debug-message channel msg)`，统一走项目的
+`debug-std` / `debug-events` 调试频道。
+
+## Why
+
+直接使用 `display` 输出到 stdout 的日志没有时间戳，也无法通过项目的调试开关
+（如 `-debug-std`、`-debug-events`）和调试控制台集中管理。改成 `debug-message`
+后：
+
+- 每条日志自动带上 `YYYY-MM-DD-HH.MM.SS.mmm` 时间戳；
+- 可以通过 debug channel 开关按需开启或关闭；
+- 与 `tm_ostream` 调试体系保持一致，方便跨平台（包括 Windows）排查启动性能。
+
+## How
+
+- `TeXmacs/progs/telemetry/*.scm`：所有 `[telemetry] ...` 日志从 `(display ...)`
+  改为 `(debug-message "debug-events" ...)`；
+- `TeXmacs/progs/init-research.scm`：启动阶段的 `Benchmark 1/2`、
+  `Booting TeXmacs kernel functionality`、`Initialization done`、
+  `Forcing delayed loads`、菜单展开 benchmark 等日志从 `(display ...)` /
+  `(display* ...)` 改为 `(debug-message "debug-std" ...)`；
+- 保留 telemetry 初始化失败时写到 `current-error-port` 的错误输出。
+
+## 涉及文件
+
+- `TeXmacs/progs/telemetry/init-telemetry.scm`
+- `TeXmacs/progs/telemetry/telemetry-track.scm`
+- `TeXmacs/progs/telemetry/telemetry-utils.scm`
+- `TeXmacs/progs/init-research.scm`
+- `devel/1142.md`

--- a/devel/1142.md
+++ b/devel/1142.md
@@ -20,10 +20,11 @@
 
 - `TeXmacs/progs/telemetry/*.scm`：所有 `[telemetry] ...` 日志从 `(display ...)`
   改为 `(debug-message "debug-events" ...)`；
-- `TeXmacs/progs/init-research.scm`：启动阶段的 `Benchmark 1/2`、
+- `TeXmacs/progs/init-research.scm`：启动阶段的 `Benchmark 2`、
   `Booting TeXmacs kernel functionality`、`Initialization done`、
   `Forcing delayed loads`、菜单展开 benchmark 等日志从 `(display ...)` /
   `(display* ...)` 改为 `(debug-message "debug-std" ...)`；
+  同时移除无意义的 `Benchmark 1` fib(30) 计算；
 - 保留 telemetry 初始化失败时写到 `current-error-port` 的错误输出。
 
 ## 涉及文件

--- a/devel/1142.md
+++ b/devel/1142.md
@@ -43,8 +43,8 @@
 - 保留 `Welcome to Mogan STEM`、`Installation completed` 等启动欢迎信息为 `debug_boot`。
 - 保留 telemetry 初始化失败时写到 `current-error-port` 的错误输出。
 - 修复 `src/System/Link/texmacs_server.cpp` 中 `Starting server...`
-  直接输出 `bool` 的问题：`tm_ostream` 不直接支持 `bool`，改为
-  `as_string_bool (started)` 转换为字符串后输出。
+  日志的类型问题：`the_server->start ()` 返回 `string`，原代码误声明为
+  `bool`，改为 `string started` 后直接输出到 `debug_std`。
 
 ## 涉及文件
 

--- a/devel/1142.md
+++ b/devel/1142.md
@@ -42,6 +42,9 @@
 - `src/Plugins/Qt/QTMOAuth.cpp` 中的端口日志改为 `DEBUG_IO` + `debug_io`（OAuth 属于网络流程）。
 - 保留 `Welcome to Mogan STEM`、`Installation completed` 等启动欢迎信息为 `debug_boot`。
 - 保留 telemetry 初始化失败时写到 `current-error-port` 的错误输出。
+- 修复 `src/System/Link/texmacs_server.cpp` 中 `Starting server...`
+  直接输出 `bool` 的问题：`tm_ostream` 不直接支持 `bool`，改为
+  `as_string_bool (started)` 转换为字符串后输出。
 
 ## 涉及文件
 

--- a/src/Mogan/Cache/thumbnail_cache.cpp
+++ b/src/Mogan/Cache/thumbnail_cache.cpp
@@ -7,8 +7,9 @@
 
 #include "thumbnail_cache.hpp"
 
+#include "tm_debug.hpp"
+
 #include <QCoreApplication>
-#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
@@ -219,7 +220,8 @@ ThumbnailCache::clear () {
   for (const QString& file : cacheDir.entryList (QDir::Files)) {
     cacheDir.remove (file);
   }
-  qDebug () << "[ThumbnailCache] Cleared all cached thumbnails";
+  if (DEBUG_STD)
+    debug_std << "[ThumbnailCache] Cleared all cached thumbnails\n";
 }
 
 void
@@ -273,7 +275,9 @@ ThumbnailCache::loadIndex () {
 
   QFile file (path);
   if (!file.open (QIODevice::ReadOnly)) {
-    qWarning () << "[ThumbnailCache] Failed to read index:" << path;
+    if (DEBUG_STD)
+      debug_std << "[ThumbnailCache] Failed to read index: "
+                << qPrintable (path) << "\n";
     return;
   }
 
@@ -286,8 +290,9 @@ ThumbnailCache::loadIndex () {
   for (auto it= obj.begin (); it != obj.end (); ++it) {
     diskIndex_[it.key ()]= it.value ().toObject ();
   }
-  qDebug () << "[ThumbnailCache] Loaded index with" << diskIndex_.size ()
-            << "entries";
+  if (DEBUG_STD)
+    debug_std << "[ThumbnailCache] Loaded index with " << diskIndex_.size ()
+              << " entries\n";
 }
 
 void
@@ -307,7 +312,9 @@ ThumbnailCache::saveIndex () {
     file.close ();
   }
   else {
-    qWarning () << "[ThumbnailCache] Failed to write index:" << path;
+    if (DEBUG_STD)
+      debug_std << "[ThumbnailCache] Failed to write index: "
+                << qPrintable (path) << "\n";
   }
 }
 
@@ -322,6 +329,8 @@ void
 ThumbnailCache::saveToDisk (const QString& key, const QPixmap& pixmap) {
   QString path= diskPath (key);
   if (!pixmap.save (path, "JPEG", 85)) {
-    qWarning () << "[ThumbnailCache] Failed to write image:" << path;
+    if (DEBUG_STD)
+      debug_std << "[ThumbnailCache] Failed to write image: "
+                << qPrintable (path) << "\n";
   }
 }

--- a/src/Mogan/Cache/thumbnail_loader.cpp
+++ b/src/Mogan/Cache/thumbnail_loader.cpp
@@ -7,7 +7,9 @@
 
 #include "thumbnail_loader.hpp"
 
-#include <QDebug>
+#include "qt_utilities.hpp"
+#include "thumbnail_cache.hpp"
+
 #include <QImage>
 #include <QLabel>
 #include <QLocale>
@@ -15,9 +17,6 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QTimeZone>
-
-#include "qt_utilities.hpp"
-#include "thumbnail_cache.hpp"
 
 ThumbnailLoader::ThumbnailLoader (QObject* parent) : QObject (parent) {
   networkManager_= new QNetworkAccessManager (this);
@@ -46,19 +45,23 @@ ThumbnailLoader::load (QLabel* label, const QString& url,
 
     // 如果该 URL 已在本次会话中验证过 freshness，直接复用缓存
     if (validatedUrls_.contains (url)) {
-      qDebug () << "[ThumbnailLoader] Cache hit:" << url;
+      if (DEBUG_IO)
+        debug_io << "[ThumbnailLoader] Cache hit: " << qPrintable (url) << "\n";
       return;
     }
 
     // 缓存存在但尚未验证 freshness，发送条件请求（If-None-Match）校验 ETag
-    qDebug () << "[ThumbnailLoader] Cache validate:" << url;
+    if (DEBUG_IO)
+      debug_io << "[ThumbnailLoader] Cache validate: " << qPrintable (url)
+               << "\n";
     queue_.enqueue ({label, url, cached.etag, targetSize});
     processQueue ();
     return;
   }
 
   // 缓存未命中，走网络下载
-  qDebug () << "[ThumbnailLoader] Download:" << url;
+  if (DEBUG_IO)
+    debug_io << "[ThumbnailLoader] Download: " << qPrintable (url) << "\n";
   queue_.enqueue ({label, url, QString (), targetSize});
   processQueue ();
 }
@@ -94,7 +97,9 @@ ThumbnailLoader::processQueue () {
           reply->attribute (QNetworkRequest::HttpStatusCodeAttribute).toInt ();
       if (httpStatus == 304) {
         // 服务器返回 304 Not Modified，缓存仍然新鲜，标记该 URL 已验证
-        qDebug () << "[ThumbnailLoader] Cache fresh:" << req.url;
+        if (DEBUG_IO)
+          debug_io << "[ThumbnailLoader] Cache fresh: " << qPrintable (req.url)
+                   << "\n";
         validatedUrls_.insert (req.url);
         reply->deleteLater ();
         processQueue ();

--- a/src/Mogan/TemplateCenter/template_api.cpp
+++ b/src/Mogan/TemplateCenter/template_api.cpp
@@ -11,7 +11,8 @@
 
 #include "template_api.hpp"
 
-#include <QDebug>
+#include "qt_utilities.hpp"
+
 #include <QDir>
 #include <QFile>
 #include <QJsonArray>
@@ -206,14 +207,17 @@ TemplateAPI::incrementDownloadCount (const QString& templateId) {
   QNetworkReply* reply= networkManager_->post (request, bodyData);
   connect (reply, &QNetworkReply::finished, [reply, templateId] () {
     if (reply->error () != QNetworkReply::NoError) {
-      qWarning ()
-          << "[TemplateAPI] Failed to increment download count for template:"
-          << templateId << "Error:" << reply->errorString ();
+      if (DEBUG_IO)
+        debug_io
+            << "[TemplateAPI] Failed to increment download count for template: "
+            << qPrintable (templateId)
+            << " Error: " << qPrintable (reply->errorString ()) << "\n";
     }
     else {
-      qDebug () << "[TemplateAPI] Successfully incremented download count for "
-                   "template:"
-                << templateId;
+      if (DEBUG_IO)
+        debug_io << "[TemplateAPI] Successfully incremented download count for "
+                    "template: "
+                 << qPrintable (templateId) << "\n";
     }
     reply->deleteLater ();
   });
@@ -446,7 +450,7 @@ TemplateAPI::parseCategoriesResponse (const QJsonValue& data) {
     array= data.toArray ();
   }
   else {
-    qWarning () << "[Template] Categories data is not an array";
+    if (DEBUG_IO) debug_io << "[Template] Categories data is not an array\n";
     return categories;
   }
 
@@ -484,7 +488,8 @@ TemplateAPI::parseTemplatesResponse (const QJsonValue& data) {
     array= data.toObject ().value ("items").toArray ();
   }
   else {
-    qWarning () << "[Template] Templates data is not an object or array";
+    if (DEBUG_IO)
+      debug_io << "[Template] Templates data is not an object or array\n";
     return metadata;
   }
 

--- a/src/Mogan/TemplateCenter/template_cache.cpp
+++ b/src/Mogan/TemplateCenter/template_cache.cpp
@@ -11,7 +11,8 @@
 
 #include "template_cache.hpp"
 
-#include <QDebug>
+#include "tm_debug.hpp"
+
 #include <QDir>
 #include <QFile>
 #include <QJsonArray>
@@ -55,14 +56,16 @@ TemplateCache::loadMetadataCache () {
 
   QFile file (cachePath);
   if (!file.open (QIODevice::ReadOnly)) {
-    qWarning () << "[Template] Failed to open metadata cache:" << cachePath;
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to open metadata cache: "
+                << qPrintable (cachePath) << "\n";
     return metadata;
   }
 
   QByteArray    data= file.readAll ();
   QJsonDocument doc = QJsonDocument::fromJson (data);
   if (doc.isNull () || !doc.isObject ()) {
-    qWarning () << "[Template] Invalid metadata cache format";
+    if (DEBUG_STD) debug_std << "[Template] Invalid metadata cache format\n";
     return metadata;
   }
 
@@ -158,7 +161,9 @@ TemplateCache::saveMetadataCache (
   QString cachePath= metadataCachePath ();
   QFile   file (cachePath);
   if (!file.open (QIODevice::WriteOnly)) {
-    qWarning () << "[Template] Failed to write metadata cache:" << cachePath;
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to write metadata cache: "
+                << qPrintable (cachePath) << "\n";
     return;
   }
 
@@ -176,8 +181,10 @@ TemplateCache::loadRecommendIdsCache () {
 
   QFile file (cachePath);
   if (!file.open (QIODevice::ReadOnly)) {
-    qWarning () << "[Template] Failed to open metadata cache for recommend IDs:"
-                << cachePath;
+    if (DEBUG_STD)
+      debug_std
+          << "[Template] Failed to open metadata cache for recommend IDs: "
+          << qPrintable (cachePath) << "\n";
     return result;
   }
 
@@ -222,8 +229,10 @@ TemplateCache::saveRecommendIdsCache (const QStringList& recommendIds) {
   QJsonDocument doc (root);
   QFile         file (cachePath);
   if (!file.open (QIODevice::WriteOnly)) {
-    qWarning () << "[Template] Failed to write recommend IDs to metadata cache:"
-                << cachePath;
+    if (DEBUG_STD)
+      debug_std
+          << "[Template] Failed to write recommend IDs to metadata cache: "
+          << qPrintable (cachePath) << "\n";
     return;
   }
   file.write (doc.toJson (QJsonDocument::Compact));
@@ -273,11 +282,14 @@ TemplateCache::removeCachedTemplate (const QString& templateId) {
     // Remove file
     bool removed= QFile::remove (it->localPath);
     if (!removed) {
-      qWarning () << "[Template] Failed to remove cached template file:"
-                  << it->localPath;
+      if (DEBUG_STD)
+        debug_std << "[Template] Failed to remove cached template file: "
+                  << qPrintable (it->localPath) << "\n";
     }
     else {
-      qDebug () << "[Template] Removed cached template file:" << it->localPath;
+      if (DEBUG_STD)
+        debug_std << "[Template] Removed cached template file: "
+                  << qPrintable (it->localPath) << "\n";
     }
 
     cacheIndex_.erase (it);
@@ -352,16 +364,19 @@ TemplateCache::loadCategoriesCache () {
   QString   lockPath= cachePath + ".lock";
   QLockFile lockFile (lockPath);
   if (!lockFile.tryLock (5000)) { // Wait up to 5 seconds
-    qWarning ()
-        << "[Template] Could not acquire lock for categories cache read:"
-        << lockPath;
+    if (DEBUG_STD)
+      debug_std
+          << "[Template] Could not acquire lock for categories cache read: "
+          << qPrintable (lockPath) << "\n";
     return categories;
   }
 
   QFile file (cachePath);
   if (!file.open (QIODevice::ReadOnly)) {
-    qWarning () << "[Template] Failed to open categories cache:" << cachePath
-                << "Error:" << file.errorString ();
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to open categories cache: "
+                << qPrintable (cachePath)
+                << " Error: " << qPrintable (file.errorString ()) << "\n";
     return categories;
   }
 
@@ -369,9 +384,10 @@ TemplateCache::loadCategoriesCache () {
   QJsonParseError parseError;
   QJsonDocument   doc= QJsonDocument::fromJson (data, &parseError);
   if (doc.isNull () || !doc.isObject ()) {
-    qWarning () << "[Template] Invalid categories cache format:"
-                << parseError.errorString () << "at offset"
-                << parseError.offset;
+    if (DEBUG_STD)
+      debug_std << "[Template] Invalid categories cache format: "
+                << qPrintable (parseError.errorString ()) << " at offset "
+                << parseError.offset << "\n";
     // Remove corrupted cache file to trigger regeneration
     file.close ();
     QFile::remove (cachePath);
@@ -396,9 +412,11 @@ TemplateCache::loadCategoriesCache () {
       categories.append (category);
     }
     else {
-      qWarning ()
-          << "[Template] Skipping invalid category: missing id or name. ID:"
-          << category.id << "Name:" << category.name;
+      if (DEBUG_STD)
+        debug_std
+            << "[Template] Skipping invalid category: missing id or name. ID: "
+            << qPrintable (category.id)
+            << " Name: " << qPrintable (category.name) << "\n";
     }
   }
 
@@ -408,8 +426,9 @@ TemplateCache::loadCategoriesCache () {
                return a.order < b.order;
              });
 
-  qDebug () << "[Template] Loaded" << categories.size ()
-            << "categories from cache";
+  if (DEBUG_STD)
+    debug_std << "[Template] Loaded " << categories.size ()
+              << " categories from cache\n";
   return categories;
 }
 
@@ -439,29 +458,34 @@ TemplateCache::saveCategoriesCache (const QList<TemplateCategory>& categories) {
   QString   lockPath= cachePath + ".lock";
   QLockFile lockFile (lockPath);
   if (!lockFile.tryLock (5000)) { // Wait up to 5 seconds
-    qWarning ()
-        << "[Template] Could not acquire lock for categories cache write:"
-        << lockPath;
+    if (DEBUG_STD)
+      debug_std
+          << "[Template] Could not acquire lock for categories cache write: "
+          << qPrintable (lockPath) << "\n";
     return;
   }
 
   QFile file (cachePath);
   if (!file.open (QIODevice::WriteOnly | QIODevice::Truncate)) {
-    qWarning () << "[Template] Failed to write categories cache:" << cachePath
-                << "Error:" << file.errorString ();
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to write categories cache: "
+                << qPrintable (cachePath)
+                << " Error: " << qPrintable (file.errorString ()) << "\n";
     return;
   }
 
   qint64 bytesWritten= file.write (doc.toJson (QJsonDocument::Compact));
   if (bytesWritten == -1) {
-    qWarning () << "[Template] Failed to write categories cache data:"
-                << file.errorString ();
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to write categories cache data: "
+                << qPrintable (file.errorString ()) << "\n";
     file.close ();
     QFile::remove (cachePath);
   }
   else {
-    qDebug () << "[Template] Saved" << categories.size ()
-              << "categories to cache";
+    if (DEBUG_STD)
+      debug_std << "[Template] Saved " << categories.size ()
+                << " categories to cache\n";
   }
 }
 
@@ -536,7 +560,9 @@ TemplateCache::saveCacheIndex () {
   QString indexPath= cacheIndexPath ();
   QFile   file (indexPath);
   if (!file.open (QIODevice::WriteOnly)) {
-    qWarning () << "[Template] Failed to write cache index:" << indexPath;
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to write cache index: "
+                << qPrintable (indexPath) << "\n";
     return;
   }
 

--- a/src/Mogan/TemplateCenter/template_manager.cpp
+++ b/src/Mogan/TemplateCenter/template_manager.cpp
@@ -13,9 +13,9 @@
 #include "template_api.hpp"
 #include "template_cache.hpp"
 
+#include "image_cache_base.hpp"
+#include "qt_utilities.hpp"
 #include <QCryptographicHash>
-#include <QDebug>
-#include <QDir>
 #include <QEventLoop>
 #include <QFile>
 #include <QJsonArray>
@@ -101,7 +101,8 @@ TemplateManager::initialize () {
 
   // Initialize cache
   if (!cache_->initialize ()) {
-    qWarning () << "[Template] Failed to initialize template cache";
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to initialize template cache\n";
     // Continue without cache - will work in degraded mode
   }
 
@@ -210,29 +211,32 @@ TemplateManager::loadCategoriesFromScheme (const string& filePath) {
 
   // Check if Scheme interpreter is available
   if (!tm_s7) {
-    qWarning () << "[Template] Scheme interpreter not available";
+    if (DEBUG_STD) debug_std << "[Template] Scheme interpreter not available\n";
     return categories;
   }
 
   // Load and evaluate the Scheme file
   tmscm result= eval_scheme_file (filePath);
   if (tmscm_is_null (result)) {
-    qWarning () << "[Template] Failed to load categories from Scheme file:"
-                << QString::fromUtf8 (as_charp (filePath));
+    if (DEBUG_STD)
+      debug_std << "[Template] Failed to load categories from Scheme file: "
+                << as_charp (filePath) << "\n";
     return categories;
   }
 
   // Call (template-get-categories) to get the category list
   tmscm categoriesFunc= s7_name_to_value (tm_s7, "template-get-categories");
   if (categoriesFunc == s7_undefined (tm_s7)) {
-    qWarning () << "[Template] template-get-categories function not found";
+    if (DEBUG_STD)
+      debug_std << "[Template] template-get-categories function not found\n";
     return categories;
   }
 
   // Use eval_scheme with string expression to call the function
   tmscm categoriesList= eval_scheme ("(template-get-categories)");
   if (tmscm_is_null (categoriesList) || !tmscm_is_list (categoriesList)) {
-    qWarning () << "[Template] Invalid categories list from Scheme";
+    if (DEBUG_STD)
+      debug_std << "[Template] Invalid categories list from Scheme\n";
     return categories;
   }
 
@@ -371,12 +375,16 @@ TemplateManager::verifyLocalTemplate (const QString& templateId) {
     if (!tmpl->fileMd5.isEmpty ()) {
       QString actualMd5= computeFileMd5 (tmpl->localPath);
       if (actualMd5 == tmpl->fileMd5) {
-        qDebug () << "[Template]" << templateId << "MD5 verified:" << actualMd5;
+        if (DEBUG_STD)
+          debug_std << "[Template] " << qPrintable (templateId)
+                    << " MD5 verified: " << qPrintable (actualMd5) << "\n";
         return true;
       }
-      qWarning () << "[Template]" << templateId
-                  << "MD5 mismatch (expected:" << tmpl->fileMd5
-                  << "actual:" << actualMd5 << "), clearing cache";
+      if (DEBUG_STD)
+        debug_std << "[Template] " << qPrintable (templateId)
+                  << " MD5 mismatch (expected: " << qPrintable (tmpl->fileMd5)
+                  << " actual: " << qPrintable (actualMd5)
+                  << "), clearing cache\n";
       cache_->removeCachedTemplate (templateId);
       tmpl->localPath.clear ();
       tmpl->isLocal= false;
@@ -553,7 +561,9 @@ TemplateManager::onRemoteCategoriesLoaded (
 void
 TemplateManager::onRemoteCategoriesFailed (const QString& error) {
   isRefreshingCategories_= false;
-  qWarning () << "[Template] Failed to load remote categories:" << error;
+  if (DEBUG_IO)
+    debug_io << "[Template] Failed to load remote categories: "
+             << qPrintable (error) << "\n";
 }
 
 void
@@ -564,7 +574,9 @@ TemplateManager::onRemoteTemplatesLoaded (
   // 空数据保护：本地已有数据时，空响应视为异常
   if (remoteMetadata.isEmpty () && !templates_.isEmpty ()) {
     QString error= qt_translate ("Remote templates list is empty");
-    qWarning () << "[Template] Skip templates merge:" << error;
+    if (DEBUG_IO)
+      debug_io << "[Template] Skip templates merge: " << qPrintable (error)
+               << "\n";
     pendingIncrementalCategoryId_.clear ();
     emit templatesLoaded ();
     emit templatesLoadFailed (error);
@@ -613,7 +625,9 @@ void
 TemplateManager::onRemoteTemplatesFailed (const QString& error) {
   isRefreshingTemplates_= false;
   pendingIncrementalCategoryId_.clear ();
-  qWarning () << "[Template] Failed to load remote templates:" << error;
+  if (DEBUG_IO)
+    debug_io << "[Template] Failed to load remote templates: "
+             << qPrintable (error) << "\n";
   emit templatesLoaded ();
   emit templatesLoadFailed (error);
 }
@@ -625,7 +639,8 @@ TemplateManager::onRemoteRecommendTemplatesLoaded (
   recommendTemplatesFetched_     = true;
 
   if (metadata.isEmpty () && !templates_.isEmpty ()) {
-    qWarning () << "[Template] Skip recommend templates merge: empty list";
+    if (DEBUG_IO)
+      debug_io << "[Template] Skip recommend templates merge: empty list\n";
     emit recommendTemplatesLoaded ();
     return;
   }
@@ -644,7 +659,9 @@ TemplateManager::onRemoteRecommendTemplatesLoaded (
 void
 TemplateManager::onRemoteRecommendTemplatesFailed (const QString& error) {
   isRefreshingRecommendTemplates_= false;
-  qWarning () << "[Template] Failed to load recommend templates:" << error;
+  if (DEBUG_IO)
+    debug_io << "[Template] Failed to load recommend templates: "
+             << qPrintable (error) << "\n";
   emit recommendTemplatesLoadFailed (error);
 }
 
@@ -723,7 +740,9 @@ TemplateManager::mergeMetadata (
       if (isUpdated && existing->isLocal) {
         // Remote template has been updated, clear local cache to force
         // re-download
-        qDebug () << "[Template]" << id << "updated, clearing cache";
+        if (DEBUG_STD)
+          debug_std << "[Template] " << qPrintable (id)
+                    << " updated, clearing cache\n";
         cache_->removeCachedTemplate (id);
         existing->localPath.clear ();
         existing->isLocal= false;
@@ -764,7 +783,9 @@ TemplateManager::mergeMetadata (
     if (!tmpl->isLocal && cache_->isTemplateCached (tmpl->id)) {
       tmpl->isLocal  = true;
       tmpl->localPath= cache_->cachedTemplatePath (tmpl->id);
-      qDebug () << "[Template]" << tmpl->id << "found in cache";
+      if (DEBUG_STD)
+        debug_std << "[Template] " << qPrintable (tmpl->id)
+                  << " found in cache\n";
     }
   }
 }
@@ -786,9 +807,10 @@ TemplateManager::templateFilePath (const QString& templateId) const {
   // Only allow alphanumeric characters, hyphens, underscores, and dots
   static const QRegularExpression validIdRegex ("^[a-zA-Z0-9._-]+$");
   if (!validIdRegex.match (templateId).hasMatch ()) {
-    qWarning ()
-        << "[Template] Invalid templateId (potential path traversal attempt):"
-        << templateId;
+    if (DEBUG_STD)
+      debug_std << "[Template] Invalid templateId (potential path traversal "
+                   "attempt): "
+                << qPrintable (templateId) << "\n";
     return QString ();
   }
 

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -25,7 +25,6 @@
 
 #include <QtCore/qcryptographichash.h>
 #include <QtCore/qdatetime.h>
-#include <QtCore/qdebug.h>
 #include <QtCore/qjsonarray.h>
 #include <QtCore/qjsondocument.h>
 #include <QtCore/qrandom.h>
@@ -81,10 +80,10 @@ QTMOAuth::QTMOAuth (QObject* parent) {
   // 如果所有端口都被占用，使用第一个端口
   if (m_port == -1) {
     m_port= portList.first ();
-    debug_boot << "All ports occupied, using:" << m_port << "\n";
+    if (DEBUG_IO) debug_io << "All ports occupied, using:" << m_port << "\n";
   }
   else {
-    debug_boot << "Using available port:" << m_port << "\n";
+    if (DEBUG_IO) debug_io << "Using available port:" << m_port << "\n";
   }
 
   m_reply= new QOAuthHttpServerReplyHandler (

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -169,10 +169,10 @@ qt_gui_rep::qt_gui_rep (int& argc, char** argv)
 #ifdef MACOSX_EXTENSIONS
     double mac_hidpi= mac_screen_scale_factor ();
     if (DEBUG_STD)
-      debug_boot << "Mac Screen scaleFfactor: " << mac_hidpi << "\n";
+      debug_std << "Mac Screen scaleFfactor: " << mac_hidpi << "\n";
 
     if (mac_hidpi == 2) {
-      if (DEBUG_STD) debug_boot << "Setting up HiDPI mode\n";
+      if (DEBUG_STD) debug_std << "Setting up HiDPI mode\n";
 #if (QT_VERSION < 0x050000)
       retina_factor= 2;
       if (tm_style_sheet == "") retina_scale= 1.4;
@@ -191,8 +191,8 @@ qt_gui_rep::qt_gui_rep (int& argc, char** argv)
     SI w, h;
     get_extents (w, h);
     if (DEBUG_STD)
-      debug_boot << "Screen extents: " << w / PIXEL << " x " << h / PIXEL
-                 << "\n";
+      debug_std << "Screen extents: " << w / PIXEL << " x " << h / PIXEL
+                << "\n";
     if (min (w, h) >= 1440 * PIXEL) {
       retina_zoom = 2;
       retina_scale= (tm_style_sheet == "" ? 1.0 : 1.6666);

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -3329,11 +3329,14 @@ qt_tm_widget_rep::checkVersionUpdate () {
       QString    localVersion = XMACS_VERSION;
 
       if (!remoteVersion.isEmpty ()) {
-        qDebug () << "[VersionUpdate] Parsed remote version:" << remoteVersion;
+        if (DEBUG_IO)
+          debug_io << "[VersionUpdate] Parsed remote version: "
+                   << qPrintable (remoteVersion) << "\n";
       }
 
       if (remoteVersion.isEmpty ()) {
-        qDebug () << "[VersionUpdate] Failed to parse version from response";
+        if (DEBUG_IO)
+          debug_io << "[VersionUpdate] Failed to parse version from response\n";
         syncScmUpdateNotification (false);
       }
       else if (isVersionNewer (remoteVersion, localVersion)) {
@@ -3344,8 +3347,9 @@ qt_tm_widget_rep::checkVersionUpdate () {
       }
     }
     else {
-      qDebug () << "[VersionUpdate] Failed to fetch remote version:"
-                << reply->errorString ();
+      if (DEBUG_IO)
+        debug_io << "[VersionUpdate] Failed to fetch remote version: "
+                 << qPrintable (reply->errorString ()) << "\n";
       syncScmUpdateNotification (false);
     }
     reply->deleteLater ();

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -888,14 +888,14 @@ TeXmacs_main (int argc, char** argv) {
   if (!use_native_menubar) use_unified_toolbar= false;
   // End user preferences
 
-  if (DEBUG_STD) debug_boot << "Installing internal plug-ins...\n";
+  if (DEBUG_STD) debug_std << "Installing internal plug-ins...\n";
   bench_start ("initialize plugins");
   bench_cumul ("initialize plugins");
-  if (DEBUG_STD) debug_boot << "Opening display...\n";
+  if (DEBUG_STD) debug_std << "Opening display...\n";
 
   gui_open (argc, argv);
   set_default_font (the_default_font);
-  if (DEBUG_STD) debug_boot << "Starting server...\n";
+  if (DEBUG_STD) debug_std << "Starting server...\n";
   { // opening scope for server sv
 #ifdef QTTEXMACS
     server sv (app_type::RESEARCH);
@@ -915,7 +915,7 @@ TeXmacs_main (int argc, char** argv) {
       string s= argv[i];
       if ((N (s) >= 2) && (s (0, 2) == "--")) s= s (1, N (s));
       if ((s[0] != '-') && (s[0] != '+')) {
-        if (DEBUG_STD) debug_boot << "Loading " << s << "...\n";
+        if (DEBUG_STD) debug_std << "Loading " << s << "...\n";
         url u= url_system (s);
         if (!is_rooted (u)) u= resolve (url_pwd (), "") * u;
         string b= scm_quote (as_string (u));
@@ -948,7 +948,7 @@ TeXmacs_main (int argc, char** argv) {
     bench_reset ("initialize plugins");
     bench_reset ("initialize scheme");
 
-    if (DEBUG_STD) debug_boot << "Starting event loop...\n";
+    if (DEBUG_STD) debug_std << "Starting event loop...\n";
     texmacs_started= true;
     if (!disable_error_recovery) {
       // 注册信号处理器，确保子进程被正确清理
@@ -1000,13 +1000,13 @@ TeXmacs_main (int argc, char** argv) {
 #endif
     gui_start_loop ();
 
-    if (DEBUG_STD) debug_boot << "Stopping server...\n";
+    if (DEBUG_STD) debug_std << "Stopping server...\n";
   } // ending scope for server sv
 
-  if (DEBUG_STD) debug_boot << "Closing display...\n";
+  if (DEBUG_STD) debug_std << "Closing display...\n";
   gui_close ();
 
-  if (DEBUG_STD) debug_boot << "Good bye...\n";
+  if (DEBUG_STD) debug_std << "Good bye...\n";
 }
 
 #ifdef QTTEXMACS

--- a/src/System/Link/texmacs_server.cpp
+++ b/src/System/Link/texmacs_server.cpp
@@ -97,7 +97,8 @@ server_start () {
   }
   if (!the_server->alive) {
     bool started= the_server->start ();
-    if (DEBUG_STD) debug_std << "Starting server... " << started << "\n";
+    if (DEBUG_STD)
+      debug_std << "Starting server... " << as_string_bool (started) << "\n";
   }
 }
 

--- a/src/System/Link/texmacs_server.cpp
+++ b/src/System/Link/texmacs_server.cpp
@@ -12,6 +12,7 @@
 #include "client_server.hpp"
 #include "scheme.hpp"
 #include "socket_server.hpp"
+#include "tm_debug.hpp"
 #include "tm_link.hpp"
 
 #ifdef QTTEXMACS
@@ -94,8 +95,10 @@ server_start () {
     (void) eval ("(use-modules (server server-live))");
     the_server= tm_new<socket_server_rep> (6561);
   }
-  if (!the_server->alive)
-    cout << "TeXmacs] Starting server... " << the_server->start () << "\n";
+  if (!the_server->alive) {
+    bool started= the_server->start ();
+    if (DEBUG_STD) debug_std << "Starting server... " << started << "\n";
+  }
 }
 
 void

--- a/src/System/Link/texmacs_server.cpp
+++ b/src/System/Link/texmacs_server.cpp
@@ -96,9 +96,8 @@ server_start () {
     the_server= tm_new<socket_server_rep> (6561);
   }
   if (!the_server->alive) {
-    bool started= the_server->start ();
-    if (DEBUG_STD)
-      debug_std << "Starting server... " << as_string_bool (started) << "\n";
+    string started= the_server->start ();
+    if (DEBUG_STD) debug_std << "Starting server... " << started << "\n";
   }
 }
 


### PR DESCRIPTION
## Summary

将 Scheme 层面的 telemetry 调试日志、`init-research.scm` 中的启动阶段日志、模板中心（TemplateCenter）/缩略图缓存（ThumbnailCache）的 C++ 日志，以及启动和 OAuth 阶段直接输出到 `cout` 的日志，从原生的 `(display ...)` / `qDebug()/qWarning()` / `cout` 改为项目调试体系中的 `debug-message` / `debug_std` / `debug_io` / `debug_boot`，统一由调试开关控制。

主要改动：
- `TeXmacs/progs/telemetry/*.scm`：telemetry 日志改为 `(debug-message "debug-events" ...)`；
- `TeXmacs/progs/init-research.scm`：启动阶段日志改为 `(debug-message "debug-std" ...)`，并移除无意义的 `Benchmark 1` fib(30) 计算；
- 模板中心与缩略图缓存的 C++ 日志从 `qDebug()/qWarning()` 改为 `DEBUG_STD`/`DEBUG_IO` + `debug_std`/`debug_io`；
- 启动阶段进度日志统一改为 `DEBUG_STD` + `debug_std`；
- `QTMOAuth.cpp` 中的端口日志改为 `DEBUG_IO` + `debug_io`。

## Test plan

- [ ] 本地构建 `xmake b stem` 通过
- [ ] 启动 Mogan STEM，确认 stdout 不再直接输出启动日志
- [ ] 带 `-debug-std` 启动，确认启动日志带时间戳正常输出
- [ ] 带 `-debug-events` 启动并操作，确认 telemetry 日志带时间戳正常输出
- [ ] 模板中心加载/缩略图缓存相关功能无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)