### PR TITLE
[1143] telemetry STARTUP 改名 OPEN，事件循环日志附带启动耗时

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -612,7 +612,6 @@
     (use-modules (telemetry telemetry-track))
     (use-modules (telemetry init-telemetry))
     (init-telemetry)
-    (track-event "OPEN" '())
   ) ;lambda
   (lambda args
     (let ((msg (string-append "[telemetry] error: init failed: " (object->string args) "\n")

--- a/TeXmacs/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/progs/telemetry/telemetry-track.scm
@@ -81,7 +81,7 @@
 
 (define-public (important-event? event-type)
   (or (string=? event-type "HEART_BEAT")
-    (string=? event-type "STARTUP")
+    (string=? event-type "OPEN")
     (string=? event-type "TUTORIAL")
     (string=? event-type "INVITE_CLICK")
     (string=? event-type "VIP_CLICK")
@@ -123,10 +123,10 @@
           (if (important-event? event-type)
             (begin
               (telemetry-flush)
-              ;; STARTUP 的 track 已由 C++ 侧推迟到事件循环起跑后触发；
+              ;; OPEN 的 track 已由 C++ 侧推迟到事件循环起跑后触发；
               ;; upload 再额外延后 500ms，让首帧先绘制，避免 plugin-feed
               ;; 拉起 telemetry 插件进程与首页展示抢时间
-              (if (string=? event-type "STARTUP")
+              (if (string=? event-type "OPEN")
                 (delayed (:pause 500) (upload-events event-type))
                 (upload-events event-type)
               ) ;if

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -180,6 +180,13 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     shortcut-edit 等）均各自 import，无传递依赖。另在
     `init-research.scm` 保留 `bench tm-files` 计时
     （texmacs-time + debug-std 日志），便于后续继续观测
+16. telemetry 事件改名：scheme 侧 `(track-event "OPEN")`（init-research.scm
+    启动尾声）移除，C++ 侧 `telemetry_track ("STARTUP")` 改为
+    `telemetry_track ("OPEN")`——OPEN 统一在事件循环起跑后由 C++ 触发；
+    `telemetry-track.scm` 的 `important-event?` 及 500ms 延迟 upload 分支
+    同步把 "STARTUP" 改为 "OPEN"。另在 "Starting event loop..." 的
+    debug-std 日志中附带 `texmacs_time()`（进程起跑至进入事件循环的毫秒数，
+    lolly 静态 start_time 为基准），用于直接观测启动总耗时
 
 本次分段计时（临时 `boot-bench` 打点，测完即删，未入库）实测
 init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -26,6 +26,7 @@
 #include "telemetry.hpp"
 #include "tm_file.hpp"
 #include "tm_link.hpp"
+#include "tm_timer.hpp"
 
 #include <functional>
 #include <signal.h>
@@ -949,11 +950,12 @@ TeXmacs_main (int argc, char** argv) {
     bench_reset ("initialize plugins");
     bench_reset ("initialize scheme");
 
-    if (DEBUG_STD) debug_std << "Starting event loop...\n";
+    if (DEBUG_STD)
+      debug_std << "Starting event loop... (" << texmacs_time () << " ms)\n";
     texmacs_started= true;
-    // 事件循环起跑后再上报 STARTUP，避免 track 同步写 jsonl 及
+    // 事件循环起跑后再上报 OPEN，避免 track 同步写 jsonl 及
     // plugin-feed 拉起 telemetry 插件阻塞首帧（原先在启动页 showEvent 触发）
-    telemetry_track ("STARTUP");
+    telemetry_track ("OPEN");
     if (!disable_error_recovery) {
       // 注册信号处理器，确保子进程被正确清理
       // 包括崩溃类信号和用户中断信号


### PR DESCRIPTION
## Summary
- 移除 `init-research.scm` 启动尾声的 `(track-event "OPEN")`，OPEN 事件统一由 C++ 在事件循环起跑后触发（原 `telemetry_track ("STARTUP")` 改名）
- `telemetry-track.scm` 的 `important-event?` 及 500ms 延迟 upload 分支同步改为 "OPEN"，OPEN 仍触发一次 flush + 延迟上传
- "Starting event loop..." 的 debug-std 日志附带 `texmacs_time()`，可直接观测进程启动到进入事件循环的毫秒数

## Test plan
- [x] `xmake b stem` 构建通过
- [x] `gf fmt --changed-since=main` 无格式变更
- [ ] 启动 mogan 确认 debug-std 输出 `Starting event loop... (N ms)` 且 telemetry OPEN 正常上报