### PR TITLE
[1149] 升级 Goldfish 到 18.11.18

### DIFF
--- a/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-1.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-1.scm
@@ -132,28 +132,13 @@
       (list-ref x 9)
     ) ;define
 
-    (define (take l k)
-      (let loop
-        ((l l) (k k))
-        (if (zero? k) '() (cons (car l) (loop (cdr l) (- k 1))))
-      ) ;let
-    ) ;define
+    (define take g_take)
 
     (define drop list-tail)
 
-    (define (take-right l k)
-      (let loop
-        ((lag l) (lead (drop l k)))
-        (if (pair? lead) (loop (cdr lag) (cdr lead)) lag)
-      ) ;let
-    ) ;define
+    (define take-right g_take_right)
 
-    (define (drop-right l k)
-      (let loop
-        ((lag l) (lead (drop l k)))
-        (if (pair? lead) (cons (car lag) (loop (cdr lag) (cdr lead))) '())
-      ) ;let
-    ) ;define
+    (define drop-right g_drop_right)
 
     (define (split-at lst i)
       (when (< i 0)
@@ -268,22 +253,7 @@
       (apply append (apply map proc lists))
     ) ;define
 
-    (define (filter pred l)
-      (let recur
-        ((l l))
-        (if (null-list? l)
-          l
-          (let ((head (car l)) (tail (cdr l)))
-            (if (pred head)
-              (let ((new-tail (recur tail)))
-                (if (eq? tail new-tail) l (cons head new-tail))
-              ) ;let
-              (recur tail)
-            ) ;if
-          ) ;let
-        ) ;if
-      ) ;let
-    ) ;define
+    (define filter g_filter)
 
     (define (partition pred l)
       (let loop

--- a/TeXmacs/plugins/goldfish/src/goldfish.hpp
+++ b/TeXmacs/plugins/goldfish/src/goldfish.hpp
@@ -68,7 +68,7 @@
 #include <isocline.h>
 #endif
 
-#define GOLDFISH_VERSION "18.11.17"
+#define GOLDFISH_VERSION "18.11.18"
 
 #define GOLDFISH_PATH_MAXN TB_PATH_MAXN
 

--- a/TeXmacs/plugins/goldfish/src/s7.c
+++ b/TeXmacs/plugins/goldfish/src/s7.c
@@ -480,8 +480,9 @@ using namespace std; /* the code has to work in C as well as C++, so we can't
 #if (defined(__GNUC__))
 #define s7_complex_i 1.0i
 #else
-#define s7_complex_i (s7_complex) _Complex_I /* a float, but we want a double  \
-                                              */
+#define s7_complex_i                                                           \
+  (s7_complex) _Complex_I /* a float, but we want a double                     \
+                           */
 #endif
 #endif
 
@@ -2552,8 +2553,9 @@ check_ref_two (s7_pointer p, uint8_t expected_type, int32_t other_type,
 #define T_Met(P)                                                               \
   check_ref_met (P, __func__,                                                  \
                  __LINE__) /* anything that might contain a method */
-#define T_Muti(P) check_ref_muti (P, __func__, __LINE__) /* a mutable integer  \
-                                                          */
+#define T_Muti(P)                                                              \
+  check_ref_muti (P, __func__, __LINE__) /* a mutable integer                  \
+                                          */
 #define T_Nmv(P)                                                               \
   check_ref_nmv (                                                              \
       P, __func__,                                                             \
@@ -3703,8 +3705,9 @@ make_boolean (s7_scheme* sc, bool val) {
 #define set_opt1(p, x, Role)                                                   \
   set_opt1_1 (T_Pair (p), x, Role, __func__, __LINE__)
 
-#define OPT2_KEY (1 << 13)    /* case key */
-#define OPT2_SLOW (1 << 14)   /* slow list in member/assoc circular list check \
+#define OPT2_KEY (1 << 13) /* case key */
+#define OPT2_SLOW                                                              \
+  (1 << 14)                   /* slow list in member/assoc circular list check \
                                */
 #define OPT2_SYM (1 << 15)    /* symbol */
 #define OPT2_PAIR (1 << 16)   /* pair */
@@ -4619,8 +4622,9 @@ slot_expression (s7_pointer p) {
 #define c_function_is_aritable(f, N)                                           \
   ((c_function_min_args (f) <= N) && (c_function_max_args (f) >= N))
 #define c_function_name(f) c_function_data (f)->name /* const char* */
-#define c_function_name_length(f) c_function_data (f)->name_length /* int32_t  \
-                                                                    */
+#define c_function_name_length(f)                                              \
+  c_function_data (f)->name_length                           /* int32_t        \
+                                                              */
 #define c_function_documentation(f) c_function_data (f)->doc /* const char* */
 #define c_function_signature(f)                                                \
   T_Prf (c_function_data (f)->signature) /* pair or #f */
@@ -8910,7 +8914,7 @@ methods_or_bust_pp (s7_scheme* sc, s7_pointer obj, s7_pointer method1,
                     s7_pointer method2, s7_pointer x1, s7_pointer x2,
                     s7_pointer typ,
                     int32_t    num) { /* this is for the memq/memv and assq/assv
-                                      equivalence in r7rs */
+                                   equivalence in r7rs */
   s7_pointer func;
   if (!has_active_methods (sc, obj))
     wrong_type_error_nr (sc, method1, num, obj, typ);
@@ -16660,7 +16664,7 @@ number_to_string_with_radix (s7_scheme* sc, s7_pointer obj, int32_t radix,
           sc,
           wrap_real (sc, x / pow ((double) radix,
                                     (double) ep)), /* divide it down to one digit,
-                                                    then the fractional part */
+                                                  then the fractional part */
           radix, width, precision, float_choice, &len);
       b1     = inline_mallocate (sc, len + 8);
       p      = (char*) block_data (b1);
@@ -21868,7 +21872,7 @@ next_random (s7_pointer r) {
 
   s7_uint x= random_seed (r), c= random_carry (r);
   s7_uint u_result= x;
-      /* Or, result = x ^ (x << 32) (see above) */ /* s7_uint == uint64_t */
+  /* Or, result = x ^ (x << 32) (see above) */ /* s7_uint == uint64_t */
   const __uint128_t t= MWC_A1 * (__uint128_t) x + c;
   random_seed (r)    = t;
   random_carry (r)   = t >> 64;
@@ -24410,7 +24414,7 @@ string_read_line (s7_scheme* sc, s7_pointer port, bool with_eol) {
   const char*  start     = port_str + port_start;
   const char*  cur       = (const char*) strchr (
       start, (int) '\n'); /* this can run off the end making valgrind unhappy,
-                                     but I think it's innocuous */
+                                             but I think it's innocuous */
   if (cur) {
     s7_int len;
     port_line_number (port)++;
@@ -44868,8 +44872,8 @@ symbol_equivalent (s7_scheme* sc, s7_pointer x, s7_pointer y,
   return (
       (is_slot (global_slot (x))) && /* the optimizer can replace the original
                                         symbol with its value */
-      (is_syntax (global_value (x))) &&
-      (is_slot (global_slot (y))) && (is_syntax (global_value (y))) &&
+      (is_syntax (global_value (x))) && (is_slot (global_slot (y))) &&
+      (is_syntax (global_value (y))) &&
       (syntax_symbol (global_value (x)) == syntax_symbol (global_value (y))));
 }
 
@@ -54824,8 +54828,8 @@ fx_sub_mul_mul (s7_scheme* sc, s7_pointer arg) /* (- (* x1 x2) (* x3 x4)) */
   s7_pointer x1= lookup (sc, car (p1));
   s7_pointer x2= lookup (sc, cadr (p1));
   s7_pointer p2= opt1_pair (cdr (arg));
-      /* cdadr(arg) */ /* here and elsewhere this should be GC safe -- opssq->*
-                          (no methods?) etc */
+  /* cdadr(arg) */ /* here and elsewhere this should be GC safe -- opssq->*
+                      (no methods?) etc */
   s7_pointer x3= lookup (sc, car (p2));
   s7_pointer x4= lookup (sc, cadr (p2));
   if ((is_t_real (x1)) && (is_t_real (x2)) && (is_t_real (x3)) &&
@@ -55628,7 +55632,7 @@ fx_and_s_2 (s7_scheme* sc, s7_pointer arg) {
 static s7_pointer
 fx_len2_t (s7_scheme* sc, s7_pointer arg) {
   s7_pointer val= t_lookup (sc, opt1_sym (cdr (arg)), arg);
-      /* isn't this unprotected from mock pair? */ /* opt1_sym == cadadr(arg) */
+  /* isn't this unprotected from mock pair? */ /* opt1_sym == cadadr(arg) */
   return (make_boolean (sc, is_pair (val) && (is_pair (cdr (val))) &&
                                 (is_null (cddr (val)))));
 }
@@ -60299,7 +60303,7 @@ d_7pi_ok (s7_scheme* sc, opt_info* opc, s7_pointer s_func,
   const int32_t start= sc->pc;
   s7_d_7pi_t    ifunc= s7_d_7pi_function (
       s_func); /* ifunc: float_vector_ref_d_7pi, s_func:
-                     global_value(sc->float_vector_ref_symbol) */
+                        global_value(sc->float_vector_ref_symbol) */
   if (!ifunc) {
     if ((is_eq_initial_c_function_data (sc->vector_ref_symbol, s_func)) &&
         (is_normal_symbol (
@@ -61153,8 +61157,8 @@ opt_d_dd_ff_mul_sss_unchecked (opt_info* o) {
   s7_double  x1 = float_vector (vec, (i1 * vector_offset (vec, 0)) + i2);
   o1            = q_func2_arg (o).o1;
   vec           = slot_value (q_arg1 (o1).p);
-  i1            = integer (
-      slot_value (q_arg2 (o1).p)); /* in (* (A i j) (B j k)) we could reuse
+  i1            = integer (slot_value (
+      q_arg2 (o1).p)); /* in (* (A i j) (B j k)) we could reuse
                                                   i2->i1 (flipping args below) */
   i2= integer (slot_value (q_arg3 (o1).p));
   return (x1 * float_vector (vec, (i1 * vector_offset (vec, 0)) + i2));
@@ -66198,7 +66202,7 @@ p_implicit_ok (s7_scheme* sc, s7_pointer s_slot, s7_pointer expr, int32_t len) {
         return_true (sc, expr);
       }
     }
-  }      /* len==2 */
+  } /* len==2 */
   else { /* len > 2 */
     if ((is_t_vector (obj)) && (len == 3) && (vector_rank (obj) == 2)) {
       const s7_pointer arg2_slot= opt_integer_symbol (sc, caddr (expr));
@@ -69991,8 +69995,8 @@ g_for_each_closure (s7_scheme* sc, s7_pointer clo,
         if (iterator_is_at_end (seq)) return (clear_for_each (sc));
         func (sc);
       }
-    }    /* we never get here -- the while loops above exit via return
-            #<unspecified> */
+    } /* we never get here -- the while loops above exit via return
+         #<unspecified> */
     else /* not func -- unneeded "else" but otherwise confusing code */
     {
       set_no_cell_opt (body);
@@ -73158,12 +73162,13 @@ unbound_variable_error_nr (s7_scheme* sc, s7_pointer sym) {
             "call-with-output-string",
             "set-current-output-port"};
 
-        static const int32_t main_names_index[LEVEN_MAX_LEN]= {
-            0,   7,   27,  62,  103, 156, 184, 206, 243, 265, 296, 321,
-            344, 361, 378, 397, 407, 417, 425, 432, 435, 440, 442}; /* 443==NULL,
-                                                                       7858 -
-                                                                       3576
-                                                                       bytes */
+        static const int32_t main_names_index
+            [LEVEN_MAX_LEN]= {0,   7,   27,  62,  103, 156, 184, 206,
+                              243, 265, 296, 321, 344, 361, 378, 397,
+                              407, 417, 425, 432, 435, 440, 442}; /* 443==NULL,
+                                                                     7858 -
+                                                                     3576
+                                                                     bytes */
         const int32_t start= main_names_index[sym_len - 2],
                       end  = main_names_index[sym_len - 1];
 #if 0
@@ -77780,9 +77785,10 @@ check_recur (s7_scheme* sc, s7_pointer name, int32_t pars, s7_pointer args,
                          (is_fxable (sc, cadr (la2))) &&
                          (is_fxable (sc, caddr (la2)))) {
                   set_safe_optimize_op (
-                      body, OP_RECUR_COND_A_A_A_A_opA_L2Aq); /* see
-                                                                if_a_a_if_a_l2a_opa_l2a,
-                                                                first l2a->a */
+                      body,
+                      OP_RECUR_COND_A_A_A_A_opA_L2Aq); /* see
+                                                          if_a_a_if_a_l2a_opa_l2a,
+                                                          first l2a->a */
                   fx_annotate_arg (sc, cdr (la_clause), args);
                   happy= true;
                 }
@@ -84503,7 +84509,7 @@ op_implicit_vector_ref_aa (
                         ? make_real (sc, float_vector (vec, index))
                         : vector_getter (vec) (
                            sc, vec, index); /* check for normal vector saves in
-                                                  some cases, costs in others */
+                                                     some cases, costs in others */
       unstack_gc_protect (sc);
       return (true);
     }
@@ -106370,6 +106376,38 @@ is #t, the string is also sent to the current-output-port."
   sc->list_tail_symbol= defun ("list-tail", list_tail, 2, 0, false);
   sc->make_list_symbol= defun ("make-list", make_list, 1, 1, false);
   set_is_saver (sc->make_list_symbol);
+
+#define H_filter                                                               \
+  "(g_filter pred lst) returns a list of the elements of lst for which (pred " \
+  "element) is not #f"
+#define Q_filter                                                               \
+  s7_make_signature (sc, 3, sc->is_list_symbol, sc->is_procedure_symbol,       \
+                     sc->is_list_symbol)
+  s7_define_semisafe_typed_function (sc, "g_filter", g_filter, 2, 0, false,
+                                     H_filter, Q_filter);
+
+#define H_take "(g_take lst k) returns a list of the first k elements of lst"
+#define Q_take                                                                 \
+  s7_make_signature (sc, 3, sc->is_list_symbol, sc->is_list_symbol,            \
+                     sc->is_integer_symbol)
+  s7_define_semisafe_typed_function (sc, "g_take", g_take, 2, 0, false, H_take,
+                                     Q_take);
+
+/* take-right can return the non-pair tail of a dotted list, hence the #t return
+ * signature */
+#define H_take_right "(g_take_right lst k) returns the last k elements of lst"
+#define Q_take_right                                                           \
+  s7_make_signature (sc, 3, sc->T, sc->is_list_symbol, sc->is_integer_symbol)
+  s7_define_semisafe_typed_function (sc, "g_take_right", g_take_right, 2, 0,
+                                     false, H_take_right, Q_take_right);
+
+#define H_drop_right                                                           \
+  "(g_drop_right lst k) returns a list of all but the last k elements of lst"
+#define Q_drop_right                                                           \
+  s7_make_signature (sc, 3, sc->is_list_symbol, sc->is_list_symbol,            \
+                     sc->is_integer_symbol)
+  s7_define_semisafe_typed_function (sc, "g_drop_right", g_drop_right, 2, 0,
+                                     false, H_drop_right, Q_drop_right);
 
   sc->length_symbol= defun ("length", length, 1, 0, false);
   sc->copy_symbol  = defun ("copy", copy, 1, 3, false);

--- a/TeXmacs/plugins/goldfish/src/s7_liii_list.c
+++ b/TeXmacs/plugins/goldfish/src/s7_liii_list.c
@@ -7,575 +7,803 @@
 #include "s7_liii_list.h"
 #include "s7_internal_helpers.h"
 
-s7_pointer g_is_null(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer p = s7_car(args);
-  if (s7_is_null(sc, p)) return(s7_t(sc));
+#include <stddef.h>
+
+s7_pointer
+g_is_null (s7_scheme* sc, s7_pointer args) {
+  s7_pointer p= s7_car (args);
+  if (s7_is_null (sc, p)) return (s7_t (sc));
   {
-    s7_pointer func = s7_method(sc, p, s7_make_symbol(sc, "null?"));
-    if (func == s7_undefined(sc)) return(s7_f(sc));
-    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+    s7_pointer func= s7_method (sc, p, s7_make_symbol (sc, "null?"));
+    if (func == s7_undefined (sc)) return (s7_f (sc));
+    return (s7_apply_function (sc, func, s7_cons (sc, p, s7_nil (sc))));
   }
 }
 
 /* -------------------------------- pair? -------------------------------- */
 
-s7_pointer g_is_pair(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer p = s7_car(args);
-  if (s7_is_pair(p)) return(s7_t(sc));
-  if (!s7i_has_active_methods(sc, p)) return(s7_f(sc));
+s7_pointer
+g_is_pair (s7_scheme* sc, s7_pointer args) {
+  s7_pointer p= s7_car (args);
+  if (s7_is_pair (p)) return (s7_t (sc));
+  if (!s7i_has_active_methods (sc, p)) return (s7_f (sc));
   {
-    s7_pointer sym = s7_make_symbol(sc, "pair?");
-    s7_pointer func = s7i_find_method_with_let(sc, p, sym);
-    if (func == s7_undefined(sc)) return(s7_f(sc));
-    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+    s7_pointer sym = s7_make_symbol (sc, "pair?");
+    s7_pointer func= s7i_find_method_with_let (sc, p, sym);
+    if (func == s7_undefined (sc)) return (s7_f (sc));
+    return (s7_apply_function (sc, func, s7_cons (sc, p, s7_nil (sc))));
   }
 }
 
 /* -------------------------------- list? -------------------------------- */
 
-s7_pointer g_is_list(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer p = s7_car(args);
-  if (s7_is_list(sc, p)) return(s7_t(sc));
-  if (!s7i_has_active_methods(sc, p)) return(s7_f(sc));
+s7_pointer
+g_is_list (s7_scheme* sc, s7_pointer args) {
+  s7_pointer p= s7_car (args);
+  if (s7_is_list (sc, p)) return (s7_t (sc));
+  if (!s7i_has_active_methods (sc, p)) return (s7_f (sc));
   {
-    s7_pointer sym = s7_make_symbol(sc, "list?");
-    s7_pointer func = s7i_find_method_with_let(sc, p, sym);
-    if (func == s7_undefined(sc)) return(s7_f(sc));
-    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+    s7_pointer sym = s7_make_symbol (sc, "list?");
+    s7_pointer func= s7i_find_method_with_let (sc, p, sym);
+    if (func == s7_undefined (sc)) return (s7_f (sc));
+    return (s7_apply_function (sc, func, s7_cons (sc, p, s7_nil (sc))));
   }
 }
 
-/* -------------------------------- proper-list? -------------------------------- */
+/* -------------------------------- proper-list?
+ * -------------------------------- */
 
-s7_pointer g_is_proper_list(s7_scheme *sc, s7_pointer args)
-{
-  return(s7_make_boolean(sc, s7_is_proper_list(sc, s7_car(args))));
+s7_pointer
+g_is_proper_list (s7_scheme* sc, s7_pointer args) {
+  return (s7_make_boolean (sc, s7_is_proper_list (sc, s7_car (args))));
 }
 
-s7_pointer g_car(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (s7_is_pair(lst)) return(s7_car(lst));
-  return(s7i_sole_arg_method_or_bust(sc, lst, "car", args, "a pair"));
+s7_pointer
+g_car (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (s7_is_pair (lst)) return (s7_car (lst));
+  return (s7i_sole_arg_method_or_bust (sc, lst, "car", args, "a pair"));
 }
 
-s7_pointer g_cdr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (s7_is_pair(lst)) return(s7_cdr(lst));
-  return(s7i_sole_arg_method_or_bust(sc, lst, "cdr", args, "a pair"));
+s7_pointer
+g_cdr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (s7_is_pair (lst)) return (s7_cdr (lst));
+  return (s7i_sole_arg_method_or_bust (sc, lst, "cdr", args, "a pair"));
 }
 
-s7_pointer g_caar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "caar", 1, lst, "a pair whose car is also a pair"));
-  return(s7_caar(lst));
+s7_pointer
+g_caar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "caar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  return (s7_caar (lst));
 }
 
-s7_pointer g_cadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadr", 1, lst, "a pair whose cdr is also a pair"));
-  return(s7_cadr(lst));
+s7_pointer
+g_cadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  return (s7_cadr (lst));
 }
 
-s7_pointer g_cdar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdar", 1, lst, "a pair whose car is also a pair"));
-  return(s7_cdar(lst));
+s7_pointer
+g_cdar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  return (s7_cdar (lst));
 }
 
-s7_pointer g_cddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddr", 1, lst, "a pair whose cdr is also a pair"));
-  return(s7_cddr(lst));
+s7_pointer
+g_cddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  return (s7_cddr (lst));
 }
 
-/* -------------------------------- 3-level cxxxr -------------------------------- */
+/* -------------------------------- 3-level cxxxr
+ * -------------------------------- */
 
-s7_pointer g_caaar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caaar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_caar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaar", 1, lst, "a pair whose caar is also a pair"));
-  return(s7_caaar(lst));
+s7_pointer
+g_caaar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caaar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_caar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaar", 1, lst,
+                                     "a pair whose caar is also a pair"));
+  return (s7_caaar (lst));
 }
 
-s7_pointer g_caadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caadr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caadr", 1, lst, "a pair whose cadr is also a pair"));
-  return(s7_caadr(lst));
+s7_pointer
+g_caadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caadr", 1, lst,
+                                     "a pair whose cadr is also a pair"));
+  return (s7_caadr (lst));
 }
 
-s7_pointer g_cadar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cadar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_cdar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadar", 1, lst, "a pair whose cdar is also a pair"));
-  return(s7_cadar(lst));
+s7_pointer
+g_cadar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cadar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_cdar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadar", 1, lst,
+                                     "a pair whose cdar is also a pair"));
+  return (s7_cadar (lst));
 }
 
-s7_pointer g_caddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caddr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caddr", 1, lst, "a pair whose cddr is also a pair"));
-  return(s7_caddr(lst));
+s7_pointer
+g_caddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caddr", 1, lst,
+                                     "a pair whose cddr is also a pair"));
+  return (s7_caddr (lst));
 }
 
-s7_pointer g_cdaar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_caar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaar", 1, lst, "a pair whose caar is also a pair"));
-  return(s7_cdaar(lst));
+s7_pointer
+g_cdaar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdaar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_caar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaar", 1, lst,
+                                     "a pair whose caar is also a pair"));
+  return (s7_cdaar (lst));
 }
 
-s7_pointer g_cdddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdddr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdddr", 1, lst, "a pair whose cddr is also a pair"));
-  return(s7_cdddr(lst));
+s7_pointer
+g_cdddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdddr", 1, lst,
+                                     "a pair whose cddr is also a pair"));
+  return (s7_cdddr (lst));
 }
 
