### PR TITLE
[1143] 窗口构造三项延后优化，tm_widget ctor 185ms → 110ms

### DIFF
--- a/devel/1143.md
+++ b/devel/1143.md
@@ -95,6 +95,31 @@ resume 守卫（15:43 运行）使 resume 从 222ms 降到 12ms（菜单/工具�
 加载纯属浪费，已直接移除该模块（init-research.scm:566 注册一并删除）。
 移除后 force 总耗时 1764ms → 1270ms。
 
+### 3.5 窗口构造（ensure_window）耗时分布（07-20 插桩实测）
+
+> 本节数据来自临时 `debug-std` 分段插桩（构造各阶段、native_picture、
+> MuPDF context、event_loop 首次 update 等），测完已在合并前移除，
+> 未进入最终提交。
+
+对 `qt_tm_widget_rep` 构造全程分段打点，两次运行一致。gap 分布：
+
+| 区间 | 耗时 | 位置 |
+|---|---|---|
+| system buttons → login dialog done | ~90-113ms | `new QWK::LoginDialog` + `setupLoginDialog`（qt_tm_widget.cpp） |
+| notification bar → checkNetworkAvailable | ~37ms | 构造期同步创建 QNetworkAccessManager（请求本身已是异步） |
+| central widget → docks done | ~23-28ms | dock 创建 |
+| update_visibility → ctor done | 5~40ms | 登录信号连接；已登录时同步 `refreshMembershipInfoInBackground()` |
+| MuPDF 路径（首次 native_picture / fz_new_context） | 0ms | 首次 native_picture 是 0×0 backing store（simple_widget 构造链），同毫秒完成 |
+
+结论：MuPDF 初始化无 gap（排除分支名最初的怀疑）。
+
+三轮优化（18-20）后复测：ctor 合计 185ms → 110ms，ensure_window
+~204ms → ~166ms。关键经验：ensure_window 内有大块 Qt 子系统一次性
+暖场成本（字体/样式/网络栈），只删 line item 会让成本迁到下一个重控件
+（status bar 段由 0ms 涨到 ~53ms）；有效做法是把工作 `singleShot(0)`
+挪出关键路径——延后后首次 QNetworkAccessManager 创建在事件循环里
+仅花 1ms。剩余段：status bar ~53ms（冷缓存）、docks ~28ms、map ~17ms。
+
 ## 4 优化方向
 
 - ~~**移除 Benchmark 1/2**~~（已完成）：`init-research.scm` 中两处 `fib 30`
@@ -187,6 +212,19 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     同步把 "STARTUP" 改为 "OPEN"。另在 "Starting event loop..." 的
     debug-std 日志中附带 `texmacs_time()`（进程起跑至进入事件循环的毫秒数，
     lolly 静态 start_time 为基准），用于直接观测启动总耗时
+17. ~~窗口构造路径分段计时日志~~（临时插桩，已移除）：`qt_tm_widget_rep`
+    构造各阶段、`ensure_window`/`new_window`/`get_new_view`/`attach_view`、
+    `event_loop` 首次 update、首次 native_picture 与 MuPDF context 创建、
+    native_picture 前 5 次真实尺寸 pixmap 分配计时（实测结果见 3.5）
+18. `checkNetworkAvailable()` 移出构造主路径：改为 `QTimer::singleShot(0)`
+    进事件循环后再执行（网络请求本身已是异步，省的是构造期同步创建
+    QNetworkAccessManager 的 ~37ms）
+19. `QWK::LoginDialog` 惰性创建：构造期不再 `new` + `setupLoginDialog`
+    （~90-113ms），新增 `ensureLoginDialog()` 访问器，三处
+    `show_login_dialog_at_button` 显示路径首次使用时才创建；
+    `triggerOAuth2` 补判空
+20. 已登录时 ctor 尾部的 `refreshMembershipInfoInBackground()` 改
+    `QTimer::singleShot(0)` 延后（~43ms 出关键路径）
 
 本次分段计时（临时 `boot-bench` 打点，测完即删，未入库）实测
 init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、
