### PR TITLE
[1143] 修复键盘模块延迟加载引入的 scheme 测试回归并补齐 CI 触发路径

### DIFF
--- a/.github/workflows/ci-debian13.yml
+++ b/.github/workflows/ci-debian13.yml
@@ -17,6 +17,8 @@ on:
       - "xmake/packages/**"
       - ".github/workflows/ci-debian13.yml"
       - "TeXmacs/tests/*.scm"
+      - "TeXmacs/progs/**"
+      - "TeXmacs/plugins/**"
       - "3rdparty/**"
   pull_request:
     branches: [main]
@@ -35,6 +37,8 @@ on:
       - "xmake/packages/**"
       - ".github/workflows/ci-debian13.yml"
       - "TeXmacs/tests/*.scm"
+      - "TeXmacs/progs/**"
+      - "TeXmacs/plugins/**"
       - "3rdparty/**"
   workflow_dispatch:
 
@@ -125,6 +129,8 @@ jobs:
               - 'xmake/packages.lua'
               - 'xmake/packages/**'
               - 'TeXmacs/tests/*.scm'
+              - 'TeXmacs/progs/**'
+              - 'TeXmacs/plugins/**'
               - '3rdparty/**'
 
       - name: config

--- a/.github/workflows/ci-fedora.yml
+++ b/.github/workflows/ci-fedora.yml
@@ -14,6 +14,8 @@ on:
       - "xmake/packages/**"
       - ".github/workflows/ci-fedora.yml"
       - "TeXmacs/tests/*.scm"
+      - "TeXmacs/progs/**"
+      - "TeXmacs/plugins/**"
   pull_request:
     branches: [main]
     paths:
@@ -28,6 +30,8 @@ on:
       - "xmake/packages/**"
       - ".github/workflows/ci-fedora.yml"
       - "TeXmacs/tests/*.scm"
+      - "TeXmacs/progs/**"
+      - "TeXmacs/plugins/**"
 
 env:
   XMAKE_ROOT: y
@@ -112,6 +116,8 @@ jobs:
               - 'xmake/packages.lua'
               - 'xmake/packages/**'
               - 'TeXmacs/tests/*.scm'
+              - 'TeXmacs/progs/**'
+              - 'TeXmacs/plugins/**'
 
       - name: config
         run: xmake config -vD --policies=build.ccache -o tmp/build -m releasedbg --yes

--- a/.github/workflows/ci-macos-arm64.yml
+++ b/.github/workflows/ci-macos-arm64.yml
@@ -30,6 +30,8 @@ on:
       - 'moebius/xmake.lua'
       - '.github/workflows/ci-macos-arm64.yml'
       - 'TeXmacs/tests/*.scm'
+      - 'TeXmacs/progs/**'
+      - 'TeXmacs/plugins/**'
       - '3rdparty/**'
   pull_request:
     branches: [ main ]
@@ -60,6 +62,8 @@ on:
       - 'moebius/xmake.lua'
       - '.github/workflows/ci-macos-arm64.yml'
       - 'TeXmacs/tests/*.scm'
+      - 'TeXmacs/progs/**'
+      - 'TeXmacs/plugins/**'
       - '3rdparty/**'
 
 jobs:
@@ -118,6 +122,8 @@ jobs:
               - 'xmake/packages/**'
               - 'xmake-requires.lock'
               - 'TeXmacs/tests/*.scm'
+              - 'TeXmacs/progs/**'
+              - 'TeXmacs/plugins/**'
               - '3rdparty/**'
 
       - name: cache xmake

