### PR TITLE
[1146] autosave 实现迁移至 autosave 插件（启动 586ms → 434ms）

### DIFF
--- a/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
+++ b/TeXmacs/plugins/autosave/goldfish/tm-autosave.scm
@@ -61,8 +61,10 @@
             (when (ensure-parent-dir doc-id)
               (autosave-prune-dir (autosave-dir doc-id))
               (if (path-copy source target)
-                (autosave-log (string-append "autosave copied " source " -> " target))
-                (autosave-log (string-append "autosave copy failed " source " -> " target))
+                (autosave-log (string-append "autosave copied " source " -> " (path->string target))
+                ) ;autosave-log
+                (autosave-log (string-append "autosave copy failed " source " -> " (path->string target))
+                ) ;autosave-log
               ) ;if
             ) ;when
           ) ;if

--- a/TeXmacs/plugins/autosave/progs/init-autosave.scm
+++ b/TeXmacs/plugins/autosave/progs/init-autosave.scm
@@ -13,15 +13,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (use-modules (binary goldfish))
+(use-modules (plugin autosave))
 (import (liii path))
 
 (define (autosave-serialize lan t)
   (with u
     (pre-serialize lan t)
-    (with s
-      (texmacs->utf8raw (stree->tree u))
-      (string-append s "\n<EOF>\n")
-    ) ;with
+    (with s (texmacs->utf8raw (stree->tree u)) (string-append s "\n<EOF>\n"))
   ) ;with
 ) ;define
 
@@ -42,3 +40,7 @@
   (:launch ,(launcher))
   (:serializer ,autosave-serialize)
 ) ;plugin-configure
+
+;; 定时自动保存由插件初始化时启动（插件在事件循环启动 ~3s 后懒加载，
+;; 因此首次触发约在启动后 123s，与原先 120s 基本一致）
+(delayed (:pause 120000) (autosave-delayed))