-s7_pointer g_cdadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdadr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdadr", 1, lst, "a pair whose cadr is also a pair"));
-  return(s7_cdadr(lst));
+s7_pointer
+g_cdadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdadr", 1, lst,
+                                     "a pair whose cadr is also a pair"));
+  return (s7_cdadr (lst));
 }
 
-s7_pointer g_cddar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cddar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_cdar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddar", 1, lst, "a pair whose cdar is also a pair"));
-  return(s7_cddar(lst));
+s7_pointer
+g_cddar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cddar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_cdar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddar", 1, lst,
+                                     "a pair whose cdar is also a pair"));
+  return (s7_cddar (lst));
 }
 
-/* -------------------------------- 4-level cxxxr -------------------------------- */
+/* -------------------------------- 4-level cxxxr
+ * -------------------------------- */
 
-s7_pointer g_caaaar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caaaar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaaar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_caar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaaar", 1, lst, "a pair whose caar is also a pair"));
-  if (!s7_is_pair(s7_caaar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaaar", 1, lst, "a pair whose caaar is also a pair"));
-  return(s7_caaaar(lst));
+s7_pointer
+g_caaaar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caaaar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaaar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_caar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaaar", 1, lst,
+                                     "a pair whose caar is also a pair"));
+  if (!s7_is_pair (s7_caaar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaaar", 1, lst,
+                                     "a pair whose caaar is also a pair"));
+  return (s7_caaaar (lst));
 }
 
