### PR TITLE
[0850] 消除 conditional master routine 启动告警

### DIFF
--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -13,7 +13,6 @@
 (texmacs-module (generic diff-text)
   (:use (kernel texmacs tm-define)
     (utils library cursor)
-    (version version-compare)
   ) ;:use
 ) ;texmacs-module
 
@@ -107,12 +106,6 @@
 (tm-define (diff-enable?) (not (community-stem?)))
 
 ;; =============================================================================
-;; Model evaluation & Feedback functions
-;; =============================================================================
-
-(tm-define (diff-feedback action) (noop))
-
-;; =============================================================================
 ;; Diff Text core control flow
 ;; =============================================================================
 
@@ -199,4 +192,13 @@
   (when (not (== key "move"))
     (delayed (:idle 0) (diff-check-popup))
   ) ;when
+) ;tm-define
+
+;; =============================================================================
+;; Feedback functions
+;; =============================================================================
+
+(tm-define (diff-feedback action)
+  ;; Action can be 'accept, 'reject, or 'ignore
+  (noop)
 ) ;tm-define

--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -11,9 +11,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (generic diff-text)
-  (:use (kernel texmacs tm-define)
-    (utils library cursor)
-  ) ;:use
+  (:use (kernel texmacs tm-define) (utils library cursor))
 ) ;texmacs-module
 
 ;; =============================================================================

--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -41,12 +41,8 @@
 (tm-define (ghost-enable?) (not (community-stem?)))
 
 ;; =============================================================================
-;; Model evaluation & Feedback functions
+;; Model evaluation
 ;; =============================================================================
-(tm-define (ghost-feedback action)
-  ;; Action can be 'accept, 'reject, or 'ignore
-  (noop)
-) ;tm-define
 
 (define (mock-cloud-api)
   ;; Simulate cloud API response with confidence level (100%)
@@ -155,4 +151,13 @@
   (when (not (== key "move"))
     (ignore-ghost)
   ) ;when
+) ;tm-define
+
+;; =============================================================================
+;; Feedback functions
+;; =============================================================================
+
+(tm-define (ghost-feedback action)
+  ;; Action can be 'accept, 'reject, or 'ignore
+  (noop)
 ) ;tm-define

