### PR TITLE
[1143] tm-files 移除死导入，模块加载 ~78ms → ~34ms

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -135,11 +135,17 @@
 (lazy-menu (bibtex bib-widgets) open-bibliography-inserter)
 
 ;; (display "Booting main TeXmacs functionality\n")
-(use-modules (texmacs texmacs tm-server)
-  (texmacs texmacs tm-view)
-  (texmacs texmacs tm-files)
-  (texmacs texmacs tm-print)
-) ;use-modules
+(use-modules (texmacs texmacs tm-server) (texmacs texmacs tm-view))
+
+(define tm-files-boot-start (texmacs-time))
+(use-modules (texmacs texmacs tm-files))
+(debug-message "debug-std"
+  (string-append "bench tm-files: "
+    (number->string (- (texmacs-time) tm-files-boot-start))
+    " ms\n"
+  ) ;string-append
+) ;debug-message
+(use-modules (texmacs texmacs tm-print))
 (use-modules (texmacs keyboard config-kbd))
 (lazy-menu (texmacs menus file-menu)
   file-menu

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -22,7 +22,6 @@
 ) ;texmacs-module
 
 (import (only (liii string) string-contains))
-(import (only (liii hashlib) md5))
 (import (only (liii uuid) uuid4))
 (import (only (liii path)
           path->string
@@ -40,19 +39,9 @@
           path-unlink
         ) ;only
 ) ;import
-(import (only (liii os) mkdir))
-(import (liii njson))
 (import (liii json))
 (import (only (srfi srfi-1) find))
 (import (only (srfi srfi-1) remove))
-(import (only (srfi srfi-19)
-          TIME-UTC
-          current-date
-          current-time
-          date->string
-          time-second
-        ) ;only
-) ;import
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Remember last save/open directory

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -173,6 +173,13 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
 14. `(llm chat-loader)` 从 `init-research.scm` 启动主路径移至 llm 插件
     `plugins/llm/progs/init-llm.scm`（插件懒加载阶段再载入），
     init-research.scm 不再同步 use-modules
+15. 移除 `tm-files.scm` 4 个死导入（`liii hashlib` md5、`liii os` mkdir、
+    `liii njson`、`srfi srfi-19`，均无实际使用），模块加载耗时
+    ~78ms → ~34ms（-56%），收益主要来自 srfi-19（1699 行）与 liii os
+    不再在此首次加载；使用方（search-widgets/telemetry-utils/
+    shortcut-edit 等）均各自 import，无传递依赖。另在
+    `init-research.scm` 保留 `bench tm-files` 计时
+    （texmacs-time + debug-std 日志），便于后续继续观测
 
 本次分段计时（临时 `boot-bench` 打点，测完即删，未入库）实测
 init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、
@@ -181,7 +188,8 @@ init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、
 chat-loader 迁出后 04 main 降至 ~240ms。后续优化目标：tm-server 与
 tm-files 的模块加载内容。
 
-涉及文件：`TeXmacs/progs/init-research.scm`（-39 行、移出 lazy-keyboard 注册、移出 chat-loader）、
+涉及文件：`TeXmacs/progs/init-research.scm`（-39 行、移出 lazy-keyboard 注册、移出 chat-loader、保留 bench tm-files 计时）、
+`TeXmacs/progs/texmacs/texmacs/tm-files.scm`（移除 4 个死导入）、
 `src/Edit/Interface/edit_interface.cpp`（resume 守卫）、
 `src/Plugins/Qt/qt_tm_widget.{cpp,hpp}`（推迟 chrome 补装）、
 `TeXmacs/progs/database/bib-kbd.scm`（删除）、


### PR DESCRIPTION
## Summary
- `tm-files.scm` 移除 4 个死导入（`liii hashlib` md5、`liii os` mkdir、`liii njson`、`srfi srfi-19`），文件内均无实际使用
- 模块加载耗时 ~78ms → ~34ms（-56%），收益主要来自 srfi-19（1699 行）与 liii os 不再在启动期首次加载
- 已确认其他使用方（search-widgets/telemetry-utils/shortcut-edit/tm-dialogue 等）均各自 import，不依赖 tm-files 的传递加载
- `init-research.scm` 保留 `bench tm-files` 计时（texmacs-time + debug-std），便于后续继续观测启动耗时

## Test plan
- [x] headless 启动 5 次取 bench 日志，前后对比（78/76/81/90/80 → 35/34/32/34/36 ms）
- [ ] CI 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)