-s7_pointer g_caaadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caaadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaadr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaadr", 1, lst, "a pair whose cadr is also a pair"));
-  if (!s7_is_pair(s7_caadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaadr", 1, lst, "a pair whose caadr is also a pair"));
-  return(s7_caaadr(lst));
+s7_pointer
+g_caaadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caaadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaadr", 1, lst,
+                                     "a pair whose cadr is also a pair"));
+  if (!s7_is_pair (s7_caadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaadr", 1, lst,
+                                     "a pair whose caadr is also a pair"));
+  return (s7_caaadr (lst));
 }
 
-s7_pointer g_caadar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caadar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "caadar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_cdar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caadar", 1, lst, "a pair whose cdar is also a pair"));
-  if (!s7_is_pair(s7_cadar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caadar", 1, lst, "a pair whose cadar is also a pair"));
-  return(s7_caadar(lst));
+s7_pointer
+g_caadar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caadar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "caadar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_cdar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caadar", 1, lst,
+                                     "a pair whose cdar is also a pair"));
+  if (!s7_is_pair (s7_cadar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caadar", 1, lst,
+                                     "a pair whose cadar is also a pair"));
+  return (s7_caadar (lst));
 }
 
-s7_pointer g_cadaar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cadaar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadaar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_caar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadaar", 1, lst, "a pair whose caar is also a pair"));
-  if (!s7_is_pair(s7_cdaar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadaar", 1, lst, "a pair whose cdaar is also a pair"));
-  return(s7_cadaar(lst));
+s7_pointer
+g_cadaar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cadaar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadaar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_caar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadaar", 1, lst,
+                                     "a pair whose caar is also a pair"));
+  if (!s7_is_pair (s7_cdaar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadaar", 1, lst,
+                                     "a pair whose cdaar is also a pair"));
+  return (s7_cadaar (lst));
 }
 
