### PR TITLE
[0857] 修复绘图区文本框上悬停光标时错乱且不复位

### DIFF
--- a/devel/0857.md
+++ b/devel/0857.md
@@ -1,0 +1,31 @@
+# [0857] 修复绘图区文本框上悬停光标时错乱且不复位
+
+## 1 相关文档
+- [0817.md](0817.md) - 绘图后自动切换到移动模式（引入 `over_graphics` 时跳过光标复位）
+- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑
+
+## 2 任务相关的代码文件
+- `src/Edit/Interface/edit_mouse.cpp` — 悬停光标链重构，`over_graphics` 单独走分支
+- `src/Edit/Interface/edit_interface.hpp` — 新增 `hover_style_cursor` 锁存
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 绘图区插入文本框，鼠标悬停其上时，光标不再变成上下/左右 resize 样式；
+2. 绘图区绘制完图形，鼠标拖拽时，光标应该变成移动样式，移开后恢复为正常光标；
+
+## 4 What
+- 鼠标悬停绘图区文本框时，光标变成上下/左右 resize 样式，且移开后不恢复。
+
+## 5 Why
+- resize 光标只能由悬停光标链中的表格/图片手柄分支（`table_scale_hit`、`last_image_brec`、`table_line_hit`）设置；0817 起 `over_graphics` 时 else 分支跳过 `normal` 复位（为避免手型光标闪回），该光标一旦在绘图区内被套上就无人清理。
+
+## 6 How
+- 悬停光标链重构为两段：`over_graphics` 走绘图区专用分支，光标交由绘图模式管理，仅经 `hover_style_cursor` 锁存复位残留样式，并维持 image/text popup 状态；非绘图区走原始正常链，行为与上游一致。
+- 各设置非默认样式的分支（手柄/表格线/超链接/图片）均置位 `hover_style_cursor`，进入绘图区后的下一个 move 事件复位为 normal。

--- a/src/Edit/Interface/edit_interface.hpp
+++ b/src/Edit/Interface/edit_interface.hpp
@@ -102,6 +102,7 @@ protected:
   void   table_line_apply (SI x, SI y);
   void   table_line_stop ();
   int    table_scale_handle_type   = 0; // 0: N/A; 1: 下方; 2: 右方; 3: 右下方
+  bool   hover_style_cursor        = false;   // 悬停链刚设置了非默认光标样式
   path   table_scale_path          = path (); // 重绘时实时更新
   SI     table_scale_start_x       = 0;
   SI     table_scale_start_y       = 0;

--- a/src/Edit/Interface/edit_mouse.cpp
+++ b/src/Edit/Interface/edit_mouse.cpp
@@ -939,15 +939,35 @@ edit_interface_rep::mouse_any (string type, SI x, SI y, int mods, time_t t,
       }
     }
   }
-  if (over_handles) {
+  
+  // 绘图区光标由绘图模式管理，单独走分支仅复位残留悬停样式；其余走正常光标链
+  bool over_gr= over_graphics (x, y);
+  if (over_gr) {
+    if (hover_style_cursor) {
+      set_cursor_style ("normal");
+      hover_style_cursor= false;
+    }
+#ifdef QTTEXMACS
+    hide_image_popup ();
+#endif
+    update_text_popup ();
+  }
+  else if (over_handles) {
     if (handle_cursor != "") set_cursor_style (handle_cursor);
     else set_cursor_style ("size_all");
+    hover_style_cursor= true;
   }
-  else if (hovering_table)
+  else if (hovering_table) {
     set_cursor_style (hovering_table == 1 ? "size_ver" : "size_hor");
-  else if (hovering_hlink) set_cursor_style ("pointing_hand");
+    hover_style_cursor= true;
+  }
+  else if (hovering_hlink) {
+    set_cursor_style ("pointing_hand");
+    hover_style_cursor= true;
+  }
   else if (hovering_image) {
     set_cursor_style ("pointing_hand");
+    hover_style_cursor       = true;
     path path_of_image_parent= path_up (current_path);
     tree tree_of_image_parent= subtree (et, path_of_image_parent);
     if (should_show_image_popup (tree_of_image_parent)) {
@@ -959,7 +979,8 @@ edit_interface_rep::mouse_any (string type, SI x, SI y, int mods, time_t t,
     hide_text_popup ();
   }
   else {
-    if (!over_graphics (x, y)) set_cursor_style ("normal");
+    set_cursor_style ("normal");
+    hover_style_cursor= false;
 #ifdef QTTEXMACS
     hide_image_popup ();
 #endif

--- a/src/Edit/Interface/edit_mouse.cpp
+++ b/src/Edit/Interface/edit_mouse.cpp
@@ -939,7 +939,7 @@ edit_interface_rep::mouse_any (string type, SI x, SI y, int mods, time_t t,
       }
     }
   }
-  
+
   // 绘图区光标由绘图模式管理，单独走分支仅复位残留悬停样式；其余走正常光标链
   bool over_gr= over_graphics (x, y);
   if (over_gr) {


### PR DESCRIPTION
# [0857] 修复绘图区文本框上悬停光标时错乱且不复位

## 1 相关文档
- [0817.md](0817.md) - 绘图后自动切换到移动模式（引入 `over_graphics` 时跳过光标复位）
- [0818.md](0818.md) - 重构绘图区鼠标处理 & 工具切换逻辑

## 2 任务相关的代码文件
- `src/Edit/Interface/edit_mouse.cpp` — 悬停光标链重构，`over_graphics` 单独走分支
- `src/Edit/Interface/edit_interface.hpp` — 新增 `hover_style_cursor` 锁存

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 绘图区插入文本框，鼠标悬停其上时，光标不再变成上下/左右 resize 样式；
2. 绘图区绘制完图形，鼠标拖拽时，光标应该变成移动样式，移开后恢复为正常光标；

## 4 What
- 鼠标悬停绘图区文本框时，光标变成上下/左右 resize 样式，且移开后不恢复。

## 5 Why
- resize 光标只能由悬停光标链中的表格/图片手柄分支（`table_scale_hit`、`last_image_brec`、`table_line_hit`）设置；0817 起 `over_graphics` 时 else 分支跳过 `normal` 复位（为避免手型光标闪回），该光标一旦在绘图区内被套上就无人清理。

## 6 How
- 悬停光标链重构为两段：`over_graphics` 走绘图区专用分支，光标交由绘图模式管理，仅经 `hover_style_cursor` 锁存复位残留样式，并维持 image/text popup 状态；非绘图区走原始正常链，行为与上游一致。
- 各设置非默认样式的分支（手柄/表格线/超链接/图片）均置位 `hover_style_cursor`，进入绘图区后的下一个 move 事件复位为 normal。
