### PR TITLE
[1142] 移除 Scheme 层 qt4-gui / qt5-gui 兼容代码

### DIFF
--- a/TeXmacs/progs/kernel/boot/abbrevs.scm
+++ b/TeXmacs/progs/kernel/boot/abbrevs.scm
@@ -259,10 +259,3 @@
 ) ;define-public
 
 (define-public (alt-windows-delete l) (for-each alt-window-delete l))
-
-(define-public (qt4-gui?) (== (gui-version) "qt4"))
-(define-public (qt4-or-later-gui?) (in? (gui-version) (list "qt4" "qt5" "qt6")))
-(define-public (qt5-gui?) (== (gui-version) "qt5"))
-(define-public (qt5-or-later-gui?) (in? (gui-version) (list "qt5" "qt6")))
-(define-public (qt6-gui?) (== (gui-version) "qt6"))
-(define-public (qt6-or-later-gui?) (in? (gui-version) (list "qt6")))

--- a/TeXmacs/progs/texmacs/menus/view-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/view-widgets.scm
@@ -56,45 +56,24 @@
 ) ;tm-define
 
 (tm-widget (retina-settings-widget cmd)
-  (centered (assuming (and (os-macos?) (qt4-gui?))
+  (centered (assuming (and (os-macos?) (qt-gui?))
               (centered (aligned (item (text "Use retina fonts:")
                                    (toggle (set-retina-boolean-preference "retina-factor" answer)
                                      (get-retina-boolean-preference "retina-factor")
                                    ) ;toggle
                                  ) ;item
-                          (item (text "Use retina icons:")
-                            (toggle (set-retina-boolean-preference "retina-icons" answer)
-                              (get-retina-boolean-preference "retina-icons")
-                            ) ;toggle
-                          ) ;item
-                          (item (text "Scale graphical interface:")
-                            (enum (set-retina-preference "retina-scale" answer)
-                              '("1" "1.2" "1.4" "1.6" "1.8" "2" "")
-                              (get-retina-preference "retina-scale")
-                              "5em"
-                            ) ;enum
-                          ) ;item
+                          (assuming (!= (get-preference "gui theme") "")
+                            (item (text "Scale graphical interface:")
+                              (enum (set-retina-preference "retina-scale" answer)
+                                '("1" "1.2" "1.5" "2" "")
+                                (get-retina-preference "retina-scale")
+                                "5em"
+                              ) ;enum
+                            ) ;item
+                          ) ;assuming
                         ) ;aligned
               ) ;centered
             ) ;assuming
-    (assuming (and (os-macos?) (qt5-or-later-gui?))
-      (centered (aligned (item (text "Use retina fonts:")
-                           (toggle (set-retina-boolean-preference "retina-factor" answer)
-                             (get-retina-boolean-preference "retina-factor")
-                           ) ;toggle
-                         ) ;item
-                  (assuming (!= (get-preference "gui theme") "")
-                    (item (text "Scale graphical interface:")
-                      (enum (set-retina-preference "retina-scale" answer)
-                        '("1" "1.2" "1.5" "2" "")
-                        (get-retina-preference "retina-scale")
-                        "5em"
-                      ) ;enum
-                    ) ;item
-                  ) ;assuming
-                ) ;aligned
-      ) ;centered
-    ) ;assuming
     (assuming (not (os-macos?))
       (centered (aligned (item (text "Double the zoom factor for TeXmacs documents:")
                            (toggle (set-retina-boolean-preference "retina-zoom" answer)

--- a/TeXmacs/progs/texmacs/texmacs/tm-server.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-server.scm
@@ -94,11 +94,11 @@
 ) ;define
 
 (define (get-default-native-menubar)
-  (if (qt4-gui?) "on" "off")
+  "off"
 ) ;define
 
 (define (get-default-unified-toolbar)
-  (if (qt4-gui?) "on" "off")
+  "off"
 ) ;define
 
 (define-preferences ("profile" "beginner" (lambda args (noop)))

--- a/devel/1142.md
+++ b/devel/1142.md
@@ -46,6 +46,33 @@
   日志的类型问题：`the_server->start ()` 返回 `string`，原代码误声明为
   `bool`，改为 `string started` 后直接输出到 `debug_std`。
 
+## 子任务：移除 qt4-gui / qt5-gui 相关兼容代码
+
+### What
+
+清理 Scheme 层面遗留的 `qt4-gui`、`qt5-gui` 判断与兼容分支。由于 Mogan 当前仅维护 Qt 前端，
+`qt4`、`qt5` 已不再是需要单独区分的 GUI 版本，相关 `qt4-gui?`、`qt4-or-later-gui?`、
+`qt5-gui?`、`qt5-or-later-gui?` 的分支代码已失去意义，需要移除或简化。
+
+### Why
+
+- 减少无意义的版本分支，降低后续维护成本；
+- 避免 Scheme 层面对已废弃 GUI 版本的误判；
+- 与当前 Qt6 单一前端架构保持一致。
+
+### How
+
+- `TeXmacs/progs/kernel/boot/abbrevs.scm`：删除 `qt4-gui?`、`qt4-or-later-gui?`、
+  `qt5-gui?`、`qt5-or-later-gui?` 的定义。由于当前仅保留 Qt 前端，`qt5-or-later-gui?`
+  的语义可直接用已有的 `qt-gui?` 替代。`qt6-gui?` / `qt6-or-later-gui?` 同样未在 Scheme
+  层被使用，一并删除，统一使用 `qt-gui?` 判断是否为 Qt 前端。
+- `TeXmacs/progs/texmacs/texmacs/tm-server.scm`：`get-default-native-menubar` 与
+  `get-default-unified-toolbar` 原来仅在 Qt4 下返回 `"on"`，现在 Qt4 已不支持，
+  直接返回 `"off"`。
+- `TeXmacs/progs/texmacs/menus/view-widgets.scm`：
+  - 移除 macOS + Qt4 的 retina 设置分支；
+  - 将 macOS + `qt5-or-later-gui?` 分支改为 macOS + `qt-gui?`，保留 Qt 前端的显式判断。
+
 ## 涉及文件
 
 - `TeXmacs/progs/telemetry/init-telemetry.scm`
@@ -62,4 +89,7 @@
 - `src/Plugins/Qt/qt_gui.cpp`
 - `src/System/Boot/init_texmacs.cpp`
 - `src/System/Link/texmacs_server.cpp`
+- `TeXmacs/progs/kernel/boot/abbrevs.scm`
+- `TeXmacs/progs/texmacs/texmacs/tm-server.scm`
+- `TeXmacs/progs/texmacs/menus/view-widgets.scm`
 - `devel/1142.md`


### PR DESCRIPTION
## Summary

- 删除 `TeXmacs/progs/kernel/boot/abbrevs.scm` 中 qt4-gui? / qt4-or-later-gui? / qt5-gui? / qt5-or-later-gui? / qt6-gui? / qt6-or-later-gui? 的定义，统一使用已有的 `qt-gui?` 判断 Qt 前端。
- `tm-server.scm` 中 `get-default-native-menubar` 与 `get-default-unified-toolbar` 原来仅在 Qt4 下返回 `"on"`，现在直接返回 `"off"`。
- `view-widgets.scm` 移除 macOS + Qt4 的 retina 设置分支，将 macOS + `qt5-or-later-gui?` 改为 macOS + `qt-gui?`。

## Test plan

- [ ] 本地构建 `xmake b stem` 通过
- [ ] 启动 Mogan 并打开 retina 设置窗口，确认界面正常
- [ ] 批量 Scheme 测试无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)