-s7_pointer g_caaddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caaddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaddr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaddr", 1, lst, "a pair whose cddr is also a pair"));
-  if (!s7_is_pair(s7_caddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "caaddr", 1, lst, "a pair whose caddr is also a pair"));
-  return(s7_caaddr(lst));
+s7_pointer
+g_caaddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caaddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaddr", 1, lst,
+                                     "a pair whose cddr is also a pair"));
+  if (!s7_is_pair (s7_caddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "caaddr", 1, lst,
+                                     "a pair whose caddr is also a pair"));
+  return (s7_caaddr (lst));
 }
 
-s7_pointer g_cadddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cadddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadddr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadddr", 1, lst, "a pair whose cddr is also a pair"));
-  if (!s7_is_pair(s7_cdddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadddr", 1, lst, "a pair whose cdddr is also a pair"));
-  return(s7_cadddr(lst));
+s7_pointer
+g_cadddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cadddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadddr", 1, lst,
+                                     "a pair whose cddr is also a pair"));
+  if (!s7_is_pair (s7_cdddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadddr", 1, lst,
+                                     "a pair whose cdddr is also a pair"));
+  return (s7_cadddr (lst));
 }
 
-s7_pointer g_cadadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cadadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadadr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadadr", 1, lst, "a pair whose cadr is also a pair"));
-  if (!s7_is_pair(s7_cdadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cadadr", 1, lst, "a pair whose cdadr is also a pair"));
-  return(s7_cadadr(lst));
+s7_pointer
+g_cadadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cadadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadadr", 1, lst,
+                                     "a pair whose cadr is also a pair"));
+  if (!s7_is_pair (s7_cdadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cadadr", 1, lst,
+                                     "a pair whose cdadr is also a pair"));
+  return (s7_cadadr (lst));
 }
 
-s7_pointer g_caddar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "caddar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "caddar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_cdar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caddar", 1, lst, "a pair whose cdar is also a pair"));
-  if (!s7_is_pair(s7_cddar(lst)))
-    return(s7_wrong_type_arg_error(sc, "caddar", 1, lst, "a pair whose cddar is also a pair"));
-  return(s7_caddar(lst));
+s7_pointer
+g_caddar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "caddar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "caddar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_cdar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caddar", 1, lst,
+                                     "a pair whose cdar is also a pair"));
+  if (!s7_is_pair (s7_cddar (lst)))
+    return (s7_wrong_type_arg_error (sc, "caddar", 1, lst,
+                                     "a pair whose cddar is also a pair"));
+  return (s7_caddar (lst));
 }
 
-s7_pointer g_cdaaar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaaar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaaar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_caar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaaar", 1, lst, "a pair whose caar is also a pair"));
-  if (!s7_is_pair(s7_caaar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaaar", 1, lst, "a pair whose caaar is also a pair"));
-  return(s7_cdaaar(lst));
+s7_pointer
+g_cdaaar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdaaar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaaar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_caar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaaar", 1, lst,
+                                     "a pair whose caar is also a pair"));
+  if (!s7_is_pair (s7_caaar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaaar", 1, lst,
+                                     "a pair whose caaar is also a pair"));
+  return (s7_cdaaar (lst));
 }
 
-s7_pointer g_cdaadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaadr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaadr", 1, lst, "a pair whose cadr is also a pair"));
-  if (!s7_is_pair(s7_caadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaadr", 1, lst, "a pair whose caadr is also a pair"));
-  return(s7_cdaadr(lst));
+s7_pointer
+g_cdaadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdaadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaadr", 1, lst,
+                                     "a pair whose cadr is also a pair"));
+  if (!s7_is_pair (s7_caadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaadr", 1, lst,
+                                     "a pair whose caadr is also a pair"));
+  return (s7_cdaadr (lst));
 }
 