@@ -198,7 +236,7 @@ tm-files 的模块加载内容。
 涉及文件：`TeXmacs/progs/init-research.scm`（-39 行、移出 lazy-keyboard 注册、移出 chat-loader、保留 bench tm-files 计时）、
 `TeXmacs/progs/texmacs/texmacs/tm-files.scm`（移除 4 个死导入）、
 `src/Edit/Interface/edit_interface.cpp`（resume 守卫）、
-`src/Plugins/Qt/qt_tm_widget.{cpp,hpp}`（推迟 chrome 补装）、
+`src/Plugins/Qt/qt_tm_widget.{cpp,hpp}`（推迟 chrome 补装、LoginDialog 惰性创建、checkNetworkAvailable 与 membership 刷新延后）、
 `TeXmacs/progs/database/bib-kbd.scm`（删除）、
 `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`（插件加载日志、
 lazy-plugin-force-one）、

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -444,9 +444,8 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
     });
   }
   else {
-    // 商业版：完整登录功能
-    m_loginDialog= new QWK::LoginDialog (mainwindow ());
-    setupLoginDialog (m_loginDialog);
+    // 商业版：完整登录功能。LoginDialog 创建耗时 ~100ms，首屏不需要，
+    // 惰性到首次使用（ensureLoginDialog）时再创建
     QObject::connect (loginButton, &QWK::LoginButton::clicked,
                       [this] () { checkLocalTokenAndLogin (); });
   }
@@ -543,7 +542,10 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
                         call ("notification-bar-snooze-membership-expired");
                       }
                     });
-  if (!is_community_stem ()) checkNetworkAvailable ();
+  // 网络检查首屏不需要，挪到事件循环里执行，避免构造期创建
+  // QNetworkAccessManager 的同步开销
+  if (!is_community_stem ())
+    QTimer::singleShot (0, [this] () { checkNetworkAvailable (); });
 
   // 延迟检查版本更新（启动后10秒）
   QTimer::singleShot (10000, [this] () { checkVersionUpdate (); });
@@ -957,7 +959,9 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
                             }
                           });
         if (account->isLoggedIn ()) {
-          refreshMembershipInfoInBackground ();
+          // 首次创建 QNetworkAccessManager 的同步开销挪出构造关键路径
+          QTimer::singleShot (
+              0, [this] () { refreshMembershipInfoInBackground (); });
         }
       }
     }
@@ -2627,6 +2631,15 @@ qt_tm_widget_rep::onAddTabRequested () {
 }
 
 // 登录相关代码
+QWK::LoginDialog*
+qt_tm_widget_rep::ensureLoginDialog () {
+  if (!m_loginDialog) {
+    m_loginDialog= new QWK::LoginDialog (mainwindow ());
+    setupLoginDialog (m_loginDialog);
+  }
+  return m_loginDialog;
+}
+
 void
 qt_tm_widget_rep::setupLoginDialog (QWK::LoginDialog* loginDialog) {
   // 创建登录对话框内容
@@ -2993,7 +3006,7 @@ qt_tm_widget_rep::checkLocalTokenAndLogin () {
   }
   else {
     // 没有token，显示登录对话框（用户需要手动点击登录按钮）
-    show_login_dialog_at_button (m_loginDialog, loginButton);
+    show_login_dialog_at_button (ensureLoginDialog (), loginButton);
   }
 }
 