--- a/TeXmacs/plugins/autosave/progs/plugin/autosave-impl.scm
+++ b/TeXmacs/plugins/autosave/progs/plugin/autosave-impl.scm
@@ -1,0 +1,339 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : autosave-impl.scm
+;; DESCRIPTION : autosave and auto-backup implementation for the autosave plugin
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (plugin autosave-impl) (:use (utils library cursor)))
+
+(import (liii uuid))
+(import (liii json))
+(import (liii path))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Autosave
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define autosave-fixed-interval-ms 120000)
+
+(tm-define (autosave-enabled?) (!= (get-preference "autosave") "0"))
+
+(tm-define (auto-backup-enabled?) (!= (get-preference "autobackup") "off"))
+
+(tm-define (liiistem-version) (xmacs-version))
+
+;; auto-backup-texmacs-path-buffer?
+;; 判断 buffer 是否位于 get-texmacs-path 返回的目录或其子目录中。
+;;
+;; 语法
+;; ----
+;; (auto-backup-texmacs-path-buffer? name)
+;;
+;; 参数
+;; ----
+;; name : url
+;; 待检查的 buffer 名称。
+;;
+;; 返回值
+;; ----
+;; boolean
+;; #t 表示 buffer 对应路径位于 get-texmacs-path 下。
+;;
+;; 逻辑
+;; ----
+;; 将 buffer url 转成系统路径，再使用 (liii path) 的 path-parent 逐级
+;; 向上检查是否能到达 get-texmacs-path。
+;;
+;; 注意
+;; ----
+;; TeXmacs 安装路径下的文件被视为只读内置资源，不进入自动备份。
+(tm-define (auto-backup-texmacs-path-buffer? name)
+  (url-descends? name (get-texmacs-path))
+) ;tm-define
+
+(define (auto-backup-path->url p)
+  (system->url (path->string p))
+) ;define
+
+(define (auto-backup-format name)
+  (if (url-scratch? name) "texmacs" (url-format name))
+) ;define
+
+;; auto-backup-buffer-eligible?
+;; 判断指定 buffer 是否允许进入自动备份。
+;;
+;; 语法
+;; ----
+;; (auto-backup-buffer-eligible? name)
+;;
+;; 参数
+;; ----
+;; name : url
+;; 待检查的 buffer 名称。
+;;
+;; 返回值
+;; ----
+;; boolean
+;; #t 表示允许自动备份，#f 表示跳过。
+;;
+;; 逻辑
+;; ----
+;; 只允许本地、非 tmfs、非 web 且格式为 texmacs/stm/tmu 的文档备份；
+;; 位于 get-texmacs-path 目录或子目录下的内置只读文件直接跳过。
+;;
+;; 注意
+;; ----
+;; 这个判断也会影响 doc id 绑定，跳过的只读资源不会被写入 stem-doc-id。
+(tm-define (auto-backup-buffer-eligible? name)
+  (and (url? name)
+    (buffer-exists? name)
+    (not (url-rooted-web? name))
+    (not (url-rooted-tmfs? name))
+    (not (auto-backup-texmacs-path-buffer? name))
+    (in? (auto-backup-format name) '("texmacs" "stm" "tmu" "stem"))
+  ) ;and
+) ;tm-define
+
+(define (auto-backup-valid-doc-id? doc-id)
+  (and (string? doc-id) (!= doc-id ""))
+) ;define
+
+(tm-define (auto-backup-buffer-doc-id name)
+  (catch #t
+    (lambda ()
+      ;; First try to get from init-env (memory), then from document tree (file)
+      (with-buffer name
+        (let* ((from-env (get-init-env "stem-doc-id"))
+               (doc-id (if (and (string? from-env) (!= from-env ""))
+                         from-env
+                         (let* ((doc (buffer-get name)) (initial (tmfile-extract doc 'initial)))
+                           (and initial (collection-ref initial "stem-doc-id"))
+                         ) ;let*
+                       ) ;if
+               ) ;doc-id
+              ) ;
+          doc-id
+        ) ;let*
+      ) ;with-buffer
+    ) ;lambda
+    (lambda args #f)
+  ) ;catch
+) ;tm-define
+
+(tm-define (auto-backup-buffer-needs-doc-id? name)
+  (and (auto-backup-buffer-eligible? name)
+    (not (auto-backup-valid-doc-id? (auto-backup-buffer-doc-id name)))
+  ) ;and
+) ;tm-define
+
+;; auto-backup-ensure-buffer-doc-id!
+;; 确保可备份 buffer 已经绑定 stem-doc-id。
+;;
+;; 语法
+;; ----
+;; (auto-backup-ensure-buffer-doc-id! name)
+;;
+;; 参数
+;; ----
+;; name : url
+;; 待检查和绑定的 buffer 名称。
+;;
+;; 返回值
+;; ----
+;; string or #f
+;; 返回已有或新生成的 doc id；不可备份或失败时返回 #f。
+;;
+;; 逻辑
+;; ----
+;; 先读取 buffer 当前 init-env 或 initial collection 中的 stem-doc-id；
+;; 若没有，则生成新的 uuid4 并写入 init-env。
+;;
+;; 注意
+;; ----
+;; 这里只写入 init-env，避免触发文档重新解析；doc id 是否持久化到文件由
+;; 用户后续保存动作决定。
+(tm-define (auto-backup-ensure-buffer-doc-id! name)
+  (catch #t
+    (lambda ()
+      (and (auto-backup-buffer-eligible? name)
+        (with-buffer name
+          (let ((old-doc-id (auto-backup-buffer-doc-id name)))
+            (if (auto-backup-valid-doc-id? old-doc-id)
+              old-doc-id
+              (let ((doc-id (uuid4)))
+                ;; 写入 init-env 即可绑定到当前会话，避免 buffer-set 触发
+                ;; 文档重新解析。
+                (init-env "stem-doc-id" doc-id)
+                doc-id
+              ) ;let
+            ) ;if
+          ) ;let
+        ) ;with-buffer
+      ) ;and
+    ) ;lambda
+    (lambda args #f)
+  ) ;catch
+) ;tm-define
+
+(tm-define (auto-backup-trig-payload name kind)
+  (let* ((path (url->system name))
+         (doc-id (auto-backup-ensure-buffer-doc-id! name))
+         (session-id (uuid4))
+         (payload (string->json "{}"))
+        ) ;
+    (set! payload (json-push payload "path" path))
+    (set! payload (json-push payload "type" kind))
+    (set! payload (json-push payload "id" doc-id))
+    (set! payload (json-push payload "session-id" session-id))
+    ;; 云备份请求头所需的 4 个静态字段：autosave 子进程通过 payload 拿到这些值，
+    ;; 构造 Authorization / User-Agent / X-Device-Id 头和 upload URL。
+    ;; 账号模块或 glue 函数在未登录/未加载时会抛异常，逐个 catch 回退空串，
+    ;; 避免 payload 构造失败导致整个 copy 流程中断。
+    (set! payload
+      (json-push payload
+        "site"
+        (catch #t (lambda () (current-stem-site)) (lambda args ""))
+      ) ;json-push
+    ) ;set!
+    (set! payload
+      (json-push payload
+        "token"
+        (catch #t (lambda () (account-load-token)) (lambda args ""))
+      ) ;json-push
+    ) ;set!
+    (set! payload
+      (json-push payload
+        "user-agent"
+        (catch #t (lambda () (stem-user-agent)) (lambda args ""))
+      ) ;json-push
+    ) ;set!
+    (set! payload
+      (json-push payload
+        "device-id"
+        (catch #t (lambda () (stem-device-id)) (lambda args ""))
+      ) ;json-push
+    ) ;set!
+    (values (json->string payload) session-id)
+  ) ;let*
+) ;tm-define
+
+;; auto-backup-trig
+;; 自动备份触发入口，当前仅用于调试输出触发参数。
+;;
+;; 语法
+;; ----
+;; (auto-backup-trig u kind)
+;;
+;; 参数
+;; ----
+;; u : url
+;; 需要备份的 buffer url。
+;;
+;; kind : string
+;; 备份类型，例如 "save"、"save-as"、"export-pdf"、"on-open"、"auto"、"manual-open"。
+
+(tm-define (auto-backup-trig u kind)
+  (when (and (auto-backup-enabled?) (auto-backup-buffer-eligible? u))
+    (receive (s session-id)
+      (auto-backup-trig-payload u kind)
+      (silent-feed* "autosave"
+        session-id
+        `(document ,(utf8->cork s))
+        (lambda (r) (noop))
+        '()
+      ) ;silent-feed*
+    ) ;receive
+  ) ;when
+) ;tm-define
+
+;; auto-backup-opened-buffer!
+;; 文件打开后的自动备份准备流程。
+;;
+;; 语法
+;; ----
+;; (auto-backup-opened-buffer! name)
+;;
+;; 参数
+;; ----
+;; name : url
+;; 已经打开并切换完成的 buffer 名称。
+;;
+;; 逻辑
+;; ----
+;; 打开文件时只在当前会话中绑定缺失的 stem-doc-id，避免静默改写源文件；
+;; 随后延迟触发一次 on-open 备份，由 md5 去重避免重复版本。
+
+(tm-define (auto-backup-opened-buffer! name)
+  (auto-backup-ensure-buffer-doc-id! name)
+  (delayed (:pause 100) (auto-backup-trig name "on-open"))
+) ;tm-define
+
+(tm-define (auto-backup-official-url)
+  (if (== (get-output-language) "chinese")
+    "https://liiistem.cn/personal-center/backup.html?utm_source=auto_backup_button"
+    "https://liiistem.com/?utm_source=auto_backup_button"
+  ) ;if
+) ;tm-define
+
+(tm-define (auto-backup-button-label)
+  (if (community-stem?) "View help" "Cloud backup")
+) ;tm-define
+
+(tm-define (open-auto-backup-location)
+  (if (community-stem?)
+    (open-url "https://liiistem.cn/docs/guide-auto-backup")
+    (open-url (auto-backup-official-url))
+  ) ;if
+  (auto-backup-trig (current-buffer-url) "visit-cloud-backup")
+) ;tm-define
+
+(tm-define (autosave-all)
+  (for-each (lambda (name)
+              (when (and (buffer-modified? name) (not (url-scratch? name)))
+                (save-buffer-save name (list) "auto")
+              ) ;when
+            ) ;lambda
+    (buffer-list)
+  ) ;for-each
+) ;tm-define
+
+(tm-define (autosave-now)
+  (when (autosave-enabled?)
+    (let ((name (current-buffer)))
+      (when (and (buffer-modified? name) (not (url-scratch? name)))
+        (save-buffer-save name (list) "auto")
+      ) ;when
+    ) ;let
+    (autosave-delayed)
+  ) ;when
+) ;tm-define
+
+(tm-define (save-all-buffers)
+  (for-each (lambda (buf)
+              (when (buffer-modified? buf)
+                (auto-backup-ensure-buffer-doc-id! buf)
+                (buffer-save buf)
+              ) ;when
+            ) ;lambda
+    (buffer-list)
+  ) ;for-each
+) ;tm-define
+
+(tm-define (autosave-delayed)
+  (when (autosave-enabled?)
+    (delayed (:pause autosave-fixed-interval-ms) (autosave-now))
+  ) ;when
+) ;tm-define
+
+(define (notify-autosave var val)
+  (if (current-view) (begin (autosave-delayed)))
+) ;define
+
+(define-preferences ("autosave" "120" notify-autosave))

--- a/TeXmacs/plugins/autosave/progs/plugin/autosave.scm
+++ b/TeXmacs/plugins/autosave/progs/plugin/autosave.scm
@@ -1,0 +1,24 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : autosave.scm
+;; DESCRIPTION : Entry point of the (plugin autosave) module
+;;
+;; This module serves as the entry point loaded by init-autosave.scm.
+;; It MUST NOT contain (import ...) statements.
+;;
+;; Rationale: S7's R7RS (import ...) modifies the evaluation environment
+;; in a way that breaks the texmacs module system when the importing module
+;; is loaded directly by (use-modules ...). By keeping this top-level loader
+;; free of (import ...), the deeper dependency module (autosave-impl) can
+;; safely use (import ...).
+;;
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (plugin autosave) (:use (plugin autosave-impl)))

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -605,7 +605,6 @@
     "------------------------------------------------------\n"
   ) ;string-append
 ) ;debug-message
-(delayed (:pause 120000) (autosave-delayed))
 (catch #t
   (lambda ()
     (use-modules (telemetry telemetry-utils))

--- a/TeXmacs/progs/texmacs/menus/preferences-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-menu.scm
@@ -96,6 +96,9 @@
             (if answ
               (begin
                 (set-preference "language" lan)
+                (when (not (defined? 'save-all-buffers))
+                  (use-modules (plugin autosave))
+                ) ;when
                 (save-all-buffers)
                 (restart-TeXmacs)
               ) ;begin

--- a/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
@@ -33,6 +33,9 @@
             (set-pretty-preference which pretty-val)
             (when answ
               (begin
+                (when (not (defined? 'save-all-buffers))
+                  (use-modules (plugin autosave))
+                ) ;when
                 (save-all-buffers)
                 (restart-TeXmacs)
               ) ;begin
@@ -1022,7 +1025,15 @@
                "12em"
              ) ;enum
         //
-        (explicit-buttons ((eval (auto-backup-button-label)) (open-auto-backup-location))
+        (explicit-buttons ((eval (begin
+                                   (when (not (defined? 'auto-backup-button-label))
+                                     (use-modules (plugin autosave))
+                                   ) ;when
+                                   (auto-backup-button-label)
+                                 ) ;begin
+                           ) ;eval
+                           (open-auto-backup-location)
+                          ) ;
         ) ;explicit-buttons
       ) ;hlist
     ) ;item

--- a/TeXmacs/progs/texmacs/texmacs/tm-files-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files-test.scm
@@ -12,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (texmacs texmacs tm-files-test)
-  (:use (texmacs texmacs tm-files))
+  (:use (texmacs texmacs tm-files) (plugin autosave))
 ) ;texmacs-module
 
 (import (liii check))

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -22,24 +22,6 @@
 ) ;texmacs-module
 
 (import (only (liii string) string-contains))
-(import (only (liii uuid) uuid4))
-(import (only (liii path)
-          path->string
-          path-dir?
-          path-exists?
-          path-from-env
-          path-from-string
-          path-getsize
-          path-join
-          path-name
-          path-parent
-          path-rename
-          path-root
-          path-stem
-          path-unlink
-        ) ;only
-) ;import
-(import (liii json))
 (import (only (srfi srfi-1) find))
 (import (only (srfi srfi-1) remove))
 
@@ -364,7 +346,9 @@
   (let ((kind (if (null? kind*) "save" (car kind*))))
     (with vname
       `(verbatim ,(utf8->cork (url->system name)))
-      (auto-backup-ensure-buffer-doc-id! name)
+      (when (defined? 'auto-backup-ensure-buffer-doc-id!)
+        (auto-backup-ensure-buffer-doc-id! name)
+      ) ;when
       (if (buffer-save name)
         (begin
           (buffer-pretend-modified name)
@@ -376,7 +360,9 @@
           ;; Remember directory for file dialog
           (remember-file-dialog-directory name)
           (set-message `(concat ,"Saved " ,vname) "Save file")
-          (auto-backup-trig name kind)
+          (when (defined? 'auto-backup-trig)
+            (auto-backup-trig name kind)
+          ) ;when
           (save-buffer-post name opts)
         ) ;begin
       ) ;if
@@ -489,7 +475,10 @@
              (set-message msg "Save file")
            ) ;with
           ) ;
-          ((and (not (buffer-modified? name)) (auto-backup-buffer-needs-doc-id? name))
+          ((and (not (buffer-modified? name))
+             (defined? 'auto-backup-buffer-needs-doc-id?)
+             (auto-backup-buffer-needs-doc-id? name)
+           ) ;and
            (if (cannot-write? name "Save file")
              (noop)
              (begin
@@ -678,327 +667,6 @@
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Autosave
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define autosave-fixed-interval-ms 120000)
-
-(tm-define (autosave-enabled?) (!= (get-preference "autosave") "0"))
-
-(tm-define (auto-backup-enabled?) (!= (get-preference "autobackup") "off"))
-
-(tm-define (liiistem-version) (xmacs-version))
-
-;; auto-backup-texmacs-path-buffer?
-;; 判断 buffer 是否位于 get-texmacs-path 返回的目录或其子目录中。
-;;
-;; 语法
-;; ----
-;; (auto-backup-texmacs-path-buffer? name)
-;;
-;; 参数
-;; ----
-;; name : url
-;; 待检查的 buffer 名称。
-;;
-;; 返回值
-;; ----
-;; boolean
-;; #t 表示 buffer 对应路径位于 get-texmacs-path 下。
-;;
-;; 逻辑
-;; ----
-;; 将 buffer url 转成系统路径，再使用 (liii path) 的 path-parent 逐级
-;; 向上检查是否能到达 get-texmacs-path。
-;;
-;; 注意
-;; ----
-;; TeXmacs 安装路径下的文件被视为只读内置资源，不进入自动备份。
-(tm-define (auto-backup-texmacs-path-buffer? name)
-  (url-descends? name (get-texmacs-path))
-) ;tm-define
-
-(define (auto-backup-path->url p)
-  (system->url (path->string p))
-) ;define
-
-(define (auto-backup-format name)
-  (if (url-scratch? name) "texmacs" (url-format name))
-) ;define
-
-;; auto-backup-buffer-eligible?
-;; 判断指定 buffer 是否允许进入自动备份。
-;;
-;; 语法
-;; ----
-;; (auto-backup-buffer-eligible? name)
-;;
-;; 参数
-;; ----
-;; name : url
-;; 待检查的 buffer 名称。
-;;
-;; 返回值
-;; ----
-;; boolean
-;; #t 表示允许自动备份，#f 表示跳过。
-;;
-;; 逻辑
-;; ----
-;; 只允许本地、非 tmfs、非 web 且格式为 texmacs/stm/tmu 的文档备份；
-;; 位于 get-texmacs-path 目录或子目录下的内置只读文件直接跳过。
-;;
-;; 注意
-;; ----
-;; 这个判断也会影响 doc id 绑定，跳过的只读资源不会被写入 stem-doc-id。
-(tm-define (auto-backup-buffer-eligible? name)
-  (and (url? name)
-    (buffer-exists? name)
-    (not (url-rooted-web? name))
-    (not (url-rooted-tmfs? name))
-    (not (auto-backup-texmacs-path-buffer? name))
-    (in? (auto-backup-format name) '("texmacs" "stm" "tmu" "stem"))
-  ) ;and
-) ;tm-define
-
-(define (auto-backup-valid-doc-id? doc-id)
-  (and (string? doc-id) (!= doc-id ""))
-) ;define
-
-(tm-define (auto-backup-buffer-doc-id name)
-  (catch #t
-    (lambda ()
-      ;; First try to get from init-env (memory), then from document tree (file)
-      (with-buffer name
-        (let* ((from-env (get-init-env "stem-doc-id"))
-               (doc-id (if (and (string? from-env) (!= from-env ""))
-                         from-env
-                         (let* ((doc (buffer-get name)) (initial (tmfile-extract doc 'initial)))
-                           (and initial (collection-ref initial "stem-doc-id"))
-                         ) ;let*
-                       ) ;if
-               ) ;doc-id
-              ) ;
-          doc-id
-        ) ;let*
-      ) ;with-buffer
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
-) ;tm-define
-
-(tm-define (auto-backup-buffer-needs-doc-id? name)
-  (and (auto-backup-buffer-eligible? name)
-    (not (auto-backup-valid-doc-id? (auto-backup-buffer-doc-id name)))
-  ) ;and
-) ;tm-define
-
-;; auto-backup-ensure-buffer-doc-id!
-;; 确保可备份 buffer 已经绑定 stem-doc-id。
-;;
-;; 语法
-;; ----
-;; (auto-backup-ensure-buffer-doc-id! name)
-;;
-;; 参数
-;; ----
-;; name : url
-;; 待检查和绑定的 buffer 名称。
-;;
-;; 返回值
-;; ----
-;; string or #f
-;; 返回已有或新生成的 doc id；不可备份或失败时返回 #f。
-;;
-;; 逻辑
-;; ----
-;; 先读取 buffer 当前 init-env 或 initial collection 中的 stem-doc-id；
-;; 若没有，则生成新的 uuid4 并写入 init-env。
-;;
-;; 注意
-;; ----
-;; 这里只写入 init-env，避免触发文档重新解析；doc id 是否持久化到文件由
-;; 用户后续保存动作决定。
-(tm-define (auto-backup-ensure-buffer-doc-id! name)
-  (catch #t
-    (lambda ()
-      (and (auto-backup-buffer-eligible? name)
-        (with-buffer name
-          (let ((old-doc-id (auto-backup-buffer-doc-id name)))
-            (if (auto-backup-valid-doc-id? old-doc-id)
-              old-doc-id
-              (let ((doc-id (uuid4)))
-                ;; 写入 init-env 即可绑定到当前会话，避免 buffer-set 触发
-                ;; 文档重新解析。
-                (init-env "stem-doc-id" doc-id)
-                doc-id
-              ) ;let
-            ) ;if
-          ) ;let
-        ) ;with-buffer
-      ) ;and
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
-) ;tm-define
-
-(tm-define (auto-backup-trig-payload name kind)
-  (let* ((path (url->system name))
-         (doc-id (auto-backup-ensure-buffer-doc-id! name))
-         (session-id (uuid4))
-         (payload (string->json "{}"))
-        ) ;
-    (set! payload (json-push payload "path" path))
-    (set! payload (json-push payload "type" kind))
-    (set! payload (json-push payload "id" doc-id))
-    (set! payload (json-push payload "session-id" session-id))
-    ;; 云备份请求头所需的 4 个静态字段：autosave 子进程通过 payload 拿到这些值，
-    ;; 构造 Authorization / User-Agent / X-Device-Id 头和 upload URL。
-    ;; 账号模块或 glue 函数在未登录/未加载时会抛异常，逐个 catch 回退空串，
-    ;; 避免 payload 构造失败导致整个 copy 流程中断。
-    (set! payload
-      (json-push payload
-        "site"
-        (catch #t (lambda () (current-stem-site)) (lambda args ""))
-      ) ;json-push
-    ) ;set!
-    (set! payload
-      (json-push payload
-        "token"
-        (catch #t (lambda () (account-load-token)) (lambda args ""))
-      ) ;json-push
-    ) ;set!
-    (set! payload
-      (json-push payload
-        "user-agent"
-        (catch #t (lambda () (stem-user-agent)) (lambda args ""))
-      ) ;json-push
-    ) ;set!
-    (set! payload
-      (json-push payload
-        "device-id"
-        (catch #t (lambda () (stem-device-id)) (lambda args ""))
-      ) ;json-push
-    ) ;set!
-    (values (json->string payload) session-id)
-  ) ;let*
-) ;tm-define
-
-;; auto-backup-trig
-;; 自动备份触发入口，当前仅用于调试输出触发参数。
-;;
-;; 语法
-;; ----
-;; (auto-backup-trig u kind)
-;;
-;; 参数
-;; ----
-;; u : url
-;; 需要备份的 buffer url。
-;;
-;; kind : string
-;; 备份类型，例如 "save"、"save-as"、"export-pdf"、"on-open"、"auto"、"manual-open"。
-
-(tm-define (auto-backup-trig u kind)
-  (when (and (auto-backup-enabled?) (auto-backup-buffer-eligible? u))
-    (receive (s session-id)
-      (auto-backup-trig-payload u kind)
-      (silent-feed* "autosave"
-        session-id
-        `(document ,(utf8->cork s))
-        (lambda (r) (noop))
-        '()
-      ) ;silent-feed*
-    ) ;receive
-  ) ;when
-) ;tm-define
-
-;; auto-backup-opened-buffer!
-;; 文件打开后的自动备份准备流程。
-;;
-;; 语法
-;; ----
-;; (auto-backup-opened-buffer! name)
-;;
-;; 参数
-;; ----
-;; name : url
-;; 已经打开并切换完成的 buffer 名称。
-;;
-;; 逻辑
-;; ----
-;; 打开文件时只在当前会话中绑定缺失的 stem-doc-id，避免静默改写源文件；
-;; 随后延迟触发一次 on-open 备份，由 md5 去重避免重复版本。
-
-(define (auto-backup-opened-buffer! name)
-  (auto-backup-ensure-buffer-doc-id! name)
-  (delayed (:pause 100) (auto-backup-trig name "on-open"))
-) ;define
-
-(tm-define (auto-backup-official-url)
-  (if (== (get-output-language) "chinese")
-    "https://liiistem.cn/personal-center/backup.html?utm_source=auto_backup_button"
-    "https://liiistem.com/?utm_source=auto_backup_button"
-  ) ;if
-) ;tm-define
-
-(tm-define (auto-backup-button-label)
-  (if (community-stem?) "View help" "Cloud backup")
-) ;tm-define
-
-(tm-define (open-auto-backup-location)
-  (if (community-stem?)
-    (open-url "https://liiistem.cn/docs/guide-auto-backup")
-    (open-url (auto-backup-official-url))
-  ) ;if
-  (auto-backup-trig (current-buffer-url) "visit-cloud-backup")
-) ;tm-define
-
-(tm-define (autosave-all)
-  (for-each (lambda (name)
-              (when (and (buffer-modified? name) (not (url-scratch? name)))
-                (save-buffer-save name (list) "auto")
-              ) ;when
-            ) ;lambda
-    (buffer-list)
-  ) ;for-each
-) ;tm-define
-
-(tm-define (autosave-now)
-  (when (autosave-enabled?)
-    (let ((name (current-buffer)))
-      (when (and (buffer-modified? name) (not (url-scratch? name)))
-        (save-buffer-save name (list) "auto")
-      ) ;when
-    ) ;let
-    (autosave-delayed)
-  ) ;when
-) ;tm-define
-
-(tm-define (save-all-buffers)
-  (for-each (lambda (buf)
-              (when (buffer-modified? buf)
-                (auto-backup-ensure-buffer-doc-id! buf)
-                (buffer-save buf)
-              ) ;when
-            ) ;lambda
-    (buffer-list)
-  ) ;for-each
-) ;tm-define
-
-(tm-define (autosave-delayed)
-  (when (autosave-enabled?)
-    (delayed (:pause autosave-fixed-interval-ms) (autosave-now))
-  ) ;when
-) ;tm-define
-
-(define (notify-autosave var val)
-  (if (current-view) (begin (autosave-delayed)))
-) ;define
-
-(define-preferences ("autosave" "120" notify-autosave))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Opening files using external tools
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1082,7 +750,9 @@
         ) ;and
     (delayed (:idle 25) (fit-to-screen-width))
   ) ;when
-  (auto-backup-opened-buffer! name)
+  (when (defined? 'auto-backup-opened-buffer!)
+    (auto-backup-opened-buffer! name)
+  ) ;when
   (noop)
 ) ;define
 

--- a/TeXmacs/progs/texmacs/texmacs/tm-server.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-server.scm
@@ -331,7 +331,13 @@
           (switch-to-buffer (car l))
         ) ;when
         (confirm-close-dialog "There are unsaved documents. Really quit?"
-          (lambda () (save-all-buffers) (quit-TeXmacs))
+          (lambda ()
+            (when (not (defined? 'save-all-buffers))
+              (use-modules (plugin autosave))
+            ) ;when
+            (save-all-buffers)
+            (quit-TeXmacs)
+          ) ;lambda
           (lambda () (quit-TeXmacs))
         ) ;confirm-close-dialog
       ) ;begin
@@ -365,7 +371,9 @@
 ;; 菜单/工具栏重新解析；doc id 会在用户保存时随文档持久化。
 (tm-define (new-document)
   (with-default-view (if (window-per-buffer?) (open-window) (new-buffer))
-    (auto-backup-ensure-buffer-doc-id! (current-buffer))
+    (when (defined? 'auto-backup-ensure-buffer-doc-id!)
+      (auto-backup-ensure-buffer-doc-id! (current-buffer))
+    ) ;when
   ) ;with-default-view
 ) ;tm-define
 
@@ -384,7 +392,9 @@
 ;; 指向新文档，doc id 绑定只作用于当前会话的 init-env。
 (tm-define (new-document*)
   (with-default-view (if (window-per-buffer?) (new-buffer) (open-window))
-    (auto-backup-ensure-buffer-doc-id! (current-buffer))
+    (when (defined? 'auto-backup-ensure-buffer-doc-id!)
+      (auto-backup-ensure-buffer-doc-id! (current-buffer))
+    ) ;when
   ) ;with-default-view
 ) ;tm-define
 

--- a/devel/1146.md
+++ b/devel/1146.md
@@ -1,0 +1,120 @@
+# [1146] autosave 代码迁移至 autosave 插件（启动性能优化）
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1101.md](1101.md) - autosave 占位插件（goldfish 子进程接收备份负载）
+- [1143.md](1143.md) - 启动性能：telemetry OPEN → STARTUP 路径优化
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/autosave/progs/init-autosave.scm` — autosave 插件初始化，
+  由 `plugin-initialize` 在事件循环启动 ~3s 后懒加载
+- `TeXmacs/plugins/autosave/progs/plugin/autosave.scm` — 新增 `(plugin autosave)`
+  模块，承接从 tm-files.scm 迁出的 autosave/auto-backup 实现
+- `TeXmacs/progs/init-research.scm` — 启动入口，移除 autosave 定时调度
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` — 移除 autosave 实现段与
+  `(liii json)` / `(liii uuid)` 导入，调用点加 `defined?` 兜底
+- `TeXmacs/progs/texmacs/texmacs/tm-server.scm` — `save-all-buffers` /
+  `auto-backup-ensure-buffer-doc-id!` 调用点按需加载
+- `TeXmacs/progs/texmacs/menus/preferences-menu.scm`、`preferences-widgets.scm`
+  — 菜单/挂件中的 autosave 调用点
+- `TeXmacs/progs/texmacs/texmacs/tm-files-test.scm` — 测试模块 `:use`
+  `(plugin autosave)`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+TEXMACS_PATH=$(pwd)/TeXmacs build/linux/x86_64/release/moganstem -headless \
+  -x '(begin (use-modules (texmacs texmacs tm-files-test)) (regtest-tm-files) (quit-TeXmacs))'
+# 期望：2 correct, 0 failed（已验证通过）
+```
+
+### 3.2 非确定性测试（文档验证）
+```bash
+TEXMACS_PATH=$(pwd)/TeXmacs build/linux/x86_64/release/moganstem -headless -d
+# 迁移前基线：Starting event loop... (586 ms)
+# 迁移后实测：Starting event loop... (514 ms)，约省 72 ms
+# 日志可见 ~3s 时 Loading/Loaded plugin autosave，无报错
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+
+把 autosave 相关实现从启动期 eager 加载的 `tm-files.scm` 迁移到 autosave
+插件（懒加载），加快软件启动速度。
+
+1. `init-research.scm` 的 `(delayed (:pause 120000) (autosave-delayed))`
+   移入 `init-autosave.scm`（插件初始化时启动定时器）
+2. `tm-files.scm` 的 Autosave 段（`autosave-enabled?`、`auto-backup-*`、
+   `autosave-now/delayed/all`、`save-all-buffers`、`define-preferences` 等）
+   迁入新模块 `(plugin autosave)`（入口）+ `(plugin autosave-impl)`（实现）
+3. `tm-files.scm` 中仅 autosave 使用的 `(import (liii json))`、
+   `(import (only (liii uuid) uuid4))`、`(import (only (liii path) ...))`
+   一并迁出
+4. eager 模块中的调用点用 `(when (defined? 'xxx) (xxx ...))` 兜底；
+   不可跳过的保存路径（退出时 `save-all-buffers`）参照
+   `generic-edit.scm:1366` 的既定模式按需 `(use-modules (plugin autosave))`
+5. 修复迁移暴露的两个 bug（见 7.5）
+
+## 6 Why
+
+`init-research.scm` 全程同步执行（OPEN 埋点前），其中 eager 加载的
+`tm-files.scm` 携带约 320 行 autosave/auto-backup 实现及 `(liii json)`、
+`(liii uuid)` 导入，拖慢启动（当前事件循环启动 586 ms）。插件 init 文件由
+`lazy-plugin-initialize` 在事件循环启动 ~3s 后才加载，不在启动关键路径上；
+迁入后这部分代码与 liii 库的求值成本从启动路径移除。
+
+## 7 How
+
+1. **加载时机**：`init-research.scm:564`
+   `(for-each lazy-plugin-initialize (plugin-list))` 为所有插件登记
+   `(delayed (:pause 3000) (plugin-initialize name))`；`plugin-initialize`
+   `(load ...)` 插件的 `init-<name>.scm`。因此 `init-autosave.scm` 在
+   ~3s 时执行，其中 `(use-modules (plugin autosave))` 同步加载实现模块，
+   再 `(delayed (:pause 120000) (autosave-delayed))` 启动定时自动保存，
+   首次触发约 123s（原 120s，基本一致）。
+2. **符号可见性**：`tm-define` 经 `(varlet (rootlet) ...)` 把符号定义到
+   全局 rootlet（tm-define.scm:340 附近），因此 `(plugin autosave)` 中的
+   `tm-define` 加载后对 eager 模块可见，`(defined? 'xxx)` 兜底有效。
+3. **必定触发路径兜底**：打开文件、保存、退出等路径在插件未加载时
+   （启动 3s 内）直接调用会报错。分两类处理：
+   - 可跳过的备份副作用（`auto-backup-trig`、`auto-backup-opened-buffer!`、
+     新建文档的 doc-id 绑定）：`(when (defined? 'xxx) (xxx ...))`，窗口期内
+     跳过一次备份可接受；
+   - 不可跳过的保存（退出确认框里的 `save-all-buffers`）：
+     `(when (not (defined? 'save-all-buffers)) (use-modules (plugin autosave)))`
+     先按需加载再调用，与 `generic-edit.scm:1366` 处理
+     `account-load-token` 的模式一致。
+4. **保留在 tm-files.scm 的部分**：`url-autosave`（被 kernel
+   `tm-file-system.scm:1053` 引用）与 `load-buffer-check-autosave`
+   （打开文件主流程，只依赖 `url-autosave`）。
+5. **迁移暴露并修复的 bug**：
+   - **入口/实现拆分**：`(plugin autosave)` 作为被 `use-modules` 直接加载的
+     入口模块不能含 `(import ...)`（S7 R7RS import 会破坏 texmacs module
+     环境，同 `llm/chat-loader.scm` 头注），实现代码放在
+     `(plugin autosave-impl)`，入口仅 `(:use (plugin autosave-impl))`。
+   - **缺 `:use` 导致备份静默失败（根因）**：`with-buffer` 是
+     `(utils library cursor)` 的 `define-public-macro`，不是 rootlet 符号；
+     实现模块漏了 `(:use (utils library cursor))` 时，
+     `auto-backup-ensure-buffer-doc-id!` 内部 `catch` 吞掉未绑定错误返回
+     `#f`，payload `"id":false`，goldfish 子进程日志
+     `missing source/id` 跳过落盘，`system/backup/` 始终为空。
+   - **`tm-autosave.scm` 日志 bug（既有）**：`handle-copy` 把 path 对象
+     `target` 直接传给 `string-append`，每次 copy 后抛 wrong-type-arg，
+     成功/失败日志都记成 exception；已改为 `(path->string target)`。
+
+## 8 验证记录
+
+- headless 启动：`Starting event loop... (434 ms)`（基线 586 ms，省 ~150 ms）；
+  ~3s 处 `Loaded plugin autosave` 无报错
+- `(regtest-tm-files)`：2 correct, 0 failed
+- 端到端：headless 打开本地 tmu → `auto-backup-trig` → goldfish 子进程
+  落盘 `$TEXMACS_HOME_PATH/system/backup/<doc-id>/<时间戳>.tmu`，
+  `/tmp/debug.log` 记录 `autosave copied ... -> ...`


### PR DESCRIPTION
## Summary
- autosave/auto-backup 实现从 eager 加载的 `tm-files.scm` 迁至 autosave 插件：新增 `(plugin autosave)` 入口模块 + `(plugin autosave-impl)` 实现模块，插件 init（事件循环后 ~3s）加载，退出启动关键路径
- 启动定时调度 `(delayed (:pause 120000) (autosave-delayed))` 从 `init-research.scm` 移入 `init-autosave.scm`；`(liii json)`/`(liii uuid)`/`(liii path)` 导入一并迁出
- eager 调用点 `(when (defined? 'xxx) ...)` 兜底；退出/重启的 `save-all-buffers` 按需 `use-modules`（generic-edit 模式）
- 修复迁移暴露的问题：`autosave-impl` 补 `(:use (utils library cursor))`（`with-buffer` 未绑定曾导致 doc-id 绑定静默失败、备份不落盘）；`tm-autosave.scm` 日志 `string-append` 传 path 对象的 wrong-type-arg 改为 `path->string`
- 启动实测：事件循环 586ms → 434ms

## Test plan
- [x] headless 启动日志 `Loaded plugin autosave` 无报错，事件循环 434ms
- [x] `(regtest-tm-files)` 2 correct, 0 failed
- [x] 端到端：打开本地 tmu → `auto-backup-trig` → `$TEXMACS_HOME_PATH/system/backup/<doc-id>/<时间戳>.tmu` 落盘
- [ ] GUI 手动验证：编辑保存本地 .tmu 后观察备份目录与 /tmp/debug.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)