### PR TITLE
[1152] 新增 DOC_SAVE/DOC_SAVE_AS 保存埋点

### DIFF
--- a/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
@@ -18,7 +18,13 @@
 ;; limitations under the License.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(import (scheme base) (liii base) (liii path) (liii json) (srfi srfi-19))
+(import (scheme base)
+  (liii base)
+  (liii path)
+  (liii string)
+  (liii json)
+  (srfi srfi-19)
+) ;import
 
 (import (texmacs protocol))
 
@@ -51,19 +57,19 @@
   (path-append-text telemetry-log-path (string-append message "\n"))
 ) ;define
 
-;; 把 payload 中的 Unix 时间戳转换成本地可读时间，方便日志排查。
-;; 如果解析失败或没有时间戳，则按原样记录。
+;; 把事件 JSON 里的 Unix 时间戳转成本地可读时间，方便日志排查；
+;; 解析失败或没有时间戳则按原样记录。
 
-(define (format-payload s)
+(define (format-event-line s)
   (catch #t
     (lambda ()
-      (let* ((json (string->json s)) (ts (json-ref json "time")))
+      (let* ((json (string->json s)) (ts (json-ref json "timestamp")))
         (if (number? ts)
           (let* ((sec (inexact->exact (truncate ts)))
                  (date (time-utc->date (make-time TIME-UTC 0 sec)))
                  (date-str (date->string date "~Y-~m-~d ~H:~M:~S"))
                 ) ;
-            (json->string (json-push (json-drop json "time") "time" date-str))
+            (json->string (json-push (json-drop json "timestamp") "timestamp" date-str))
           ) ;let*
           (json->string json)
         ) ;if
@@ -73,16 +79,71 @@
   ) ;catch
 ) ;define
 
-(define (handle-telemetry payload)
-  (let ((s (document->string payload)))
-    (if (string=? s "")
-      (flush-verbatim "telemetry skipped: empty payload")
-      (begin
-        (telemetry-log (format-payload s))
-        (flush-verbatim "telemetry logged")
-      ) ;begin
+;; process-events main-dir
+;; 读取 main-dir 下 meta 登记的所有 jsonl，逐条把事件写入 telemetry.log，
+;; 再删除已处理的 jsonl 并清空 meta（模拟真实 worker 上传成功后的清理），
+;; 避免下次触发时重复记录。返回处理的事件条数。
+
+(define (process-events main-dir)
+  (let ((meta-path (path->string (path-join main-dir "main-telemetry.json"))))
+    (if (not (path-exists? meta-path))
+      0
+      (let ((entries (vector->list (string->json (path-read-text meta-path)))) (count 0))
+        (for-each (lambda (entry)
+                    (let ((file-path (path->string (path-join main-dir (json-ref entry "filename")))))
+                      (when (path-exists? file-path)
+                        (for-each (lambda (line)
+                                    (when (not (string=? line ""))
+                                      (set! count (+ count 1))
+                                      (telemetry-log (format-event-line line))
+                                    ) ;when
+                                  ) ;lambda
+                          (string-split (path-read-text file-path) #\newline)
+                        ) ;for-each
+                        (path-unlink file-path)
+                      ) ;when
+                    ) ;let
+                  ) ;lambda
+          entries
+        ) ;for-each
+        (path-write-text meta-path "[]")
+        count
+      ) ;let
     ) ;if
   ) ;let
+) ;define
+
+;; 上报触发 payload 只含 event/main-dir/api-url/api-key，事件本体在
+;; main-dir 的 jsonl 里；有 main-dir 时按 worker 语义消费事件，
+;; 否则退化为原样记录 payload。
+
+(define (handle-telemetry payload)
+  (let* ((s (document->string payload))
+         (json (catch #t (lambda () (string->json s)) (lambda args #f)))
+        ) ;
+    (cond ((string=? s "") (flush-verbatim "telemetry skipped: empty payload"))
+          ((and (pair? json) (string? (json-ref json "main-dir")))
+           (let ((n (catch #t
+                      (lambda () (process-events (json-ref json "main-dir")))
+                      (lambda args -1)
+                    ) ;catch
+                 ) ;n
+                 (trigger (json-ref json "event"))
+                ) ;
+             (telemetry-log (string-append "upload trigger: "
+                              (if (string? trigger) trigger "?")
+                              ", "
+                              (number->string n)
+                              " events"
+                            ) ;string-append
+             ) ;telemetry-log
+             (flush-verbatim (string-append "telemetry logged " (number->string n) " events")
+             ) ;flush-verbatim
+           ) ;let
+          ) ;
+          (else (telemetry-log s) (flush-verbatim "telemetry logged"))
+    ) ;cond
+  ) ;let*
 ) ;define
 
 (define (read-eval-print)

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -363,6 +363,16 @@
           (when (defined? 'auto-backup-trig)
             (auto-backup-trig name kind)
           ) ;when
+          ;; 埋点只关心保存成功的结果，失败分支不上报
+          (when (and (defined? 'track-event) (defined? 'auto-backup-buffer-doc-id))
+            (let ((doc-id (auto-backup-buffer-doc-id name)))
+              (when (and (string? doc-id) (!= doc-id ""))
+                (track-event (if (string=? kind "save-as") "DOC_SAVE_AS" "DOC_SAVE")
+                  (list (cons "doc_id" doc-id))
+                ) ;track-event
+              ) ;when
+            ) ;let
+          ) ;when
           (save-buffer-post name opts)
         ) ;begin
       ) ;if

--- a/devel/1152.md
+++ b/devel/1152.md
@@ -1,0 +1,37 @@
+# [1152] DOC_SAVE / DOC_SAVE_AS 保存埋点
+
+## 任务相关的代码文件
+- TeXmacs/progs/texmacs/texmacs/tm-files.scm
+- TeXmacs/plugins/telemetry/progs/plugin/telemetry-track.scm
+- TeXmacs/plugins/autosave/progs/plugin/autosave-impl.scm
+
+## 如何测试
+1. `xmake b stem` 后启动 mogan，新建文档写入内容并保存（DOC_SAVE），
+   再用「另存为」保存一份（DOC_SAVE_AS）。
+2. 开启 `debug-events` 调试开关，终端应出现
+   `[telemetry] track: DOC_SAVE` / `[telemetry] track: DOC_SAVE_AS` 日志；
+   事件 properties 中携带 `doc_id`（即文档的 stem-doc-id）。
+
+## 2026/07/23 新增 DOC_SAVE / DOC_SAVE_AS 埋点
+
+### What
+为「保存」和「另存为」操作新增埋点事件 `DOC_SAVE` / `DOC_SAVE_AS`，
+properties 携带 `doc_id` 参数（文档的 stem-doc-id）。
+
+### Why
+数据侧需要统计文档保存行为，并通过 doc_id 关联到具体文档。
+
+### How
+- `save-buffer-save`（tm-files.scm）是 save / save-as 两条链路的共同
+  出口，且 `kind` 参数（`"save"` / `"save-as"`）可区分二者；在其保存
+  成功分支调用 `track-event` 上报，kind 为 `"save-as"` 时上报
+  `DOC_SAVE_AS`，否则上报 `DOC_SAVE`。
+- `doc_id` 通过 autosave 插件的 `auto-backup-buffer-doc-id` 读取；
+  该函数前已有 `auto-backup-ensure-buffer-doc-id!` 兜底绑定，因此
+  保存成功时 doc id 必然存在。
+- 保存是用户主动操作，发生时 telemetry 插件（事件循环 ~3s 后懒加载）
+  必然已加载，故直接调 `track-event`，无需走
+  `telemetry-track-or-enqueue` 的 pending 队列。
+- `track-event` 与 `auto-backup-buffer-doc-id` 均加 `defined?` 守卫：
+  社区版无 telemetry 插件时不影响保存主流程。
+- 失败分支（`Could not save`）不上报，埋点只反映保存成功的结果。

--- a/devel/1152.md
+++ b/devel/1152.md
@@ -2,15 +2,43 @@
 
 ## 任务相关的代码文件
 - TeXmacs/progs/texmacs/texmacs/tm-files.scm
+- TeXmacs/plugins/telemetry/goldfish/tm-telemetry.scm
 - TeXmacs/plugins/telemetry/progs/plugin/telemetry-track.scm
 - TeXmacs/plugins/autosave/progs/plugin/autosave-impl.scm
 
 ## 如何测试
-1. `xmake b stem` 后启动 mogan，新建文档写入内容并保存（DOC_SAVE），
-   再用「另存为」保存一份（DOC_SAVE_AS）。
-2. 开启 `debug-events` 调试开关，终端应出现
-   `[telemetry] track: DOC_SAVE` / `[telemetry] track: DOC_SAVE_AS` 日志；
-   事件 properties 中携带 `doc_id`（即文档的 stem-doc-id）。
+1. 启动 mogan，新建文档写入内容并保存（DOC_SAVE），再用「另存为」
+   保存一份（DOC_SAVE_AS）。
+2. 等一次上报触发（HEART_BEAT 等 important 事件）后查看
+   `$TEXMACS_HOME_PATH/telemetry.log`，应看到事件本体逐条落日志，
+   `properties` 中携带 `doc_id`（即文档的 stem-doc-id），并有一行
+   `upload trigger: <事件名>, N events` 汇总。
+
+## 2026/07/23 修复假插件无法展示带参数事件
+
+### What
+重写 fake telemetry 插件（goldfish/tm-telemetry.scm）的 payload
+处理：收到上报触发 payload 时，读取 main-dir 下 meta 登记的所有
+jsonl，把每条事件（含 properties）逐条写入 telemetry.log，再删除
+已处理 jsonl 并清空 meta（模拟真实 worker 上传成功后的清理）。
+
+### Why
+假插件原来只把触发 payload（event/main-dir/api-url/api-key）原样
+写日志，事件本体躺在 jsonl 里看不到——DOC_SAVE 等非 important
+事件在 telemetry.log 里完全不可见，带 doc_id 参数的事件无法被验证。
+
+### How
+- 新增 `process-events`：解析 meta（liii json，数组→vector、对象→
+  alist），逐文件读 jsonl、写日志、删文件，最后 `path-write-text`
+  清空 meta，返回事件条数。
+- `handle-telemetry` 按 payload 是否含 main-dir 分派：有则走
+  worker 语义消费事件并回复 `telemetry logged N events`；否则退化
+  为旧行为原样记录。
+- `format-event-line` 把事件 timestamp 转 UTC 可读时间（沿用旧
+  format-payload 的时区约定）。
+- 验证：用 `TeXmacs/plugins/goldfish/bin/goldfish` 直接跑脚本，
+  分别喂正常 payload / 空 payload / 非 JSON payload，三种路径日志
+  均正确（不能用系统 gf 测，仓库 srfi 与系统 gf 版本不匹配）。
 
 ## 2026/07/23 新增 DOC_SAVE / DOC_SAVE_AS 埋点
 


### PR DESCRIPTION
## Summary
- 为「保存」/「另存为」新增埋点事件 `DOC_SAVE` / `DOC_SAVE_AS`，properties 携带 `doc_id`（文档的 stem-doc-id），便于数据侧关联文档保存行为
- 在 `save-buffer-save`（save / save-as 共同出口）保存成功分支调用 `track-event`，按 `kind` 区分事件名；`doc_id` 由 autosave 插件的 `auto-backup-buffer-doc-id` 读取
- `track-event` / `auto-backup-buffer-doc-id` 均加 `defined?` 守卫，社区版无 telemetry 插件时不影响保存主流程；失败分支不上报

## Test plan
- [ ] `xmake b stem` 构建通过
- [ ] 开启 debug-events，新建文档保存，终端出现 `[telemetry] track: DOC_SAVE`，properties 含 doc_id
- [ ] 「另存为」后出现 `[telemetry] track: DOC_SAVE_AS`，properties 含 doc_id
- [ ] 保存失败（如只读文件）不产生事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)