@@ -3035,7 +3048,7 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
         // 定义统一的错误处理逻辑
         auto handleError= [this] (const QString& errorMessage) {
           showNotLoggedInDialog (qt_translate (from_qstring (errorMessage)));
-          show_login_dialog_at_button (m_loginDialog, loginButton);
+          show_login_dialog_at_button (ensureLoginDialog (), loginButton);
         };
 
         if (reply->error () == QNetworkReply::NoError) {
@@ -3071,7 +3084,7 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
                                            periodLabelColor, productType);
 
             if (showDialog) {
-              show_login_dialog_at_button (m_loginDialog, loginButton);
+              show_login_dialog_at_button (ensureLoginDialog (), loginButton);
             }
           }
           else {
@@ -3098,7 +3111,7 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
 void
 qt_tm_widget_rep::triggerOAuth2 () {
   // 隐藏对话框，因为需要用户进行OAuth2认证
-  if (m_loginDialog->isVisible ()) {
+  if (m_loginDialog && m_loginDialog->isVisible ()) {
     m_loginDialog->hide ();
   }
   // 直接调用scheme代码触发OAuth2登录流程

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -127,18 +127,19 @@ class qt_tm_widget_rep : public qt_window_widget_rep {
   QString m_currentScmNotificationItem;
 
 private:
-  void onAddTabRequested ();
-  void setupLoginDialog (QWK::LoginDialog* loginDialog);
-  void checkLocalTokenAndLogin ();
-  void fetchUserInfo (const QString& token, bool showDialog= true);
-  void refreshLoginDialogPlacement ();
-  bool shouldShowLoginDialogUpdateSection ();
-  void setLoginDialogUpdateSectionVisible (bool visible);
-  void refreshMembershipInfoInBackground ();
-  void refreshScmNotificationBar ();
-  void syncScmUpdateNotification (bool           updateAvailable,
-                                  const QString& remoteVersion= QString ());
-  void syncScmGuestNotification (bool visible);
+  void              onAddTabRequested ();
+  void              setupLoginDialog (QWK::LoginDialog* loginDialog);
+  QWK::LoginDialog* ensureLoginDialog ();
+  void              checkLocalTokenAndLogin ();
+  void              fetchUserInfo (const QString& token, bool showDialog= true);
+  void              refreshLoginDialogPlacement ();
+  bool              shouldShowLoginDialogUpdateSection ();
+  void              setLoginDialogUpdateSectionVisible (bool visible);
+  void              refreshMembershipInfoInBackground ();
+  void              refreshScmNotificationBar ();
+  void              syncScmUpdateNotification (bool           updateAvailable,
+                                               const QString& remoteVersion= QString ());
+  void              syncScmGuestNotification (bool visible);
   void
        syncScmMembershipNotification (bool           hasData,
                                       const QString& memberType = QString (),


### PR DESCRIPTION
## Summary
- `checkNetworkAvailable()` 改 `QTimer::singleShot(0)`，移出构造期 QNetworkAccessManager 首次创建的 ~37ms
- `QWK::LoginDialog` 惰性创建：新增 `ensureLoginDialog()`，首次显示时才 `new` + `setupLoginDialog`，移出构造期 ~90-113ms
- 已登录时 `refreshMembershipInfoInBackground()` 改 `singleShot(0)`，ctor 尾部 43ms → 0ms
- 排查用的临时 debug-std 分段插桩已在合并前移除，实测数据记录在 devel/1143.md 3.5

关键结论：ensure_window 内大块成本是 Qt 子系统一次性暖场（字体/样式/网络栈），只在构造内部删项会让成本迁移到下一个重控件（status bar 段 0→53ms）；把工作挪到事件循环起跑后才真正出关键路径——延后后网络栈首次初始化在事件循环里仅 1ms。

实测（同机三次运行）：tm_widget ctor 合计 185ms → 110ms，ensure_window ~204ms → ~166ms。

## Test plan
- [x] `xmake b stem` 构建通过
- [x] 本地启动二进制验证：ctor 各段日志确认延后生效（deferred 日志与前后同毫秒），defer 任务在 ensure_window done 之后的事件循环里执行
- [ ] 启动后点击登录按钮，确认登录对话框正常弹出（惰性创建路径）
- [ ] 已登录状态下启动，确认会员信息/通知栏正常刷新（membership 延后路径）

🤖 Generated with [Claude Code](https://claude.com/claude-code)