### PR TITLE
[0851] 点赞/踩按钮改用 SVG 图标

### DIFF
--- a/TeXmacs/misc/images/feedback/bad-ico-white.svg
+++ b/TeXmacs/misc/images/feedback/bad-ico-white.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<g transform="translate(0,48) scale(1,-1)">
+<path style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M17.536,21.506c1.849-2.91,3.869-5.757,5.731-8.66c0.185-0.287,0.306-0.643,0.432-1.09c0,0,1.609-5.662,1.646-5.766
+	c0.46-1.283,1.228-1.692,2.508-1.373c0.86,0.216,1.592,0.709,2.177,1.467c0.823,1.067,1.122,2.272,1.291,3.203
+	c0.323,1.792,0.21,3.661-0.356,5.882C30.589,16.637,29.5,20.5,29.5,20.5h5.936c1.442,0.003,2.762,0.561,3.716,1.569
+	c0.937,0.991,1.412,2.308,1.337,3.709c-0.034,0.631-0.19,1.21-0.329,1.722c0,0-1.727,6.756-2.565,9.995
+	c-0.929,3.587-4.102,6.018-7.71,6.018c-0.255,0-0.513-0.012-0.772-0.037c-0.504-0.048-6.644-1.358-11.419-2.393"/>
+<path style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M14.5,42.5h-4c-1.657,0-3-1.343-3-3v-16c0-1.657,1.343-3,3-3h7v19C17.5,41.157,16.157,42.5,14.5,42.5z"/>
+</g>
+</svg>

--- a/TeXmacs/misc/images/feedback/bad-ico.svg
+++ b/TeXmacs/misc/images/feedback/bad-ico.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<g transform="translate(0,48) scale(1,-1)">
+<path style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M17.536,21.506c1.849-2.91,3.869-5.757,5.731-8.66c0.185-0.287,0.306-0.643,0.432-1.09c0,0,1.609-5.662,1.646-5.766
+	c0.46-1.283,1.228-1.692,2.508-1.373c0.86,0.216,1.592,0.709,2.177,1.467c0.823,1.067,1.122,2.272,1.291,3.203
+	c0.323,1.792,0.21,3.661-0.356,5.882C30.589,16.637,29.5,20.5,29.5,20.5h5.936c1.442,0.003,2.762,0.561,3.716,1.569
+	c0.937,0.991,1.412,2.308,1.337,3.709c-0.034,0.631-0.19,1.21-0.329,1.722c0,0-1.727,6.756-2.565,9.995
+	c-0.929,3.587-4.102,6.018-7.71,6.018c-0.255,0-0.513-0.012-0.772-0.037c-0.504-0.048-6.644-1.358-11.419-2.393"/>
+<path style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M14.5,42.5h-4c-1.657,0-3-1.343-3-3v-16c0-1.657,1.343-3,3-3h7v19C17.5,41.157,16.157,42.5,14.5,42.5z"/>
+</g>
+</svg>

--- a/TeXmacs/misc/images/feedback/good-ico-white.svg
+++ b/TeXmacs/misc/images/feedback/good-ico-white.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<path style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M17.536,21.506c1.849-2.91,3.869-5.757,5.731-8.66c0.185-0.287,0.306-0.643,0.432-1.09c0,0,1.609-5.662,1.646-5.766
+	c0.46-1.283,1.228-1.692,2.508-1.373c0.86,0.216,1.592,0.709,2.177,1.467c0.823,1.067,1.122,2.272,1.291,3.203
+	c0.323,1.792,0.21,3.661-0.356,5.882C30.589,16.637,29.5,20.5,29.5,20.5h5.936c1.442,0.003,2.762,0.561,3.716,1.569
+	c0.937,0.991,1.412,2.308,1.337,3.709c-0.034,0.631-0.19,1.21-0.329,1.722c0,0-1.727,6.756-2.565,9.995
+	c-0.929,3.587-4.102,6.018-7.71,6.018c-0.255,0-0.513-0.012-0.772-0.037c-0.504-0.048-6.644-1.358-11.419-2.393"/>
+<path style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M14.5,42.5h-4c-1.657,0-3-1.343-3-3v-16c0-1.657,1.343-3,3-3h7v19C17.5,41.157,16.157,42.5,14.5,42.5z"/>
+</svg>

