### PR TITLE
[1143] lazy-keyboard 注册迁移至 keyboard 插件

### DIFF
--- a/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
+++ b/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
@@ -10,7 +10,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (keyboard))
+(texmacs-module (keyboard) (:use (texmacs texmacs tm-view)))
 
 (lazy-keyboard (utils automate auto-kbd) in-auto?)
 (lazy-keyboard (texmacs keyboard prefix-kbd) always?)

--- a/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
+++ b/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
@@ -34,3 +34,11 @@
 (lazy-keyboard (version version-kbd) with-versioning-tool?)
 
 (lazy-keyboard-force #t)
+
+(delayed (:idle 0)
+  (kbd-map (:require (or (full-screen?) (full-screen-edit?)))
+   ("escape" (exit-fullscreen) "Exit full screen")
+   ("M-" (exit-fullscreen) "Exit full screen")
+   ("A-" (exit-fullscreen) "Exit full screen")
+  ) ;kbd-map
+) ;delayed

--- a/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
+++ b/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
@@ -1,0 +1,36 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-keyboard.scm
+;; DESCRIPTION : Initialize the keyboard plugin
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (keyboard))
+
+(lazy-keyboard (utils automate auto-kbd) in-auto?)
+(lazy-keyboard (texmacs keyboard prefix-kbd) always?)
+(lazy-keyboard (generic generic-kbd) always?)
+(lazy-keyboard (generic search-kbd))
+(lazy-keyboard (text text-kbd) in-text?)
+(lazy-keyboard (text text-kbd-utf8) in-text?)
+(lazy-keyboard (math math-kbd) in-math?)
+(lazy-keyboard (math math-sem-edit) in-sem-math?)
+(lazy-keyboard (prog prog-kbd) in-prog?)
+(lazy-keyboard (source source-kbd) always?)
+(lazy-keyboard (table table-kbd) in-table?)
+(lazy-keyboard (graphics graphics-kbd) in-active-graphics?)
+(lazy-keyboard (education edu-kbd) in-edu-text?)
+(lazy-keyboard (dynamic fold-kbd) always?)
+(lazy-keyboard (dynamic scripts-kbd) always?)
+(lazy-keyboard (dynamic calc-kbd) always?)
+(lazy-keyboard (doc tmdoc-kbd) in-manual?)
+(lazy-keyboard (doc apidoc-kbd) developer-mode?)
+(lazy-keyboard (link link-kbd) with-linking-tool?)
+(lazy-keyboard (version version-kbd) with-versioning-tool?)
+
+(lazy-keyboard-force #t)

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -130,7 +130,6 @@
 (lazy-tmfs-handler (utils automate auto-tmfs) automate)
 (lazy-define (utils automate auto-tmfs) auto-load-help)
 (lazy-define (utils misc gui-keyboard) get-keyboard)
-(lazy-keyboard (utils automate auto-kbd) in-auto?)
 ;; (display* "time: " (- (texmacs-time) boot-start) "\n")
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
@@ -148,7 +147,6 @@
   (texmacs texmacs tm-print)
 ) ;use-modules
 (use-modules (texmacs keyboard config-kbd))
