### PR TITLE
[1143] 移除启动时遗留 Benchmark 代码

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -59,24 +59,6 @@
 ) ;let
 
 
-(let ()
-  (define (fib n)
-    (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2))))
-  ) ;define
-  (define start (texmacs-time))
-  (define result (fib 30))
-  (define elapsed (- (texmacs-time) start))
-  (debug-message "debug-std"
-    (string-append "Benchmark 1\n"
-      (number->string result)
-      "\n"
-      "Time: "
-      (number->string elapsed)
-      "\n"
-    ) ;string-append
-  ) ;debug-message
-) ;let
-
 (define developer-mode? #f)
 
 (define boot-start (texmacs-time))
@@ -709,27 +691,6 @@
 (texmacs-banner)
 (debug-message "debug-std" "Initialization done\n")
 
-(let ()
-  (define start (texmacs-time))
-  (tm-define (tm-fib n) (if (< n 2) n (+ (tm-fib (- n 1)) (tm-fib (- n 2)))))
-  (define result (tm-fib 30))
-  (define elapsed (- (texmacs-time) start))
-  (debug-message "debug-std"
-    (string-append "------------------------------------------------------\n"
-      "Benchmark 2\n"
-      (number->string result)
-      "\n"
-      "Time: "
-      (number->string elapsed)
-      "\n"
-      "------------------------------------------------------\n"
-    ) ;string-append
-  ) ;debug-message
-) ;let
-
-(debug-message "debug-std"
-  "------------------------------------------------------\n"
-) ;debug-message
 (debug-message "debug-std" "Forcing delayed loads\n")
 (lazy-keyboard-force #t)
 (debug-message "debug-std"

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -1,0 +1,55 @@
+# [1143] 启动性能：telemetry OPEN → STARTUP 路径优化
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/init-research.scm` — OPEN 事件埋点（:698）及之后的初始化收尾
+- `src/Plugins/Qt/QTMStartupTabWidget.cpp` — STARTUP 事件埋点（:104，首次 showEvent）
+- `src/Plugins/Qt/qt_tm_widget.cpp` — 启动页 widget 创建（:1102 `sync_startup_tab_mode`）
+- `src/Plugins/Qt/QTMOAuth.cpp` — `refreshToken`（:242，"Start refresh token..."）
+- `src/Plugins/MuPDF/mupdf_renderer.cpp` — MuPDF 渲染器初始化（:37）
+- `src/Edit/Interface/edit_interface.cpp` — `bench_start ("resume")`（:115）
+- `TeXmacs/progs/kernel/gui/kbd-define.scm` — `lazy-keyboard-force` 实现
+
+## 3 代码路径（OPEN → STARTUP）
+
+启动日志实测总耗时约 1.6s（14:41:40.690 → 14:41:42.298），各段如下：
+
+1. **OPEN 埋点**（40.690）— `init-research.scm:692-708`：`init-telemetry` 后 `(track-event "OPEN" '())`
+2. **texmacs-banner + "Initialization done"** — `init-research.scm:709-710`
+3. **Benchmark 2（tm-fib 30）**（~111ms）— `init-research.scm:712-728`，每次启动都跑的遗留基准代码
+4. **"Forcing delayed loads"**（~1.0s，最大头）— `init-research.scm:733-744`：`(lazy-keyboard-force #t)` 同步强制加载所有延迟的键盘/模块定义
+5. **"Start refresh token..."** — `QTMOAuth.cpp:244`，QNetworkAccessManager 异步请求，不阻塞
+6. **"Use MuPDF render" + 字体加载**（~180ms）— `mupdf_renderer.cpp:37` 首次渲染时初始化，加载 `ecrm10.tfm`/`ecss10.tfm`、`larm.enc`/`grmn.enc`
+7. **bench "resume"**（173ms）— `edit_interface.cpp:115`
+8. **STARTUP 埋点**（42.298）— `QTMStartupTabWidget::showEvent` 首次显示时 `telemetry_track ("STARTUP")`（`QTMStartupTabWidget.cpp:99-106`）
+
+## 4 优化方向
+
+- ~~**移除 Benchmark 1/2**~~（已完成）：`init-research.scm` 中两处 `fib 30` 遗留基准代码（原 :62-78、:712-728），各占 ~100ms，已删除
+- **拆解 `lazy-keyboard-force`**：占 ~1s，可改为 idle 分批加载，或只强制加载首屏必需的键盘定义
+- **MuPDF/字体预热**：首屏渲染触发的渲染器初始化和字体加载（~180ms）可移到 idle 预热
+
+## 5 如何测试
+
+```bash
+xmake b stem
+MOGAN_TEST_GUI=1 xmake r <启动相关测试>
+# 或直接启动二进制，观察 debug-std/debug-events 日志时间戳
+```
+
+## 6 What
+梳理 telemetry OPEN → STARTUP 之间的启动代码路径并标注各段耗时，为启动性能优化提供依据。
+
+已完成改动：
+1. 删除 `init-research.scm` 中 Benchmark 1（`fib 30`，原 :62-78）
+2. 删除 Benchmark 2（`tm-fib 30`，原 :712-728，连同收尾分隔线输出）
+
+涉及文件：`TeXmacs/progs/init-research.scm`（-39 行）
+
+## 7 Why
+OPEN → STARTUP 约 1.6s，是用户可感知的启动延迟，其中 `lazy-keyboard-force` 和遗留 Benchmark 代码有明显优化空间。
+
+## 8 How
+通过 `debug-std`/`debug-events` 日志时间戳分段定位，结合源码找到每段对应的埋点与实现位置。


### PR DESCRIPTION
## Summary
- 梳理 telemetry OPEN → STARTUP 启动代码路径并记录于 devel/1143.md（总耗时约 1.6s）
- 删除 init-research.scm 中两处遗留基准代码（Benchmark 1 `fib 30`、Benchmark 2 `tm-fib 30`），每次启动约省 200ms+

## Test plan
- [x] `gf fmt --changed-since=main` 通过
- [x] 确认无其他代码引用 `tm-fib` / Benchmark 输出
- [ ] 启动 Mogan 验证 debug-std 日志不再出现 Benchmark 输出且启动正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)