--- a/TeXmacs/misc/images/feedback/good-ico.svg
+++ b/TeXmacs/misc/images/feedback/good-ico.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<path style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M17.536,21.506c1.849-2.91,3.869-5.757,5.731-8.66c0.185-0.287,0.306-0.643,0.432-1.09c0,0,1.609-5.662,1.646-5.766
+	c0.46-1.283,1.228-1.692,2.508-1.373c0.86,0.216,1.592,0.709,2.177,1.467c0.823,1.067,1.122,2.272,1.291,3.203
+	c0.323,1.792,0.21,3.661-0.356,5.882C30.589,16.637,29.5,20.5,29.5,20.5h5.936c1.442,0.003,2.762,0.561,3.716,1.569
+	c0.937,0.991,1.412,2.308,1.337,3.709c-0.034,0.631-0.19,1.21-0.329,1.722c0,0-1.727,6.756-2.565,9.995
+	c-0.929,3.587-4.102,6.018-7.71,6.018c-0.255,0-0.513-0.012-0.772-0.037c-0.504-0.048-6.644-1.358-11.419-2.393"/>
+<path style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;" d="
+	M14.5,42.5h-4c-1.657,0-3-1.343-3-3v-16c0-1.657,1.343-3,3-3h7v19C17.5,41.157,16.157,42.5,14.5,42.5z"/>
+</svg>

--- a/TeXmacs/misc/images/images.qrc
+++ b/TeXmacs/misc/images/images.qrc
@@ -5,6 +5,11 @@
         <file>ocr-button/right-align.svg</file>
         <file>ocr-button/ocr.svg</file>
 
+        <file>feedback/good-ico.svg</file>
+        <file>feedback/bad-ico.svg</file>
+        <file>feedback/good-ico-white.svg</file>
+        <file>feedback/bad-ico-white.svg</file>
+
         <file>tabpage/add.svg</file>
         <file>tabpage/close.svg</file>
 

--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -884,6 +884,14 @@ QWidget#centralWidget QPushButton#bad_btn {
   border: none;
 }
 
+QWidget#centralWidget QPushButton#good_btn {
+  qproperty-icon: url(":/feedback/good-ico-white.svg");
+}
+
+QWidget#centralWidget QPushButton#bad_btn {
+  qproperty-icon: url(":/feedback/bad-ico-white.svg");
+}
+
 QWidget#centralWidget QPushButton#good_btn:hover,
 QWidget#centralWidget QPushButton#bad_btn:hover {
   background-color: rgba(255, 255, 255, 0.1);

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -837,6 +837,14 @@ QPushButton#good_btn, QPushButton#bad_btn {
   border: none;
 }
 
+QPushButton#good_btn {
+  qproperty-icon: url(":/feedback/good-ico.svg");
+}
+
+QPushButton#bad_btn {
+  qproperty-icon: url(":/feedback/bad-ico.svg");
+}
+
 QPushButton#good_btn:hover, QPushButton#bad_btn:hover {
   background-color: #f3f4f6;
 }

--- a/devel/0851.md
+++ b/devel/0851.md
@@ -1,0 +1,24 @@
+# [0851] 点赞/踩按钮改用 SVG 图标
+
+## 1 相关文档
+- [0849.md](0849.md) - 弹窗与 version-both 黑暗模式适配
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/QTMUserPromptPopup.cpp` — 点赞/踩按钮改为纯图标按钮，图标尺寸经 DpiUtils 缩放
+- `TeXmacs/misc/images/images.qrc` — 注册 `feedback/` 下的 4 个 SVG
+- `TeXmacs/misc/themes/liii.css` / `liii-night.css` — 主题 CSS 用 `qproperty-icon` 指定图标路径
+
+## 3 如何测试
+
+### 3.1 非确定性测试（交互验证）
+1. 触发 AI diff 或 ghost text 弹窗，确认点赞/踩按钮显示为 SVG 图标（非 emoji）；
+2. 浅色与黑暗模式下各显示对应版本，确认图标显示有无问题；
+
+## 4 What
+- 将弹窗点赞（👍）/踩（👎）emoji 替换为 `good-ico.svg` / `bad-ico.svg`；
+- 深色主题使用对应的 `-white` 反色版本。
+
+## 5 How
+- **资源**：`images.qrc` 新增 `feedback/good-ico.svg`、`feedback/bad-ico.svg` 及其 `-white` 版本，前缀沿用 `/`。
+- **CSS**：liii.css 与 liii-night.css 分别为 `QPushButton#good_btn` / `#bad_btn` 添加 `qproperty-icon: url(":/feedback/...")`。两个按钮图标不同，必须分写成独立规则，不可用逗号合写图标属性。
+- **C++**：按钮构造传空串避免 emoji 与图标叠显；新增常量 `kIconButtonSize`（18），`applyIconButtonGeometry` 用 `setIconSize(QSize(DpiUtils::scaled(...), ...))` 控制渲染尺寸，替代原依赖 `font-size` 的 emoji 方案。图标路径走 CSS（随主题切换深浅），尺寸走 C++（随 DPI 缩放），与既有 ocr 按钮模式一致。