--- a/TeXmacs/progs/kernel/old-gui/old-gui-test.scm
+++ b/TeXmacs/progs/kernel/old-gui/old-gui-test.scm
@@ -270,8 +270,6 @@
   (check (defined? 'widget-ref) => #t)
   (check (defined? 'widget-set!) => #t)
   (check (defined? 'widget-delayed) => #t)
-  (check (defined? 'widget->script) => #t)
-  (check (defined? 'script->widget) => #t)
   (check (defined? 'display*) => #t)
   (check (defined? 'noop) => #t)
   (check (defined? 'tree->string) => #t)

--- a/TeXmacs/progs/kernel/texmacs/tm-define-test.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-define-test.scm
@@ -29,8 +29,9 @@
 
 (tm-define alias-car car)
 
+(tm-define s2f string->float)
+
 (define (test-procedure-name)
-  ;; (tm-define s2f string->float)
   (check (procedure-name string->float) => 's2f)
   (check (procedure-name car) => 'alias-car)
   (check (procedure-name utf8->cork) => 'utf8->cork)

--- a/TeXmacs/progs/prog/scheme-tools-test.scm
+++ b/TeXmacs/progs/prog/scheme-tools-test.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (prog scheme-tools-test) (:use (prog scheme-tools-test)))
+(texmacs-module (prog scheme-tools-test) (:use (prog scheme-tools)))
 
 (import (liii check))
 

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -225,6 +225,23 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     `triggerOAuth2` 补判空
 20. 已登录时 ctor 尾部的 `refreshMembershipInfoInBackground()` 改
     `QTimer::singleShot(0)` 延后（~43ms 出关键路径）
+21. 修复 #4021 引入的 scheme 测试回归：键盘模块移入插件延迟加载后，
+    启动期不再强载 `scripts-kbd`/`graphics-utils` 等模块，三个测试
+    因隐式依赖该副作用而挂：
+    - `old-gui-test.scm`：删除 `widget->script`/`script->widget` 两条
+      `defined?` 检查——二者定义在 `(dynamic scripts-edit)`，与 old-gui
+      无关，仅靠启动强载 `scripts-kbd` 间接载入；显式 `:use` 该模块在
+      headless 下会段错误（其依赖链经 `(liii account)` 插件模块，
+      glue 函数在社区版未注册），不能作为修复手段
+    - `scheme-tools-test.scm`：修正笔误 `(:use (prog scheme-tools-test))`
+      （自引用）为 `(:use (prog scheme-tools))`
+    - `tm-define-test.scm`：补回 `(tm-define s2f string->float)`（文件内
+      本有注释掉的定义，原依赖 `graphics-utils` 启动期注册的全局别名）
+22. CI 触发规则补齐：`ci-debian13.yml`/`ci-fedora.yml`/
+    `ci-macos-arm64.yml` 的触发 paths 与 paths-filter `mogan` 过滤器
+    原先只含 `TeXmacs/tests/*.scm`，纯 `TeXmacs/progs/**` 或
+    `TeXmacs/plugins/**` 改动（如 #4021）不触发 CI，scheme 测试回归
+    未被拦截；现补入 `TeXmacs/progs/**` 与 `TeXmacs/plugins/**`
 
 本次分段计时（临时 `boot-bench` 打点，测完即删，未入库）实测
 init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、


### PR DESCRIPTION
## Summary
- 用户报告 024a9483 弄挂 scheme tests，bisect 后定位真正引入者是 db571d083（#4021，lazy-keyboard 注册迁移至 keyboard 插件）：键盘模块改为插件延迟加载后，启动期不再强载 scripts-kbd/graphics-utils 等模块，三个测试因隐式依赖该副作用而挂
- old-gui-test：删除 widget->script/script->widget 两条 defined? 检查（符号属于 (dynamic scripts-edit)，与 old-gui 无关；显式 :use 该模块在 headless 下会段错误——其依赖链经 (liii account) 插件模块，glue 函数在社区版未注册，不能作为修复手段）
- scheme-tools-test：修正笔误 (:use (prog scheme-tools-test))（自引用）为 (:use (prog scheme-tools))
- tm-define-test：补回 (tm-define s2f string->float)（原依赖 graphics-utils 启动期注册的全局别名，文件内本有注释掉的定义）
- CI：ci-debian13/ci-fedora/ci-macos-arm64 的触发 paths 与 paths-filter mogan 过滤器原先只含 TeXmacs/tests/*.scm，纯 TeXmacs/progs/** 或 TeXmacs/plugins/** 改动（如 #4021）不会触发 CI，导致回归未被拦截；现补入 TeXmacs/progs/** 与 TeXmacs/plugins/**

## Test plan
- [x] xmake r old-gui-test — 12 correct, 0 failed
- [x] xmake r scheme-tools-test — 7 correct, 0 failed
- [x] xmake r tm-define-test — 10 correct, 0 failed
- [x] xmake run --group=scheme_tests — 全部通过
- [ ] CI 通过（本次 PR 改动涉及 TeXmacs/progs/** 与 workflow 文件，可验证新触发规则生效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)