### PR TITLE
[0852] ghost-text 触发条件收窄

### DIFF
--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -72,7 +72,7 @@
         (when (and (== ghost-serial current)
                 (not-in-tab-cycling?)
                 (or (in-text?) (in-math?))
-                (not (in-llm-chat-buffer?))
+                (in-editor-buffer?)
               ) ;and
           (generate-ghost-text)
         ) ;when
@@ -129,13 +129,10 @@
   (not (== last-key-press "tab"))
 ) ;define
 
-(define (in-llm-chat-buffer?)
-  (and (defined? 'chat-input-buffer?)
-    (defined? 'chat-message-buffer?)
-    (or (chat-input-buffer? (current-buffer-url))
-      (chat-message-buffer? (current-buffer-url))
-    ) ;or
-  ) ;and
+(define (in-editor-buffer?)
+  (let* ((u (current-buffer-url)) (s (url->unix u)))
+    (or (not (url-rooted-tmfs? u)) (string-starts? s "tmfs://part/"))
+  ) ;let*
 ) ;define
 
 (tm-define (kbd-insert s)

--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -69,7 +69,7 @@
     (set! ghost-serial (+ ghost-serial 1))
     (let ((current ghost-serial))
       (delayed (:idle 500)
-        (when (and (== ghost-serial current) (not-in-tab-cycling?) (not (in-hybrid?)))
+        (when (and (== ghost-serial current) (not-in-tab-cycling?) (or (in-text?) (in-math?)) (not (in-llm-chat-buffer?)))
           (generate-ghost-text)
         ) ;when
       ) ;delayed
@@ -124,6 +124,12 @@
 (define (not-in-tab-cycling?)
   (not (== last-key-press "tab"))
 ) ;define
+
+(define (in-llm-chat-buffer?)
+  (and (defined? 'chat-input-buffer?)
+       (defined? 'chat-message-buffer?)
+       (or (chat-input-buffer? (current-buffer-url))
+           (chat-message-buffer? (current-buffer-url))))) ;define
 
 (tm-define (kbd-insert s)
   (former s)

--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -69,7 +69,11 @@
     (set! ghost-serial (+ ghost-serial 1))
     (let ((current ghost-serial))
       (delayed (:idle 500)
-        (when (and (== ghost-serial current) (not-in-tab-cycling?) (or (in-text?) (in-math?)) (not (in-llm-chat-buffer?)))
+        (when (and (== ghost-serial current)
+                (not-in-tab-cycling?)
+                (or (in-text?) (in-math?))
+                (not (in-llm-chat-buffer?))
+              ) ;and
           (generate-ghost-text)
         ) ;when
       ) ;delayed
@@ -127,9 +131,12 @@
 
 (define (in-llm-chat-buffer?)
   (and (defined? 'chat-input-buffer?)
-       (defined? 'chat-message-buffer?)
-       (or (chat-input-buffer? (current-buffer-url))
-           (chat-message-buffer? (current-buffer-url))))) ;define
+    (defined? 'chat-message-buffer?)
+    (or (chat-input-buffer? (current-buffer-url))
+      (chat-message-buffer? (current-buffer-url))
+    ) ;or
+  ) ;and
+) ;define
 
 (tm-define (kbd-insert s)
   (former s)

--- a/devel/0852.md
+++ b/devel/0852.md
@@ -15,17 +15,17 @@ xmake r stem
 ```
 
 ### 3.2 非确定性测试（交互验证）
-1. ghost text在 LLM 侧边会话中不应该被触发，即敲入文字后不会自动补全。
+1. ghost text在 LLM 侧边会话和文本查找与替换（`Ctrl+F` 触发）中不应该被触发，即敲入文字后不会自动补全。
 2. ghost text只在文本和数学环境下触发，敲入文字后自动补全，且不和tab cycling冲突
 
 ## 4 What
 - Ghost Text 触发条件由黑名单（排除 hybrid）改为白名单：仅在普通文本模式或数学模式下触发。
-- 新增 `in-llm-chat-buffer?` 判断，排除 LLM chat 侧边栏的输入/消息 buffer。
+- 触发条件进一步收窄为「只在编辑器文档 buffer 中生效」：新增 `in-editor-buffer?`，当前 buffer 必须是真正的编辑器文档（磁盘文件，或文档分片 `tmfs://part/`）。
 
 ## 5 Why
 - 黑名单每新增一种不应补全的模式都要追加排除项，易遗漏；改为白名单只在确实需要补全的文本/数学模式触发，prog/session/src/graphics/hybrid 等一律不弹，更稳健。
-- LLM 侧边栏的输入/消息 buffer 内部仍是文本模式，`in-text?` 无法将其区分；用户正在与模型对话时叠加自动补全既干扰又无意义，需按 buffer 维度单独排除。
+- buffer 维度同理：原本只排除 LLM chat 一种，但查找/替换（`tmfs://aux/replace`）、prog、source、help 等侧边栏 buffer 内部也处于文本模式，`in-text?` 无法区分。逐个黑名单排除同样易遗漏（替换框里弹补全正是漏洞之一）。改为白名单，只认磁盘文件文档，一次性覆盖所有 tmfs 辅助 buffer。
 
 ## 6 How
 1. **白名单触发条件**：在 `trigger-ghost-text` 的延迟触发条件中，将原来的 `(not (in-hybrid?))` 替换为 `(or (in-text?) (in-math?))`，复用 `tm-modes` 现成谓词（`ghost-text.scm` 已 `(:use (kernel texmacs tm-modes))`），hybrid 等非文本/数学模式被自动过滤。
-2. **排除 LLM chat buffer**：新增辅助函数 `in-llm-chat-buffer?`，通过 `(defined? 'chat-input-buffer?)`/`(defined? 'chat-message-buffer?)` 兜底 llm 插件的懒加载（插件未加载时符号 unbound，直接调用会抛错，写法与 `table-edit.scm` 一致），再用这两个由 `(llm chat-protocol)` 导出的谓词判断当前 buffer URL 是否以 `tmfs://chat/` 开头。触发条件追加 `(not (in-llm-chat-buffer?))`。
+2. **白名单 buffer 判定**：新增辅助函数 `in-editor-buffer?`，判断当前 buffer 是否为真正的编辑器文档——非 `tmfs://` URL（磁盘文件），或 `tmfs://part/`（文档分片），判定与 `buffer-in-recent-menu?`（`kernel/library/base.scm`）一致。`url-rooted-tmfs?`、`url->unix`、`string-starts?` 均为全局 glue/kernel 函数，无需 `(:use`。触发条件以 `(in-editor-buffer?)` 替代原先的 `(not (in-llm-chat-buffer?))`，不再依赖 llm 插件懒加载的 `chat-input-buffer?`/`chat-message-buffer?`，也从源头排除所有 tmfs 辅助 buffer。

--- a/devel/0852.md
+++ b/devel/0852.md
@@ -1,0 +1,31 @@
+# [0852] ghost-text 触发条件收窄
+
+## 1 相关文档
+- [0834.md](0834.md) - 自动补全初步实现（Ghost Text 核心控制流）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/ghost-text.scm` — 收窄触发条件并新增 `in-llm-chat-buffer?`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. ghost text在 LLM 侧边会话中不应该被触发，即敲入文字后不会自动补全。
+2. ghost text只在文本和数学环境下触发，敲入文字后自动补全，且不和tab cycling冲突
+
+## 4 What
+- Ghost Text 触发条件由黑名单（排除 hybrid）改为白名单：仅在普通文本模式或数学模式下触发。
+- 新增 `in-llm-chat-buffer?` 判断，排除 LLM chat 侧边栏的输入/消息 buffer。
+
+## 5 Why
+- 黑名单每新增一种不应补全的模式都要追加排除项，易遗漏；改为白名单只在确实需要补全的文本/数学模式触发，prog/session/src/graphics/hybrid 等一律不弹，更稳健。
+- LLM 侧边栏的输入/消息 buffer 内部仍是文本模式，`in-text?` 无法将其区分；用户正在与模型对话时叠加自动补全既干扰又无意义，需按 buffer 维度单独排除。
+
+## 6 How
+1. **白名单触发条件**：在 `trigger-ghost-text` 的延迟触发条件中，将原来的 `(not (in-hybrid?))` 替换为 `(or (in-text?) (in-math?))`，复用 `tm-modes` 现成谓词（`ghost-text.scm` 已 `(:use (kernel texmacs tm-modes))`），hybrid 等非文本/数学模式被自动过滤。
+2. **排除 LLM chat buffer**：新增辅助函数 `in-llm-chat-buffer?`，通过 `(defined? 'chat-input-buffer?)`/`(defined? 'chat-message-buffer?)` 兜底 llm 插件的懒加载（插件未加载时符号 unbound，直接调用会抛错，写法与 `table-edit.scm` 一致），再用这两个由 `(llm chat-protocol)` 导出的谓词判断当前 buffer URL 是否以 `tmfs://chat/` 开头。触发条件追加 `(not (in-llm-chat-buffer?))`。


### PR DESCRIPTION
# [0852] ghost-text 触发条件收窄

## 1 相关文档
- [0834.md](0834.md) - 自动补全初步实现（Ghost Text 核心控制流）

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/ghost-text.scm` — 收窄触发条件并新增 `in-llm-chat-buffer?`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. ghost text在 LLM 侧边会话中不应该被触发，即敲入文字后不会自动补全。
2. ghost text只在文本和数学环境下触发，敲入文字后自动补全，且不和tab cycling冲突

## 4 What
- Ghost Text 触发条件由黑名单（排除 hybrid）改为白名单：仅在普通文本模式或数学模式下触发。
- 新增 `in-llm-chat-buffer?` 判断，排除 LLM chat 侧边栏的输入/消息 buffer。

## 5 Why
- 黑名单每新增一种不应补全的模式都要追加排除项，易遗漏；改为白名单只在确实需要补全的文本/数学模式触发，prog/session/src/graphics/hybrid 等一律不弹，更稳健。
- LLM 侧边栏的输入/消息 buffer 内部仍是文本模式，`in-text?` 无法将其区分；用户正在与模型对话时叠加自动补全既干扰又无意义，需按 buffer 维度单独排除。

## 6 How
1. **白名单触发条件**：在 `trigger-ghost-text` 的延迟触发条件中，将原来的 `(not (in-hybrid?))` 替换为 `(or (in-text?) (in-math?))`，复用 `tm-modes` 现成谓词（`ghost-text.scm` 已 `(:use (kernel texmacs tm-modes))`），hybrid 等非文本/数学模式被自动过滤。
2. **排除 LLM chat buffer**：新增辅助函数 `in-llm-chat-buffer?`，通过 `(defined? 'chat-input-buffer?)`/`(defined? 'chat-message-buffer?)` 兜底 llm 插件的懒加载（插件未加载时符号 unbound，直接调用会抛错，写法与 `table-edit.scm` 一致），再用这两个由 `(llm chat-protocol)` 导出的谓词判断当前 buffer URL 是否以 `tmfs://chat/` 开头。触发条件追加 `(not (in-llm-chat-buffer?))`。