-(lazy-keyboard (texmacs keyboard prefix-kbd) always?)
 (lazy-menu (texmacs menus file-menu)
   file-menu
   go-menu
@@ -176,7 +174,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting generic mode\n")
-(lazy-keyboard (generic generic-kbd) always?)
 (lazy-menu (generic generic-menu) focus-menu texmacs-focus-icons)
 (lazy-menu (generic format-menu)
   format-menu
@@ -231,7 +228,6 @@
   interactive-replace
   search-next-match
 ) ;lazy-define
-(lazy-keyboard (generic search-kbd))
 (lazy-define (generic spell-widgets)
   spell-toolbar
   open-spell
@@ -274,8 +270,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting text mode\n")
-(lazy-keyboard (text text-kbd) in-text?)
-(lazy-keyboard (text text-kbd-utf8) in-text?)
 (lazy-menu (text text-menu)
   text-format-menu
   text-format-icons
@@ -290,8 +284,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting math mode\n")
-(lazy-keyboard (math math-kbd) in-math?)
-(lazy-keyboard (math math-sem-edit) in-sem-math?)
 (lazy-menu (math math-menu)
   math-format-menu
   math-format-icons
@@ -310,7 +302,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting programming modes\n")
-(lazy-keyboard (prog prog-kbd) in-prog?)
 (lazy-menu (prog prog-menu)
   prog-format-menu
   prog-format-icons
@@ -321,7 +312,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting source mode\n")
-(lazy-keyboard (source source-kbd) always?)
 (lazy-menu (source source-menu)
   source-macros-menu
   source-menu
@@ -357,7 +347,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting table mode\n")
-(lazy-keyboard (table table-kbd) in-table?)
 (lazy-menu (table table-menu) insert-table-menu)
 (lazy-define (table table-edit) table-resize-notify)
 (lazy-define (table table-widgets) open-cell-properties open-table-properties)
@@ -367,7 +356,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting graphics mode\n")
-(lazy-keyboard (graphics graphics-kbd) in-active-graphics?)
 (lazy-menu (graphics graphics-menu) graphics-menu graphics-icons)
 (lazy-define (graphics graphics-object)
   graphics-init-state
@@ -422,15 +410,11 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting educational features\n")
-(lazy-keyboard (education edu-kbd) in-edu-text?)
 (lazy-menu (education edu-menu) edu-insert-menu)
 ;; (display* "time: " (- (texmacs-time) boot-start) "\n")
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting dynamic features\n")
-(lazy-keyboard (dynamic fold-kbd) always?)
-(lazy-keyboard (dynamic scripts-kbd) always?)
-(lazy-keyboard (dynamic calc-kbd) always?)
 (lazy-menu (dynamic fold-menu)
   insert-fold-menu
   dynamic-menu
@@ -467,8 +451,6 @@
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting documentation\n")
-(lazy-keyboard (doc tmdoc-kbd) in-manual?)
-(lazy-keyboard (doc apidoc-kbd) developer-mode?)
 (lazy-menu (doc tmdoc-menu) tmdoc-menu tmdoc-icons)
 (lazy-menu (doc help-menu) help-menu)
 (lazy-define (doc tmdoc)
@@ -577,7 +559,6 @@
 
 ;; (display "Booting linking facilities\n")
 (lazy-menu (link link-menu) link-menu)
-(lazy-keyboard (link link-kbd) with-linking-tool?)
 (lazy-define (link link-edit) create-unique-id)
 (lazy-define (link link-navigate)
   link-active-upwards
@@ -597,7 +578,6 @@
 
 ;; (display "Booting versioning facilities\n")
 (lazy-menu (version version-menu) version-menu)
-(lazy-keyboard (version version-kbd) with-versioning-tool?)
 (lazy-define (version version-tmfs) update-buffer commit-buffer)
 ;; (display* "time: " (- (texmacs-time) boot-start) "\n")
 ;; (display* "memory: " (texmacs-memory) " bytes\n")

--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -258,14 +258,6 @@
   ) ;if
 ) ;define
 
-(delayed (:idle 0)
-  (kbd-map (:require (or (full-screen?) (full-screen-edit?)))
-   ("escape" (exit-fullscreen) "Exit full screen")
-   ("M-" (exit-fullscreen) "Exit full screen")
-   ("A-" (exit-fullscreen) "Exit full screen")
-  ) ;kbd-map
-) ;delayed
-
 (define panorama-revert (make-ahash-table))
 
 (define (panorama-mode?)

--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -259,7 +259,6 @@
 ) ;define
 
 (delayed (:idle 0)
-  (lazy-keyboard-force #t)
   (kbd-map (:require (or (full-screen?) (full-screen-edit?)))
    ("escape" (exit-fullscreen) "Exit full screen")
    ("M-" (exit-fullscreen) "Exit full screen")

--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -251,12 +251,12 @@
   ) ;let*
 ) ;tm-define
 
-(define (exit-fullscreen)
+(tm-define (exit-fullscreen)
   (if (full-screen-edit?)
     (toggle-full-screen-edit-mode)
     (toggle-full-screen-mode)
   ) ;if
-) ;define
+) ;tm-define
 
 (define panorama-revert (make-ahash-table))
 

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -167,8 +167,9 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     模块注册移入 `plugins/keyboard/progs/init-keyboard.scm`，并在文件末尾
     `(lazy-keyboard-force #t)` 统一强载——键盘模块的加载从启动主路径移到
     插件延迟初始化阶段（`lazy-plugin-initialize` 的 `:pause 3000`）集中完成；
-    同时移除 `tm-view.scm` 中 `delayed (:idle 0)` 的 `(lazy-keyboard-force #t)`
-    （其职责已由插件末尾的强载接管）
+    同时移除 `tm-view.scm` 中 `delayed (:idle 0)` 整块（启动时
+    `(lazy-keyboard-force #t)` 及 fullscreen 退出快捷键 kbd-map），
+    kbd-map 一并移至插件文件末尾，强载职责由插件接管
 
 涉及文件：`TeXmacs/progs/init-research.scm`（-39 行、移出 lazy-keyboard 注册）、
 `src/Edit/Interface/edit_interface.cpp`（resume 守卫）、
@@ -183,7 +184,7 @@ lazy-plugin-force-one）、
 `src/Plugins/Qt/QTMStartupTabWidget.{cpp,hpp}`（移除 showEvent 触发）、
 `src/System/Boot/init_texmacs.cpp`（事件循环起跑后触发 STARTUP）、
 `TeXmacs/plugins/keyboard/progs/init-keyboard.scm`（新增）、
-`TeXmacs/progs/texmacs/texmacs/tm-view.scm`（移除启动时 lazy-keyboard-force）
+`TeXmacs/progs/texmacs/texmacs/tm-view.scm`（移除 delayed 强载及 fullscreen kbd-map）
 
 ## 7 Why
 OPEN → STARTUP 约 1.3~1.6s，是用户可感知的启动延迟。首屏（启动页）不依赖

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -14,6 +14,8 @@
 - `src/Edit/Interface/edit_interface.cpp` — `resume()` 与 `bench_start ("resume")`（:113-115）
 - `src/Texmacs/Data/new_view.cpp` — `attach_view()`（:566-587），:585 触发 `resume()`
 - `TeXmacs/progs/kernel/gui/kbd-define.scm` — `lazy-keyboard-force` 实现
+- `TeXmacs/plugins/keyboard/progs/init-keyboard.scm` — 键盘插件（新增），
+  集中注册全部 lazy-keyboard 并在末尾强载
 
 ## 3 代码路径（OPEN → STARTUP）
 
@@ -161,8 +163,14 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     同步执行 track + flush + plugin-feed）移到 `init_texmacs.cpp` 的
     "Starting event loop" 之后（`texmacs_started= true` 处）；删除
     showEvent override 与 `startupTracked_` 成员
+13. 新增 keyboard 插件：`init-research.scm` 中全部 20 条 `lazy-keyboard`
+    模块注册移入 `plugins/keyboard/progs/init-keyboard.scm`，并在文件末尾
+    `(lazy-keyboard-force #t)` 统一强载——键盘模块的加载从启动主路径移到
+    插件延迟初始化阶段（`lazy-plugin-initialize` 的 `:pause 3000`）集中完成；
+    同时移除 `tm-view.scm` 中 `delayed (:idle 0)` 的 `(lazy-keyboard-force #t)`
+    （其职责已由插件末尾的强载接管）
 
-涉及文件：`TeXmacs/progs/init-research.scm`（-39 行）、
+涉及文件：`TeXmacs/progs/init-research.scm`（-39 行、移出 lazy-keyboard 注册）、
 `src/Edit/Interface/edit_interface.cpp`（resume 守卫）、
 `src/Plugins/Qt/qt_tm_widget.{cpp,hpp}`（推迟 chrome 补装）、
 `TeXmacs/progs/database/bib-kbd.scm`（删除）、
@@ -173,7 +181,9 @@ lazy-plugin-force-one）、
 `TeXmacs/progs/kernel/gui/kbd-define.scm`（lazy-keyboard-force 日志）、
 `TeXmacs/progs/telemetry/telemetry-track.scm`（注释更新）、
 `src/Plugins/Qt/QTMStartupTabWidget.{cpp,hpp}`（移除 showEvent 触发）、
-`src/System/Boot/init_texmacs.cpp`（事件循环起跑后触发 STARTUP）
+`src/System/Boot/init_texmacs.cpp`（事件循环起跑后触发 STARTUP）、
+`TeXmacs/plugins/keyboard/progs/init-keyboard.scm`（新增）、
+`TeXmacs/progs/texmacs/texmacs/tm-view.scm`（移除启动时 lazy-keyboard-force）
 
 ## 7 Why
 OPEN → STARTUP 约 1.3~1.6s，是用户可感知的启动延迟。首屏（启动页）不依赖


### PR DESCRIPTION
## Summary
- 新增 `plugins/keyboard/progs/init-keyboard.scm`：`init-research.scm` 中全部 20 条 `lazy-keyboard` 模块注册移入该插件，末尾 `(lazy-keyboard-force #t)` 统一强载，键盘模块加载从启动主路径移到插件延迟初始化阶段
- `tm-view.scm` 中 `delayed (:idle 0)` 整块（启动时强载 + fullscreen 退出快捷键 kbd-map）移至插件文件末尾，插件 `(:use (texmacs texmacs tm-view))` 保证 `exit-fullscreen` 等符号可用

## Test plan
- [ ] 构建 `xmake b stem` 后启动，确认键盘快捷键（text/math 等模式）正常
- [ ] 确认 fullscreen 下 escape/M-/A- 退出快捷键生效
- [ ] 观察 debug-std 日志确认 keyboard 插件加载与 lazy-keyboard-force 调用

🤖 Generated with [Claude Code](https://claude.com/claude-code)