### PR TITLE
[1149] list.scm 改用 g_* C 绑定提速

### DIFF
--- a/TeXmacs/progs/kernel/library/list.scm
+++ b/TeXmacs/progs/kernel/library/list.scm
@@ -117,12 +117,7 @@
 ;; Extraction of sublists
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-public (list-head lis k)
-  (let recur
-    ((lis lis) (k k))
-    (if (zero? k) '() (cons (car lis) (recur (cdr lis) (- k 1))))
-  ) ;let
-) ;define-public
+(define-public (list-head lis k) (g_take lis k))
 
 (define-public list-take list-head)
 ;; SRFI-1
@@ -131,12 +126,12 @@
 
 (define-public (list-take-right l i)
   "Return the last @i elements of @l."
-  (list-tail l (- (length l) i))
+  (g_take_right l i)
 ) ;define-public
 
 (define-public (list-drop-right l i)
   "Return all but the last @i elements of @l."
-  (list-head l (- (length l) i))
+  (g_drop_right l i)
 ) ;define-public
 
 (define-public (sublist l i j)
@@ -254,7 +249,7 @@
 
 (define-public (list-filter l pred?)
   "Return the list of elements from @l which match @pred?."
-  (apply append (map (lambda (x) (if (pred? x) (list x) (list))) l))
+  (g_filter pred? l)
 ) ;define-public
 
 (provide-public (filter-map fun . args)

--- a/devel/1149.md
+++ b/devel/1149.md
@@ -23,3 +23,39 @@ gf eval '(import (srfi srfi-1)) (display (take (iota 5) 3)) (newline)'
 gf eval '(import (srfi srfi-1)) (display (take-right (iota 5) 2)) (newline)'
 gf eval '(import (srfi srfi-1)) (display (drop-right (iota 5) 2)) (newline)'
 ```
+
+## 2026-07-20 应用 g_* 优化 mogan kernel/library/list.scm
+
+### What
+把 mogan 的 `TeXmacs/progs/kernel/library/list.scm` 中四个列表函数改为转调
+新的 goldfish C 绑定：
+
+- `list-head lis k` → `(g_take lis k)`（原为手写递归）
+- `list-take-right l i` → `(g_take_right l i)`（原为 `list-tail` + `length`，
+  扫两遍）
+- `list-drop-right l i` → `(g_drop_right l i)`（原为 `list-head` + `length`，
+  扫两遍）
+- `list-filter l pred?` → `(g_filter pred? l)`（原为 `apply append` + `map`
+  + lambda 闭包；mogan 参数顺序是 `(l pred?)`，调用时翻转成 srfi-1 的
+  `(pred? l)`）
+
+`list-take`/`list-drop` 是 `list-head`/`list-tail` 的别名，自动跟着走；
+`list-remove`/`list-intersection`/`list-difference`/`assoc-remove!`/
+`assoc-difference`/`assoc-delta`/`assoc-exclude` 等都内建用 `list-filter`，
+间接跟着提速。
+
+### Why
+- `list-filter` 旧实现 `(apply append (map (lambda (x) (if (pred? x) (list x) (list))) l))`
+  对每个元素分配 1 个单元素 list + 1 个 lambda 闭包调用 + 1 次 append 调用，
+  C 实现单遍扫描、末尾全匹配后缀结构共享（filter 中大型列表 ~6x）
+- `list-take-right`/`list-drop-right` 旧实现先 `length` 再 `list-tail`/`list-head`，
+  相当于扫两遍；C 实现的 lead/lag 双指针一遍即可
+
+### How
+- 四个 `g_*` 是 goldfish 在 s7 rootlet 中全局注册的 C 函数（见
+  `src/s7.c` 中 `s7_define_semisafe_typed_function` 调用），mogan scheme
+  直接可用，无需 import
+- 边界语义验证：`k=0`/`k=length`/空列表/全匹配/全不匹配/dotted-list 错误
+  用例与旧实现一致；下游派生函数 `list-remove`/`list-intersection`/
+  `list-difference` 实测结果不变
+


### PR DESCRIPTION
## Summary
紧接 #4036（goldfish 18.11.18 升级）之后，把 `TeXmacs/progs/kernel/library/list.scm` 中四个高频列表函数改为转调新的 goldfish C 绑定：

- `list-head lis k` → `(g_take lis k)`（原手写递归）
- `list-take-right l i` → `(g_take_right l i)`（原 `list-tail` + `length`，扫两遍）
- `list-drop-right l i` → `(g_drop_right l i)`（原 `list-head` + `length`，扫两遍）
- `list-filter l pred?` → `(g_filter pred? l)`（原 `apply append` + `map` + lambda 闭包；参数顺序 `(l pred?)` → srfi-1 `(pred? l)` 需翻转）

`list-take`/`list-drop` 是 `list-head`/`list-tail` 别名，跟着提速；`list-remove`/`list-intersection`/`list-difference`/`assoc-remove!`/`assoc-difference`/`assoc-delta`/`assoc-exclude` 内部用 `list-filter`，间接跟着提速。

## Why
- `list-filter` 旧实现对每个元素分配 1 个单元素 list + 1 次 lambda 闭包调用 + 1 次 append；C 实现单遍扫描 + 末尾全匹配后缀结构共享（中大型列表 ~6x）
- `list-take-right`/`list-drop-right` 旧实现先 `length` 再 tail/head，C 实现的 lead/lag 双指针一遍即可

## Test plan
- [x] `xmake b stem` 构建通过
- [x] 19 项边界用例（`k=0`/`k=length`/空列表/全匹配/全不匹配/派生函数）经 moganstem headless 实测结果一致：
  ```
  list-head '(0 1 2 3 4) 3 → (0 1 2)
  list-head '() 0 → ()
  list-take-right '(0 1 2 3 4) 2 → (3 4)
  list-take-right '(0 1 2 3 4) 5 → (0 1 2 3 4)   # structure sharing
  list-drop-right '(0 1 2 3 4) 5 → ()
  list-filter '(1 2 3 4 5) odd? → (1 3 5)
  list-filter '(1 3 5) odd? → (1 3 5)            # all-pass: returns same list
  list-remove '(1 2 3 2 1) 2 → (1 3 1)
  list-intersection '(1 2 3 4) '(2 4 6) → (2 4)
  list-difference '(1 2 3 4) '(2 4 6) → (1 3)
  ```