--- a/devel/0850.md
+++ b/devel/0850.md
@@ -1,0 +1,38 @@
+# [0850] 消除 conditional master routine 启动告警
+
+## 1 相关文档
+- [0840.md](0840.md) - AI diff 功能、悬浮弹窗与差异配色实现
+- [0849.md](0849.md) - e5144d8e（define-public 化）回退说明
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/diff-text.scm` — 删除 `(version version-compare)` 导入；将 `diff-feedback` 移到文件末尾收尾
+- `TeXmacs/progs/generic/ghost-text.scm` — 将 `ghost-feedback` 移到文件末尾收尾
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 启动后观察不再报 `warning: conditional master routine ...`；
+2. ghost text / AI diff 等功能行为不变；
+
+## 4 What
+- 消除上述 6 个函数被误报为 conditional master routine 的启动告警；
+- 仅调整 `diff-text.scm` / `ghost-text.scm` 两个插件自身的定义顺序（以一个无条件的 `tm-define` 收尾），并删掉 `diff-text.scm` 中不再需要的 `(version version-compare)` 导入；不触碰 `tm-define.scm` 内核宏，也不改动任何函数体。
+
+## 5 Why
+- **根因**：`:require` / `:mode` 选项会向全局 `cur-conds` 推入条件，而模块文件加载结束后 `cur-conds` 不会自动复位。`diff-text.scm` / `ghost-text.scm` 都以带 `:require` 的重载（`mouse-event`）作为文件最后一个 `tm-define`，加载完毕后 `cur-conds` 残留着 `is-ghost-active?` / `diff-enable?` 等条件，污染其后加载的模块；被污染模块里那些全新、本应无条件的 master routine（`is-diff-active?` 等）在 `tm-define-overloaded` 新 master 分支求值时读到非空 `cur-conds`，被误报为 conditional。
+- **为什么老模块（如 tooltip、format-geometry-edit）不报**：它们同样有带 `:require` 的重载，但文件最后一个 `tm-define` 恰好是无条件 master，其宏开头的 `(set! cur-conds '())` 在展开期清空了残留，等于无意中收尾。这两个新插件以条件重载收尾，缺少这一步，才把问题暴露出来。
+- **收尾必须是 `tm-define` 而非裸 `(set! cur-conds '())`**：普通顶层 `set!` 改的是使用模块的局部 `cur-conds` 副本，后续模块求值期读到的是内核全局那份（由 `tm-define` 宏在内核定义环境中修改），两者互不相通——裸 `set!` 无效。只有走 `tm-define` 宏才能清掉被后续模块读到的那份。
+- **删除 `(version version-compare)` 导入**：`compare-versions` 仅在 `trigger-diff-text` 运行期才需要，运行期由模块解析按需加载，无需在 `:use` 中静态导入。
+- **为何不动 `tm-define.scm` 内核**：根因在两个插件自身的加载边界未收尾，属插件侧问题；内核宏机制长期稳定，且 0840 曾因改动函数定义引发 crash 被回退，故严守只改两个插件、不动内核与函数体的边界。
+
+## 6 How
+1. **`diff-text.scm` 收尾**：将原位于文件前部、体为 `(noop)` 的无条件 `diff-feedback` 移到文件最末（所有 `:require` 重载之后），独立成「Feedback functions」段。文件最后一个 `tm-define` 即为无条件 master，其宏在展开期清空 `cur-conds` 残留，加载完毕时 `cur-conds` 干净。
+2. **`ghost-text.scm` 同样收尾**：把 `ghost-feedback`（无条件 `(noop)`）移到文件末尾，消除对 diff-text 的污染。
+3. **删除无效导入**：移除 `diff-text.scm` 的 `(version version-compare)` 导入，收紧依赖。
+4. **验证**：`MOGAN_TEST_GUI=1 xmake r stem` 启动后 6 条告警全部消失，交互编辑与 AI diff 流程不 crash、行为不变。


### PR DESCRIPTION
# [0850] 消除 conditional master routine 启动告警

## 1 相关文档
- [0840.md](0840.md) - AI diff 功能、悬浮弹窗与差异配色实现
- [0849.md](0849.md) - e5144d8e（define-public 化）回退说明

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/diff-text.scm` — 删除 `(version version-compare)` 导入；将 `diff-feedback` 移到文件末尾收尾
- `TeXmacs/progs/generic/ghost-text.scm` — 将 `ghost-feedback` 移到文件末尾收尾

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 启动后观察不再报 `warning: conditional master routine ...`；
2. ghost text / AI diff 等功能行为不变；

## 4 What
- 消除上述 6 个函数被误报为 conditional master routine 的启动告警；
- 仅调整 `diff-text.scm` / `ghost-text.scm` 两个插件自身的定义顺序（以一个无条件的 `tm-define` 收尾），并删掉 `diff-text.scm` 中不再需要的 `(version version-compare)` 导入；不触碰 `tm-define.scm` 内核宏，也不改动任何函数体。

## 5 Why
- **根因**：`:require` / `:mode` 选项会向全局 `cur-conds` 推入条件，而模块文件加载结束后 `cur-conds` 不会自动复位。`diff-text.scm` / `ghost-text.scm` 都以带 `:require` 的重载（`mouse-event`）作为文件最后一个 `tm-define`，加载完毕后 `cur-conds` 残留着 `is-ghost-active?` / `diff-enable?` 等条件，污染其后加载的模块；被污染模块里那些全新、本应无条件的 master routine（`is-diff-active?` 等）在 `tm-define-overloaded` 新 master 分支求值时读到非空 `cur-conds`，被误报为 conditional。
- **为什么老模块（如 tooltip、format-geometry-edit）不报**：它们同样有带 `:require` 的重载，但文件最后一个 `tm-define` 恰好是无条件 master，其宏开头的 `(set! cur-conds '())` 在展开期清空了残留，等于无意中收尾。这两个新插件以条件重载收尾，缺少这一步，才把问题暴露出来。
- **收尾必须是 `tm-define` 而非裸 `(set! cur-conds '())`**：普通顶层 `set!` 改的是使用模块的局部 `cur-conds` 副本，后续模块求值期读到的是内核全局那份（由 `tm-define` 宏在内核定义环境中修改），两者互不相通——裸 `set!` 无效。只有走 `tm-define` 宏才能清掉被后续模块读到的那份。
- **删除 `(version version-compare)` 导入**：`compare-versions` 仅在 `trigger-diff-text` 运行期才需要，运行期由模块解析按需加载，无需在 `:use` 中静态导入。
- **为何不动 `tm-define.scm` 内核**：根因在两个插件自身的加载边界未收尾，属插件侧问题；内核宏机制长期稳定，且 0840 曾因改动函数定义引发 crash 被回退，故严守只改两个插件、不动内核与函数体的边界。

## 6 How
1. **`diff-text.scm` 收尾**：将原位于文件前部、体为 `(noop)` 的无条件 `diff-feedback` 移到文件最末（所有 `:require` 重载之后），独立成「Feedback functions」段。文件最后一个 `tm-define` 即为无条件 master，其宏在展开期清空 `cur-conds` 残留，加载完毕时 `cur-conds` 干净。
2. **`ghost-text.scm` 同样收尾**：把 `ghost-feedback`（无条件 `(noop)`）移到文件末尾，消除对 diff-text 的污染。
3. **删除无效导入**：移除 `diff-text.scm` 的 `(version version-compare)` 导入，收紧依赖。
4. **验证**：`MOGAN_TEST_GUI=1 xmake r stem` 启动后 6 条告警全部消失，交互编辑与 AI diff 流程不 crash、行为不变。