-s7_pointer g_cdadar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdadar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdadar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_cdar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdadar", 1, lst, "a pair whose cdar is also a pair"));
-  if (!s7_is_pair(s7_cadar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdadar", 1, lst, "a pair whose cadar is also a pair"));
-  return(s7_cdadar(lst));
+s7_pointer
+g_cdadar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdadar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdadar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_cdar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdadar", 1, lst,
+                                     "a pair whose cdar is also a pair"));
+  if (!s7_is_pair (s7_cadar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdadar", 1, lst,
+                                     "a pair whose cadar is also a pair"));
+  return (s7_cdadar (lst));
 }
 
-s7_pointer g_cddaar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cddaar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddaar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_caar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddaar", 1, lst, "a pair whose caar is also a pair"));
-  if (!s7_is_pair(s7_cdaar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddaar", 1, lst, "a pair whose cdaar is also a pair"));
-  return(s7_cddaar(lst));
+s7_pointer
+g_cddaar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cddaar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddaar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_caar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddaar", 1, lst,
+                                     "a pair whose caar is also a pair"));
+  if (!s7_is_pair (s7_cdaar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddaar", 1, lst,
+                                     "a pair whose cdaar is also a pair"));
+  return (s7_cddaar (lst));
 }
 
-s7_pointer g_cdaddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaddr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaddr", 1, lst, "a pair whose cddr is also a pair"));
-  if (!s7_is_pair(s7_caddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdaddr", 1, lst, "a pair whose caddr is also a pair"));
-  return(s7_cdaddr(lst));
+s7_pointer
+g_cdaddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdaddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaddr", 1, lst,
+                                     "a pair whose cddr is also a pair"));
+  if (!s7_is_pair (s7_caddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdaddr", 1, lst,
+                                     "a pair whose caddr is also a pair"));
+  return (s7_cdaddr (lst));
 }
 
-s7_pointer g_cddddr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cddddr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddddr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddddr", 1, lst, "a pair whose cddr is also a pair"));
-  if (!s7_is_pair(s7_cdddr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddddr", 1, lst, "a pair whose cdddr is also a pair"));
-  return(s7_cddddr(lst));
+s7_pointer
+g_cddddr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cddddr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddddr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddddr", 1, lst,
+                                     "a pair whose cddr is also a pair"));
+  if (!s7_is_pair (s7_cdddr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddddr", 1, lst,
+                                     "a pair whose cdddr is also a pair"));
+  return (s7_cddddr (lst));
 }
 
