### PR TITLE
[1150] 新增表格插入行基准 + chat-input-buffer? unbound 修复

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1216,7 +1216,7 @@
 (tm-define (kbd-cut) (clipboard-cut "primary"))
 (tm-define (kbd-paste)
   (clipboard-paste "primary")
-  (when (chat-input-buffer? (current-buffer-url))
+  (when (and (defined? 'chat-input-buffer?) (chat-input-buffer? (current-buffer-url)))
     (qt-chat-notify-input-height)
   ) ;when
   (when (defined? 'tutorial-notify-action)
@@ -1467,7 +1467,7 @@
                             ) ;lambda
     ) ;with-magic-paste-check
   ) ;if
-  (when (chat-input-buffer? (current-buffer-url))
+  (when (and (defined? 'chat-input-buffer?) (chat-input-buffer? (current-buffer-url)))
     (qt-chat-notify-input-height)
   ) ;when
   (when (defined? 'tutorial-notify-action)

--- a/TeXmacs/progs/generic/paste-widget.scm
+++ b/TeXmacs/progs/generic/paste-widget.scm
@@ -225,7 +225,7 @@
           (do-paste fm)
           (with-magic-paste-check (lambda () (do-paste fm)))
         ) ;if
-        (when (chat-input-buffer? (current-buffer-url))
+        (when (and (defined? 'chat-input-buffer?) (chat-input-buffer? (current-buffer-url)))
           (qt-chat-notify-input-height)
         ) ;when
       ) ;when

--- a/TeXmacs/progs/table/table-edit.scm
+++ b/TeXmacs/progs/table/table-edit.scm
@@ -162,7 +162,9 @@
 ) ;tm-define
 
 (tm-define (table-resize-notify t)
-  (when (chat-input-buffer? (current-buffer-url))
+  ;; chat-input-buffer? 由 llm 插件懒加载定义；插件未加载时（如 headless 测试
+  ;; 或未启用 chat 的发行）符号 unbound，用 defined? 兜底，避免抛错。
+  (when (and (defined? 'chat-input-buffer?) (chat-input-buffer? (current-buffer-url)))
     (qt-chat-notify-input-height)
   ) ;when
 ) ;tm-define

--- a/TeXmacs/tests/1150.scm
+++ b/TeXmacs/tests/1150.scm
@@ -1,0 +1,54 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1150.scm
+;; DESCRIPTION : 基准测试：在表格中连续插入新行的性能
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   测量"在表格里连续向下插入 N 行"的总耗时与单行平均耗时，
+;;   作为后续表格插入路径优化的对比基线。
+;;
+;;   实现要点：
+;;     - `(make 'tabular)` 新建 1×1 表格并定位光标到首个 cell，
+;;       与「插入 → 表格」菜单同源。
+;;     - `(table-insert-row #t)` 是 kbd-enter / 菜单"Row below"走的路径。
+;;     - 每行插入之间不插入 kbd 等待或排版抖动；insert 内部已驱动必要的
+;;       排版增量更新，测量的是真实用户体感的"按一下回车"链路耗时。
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r 1150
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs tests 1150))
+
+(define insert-count 1000)
+
+(define (bench-insert-rows n)
+  (make 'tabular)
+  (let ((start (texmacs-time)))
+    (let loop ((i 0))
+      (when (< i n)
+        (table-insert-row #t)
+        (loop (+ i 1))
+      ) ;when
+    ) ;let
+    (let* ((elapsed (- (texmacs-time) start))
+           (per-row (if (zero? n) 0 (/ elapsed n)))
+          ) ;
+      (display "[1150] insert ")
+      (display n)
+      (display " rows: total=")
+      (display elapsed)
+      (display " ms, per-row=")
+      (display per-row)
+      (display " ms")
+      (newline)
+    ) ;let*
+  ) ;let
+) ;define
+
+(tm-define (test_1150)
+  (bench-insert-rows insert-count)
+) ;tm-define

--- a/devel/1150.md
+++ b/devel/1150.md
@@ -1,0 +1,28 @@
+# 1150 表格插入行性能基准
+
+## 背景
+
+排查"表格里连续插入新行"的响应耗时。需要一个稳定的可重跑基准，
+便于后续优化前后对比。
+
+## What
+
+新增 `TeXmacs/tests/1150.scm`，在 headless 编辑器里：
+
+1. `(make 'tabular)` 新建一个 1×1 表格
+2. 连续调用 `(table-insert-row #t)` 插入 N 行（默认 N=1000）
+3. 用 `texmacs-time` 计时，输出总耗时与每行平均耗时
+
+实现风格参考 `TeXmacs/tests/1144.scm`（纯 headless 基准，无 GUI、
+无 `exec-delayed-at` 异步链）。
+
+## How to run
+
+```bash
+xmake b stem
+xmake r 1150
+```
+
+## 涉及文件
+
+- `TeXmacs/tests/1150.scm`（新增）


### PR DESCRIPTION
## Summary

- 新增 `TeXmacs/tests/1150.scm`：headless 基准，`(make 'tabular)` 建表后连续 `(table-insert-row #t)` 1000 次，输出总耗时与单行均值。作为后续表格插入路径优化的对比基线。
- 修复阻塞基准跑起来的根因：`chat-input-buffer?` 由 llm 插件懒加载定义，插件未加载（headless 测试、未启用 chat 的发行）时符号 unbound，任何非 chat 路径下做表格插入/粘贴都会抛 `unbound-variable`。四处调用点加 `(defined? 'chat-input-buffer?)` guard：
  - `TeXmacs/progs/table/table-edit.scm` — `table-resize-notify`（基准触发的就是这条）
  - `TeXmacs/progs/generic/generic-edit.scm` — `kbd-paste` 与 ocr-paste 路径
  - `TeXmacs/progs/generic/paste-widget.scm` — 选择性粘贴
- 本次只做基准 + unbound 修复，**不做**表格插入路径的性能优化。

## Test plan

- [x] `xmake b stem` 编译通过
- [x] `xmake r 1150` 输出 `[1150] insert 1000 rows: total=7145 ms, per-row=...`
- [x] `xmake r 1144` 等已有测试无回归（unbound 不再抛）
- [x] `gf fmt --changed-since=main` 已格式化

🤖 Generated with [Claude Code](https://claude.com/claude-code)