### PR TITLE
[0840] 消除 diff-text 模块启动时的 conditional master routine warning

### DIFF
--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -102,21 +102,21 @@
 
 (define diff-active? #f)
 
-(tm-define (is-diff-active?) diff-active?)
+(define-public (is-diff-active?) diff-active?)
 
-(tm-define (diff-enable?) (not (community-stem?)))
+(define-public (diff-enable?) (not (community-stem?)))
 
 ;; =============================================================================
 ;; Model evaluation & Feedback functions
 ;; =============================================================================
 
-(tm-define (diff-feedback action) (noop))
+(define-public (diff-feedback action) (noop))
 
 ;; =============================================================================
 ;; Diff Text core control flow
 ;; =============================================================================
 
-(tm-define (trigger-diff-text)
+(define-public (trigger-diff-text)
   (let* ((sel (selection-tree))
          (origin_stree (tree->stree sel))
          (suggested_stree (demo-suggest origin_stree))
@@ -136,9 +136,9 @@
     ;; 还原精度
     (set-preference "versioning grain" pre-grain)
   ) ;let*
-) ;tm-define
+) ;define-public
 
-(tm-define (accept-diff)
+(define-public (accept-diff)
   (let ((t (tree-innermost 'version-both)))
     (when t
       (let* ((new-val (tree-ref t 1)) (p (tree-up t)) (i (tree-index t)))
@@ -152,9 +152,9 @@
   (diff-feedback 'accept)
   (refresh-window)
   (diff-scan-next)
-) ;tm-define
+) ;define-public
 
-(tm-define (reject-diff)
+(define-public (reject-diff)
   (let ((t (tree-innermost 'version-both)))
     (when t
       (let* ((old-val (tree-ref t 0)) (p (tree-up t)) (i (tree-index t)))
@@ -168,7 +168,7 @@
   (diff-feedback 'reject)
   (refresh-window)
   (diff-scan-next)
-) ;tm-define
+) ;define-public
 
 ;; =============================================================================
 ;; Keyboard and Mouse Hooks

--- a/devel/0840.md
+++ b/devel/0840.md
@@ -53,3 +53,25 @@ xmake r stem
    重构基类 `QTMUserPromptPopup` 构造函数接收 `acceptText` 与 `rejectText` 参数，并在子类 `QTMGhostTextPopup` 与 `QTMDiffTextPopup` 中调用基构造函数定义特定的提示文案。
 5. **样式高亮与占位隐藏**：
    在 `std-fold.ts` 中，将新旧版本差异配色对齐到弹窗按键的 `#10b981` (绿) 与 `#ef4444` (红)，并使用 `text-bg-color` 附带现代极淡底色高亮（`#ecfdf5` 和 `#fef2f2`）。同时重构 `version-suppressed` 宏为空宏使其完全隐形。
+
+## 6 后续修复：消除 "conditional master routine" 启动告警
+
+### What
+启动时 Scheme 加载 `diff-text.scm` 报出 6 条 `warning: conditional master routine ...`：
+`is-diff-active?`、`diff-enable?`、`diff-feedback`、`trigger-diff-text`、`accept-diff`、`reject-diff`。
+
+### Why
+`tm-define` 宏链 (`tm-define` → `tm-define-sub` → `tm-define-overloaded`) 依赖全局
+`cur-conds`/`cur-props` 在展开期累积。当模块后续存在带 `:require` 的 `tm-define`
+（如 `kbd-tab`/`keyboard-press`/`mouse-event` 的重载），`tm-define-overloaded` 真正
+展开时读到的 `cur-conds` 可能已被后续同名宏污染，导致**首次定义**的 master routine
+被误判为带 condition，触发 warning（参见 `TeXmacs/progs/kernel/texmacs/tm-define.scm:333-336`）。
+
+### How
+这 6 个函数都是纯函数定义，没有 `:require`、也不被别处 `tm-define` 重载——不需要进入
+`tm-define` 的属性/重载分发体系。直接改为 `define-public`：
+- 保留模块导出（scheme 端可见性不变）
+- 绕开 `tm-define` 机制，warning 消失
+- 不改动 `tm-define` 实现本身（保持宏系统稳定）
+
+涉及文件：`TeXmacs/progs/generic/diff-text.scm` 第 105/107/113/119/141/157 行。


### PR DESCRIPTION
## Summary
- 启动加载 `TeXmacs/progs/generic/diff-text.scm` 时报 6 条 `warning: conditional master routine ...`（`is-diff-active?` / `diff-enable?` / `diff-feedback` / `trigger-diff-text` / `accept-diff` / `reject-diff`）。
- 根因：`tm-define` 宏链依赖展开期全局 `cur-conds`/`cur-props` 累积；模块内若同时存在带 `:require` 的 `tm-define`（`kbd-tab`/`keyboard-press`/`mouse-event` 重载），`tm-define-overloaded` 实际展开时读到的 `cur-conds` 已被污染，导致**首次定义**的 master routine 被误判为带 condition（参见 `TeXmacs/progs/kernel/texmacs/tm-define.scm:333-336`）。
- 修复：这 6 个纯函数无 `:require`、也不被别处重载，改为 `define-public` 绕开 `tm-define` 机制；`tm-define` 实现未改。语义不变。

## Test plan
- [x] `xmake b stem` 构建通过
- [x] `build/linux/x86_64/release/moganstem -headless -d -x "(quit-TeXmacs)"` 启动日志不再出现 `conditional master routine` 告警
- [ ] 商业版构建后按 `devel/0840.md` §3.2 交互流程验证 diff-text 功能仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)