-s7_pointer g_cddadr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cddadr", args, "a pair"));
-  if (!s7_is_pair(s7_cdr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddadr", 1, lst, "a pair whose cdr is also a pair"));
-  if (!s7_is_pair(s7_cadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddadr", 1, lst, "a pair whose cadr is also a pair"));
-  if (!s7_is_pair(s7_cdadr(lst)))
-    return(s7_wrong_type_arg_error(sc, "cddadr", 1, lst, "a pair whose cdadr is also a pair"));
-  return(s7_cddadr(lst));
+s7_pointer
+g_cddadr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cddadr", args, "a pair"));
+  if (!s7_is_pair (s7_cdr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddadr", 1, lst,
+                                     "a pair whose cdr is also a pair"));
+  if (!s7_is_pair (s7_cadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddadr", 1, lst,
+                                     "a pair whose cadr is also a pair"));
+  if (!s7_is_pair (s7_cdadr (lst)))
+    return (s7_wrong_type_arg_error (sc, "cddadr", 1, lst,
+                                     "a pair whose cdadr is also a pair"));
+  return (s7_cddadr (lst));
 }
 
-s7_pointer g_cdddar(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  if (!s7_is_pair(lst))
-    return(s7i_sole_arg_method_or_bust(sc, lst, "cdddar", args, "a pair"));
-  if (!s7_is_pair(s7_car(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdddar", 1, lst, "a pair whose car is also a pair"));
-  if (!s7_is_pair(s7_cdar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdddar", 1, lst, "a pair whose cdar is also a pair"));
-  if (!s7_is_pair(s7_cddar(lst)))
-    return(s7_wrong_type_arg_error(sc, "cdddar", 1, lst, "a pair whose cddar is also a pair"));
-  return(s7_cdddar(lst));
+s7_pointer
+g_cdddar (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  if (!s7_is_pair (lst))
+    return (s7i_sole_arg_method_or_bust (sc, lst, "cdddar", args, "a pair"));
+  if (!s7_is_pair (s7_car (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdddar", 1, lst,
+                                     "a pair whose car is also a pair"));
+  if (!s7_is_pair (s7_cdar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdddar", 1, lst,
+                                     "a pair whose cdar is also a pair"));
+  if (!s7_is_pair (s7_cddar (lst)))
+    return (s7_wrong_type_arg_error (sc, "cdddar", 1, lst,
+                                     "a pair whose cddar is also a pair"));
+  return (s7_cdddar (lst));
 }
 
-s7_pointer g_set_car(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  s7_pointer val = s7_cadr(args);
-  if (s7_is_pair(lst) && !s7_is_immutable(lst))
-    return(s7_set_car(lst, val));
-  if (!s7_is_pair(lst))
-    return(s7_wrong_type_arg_error(sc, "set-car!", 1, lst, "a pair"));
-  return(s7_wrong_type_arg_error(sc, "set-car!", 1, lst, "a mutable pair"));
+s7_pointer
+g_set_car (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer val= s7_cadr (args);
+  if (s7_is_pair (lst) && !s7_is_immutable (lst))
+    return (s7_set_car (lst, val));
+  if (!s7_is_pair (lst))
+    return (s7_wrong_type_arg_error (sc, "set-car!", 1, lst, "a pair"));
+  return (s7_wrong_type_arg_error (sc, "set-car!", 1, lst, "a mutable pair"));
 }
 
-s7_pointer g_set_cdr(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  s7_pointer val = s7_cadr(args);
-  if (s7_is_pair(lst) && !s7_is_immutable(lst))
-    return(s7_set_cdr(lst, val));
-  if (!s7_is_pair(lst))
-    return(s7_wrong_type_arg_error(sc, "set-cdr!", 1, lst, "a pair"));
-  return(s7_wrong_type_arg_error(sc, "set-cdr!", 1, lst, "a mutable pair"));
+s7_pointer
+g_set_cdr (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer val= s7_cadr (args);
+  if (s7_is_pair (lst) && !s7_is_immutable (lst))
+    return (s7_set_cdr (lst, val));
+  if (!s7_is_pair (lst))
+    return (s7_wrong_type_arg_error (sc, "set-cdr!", 1, lst, "a pair"));
+  return (s7_wrong_type_arg_error (sc, "set-cdr!", 1, lst, "a mutable pair"));
 }
 
-s7_pointer g_list_ref(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  s7_pointer ind = s7_cadr(args);
-  if (!s7_is_pair(lst))
-    return(s7i_method_or_bust(sc, lst, "list-ref", args, "a pair", 1));
-  if (!s7_is_integer(ind))
-    return(s7i_method_or_bust(sc, ind, "list-ref", args, "an integer", 2));
-  s7_int index = s7_integer(ind);
+s7_pointer
+g_list_ref (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer ind= s7_cadr (args);
+  if (!s7_is_pair (lst))
+    return (s7i_method_or_bust (sc, lst, "list-ref", args, "a pair", 1));
+  if (!s7_is_integer (ind))
+    return (s7i_method_or_bust (sc, ind, "list-ref", args, "an integer", 2));
+  s7_int index= s7_integer (ind);
   if (index < 0)
-    return(s7_out_of_range_error(sc, "list-ref", 2, ind, "it is negative"));
-  s7_pointer p = lst;
-  for (s7_int i = 0; (i < index) && s7_is_pair(p); i++)
-    p = s7_cdr(p);
-  if (!s7_is_pair(p))
-    return(s7_out_of_range_error(sc, "list-ref", 2, ind, "it is too large"));
-  return(s7_car(p));
+    return (s7_out_of_range_error (sc, "list-ref", 2, ind, "it is negative"));
+  s7_pointer p= lst;
+  for (s7_int i= 0; (i < index) && s7_is_pair (p); i++)
+    p= s7_cdr (p);
+  if (!s7_is_pair (p))
+    return (s7_out_of_range_error (sc, "list-ref", 2, ind, "it is too large"));
+  return (s7_car (p));
 }
 
-s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  s7_pointer ind = s7_cadr(args);
-  if (!s7_is_integer(ind))
-    return(s7i_method_or_bust(sc, ind, "list-tail", args, "an integer", 2));
-  if (!s7_is_pair(lst) && !s7_is_null(sc, lst))
-    return(s7i_method_or_bust(sc, lst, "list-tail", args, "a list", 1));
-  s7_int index = s7_integer(ind);
+s7_pointer
+g_list_tail (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer ind= s7_cadr (args);
+  if (!s7_is_integer (ind))
+    return (s7i_method_or_bust (sc, ind, "list-tail", args, "an integer", 2));
+  if (!s7_is_pair (lst) && !s7_is_null (sc, lst))
+    return (s7i_method_or_bust (sc, lst, "list-tail", args, "a list", 1));
+  s7_int index= s7_integer (ind);
   if (index < 0)
-    return(s7_out_of_range_error(sc, "list-tail", 2, ind, "it is negative"));
-  s7_pointer p = lst;
-  s7_int i;
-  for (i = 0; (i < index) && s7_is_pair(p); i++)
-    p = s7_cdr(p);
+    return (s7_out_of_range_error (sc, "list-tail", 2, ind, "it is negative"));
+  s7_pointer p= lst;
+  s7_int     i;
+  for (i= 0; (i < index) && s7_is_pair (p); i++)
+    p= s7_cdr (p);
   if (i < index)
-    return(s7_out_of_range_error(sc, "list-tail", 2, ind, "it is too large"));
-  return(p);
+    return (s7_out_of_range_error (sc, "list-tail", 2, ind, "it is too large"));
+  return (p);
 }
 
-s7_pointer g_cons(s7_scheme *sc, s7_pointer args)
-{
-  return(s7_cons(sc, s7_car(args), s7_cadr(args)));
+s7_pointer
+g_cons (s7_scheme* sc, s7_pointer args) {
+  return (s7_cons (sc, s7_car (args), s7_cadr (args)));
 }
 
-s7_pointer g_list(s7_scheme *sc, s7_pointer args)
-{
-  return(s7i_copy_proper_list(sc, args));
-}
+/* -------------------------------- filter -------------------------------- */
 
-s7_pointer g_list_set_1(s7_scheme *sc, s7_pointer lst, s7_pointer args, int32_t arg_num)
-{
-  #define H_list_set "(list-set! lst i ... val) sets the i-th element (0-based) of the list to val"
-  #define Q_list_set s7_make_circular_signature(sc, 3, 4, sc->T, sc->is_pair_symbol, sc->is_integer_symbol, sc->is_integer_or_any_at_end_symbol)
-
-  s7_int index;
-  s7_pointer p = lst, ind;
-
-  if (!s7_is_pair(lst) || s7_is_immutable(lst))
-    return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a mutable pair"));
-  ind = s7_car(args);
-  if ((arg_num > 2) && s7_is_null(sc, s7_cdr(args)))
-    {
-      s7_set_car(lst, ind);
-      return(ind);
+s7_pointer
+g_filter (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_cadr (args);
+  if (!s7_is_pair (lst)) {
+    if (s7_is_null (sc, lst)) return (s7_nil (sc));
+    return (s7_wrong_type_arg_error (sc, "filter", 2, lst, "a proper list"));
+  }
+  /* args may live in evaluator-recycled cells, so keep pred and lst in our own
+   * pairs. anchor = ((pred lst) . work), work's car holds the reversed kept
+   * elements before the current all-passing run, work's cdr later holds the
+   * result; one protected pair keeps everything GC-reachable while pred runs */
+  s7_pointer keep= s7_cons (sc, s7_car (args), s7_cons (sc, lst, s7_nil (sc)));
+  s7_pointer anchor= s7_cons (sc, keep, s7_cons (sc, s7_nil (sc), s7_nil (sc)));
+  s7_gc_protect_via_stack (sc, anchor);
+  s7_pointer work     = s7_cdr (anchor);
+  s7_pointer pred     = s7_car (keep);
+  s7_pointer run_start= NULL;
+  s7_pointer p        = lst;
+  while (s7_is_pair (p)) {
+    if (s7i_is_true (sc, s7_apply_function (
+                             sc, pred, s7i_set_plist_1 (sc, s7_car (p))))) {
+      if (!run_start) run_start= p;
     }
-  if (!s7_is_integer(ind))
-    {
-      s7_pointer full_args = s7_cons(sc, lst, args);
-      return(s7i_method_or_bust(sc, ind, "list-set!", full_args, "an integer", 2));
+    else {
+      if (run_start) {
+        for (s7_pointer q= run_start; q != p; q= s7_cdr (q))
+          s7_set_car (work, s7_cons (sc, s7_car (q), s7_car (work)));
+        run_start= NULL;
+      }
     }
-  index = s7_integer(ind);
+    p= s7_cdr (p);
+  }
+  if (!s7_is_null (sc, p)) {
+    s7_gc_unprotect_via_stack (sc, anchor);
+    return (s7_wrong_type_arg_error (sc, "filter", 2, lst, "a proper list"));
+  }
+  /* share the longest all-passing suffix, like the reference implementation */
+  s7_pointer result= (run_start) ? run_start : s7_nil (sc);
+  s7_set_cdr (work, result);
+  for (s7_pointer q= s7_car (work); s7_is_pair (q); q= s7_cdr (q)) {
+    result= s7_cons (sc, s7_car (q), result);
+    s7_set_cdr (work, result);
+  }
+  s7_gc_unprotect_via_stack (sc, anchor);
+  return (result);
+}
+
+/* -------------------------------- take -------------------------------- */
+
+s7_pointer
+g_take (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer k  = s7_cadr (args);
+  if (!s7_is_integer (k))
+    return (s7_wrong_type_arg_error (sc, "take", 2, k, "an integer"));
+  s7_int n= s7_integer (k);
+  if (n < 0)
+    return (
+        s7_wrong_type_arg_error (sc, "take", 2, k, "a non-negative integer"));
+  if (n == 0) return (s7_nil (sc));
+  /* no Scheme callbacks here, so args stay put; only the result being built
+   * needs a GC anchor, with each new pair linked in right after s7_cons */
+  s7_pointer head= s7_cons (sc, s7_nil (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, head);
+  s7_pointer tail= head;
+  s7_pointer p   = lst;
+  for (s7_int i= 0; i < n; i++) {
+    if (!s7_is_pair (p)) {
+      s7_gc_unprotect_via_stack (sc, head);
+      return (s7_wrong_type_arg_error (sc, "take", 1, lst,
+                                       "a list of sufficient length"));
+    }
+    s7_set_cdr (tail, s7_cons (sc, s7_car (p), s7_nil (sc)));
+    tail= s7_cdr (tail);
+    p   = s7_cdr (p);
+  }
+  s7_gc_unprotect_via_stack (sc, head);
+  return (s7_cdr (head));
+}
+
+/* -------------------------------- take-right / drop-right
+ * -------------------------------- */
+
+/* shared lead walk: returns NULL on success (lead advanced n pairs),
+ * otherwise the error object to return */
+static s7_pointer
+take_right_lead (s7_scheme* sc, const char* name, s7_pointer lst, s7_pointer k,
+                 s7_int n, s7_pointer* lead) {
+  if (!s7_is_integer (k))
+    return (s7_wrong_type_arg_error (sc, name, 2, k, "an integer"));
+  if (n < 0) return (s7_out_of_range_error (sc, name, 2, k, "it is negative"));
+  if (!s7_is_pair (lst) && !s7_is_null (sc, lst))
+    return (s7_wrong_type_arg_error (sc, name, 1, lst, "a list"));
+  s7_pointer p= lst;
+  for (s7_int i= 0; i < n; i++) {
+    if (!s7_is_pair (p))
+      return (s7_out_of_range_error (sc, name, 2, k, "it is too large"));
+    p= s7_cdr (p);
+  }
+  (*lead)= p;
+  return (NULL);
+}
+
+s7_pointer
+g_take_right (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer k  = s7_cadr (args);
+  s7_pointer lead;
+  s7_pointer err= take_right_lead (
+      sc, "take-right", lst, k, s7_is_integer (k) ? s7_integer (k) : 0, &lead);
+  if (err) return (err);
+  /* no allocation and no Scheme callbacks: result is a sublist of lst */
+  s7_pointer lag= lst;
+  while (s7_is_pair (lead)) {
+    lag = s7_cdr (lag);
+    lead= s7_cdr (lead);
+  }
+  return (lag);
+}
+
+s7_pointer
+g_drop_right (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer k  = s7_cadr (args);
+  s7_pointer lead;
+  s7_pointer err= take_right_lead (
+      sc, "drop-right", lst, k, s7_is_integer (k) ? s7_integer (k) : 0, &lead);
+  if (err) return (err);
+  /* dummy head anchor, same GC pattern as g_take */
+  s7_pointer head= s7_cons (sc, s7_nil (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, head);
+  s7_pointer tail= head;
+  s7_pointer lag = lst;
+  while (s7_is_pair (lead)) {
+    s7_set_cdr (tail, s7_cons (sc, s7_car (lag), s7_nil (sc)));
+    tail= s7_cdr (tail);
+    lag = s7_cdr (lag);
+    lead= s7_cdr (lead);
+  }
+  s7_gc_unprotect_via_stack (sc, head);
+  return (s7_cdr (head));
+}
+
+s7_pointer
+g_list (s7_scheme* sc, s7_pointer args) {
+  return (s7i_copy_proper_list (sc, args));
+}
+
+s7_pointer
+g_list_set_1 (s7_scheme* sc, s7_pointer lst, s7_pointer args, int32_t arg_num) {
+#define H_list_set                                                             \
+  "(list-set! lst i ... val) sets the i-th element (0-based) of the list to "  \
+  "val"
+#define Q_list_set                                                             \
+  s7_make_circular_signature (sc, 3, 4, sc->T, sc->is_pair_symbol,             \
+                              sc->is_integer_symbol,                           \
+                              sc->is_integer_or_any_at_end_symbol)
+
+  s7_int     index;
+  s7_pointer p= lst, ind;
+
+  if (!s7_is_pair (lst) || s7_is_immutable (lst))
+    return (
+        s7_wrong_type_arg_error (sc, "list-set!", 1, lst, "a mutable pair"));
+  ind= s7_car (args);
+  if ((arg_num > 2) && s7_is_null (sc, s7_cdr (args))) {
+    s7_set_car (lst, ind);
+    return (ind);
+  }
+  if (!s7_is_integer (ind)) {
+    s7_pointer full_args= s7_cons (sc, lst, args);
+    return (
+        s7i_method_or_bust (sc, ind, "list-set!", full_args, "an integer", 2));
+  }
+  index= s7_integer (ind);
 
   if (index < 0)
-    return(s7_out_of_range_error(sc, "list-set!", arg_num, ind, "it is negative"));
-  if (index > s7i_max_list_length(sc))
-    return(s7_out_of_range_error(sc, "list-set!", arg_num, ind, "it is too large"));
+    return (s7_out_of_range_error (sc, "list-set!", arg_num, ind,
+                                   "it is negative"));
+  if (index > s7i_max_list_length (sc))
+    return (s7_out_of_range_error (sc, "list-set!", arg_num, ind,
+                                   "it is too large"));
 
-  for (s7_int i = 0; (i < index) && s7_is_pair(p); i++, p = s7_cdr(p)) {}
-  if (!s7_is_pair(p))
-    {
-      if (s7_is_null(sc, p))
-        return(s7_out_of_range_error(sc, "list-set!", arg_num, ind, "it is too large"));
-      return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a proper list"));
-    }
-  if (s7_is_null(sc, s7_cddr(args)))
-    s7_set_car(p, s7_cadr(args));
-  else
-    {
-      if (!s7_is_pair(s7_car(p)))
-        return(s7_wrong_number_of_args_error(sc, "list-set!", args));
-      return(g_list_set_1(sc, s7_car(p), s7_cdr(args), arg_num + 1));
-    }
-  return(s7_cadr(args));
+  for (s7_int i= 0; (i < index) && s7_is_pair (p); i++, p= s7_cdr (p)) {
+  }
+  if (!s7_is_pair (p)) {
+    if (s7_is_null (sc, p))
+      return (s7_out_of_range_error (sc, "list-set!", arg_num, ind,
+                                     "it is too large"));
+    return (s7_wrong_type_arg_error (sc, "list-set!", 1, lst, "a proper list"));
+  }
+  if (s7_is_null (sc, s7_cddr (args))) s7_set_car (p, s7_cadr (args));
+  else {
+    if (!s7_is_pair (s7_car (p)))
+      return (s7_wrong_number_of_args_error (sc, "list-set!", args));
+    return (g_list_set_1 (sc, s7_car (p), s7_cdr (args), arg_num + 1));
+  }
+  return (s7_cadr (args));
 }
 
-s7_pointer g_list_set(s7_scheme *sc, s7_pointer args)
-{
-  return(g_list_set_1(sc, s7_car(args), s7_cdr(args), 2));
+s7_pointer
+g_list_set (s7_scheme* sc, s7_pointer args) {
+  return (g_list_set_1 (sc, s7_car (args), s7_cdr (args), 2));
 }
 
-s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer lst = s7_car(args);
-  s7_pointer p = lst;
-  s7_int index;
-  if (!s7_is_pair(lst) || s7_is_immutable(lst))
-    return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a mutable pair"));
-  index = s7_integer(s7_cadr(args));
-  if ((index < 0) || (index > s7i_max_list_length(sc)))
-    return(s7_out_of_range_error(sc, "list-set!", 2, s7_make_integer(sc, index), "it is negative or too large"));
+s7_pointer
+g_list_set_i (s7_scheme* sc, s7_pointer args) {
+  s7_pointer lst= s7_car (args);
+  s7_pointer p  = lst;
+  s7_int     index;
+  if (!s7_is_pair (lst) || s7_is_immutable (lst))
+    return (
+        s7_wrong_type_arg_error (sc, "list-set!", 1, lst, "a mutable pair"));
+  index= s7_integer (s7_cadr (args));
+  if ((index < 0) || (index > s7i_max_list_length (sc)))
+    return (s7_out_of_range_error (sc, "list-set!", 2,
+                                   s7_make_integer (sc, index),
+                                   "it is negative or too large"));
 
-  for (s7_int i = 0; (i < index) && s7_is_pair(p); i++, p = s7_cdr(p)) {}
-  if (!s7_is_pair(p))
-    {
-      if (s7_is_null(sc, p))
-        return(s7_out_of_range_error(sc, "list-set!", 2, s7_make_integer(sc, index), "it is too large"));
-      return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a proper list"));
-    }
+  for (s7_int i= 0; (i < index) && s7_is_pair (p); i++, p= s7_cdr (p)) {
+  }
+  if (!s7_is_pair (p)) {
+    if (s7_is_null (sc, p))
+      return (s7_out_of_range_error (
+          sc, "list-set!", 2, s7_make_integer (sc, index), "it is too large"));
+    return (s7_wrong_type_arg_error (sc, "list-set!", 1, lst, "a proper list"));
+  }
   {
-    s7_pointer val = s7_caddr(args);
-    s7_set_car(p, val);
-    return(val);
+    s7_pointer val= s7_caddr (args);
+    s7_set_car (p, val);
+    return (val);
   }
 }

--- a/TeXmacs/plugins/goldfish/src/s7_liii_list.h
+++ b/TeXmacs/plugins/goldfish/src/s7_liii_list.h
@@ -13,54 +13,59 @@
 extern "C" {
 #endif
 
-s7_pointer g_is_null(s7_scheme *sc, s7_pointer args);
-s7_pointer g_is_pair(s7_scheme *sc, s7_pointer args);
-s7_pointer g_is_list(s7_scheme *sc, s7_pointer args);
-s7_pointer g_is_proper_list(s7_scheme *sc, s7_pointer args);
-s7_pointer g_car(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caaar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cadar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdaar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cddar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_is_null (s7_scheme* sc, s7_pointer args);
+s7_pointer g_is_pair (s7_scheme* sc, s7_pointer args);
+s7_pointer g_is_list (s7_scheme* sc, s7_pointer args);
+s7_pointer g_is_proper_list (s7_scheme* sc, s7_pointer args);
+s7_pointer g_car (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caaar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cadar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdaar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cddar (s7_scheme* sc, s7_pointer args);
 
-s7_pointer g_caaaar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caaadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caadar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cadaar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caaddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cadddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cadadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_caddar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdaaar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdaadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdadar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cddaar(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdaddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cddddr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cddadr(s7_scheme *sc, s7_pointer args);
-s7_pointer g_cdddar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caaaar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caaadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caadar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cadaar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caaddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cadddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cadadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_caddar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdaaar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdaadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdadar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cddaar (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdaddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cddddr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cddadr (s7_scheme* sc, s7_pointer args);
+s7_pointer g_cdddar (s7_scheme* sc, s7_pointer args);
 
-s7_pointer g_set_car(s7_scheme *sc, s7_pointer args);
-s7_pointer g_set_cdr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_set_car (s7_scheme* sc, s7_pointer args);
+s7_pointer g_set_cdr (s7_scheme* sc, s7_pointer args);
 
-s7_pointer g_list_ref(s7_scheme *sc, s7_pointer args);
-s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args);
+s7_pointer g_list_ref (s7_scheme* sc, s7_pointer args);
+s7_pointer g_list_tail (s7_scheme* sc, s7_pointer args);
 
-s7_pointer g_cons(s7_scheme *sc, s7_pointer args);
-s7_pointer g_list(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cons (s7_scheme* sc, s7_pointer args);
+s7_pointer g_list (s7_scheme* sc, s7_pointer args);
+s7_pointer g_filter (s7_scheme* sc, s7_pointer args);
+s7_pointer g_take (s7_scheme* sc, s7_pointer args);
+s7_pointer g_take_right (s7_scheme* sc, s7_pointer args);
+s7_pointer g_drop_right (s7_scheme* sc, s7_pointer args);
 
-s7_pointer g_list_set(s7_scheme *sc, s7_pointer args);
-s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args);
-s7_pointer g_list_set_1(s7_scheme *sc, s7_pointer lst, s7_pointer args, int32_t arg_num);
+s7_pointer g_list_set (s7_scheme* sc, s7_pointer args);
+s7_pointer g_list_set_i (s7_scheme* sc, s7_pointer args);
+s7_pointer g_list_set_1 (s7_scheme* sc, s7_pointer lst, s7_pointer args,
+                         int32_t arg_num);
 
 #ifdef __cplusplus
 }

--- a/devel/1149.md
+++ b/devel/1149.md
@@ -1,0 +1,25 @@
+# [1149] 升级 Goldfish 到 18.11.18
+
+## What
+同步上游 goldfish v18.11.18（commit c03a4360）到 `TeXmacs/plugins/goldfish/`：
+
+- `src/goldfish.hpp`：版本号 `18.11.17` → `18.11.18`
+- `src/s7_liii_list.c`：新增 `g_filter`、`g_take`、`g_take_right`、`g_drop_right` 的 C 实现（上游 #887 / #888 / #889）
+- `src/s7_liii_list.h`：声明上述四个函数
+- `src/s7.c`：在 `list-tail`/`make-list` 注册后注册四个 `g_*` semisafe typed function
+- `goldfish/srfi/srfi-1.scm`：`filter`、`take`、`take-right`、`drop-right` 改为对应 `g_*` 别名
+
+## Why
+- filter/take/take-right/drop-right 是列表处理高频函数，C 实现相比原 Scheme
+  递归实现显著更快（filter 在中大型列表上 ~6x）
+- 为后续用 `(liii list)` 的 `filter` 替代 mogan `kernel/library/list.scm` 的
+  `list-filter` 做准备，降低启动和运行开销
+
+## 如何测试
+```
+xmake b stem
+gf eval '(import (srfi srfi-1)) (display (filter odd? (iota 10))) (newline)'
+gf eval '(import (srfi srfi-1)) (display (take (iota 5) 3)) (newline)'
+gf eval '(import (srfi srfi-1)) (display (take-right (iota 5) 2)) (newline)'
+gf eval '(import (srfi srfi-1)) (display (drop-right (iota 5) 2)) (newline)'
+```


### PR DESCRIPTION
## Summary
同步上游 goldfish v18.11.18（commit [c03a4360](https://github.com/MoganLab/goldfish/commit/c03a4360)）到 `TeXmacs/plugins/goldfish/`：

- `src/goldfish.hpp`：版本号 `18.11.17` → `18.11.18`
- `src/s7_liii_list.c`/`src/s7_liii_list.h`：新增 `g_filter`、`g_take`、`g_take_right`、`g_drop_right` 的 C 实现（上游 #887 / #888 / #889）
- `src/s7.c`：在 `list-tail`/`make-list` 后注册四个 `g_*` semisafe typed function
- `goldfish/srfi/srfi-1.scm`：`filter`/`take`/`take-right`/`drop-right` 改为对应 `g_*` 别名

## Why
- filter/take/take-right/drop-right 是列表处理高频函数，C 实现相比原 Scheme 递归实现显著更快（filter 在中大型列表上 ~6x）
- 为后续用 `(liii list)` 的 `filter` 替代 mogan `kernel/library/list.scm` 的 `list-filter` 做准备，降低启动和运行开销

## Test plan
- [x] `xmake b stem` 构建通过
- [x] `gf eval '(import (srfi srfi-1)) (display (filter odd? (iota 10))) (newline)'` → `(1 3 5 7 9)`
- [x] `gf eval '(import (srfi srfi-1)) (display (take (iota 5) 3)) (newline)'` → `(0 1 2)`
- [x] `gf eval '(import (srfi srfi-1)) (display (take-right (iota 5) 2)) (newline)'` → `(3 4)`
- [x] `gf eval '(import (srfi srfi-1)) (display (drop-right (iota 5) 2)) (newline)'` → `(0 1 2)`