### PR TITLE
[2043] 修复 Qt 异步回调捕获裸 this 的 use-after-free 隐患

### DIFF
--- a/devel/2042.md
+++ b/devel/2042.md
@@ -1,0 +1,123 @@
+# [2042] 修复 Qt 异步回调捕获裸 this 的 use-after-free 隐患
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_tm_widget.cpp` — 5 处异步回调（定时器/网络/信号）加 `QPointer<QWidget>` 守卫
+- `src/Plugins/Qt/QTMHomePage.cpp` — 构造期模板初始化 `singleShot` 改用 `mgr` 作 receiver
+- `src/System/Boot/init_texmacs.cpp` — 启动登录 `singleShot` 改用 `account` 作 receiver
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+# 本任务为 Qt 异步时序修复，无对应单元测试，依赖人工验证
+```
+
+### 3.2 非确定性测试（文档验证）
+```bash
+xmake b stem
+# 复现路径：启动后 10 秒内关闭主窗口（或切 tab/切语言触发 widget 重建），
+# 旧代码会在 checkVersionUpdate 定时器到点时 SIGSEGV；
+# 修复后定时器触发时 guard 为空，回调直接跳过，不再崩溃。
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+
+排查并修复 `qt_tm_widget_rep` 及启动流程中、Qt 异步回调捕获裸 `this`/
+裸指针的 use-after-free 隐患。崩溃现场为启动 10 秒后 `checkVersionUpdate`
+解引用已析构的 `this`（SIGSEGV）。
+
+1. `qt_tm_widget.cpp` 构造期两处 `QTimer::singleShot`（`checkNetworkAvailable`、
+   `checkVersionUpdate`）捕获裸 `this` → 加 `QPointer<QWidget> guard(qwid)`
+   守卫。
+2. `qt_tm_widget.cpp` `loginStateChanged` 信号 lambda 与其触发的
+   `refreshMembershipInfoInBackground` 延迟调用 → 加守卫（发射方 `account`
+   由 server 管理，不随 widget 析构断开）。
+3. `qt_tm_widget.cpp` `checkNetworkAvailable` / `fetchUserInfo` /
+   `checkVersionUpdate` 三处 `QNetworkReply::finished` 回调捕获裸 `this` →
+   加守卫，失效分支显式 `deleteLater` reply/manager。
+4. `fetchUserInfo` 的 `new QNetworkAccessManager()` 无 parent → 改为
+   `new QNetworkAccessManager(mainwindow())`，与其它网络请求一致。
+5. `init_texmacs.cpp` 启动登录 `QTimer::singleShot(0, [server]{...})` 捕获
+   裸 `server` → 改用 `account`（QObject）作 receiver，account 析构时定时器
+   自动断开。
+6. `QTMHomePage.cpp` 构造期 `QTimer::singleShot(0, [mgr]{...})` 捕获裸 `mgr`
+   → 改用 `mgr`（`TemplateManager`，应用级单例 QObject）作 receiver，同上模式。
+
+## 6 Why
+
+`qt_window_widget_rep::~qt_window_widget_rep()` 通过 `qwid->deleteLater()`
+**异步**销毁 QWidget。因此存在时间窗：C++ `qt_tm_widget_rep` 对象已析构、
+`this` 悬空，而 `qwid`（QMainWindow 及其子对象 QNetworkAccessManager/
+QNetworkReply、待触发的 QTimer）尚未真正 delete。
+
+此窗口内若事件循环先处理了 `QTimer` / `QNetworkReply::finished`，lambda 就
+会解引用悬挂 `this` → SIGSEGV。崩溃栈即落在 `checkVersionUpdate +704`
+（`eval`/`call` 访问失效成员）。
+
+切语言即时生效、切 tab/关窗口等会改变 widget 生命周期的操作，都会让该时间窗
+更容易被命中。
+
+## 7 How
+
+统一用 `QPointer<QWidget> guard(qwid)` 守卫。`qt_window_widget_rep::~` 走
+`qwid->deleteLater()` 异步销毁 QWidget，存在「C++ 对象 this 已析构、QWidget
+尚未真正 delete」的时间窗。捕获按值的 `QPointer` 通过监听
+`QObject::destroyed` 信号跟踪 QWidget 生命周期，**与 this 是否存活无关**，
+故 lambda 内只判 `guard`、不碰 `this`，是该代码库最贴合的写法。
+
+守卫模式统一为：
+
+```cpp
+QPointer<QWidget> guard (qwid);
+QObject::connect (sender, &Signal, [guard, this, reply, manager] () {
+  if (!guard) {                 // this 已析构
+    reply->deleteLater ();      // 失效分支用 deleteLater 回收网络资源，
+    manager->deleteLater ();    // 绝不触碰 this；deleteLater 对重复清理安全。
+    return;
+  }
+  // 正常处理 …
+});
+```
+
+> **失效分支的可达性**：`checkNetworkAvailable` / `checkVersionUpdate` 的
+> `manager` 挂在 `mainwindow()`（即 `qwid`）下，`reply` 又挂在 `manager` 下。
+> 当 `guard` 失效（`qwid` 已 delete）时，`manager`/`reply` 已作为子对象同步
+> 被销毁，`finished` 信号亦被 Qt 自动断开，lambda 不会触发——该分支对这两个
+> 函数实际不可达。`fetchUserInfo` 此前 manager 无 parent，正是唯一真正可能
+> 命中该分支的场景（现已补 parent）。保留失效分支的清理调用作为防御性代码：
+> `deleteLater` 对存活对象幂等、对已销毁对象因分支进不去而无害，且让三处
+> 网络回调模式保持一致，避免后续维护者改 parent 关系时再单独处理。
+
+对不持有网络资源的纯定时器回调，失效分支直接 `return`。
+
+`init_texmacs.cpp` 启动登录、`QTMHomePage.cpp` 模板初始化的发射方
+（`account` / `mgr`）均为应用级单例、`QObject`，采用更轻量的「receiver-form」：
+把 `QObject` 作为 `QTimer::singleShot` 的第二参数，Qt 自动在 receiver 析构时
+断开连接，无需额外守卫对象。
+
+### 排查范围（供参考）
+
+`src/Plugins/Qt/` 全量扫描了 `QTimer::singleShot` / `new QTimer` /
+`QNetworkReply::finished` / `[this]` 捕获模式，按风险分级：
+
+- **已修复（高/中）**：上述 5 处。
+- **已修复（低）**：`QTMHomePage.cpp` 构造期 `QTimer::singleShot(0, [mgr]{...})`
+  捕获裸 `mgr`。`TemplateManager` 是应用级单例、`QObject`，实际触发面极小，
+  但属同类模式，统一改成 receiver-form（`mgr` 作 receiver）保持语义自洽。
+- **已确认安全（无需改）**：`qt_tutorial.cpp`、`qt_guide_window.cpp`、
+  `qt_chat_controller.cpp`、`qt_chat_tab_widget.cpp`、`QTMOAuth.cpp`、
+  `qt_pdf_preview_widget.cpp`、`template_api.cpp` 等已用 receiver-form 或
+  `QPointer` 二次守卫；按钮 `clicked` 信号发射方是 widget 子对象、随父析构
+  自动断开，列为低风险未动。

--- a/devel/2043.md
+++ b/devel/2043.md
@@ -1,4 +1,4 @@
-# [2042] 修复 Qt 异步回调捕获裸 this 的 use-after-free 隐患
+# [2043] 修复 Qt 异步回调捕获裸 this 的 use-after-free 隐患
 
 ## 1 相关文档
 - [dddd.md](dddd.md) - 任务文档模板

--- a/src/Plugins/Qt/QTMHomePage.cpp
+++ b/src/Plugins/Qt/QTMHomePage.cpp
@@ -239,7 +239,8 @@ QTMHomePage::QTMHomePage (QWidget* parent) : QWidget (parent) {
       refreshTemplateCards ();
     }
     else if (!mgr->isInitialized ()) {
-      QTimer::singleShot (0, [mgr] () { mgr->initialize (); });
+      // mgr 作 receiver：QObject 析构时 Qt 自动断开定时器，避免悬挂
+      QTimer::singleShot (0, mgr, [mgr] () { mgr->initialize (); });
     }
   }
 }

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -29,6 +29,7 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QObject>
+#include <QPointer>
 #include <QPushButton>
 #include <QResource>
 #include <QStatusBar>
@@ -542,13 +543,22 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
                         call ("notification-bar-snooze-membership-expired");
                       }
                     });
-  // 网络检查首屏不需要，挪到事件循环里执行，避免构造期创建
-  // QNetworkAccessManager 的同步开销
+  // guard 守卫：deleteLater() 异步销毁 QWidget，存在「this 已析构、回调仍
+  // 触发」的窗口；捕获按值的 QPointer 跟踪 QWidget 生命周期（不依赖 this），
+  // 失效即跳过。本文件定时器/网络/信号回调统一此模式，下文不再赘述。
+  QPointer<QWidget> guard (qwid);
+  // 网络检查挪到事件循环，避免构造期创建 QNetworkAccessManager 的同步开销
   if (!is_community_stem ())
-    QTimer::singleShot (0, [this] () { checkNetworkAvailable (); });
+    QTimer::singleShot (0, [guard, this] () {
+      if (!guard) return;
+      checkNetworkAvailable ();
+    });
 
   // 延迟检查版本更新（启动后10秒）
-  QTimer::singleShot (10000, [this] () { checkVersionUpdate (); });
+  QTimer::singleShot (10000, [guard, this] () {
+    if (!guard) return;
+    checkVersionUpdate ();
+  });
 
   // there is a bug in the early implementation of toolbars in Qt 4.6
   // which has been fixed in 4.6.2 (at least)
@@ -947,8 +957,11 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
       QTMOAuth* account= server->getAccount ();
       // 商业版：连接登录状态变化信号
       if (!is_community_stem ()) {
+        // account 由 server 单例管理，信号不随 widget 析构断开，故仍需 guard
+        QPointer<QWidget> guard (qwid);
         QObject::connect (account, &QTMOAuth::loginStateChanged,
-                          [this] (bool loggedIn) {
+                          [guard, this] (bool loggedIn) {
+                            if (!guard) return;
                             if (loggedIn) {
                               syncScmGuestNotification (false);
                               refreshMembershipInfoInBackground ();
@@ -960,8 +973,10 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
                           });
         if (account->isLoggedIn ()) {
           // 首次创建 QNetworkAccessManager 的同步开销挪出构造关键路径
-          QTimer::singleShot (
-              0, [this] () { refreshMembershipInfoInBackground (); });
+          QTimer::singleShot (0, [guard, this] () {
+            if (!guard) return;
+            refreshMembershipInfoInBackground ();
+          });
         }
       }
     }
@@ -3012,8 +3027,8 @@ qt_tm_widget_rep::checkLocalTokenAndLogin () {
 
 void
 qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
-  // 创建网络访问管理器
-  QNetworkAccessManager* manager= new QNetworkAccessManager ();
+  // 挂到 mainwindow 下，widget 析构时连带回收，避免网络资源泄漏
+  QNetworkAccessManager* manager= new QNetworkAccessManager (mainwindow ());
 
   // 去掉token末尾的'˙'字符
   QString clean_token= token;
@@ -3042,9 +3057,17 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
   // 发送请求
   QNetworkReply* reply= manager->get (request);
 
-  // 连接信号处理响应
+  // finished 回调守卫（见构造期）。失效分支用 deleteLater 回收网络资源，
+  // 绝不触碰 this；reply 尚存活才能进回调，deleteLater 对重复清理是安全的
+  QPointer<QWidget> guard (qwid);
   QObject::connect (
-      reply, &QNetworkReply::finished, [this, reply, manager, showDialog] () {
+      reply, &QNetworkReply::finished,
+      [guard, this, reply, manager, showDialog] () {
+        if (!guard) {
+          reply->deleteLater ();
+          manager->deleteLater ();
+          return;
+        }
         // 定义统一的错误处理逻辑
         auto handleError= [this] (const QString& errorMessage) {
           showNotLoggedInDialog (qt_translate (from_qstring (errorMessage)));
@@ -3315,12 +3338,22 @@ qt_tm_widget_rep::checkNetworkAvailable () {
   QNetworkRequest        request (testUrl);
   QNetworkReply*         reply= manager->head (request);
 
-  QObject::connect (reply, &QNetworkReply::finished, [this, reply] () {
-    bool success= (reply->error () == QNetworkReply::NoError);
-    reply->deleteLater ();
-    bool isLoggedIn= as_bool (call ("logged-in?"));
-    syncScmGuestNotification (!is_community_stem () && !isLoggedIn && success);
-  });
+  // finished 回调守卫（同 fetchUserInfo / checkVersionUpdate 模式）
+  QPointer<QWidget> guard (qwid);
+  QObject::connect (reply, &QNetworkReply::finished,
+                    [guard, this, reply, manager] () {
+                      if (!guard) {
+                        reply->deleteLater ();
+                        manager->deleteLater ();
+                        return;
+                      }
+                      bool success= (reply->error () == QNetworkReply::NoError);
+                      bool isLoggedIn= as_bool (call ("logged-in?"));
+                      syncScmGuestNotification (!is_community_stem () &&
+                                                !isLoggedIn && success);
+                      reply->deleteLater ();
+                      manager->deleteLater ();
+                    });
 }
 
 // 检查版本更新，根据条件显示提示条
@@ -3371,39 +3404,48 @@ qt_tm_widget_rep::checkVersionUpdate () {
                         to_qstring (stem_user_agent ()).toUtf8 ());
 
   QNetworkReply* reply= manager->get (request);
-  QObject::connect (reply, &QNetworkReply::finished, [this, reply, manager] () {
-    if (reply->error () == QNetworkReply::NoError) {
-      QByteArray data         = reply->readAll ();
-      QString    remoteVersion= parseVersionFromTM (data);
-      QString    localVersion = XMACS_VERSION;
+  // finished 回调守卫（见构造期说明）
+  QPointer<QWidget> guard (qwid);
+  QObject::connect (
+      reply, &QNetworkReply::finished, [guard, this, reply, manager] () {
+        if (!guard) {
+          reply->deleteLater ();
+          manager->deleteLater ();
+          return;
+        }
+        if (reply->error () == QNetworkReply::NoError) {
+          QByteArray data         = reply->readAll ();
+          QString    remoteVersion= parseVersionFromTM (data);
+          QString    localVersion = XMACS_VERSION;
 
-      if (!remoteVersion.isEmpty ()) {
-        if (DEBUG_IO)
-          debug_io << "[VersionUpdate] Parsed remote version: "
-                   << qPrintable (remoteVersion) << "\n";
-      }
+          if (!remoteVersion.isEmpty ()) {
+            if (DEBUG_IO)
+              debug_io << "[VersionUpdate] Parsed remote version: "
+                       << qPrintable (remoteVersion) << "\n";
+          }
 
-      if (remoteVersion.isEmpty ()) {
-        if (DEBUG_IO)
-          debug_io << "[VersionUpdate] Failed to parse version from response\n";
-        syncScmUpdateNotification (false);
-      }
-      else if (isVersionNewer (remoteVersion, localVersion)) {
-        syncScmUpdateNotification (true, remoteVersion);
-      }
-      else {
-        syncScmUpdateNotification (false);
-      }
-    }
-    else {
-      if (DEBUG_IO)
-        debug_io << "[VersionUpdate] Failed to fetch remote version: "
-                 << qPrintable (reply->errorString ()) << "\n";
-      syncScmUpdateNotification (false);
-    }
-    reply->deleteLater ();
-    manager->deleteLater ();
-  });
+          if (remoteVersion.isEmpty ()) {
+            if (DEBUG_IO)
+              debug_io
+                  << "[VersionUpdate] Failed to parse version from response\n";
+            syncScmUpdateNotification (false);
+          }
+          else if (isVersionNewer (remoteVersion, localVersion)) {
+            syncScmUpdateNotification (true, remoteVersion);
+          }
+          else {
+            syncScmUpdateNotification (false);
+          }
+        }
+        else {
+          if (DEBUG_IO)
+            debug_io << "[VersionUpdate] Failed to fetch remote version: "
+                     << qPrintable (reply->errorString ()) << "\n";
+          syncScmUpdateNotification (false);
+        }
+        reply->deleteLater ();
+        manager->deleteLater ();
+      });
 }
 
 QString

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -1029,7 +1029,9 @@ perform_startup_login_request () {
   tm_server_rep* server=
       dynamic_cast<tm_server_rep*> (get_server ().operator->());
   if (server && server->getAccount ()) {
-    QTimer::singleShot (0, [server] () { server->getAccount ()->login (); });
+    // account 作 receiver：QObject 析构时 Qt 自动断开定时器，避免悬挂
+    QTMOAuth* account= server->getAccount ();
+    QTimer::singleShot (0, account, [account] () { account->login (); });
     g_startup_login_requested= false;
     return;
   }


### PR DESCRIPTION
## 背景

`qt_window_widget_rep` 析构走 `qwid->deleteLater()` **异步**销毁 QWidget,存在时间窗:C++ 对象 `this` 已析构、`qwid`(及其子对象 QTimer/QNetworkReply)尚未真正 delete。此窗口内若事件循环触发异步回调,lambda 即解引用悬挂 `this` → SIGSEGV(崩溃栈落在启动 10 秒后的 `checkVersionUpdate`)。

## 改动

- **`qt_tm_widget.cpp`**:6 处异步回调加 `QPointer<QWidget> guard(qwid)` 守卫
  - 构造期 `singleShot`(checkNetworkAvailable / checkVersionUpdate)
  - `loginStateChanged` 信号 lambda 及其触发的 `refreshMembershipInfoInBackground`
  - `checkNetworkAvailable` / `fetchUserInfo` / `checkVersionUpdate` 三处 `QNetworkReply::finished`
- **`fetchUserInfo\**:`new QNetworkAccessManager()` 补 `mainwindow()` parent,与其它网络请求一致,避免泄漏
- **`init_texmacs.cpp`**:启动登录 `singleShot` 改用 `account`(QTMOAuth:QObject)作 receiver,account 析构时自动断开
- **`QTMHomePage.cpp`**:模板初始化 `singleShot` 改用 `mgr`(TemplateManager 单例 QObject)作 receiver

## 守卫选型

用 `QPointer<QWidget> guard(qwid)` 按值捕获,跟踪 QWidget 生命周期而非 `this`,与 deleteLater 异步语义契合。网络回调失效分支保留 `deleteLater` 清理作为防御性代码(`deleteLater` 幂等,保持三处模式一致)。详见 `devel/2042.md`。

## 测试

`xmake b stem` 编译通过;复现路径见 `devel/2042.md` §3.2(启动 10 秒内关窗口)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)