--- a/src/Plugins/Qt/QTMUserPromptPopup.cpp
+++ b/src/Plugins/Qt/QTMUserPromptPopup.cpp
@@ -12,6 +12,7 @@
 #include "qt_dpi_utils.hpp"
 #include "server.hpp"
 #include <QFrame>
+#include <QSize>
 
 static constexpr int kContainerBorderWidth = 2;
 static constexpr int kContainerBorderRadius= 14;
@@ -24,6 +25,7 @@ static constexpr int kButtonFontPx         = 18; // 按钮字号
 static constexpr int kActionButtonPadY     = 6;  // 接受/拒绝按钮纵向内边距
 static constexpr int kActionButtonPadX     = 16; // 接受/拒绝按钮横向内边距
 static constexpr int kIconButtonPad        = 6;  // 点赞/踩按钮内边距
+static constexpr int kIconButtonSize       = 18; // 点赞/踩图标边长
 
 // 按钮配色（含 hover/pressed）由主题 CSS 提供，这里只注入随 DPI 缩放的尺寸，
 // 避免与主题 CSS 的颜色规则产生控件级/应用级合并冲突。
@@ -43,13 +45,13 @@ applyActionButtonGeometry (QPushButton* btn) {
 
 static void
 applyIconButtonGeometry (QPushButton* btn) {
+  const int size= DpiUtils::scaled (kIconButtonSize);
+  btn->setIconSize (QSize (size, size));
   btn->setStyleSheet (QString ("QPushButton { "
                                "border-radius: %1px; "
-                               "font-size: %2px; "
-                               "padding: %3px; "
+                               "padding: %2px; "
                                "}")
                           .arg (DpiUtils::scaled (kButtonBorderRadius))
-                          .arg (DpiUtils::scaled (kButtonFontPx))
                           .arg (DpiUtils::scaled (kIconButtonPad)));
 }
 
@@ -127,7 +129,7 @@ QTMUserPromptPopup::QTMUserPromptPopup (QWidget*              parent,
   innerLayout->addWidget (rejectBtn);
 
   // 3. 点赞按钮
-  goodBtn= new QPushButton ("👍", container);
+  goodBtn= new QPushButton ("", container);
   goodBtn->setObjectName ("good_btn");
   applyIconButtonGeometry (goodBtn);
   connect (goodBtn, &QPushButton::clicked, this,
@@ -135,7 +137,7 @@ QTMUserPromptPopup::QTMUserPromptPopup (QWidget*              parent,
   innerLayout->addWidget (goodBtn);
 
   // 4. 踩按钮
-  badBtn= new QPushButton ("👎", container);
+  badBtn= new QPushButton ("", container);
   badBtn->setObjectName ("bad_btn");
   applyIconButtonGeometry (badBtn);
   connect (badBtn, &QPushButton::clicked, this, &QTMUserPromptPopup::handleBad);


### PR DESCRIPTION
# [0851] 点赞/踩按钮改用 SVG 图标

## 1 相关文档
- [0849.md](0849.md) - 弹窗与 version-both 黑暗模式适配

## 2 任务相关的代码文件
- `src/Plugins/Qt/QTMUserPromptPopup.cpp` — 点赞/踩按钮改为纯图标按钮，图标尺寸经 DpiUtils 缩放
- `TeXmacs/misc/images/images.qrc` — 注册 `feedback/` 下的 4 个 SVG
- `TeXmacs/misc/themes/liii.css` / `liii-night.css` — 主题 CSS 用 `qproperty-icon` 指定图标路径

## 3 如何测试

### 3.1 非确定性测试（交互验证）
1. 触发 AI diff 或 ghost text 弹窗，确认点赞/踩按钮显示为 SVG 图标（非 emoji）；
2. 浅色与黑暗模式下各显示对应版本，确认图标显示有无问题；

## 4 What
- 将弹窗点赞（👍）/踩（👎）emoji 替换为 `good-ico.svg` / `bad-ico.svg`；
- 深色主题使用对应的 `-white` 反色版本。

## 5 How
- **资源**：`images.qrc` 新增 `feedback/good-ico.svg`、`feedback/bad-ico.svg` 及其 `-white` 版本，前缀沿用 `/`。
- **CSS**：liii.css 与 liii-night.css 分别为 `QPushButton#good_btn` / `#bad_btn` 添加 `qproperty-icon: url(":/feedback/...")`。两个按钮图标不同，必须分写成独立规则，不可用逗号合写图标属性。
- **C++**：按钮构造传空串避免 emoji 与图标叠显；新增常量 `kIconButtonSize`（18），`applyIconButtonGeometry` 用 `setIconSize(QSize(DpiUtils::scaled(...), ...))` 控制渲染尺寸，替代原依赖 `font-size` 的 emoji 方案。图标路径走 CSS（随主题切换深浅），尺寸走 C++（随 DPI 缩放），与既有 ocr 按钮模式一致。
