### PR TITLE
[1147] 移除 kernel 版 list-tail，改用 goldfish 内置实现

### DIFF
--- a/TeXmacs/progs/kernel/library/list.scm
+++ b/TeXmacs/progs/kernel/library/list.scm
@@ -124,14 +124,6 @@
   ) ;let
 ) ;define-public
 
-(define-public (list-tail lis k)
-  (let iter
-    ((lis lis) (k k))
-    (if (zero? k) lis (iter (cdr lis) (- k 1)))
-  ) ;let
-) ;define-public
-
-
 (define-public list-take list-head)
 ;; SRFI-1
 (define-public list-drop list-tail)

--- a/devel/1147.md
+++ b/devel/1147.md
@@ -1,0 +1,39 @@
+# [1147] 移除 kernel 版 list-tail，改用 goldfish 内置实现
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/kernel/library/list.scm`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake run --group=tests
+```
+
+### 3.2 非确定性测试（文档验证）
+用真实二进制验证 `list-tail` 及其依赖方（`list-drop`、`list-take-right`、`sublist`、`list-sort`）行为不变：
+```bash
+TEXMACS_PATH=$(pwd)/TeXmacs build/linux/x86_64/release/moganstem -headless -d \
+  -x "(display (list-tail '(a b c d) 2)) (newline) (display (list-drop '(a b c d) 1)) (newline)"
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+移除 `TeXmacs/progs/kernel/library/list.scm` 中自定义的 `list-tail` 实现，直接使用 goldfish 内置的 R7RS `list-tail`。
+
+## 6 Why
+kernel 版与 goldfish 内置版在正常路径语义完全一致（返回第 k 个 cdr 开始的尾子表、结构共享、支持点对结构），属于重复定义。内置版为 C 实现，更快且错误处理规范（越界抛 `out-of-range`，kernel 版报的是 `cdr` 的底层错误；非列表参数抛 `wrong-type-arg`，kernel 版在 k=0 时会静默返回原值）。
+
+## 7 How
+直接删除 `list.scm` 中的 `list-tail` 定义。`list-drop` 别名保留，自动指向内置版。所有调用点（`prologue.scm`、`srfi.scm`、search/graphics/version 等）均为合法索引用法，不依赖 kernel 版的宽松行为；`prologue.scm` 中 `list-sort` 对 `list-tail` 的引用在函数体内，调用时才解析符号，boot 时序不受影响。


### PR DESCRIPTION
## Summary
- 移除 `TeXmacs/progs/kernel/library/list.scm` 中自定义的 `list-tail` 实现，直接使用 goldfish 内置的 R7RS `list-tail`
- 两者正常路径语义完全一致（返回第 k 个 cdr 的尾子表、结构共享、支持点对结构）；内置版为 C 实现，更快且错误处理规范（越界抛 `out-of-range`、非列表参数抛 `wrong-type-arg`）
- `list-drop` 别名保留，自动指向内置版；所有调用点均为合法索引用法，boot 时序不受影响

## Test plan
- [x] `gf fmt --changed-since=main` 无改动
- [x] 手动验证 `list-tail` 及依赖方（`list-drop`、`list-take-right`、`sublist`、`list-sort`）行为不变
- [ ] CI 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)