### PR TITLE
[0859] 绘图区文本标签默认对齐改为 center

### DIFF
--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -351,7 +351,13 @@
         ,"gr-edit-grid-aspect"
         (tuple (tuple "axes" "none") (tuple "1" "none") (tuple "10" "none"))
         ,"gr-edit-grid"
-        (tuple "cartesian" (point "0" "0") "1"))
+        (tuple "cartesian" (point "0" "0") "1")
+        ,"gr-props-text-at"
+        (tuple "text-at-halign" "center" "text-at-valign" "center")
+        ,"gr-props-math-at"
+        (tuple "text-at-halign" "center" "text-at-valign" "center")
+        ,"gr-props-document-at"
+        (tuple "text-at-halign" "center" "doc-at-valign" "center"))
     ) ;set!
   ) ;when
   (graphics-reset-context 'begin)

--- a/devel/0859.md
+++ b/devel/0859.md
@@ -1,0 +1,32 @@
+# [0859] 绘图区文本标签默认对齐改为 center
+
+## 1 相关文档
+- [0825.md](0825.md) - 绘图模式按图形类型保存属性配置
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-utils.scm` — `make-graphics` 创建绘图区时写入各文本标签 type 的 per-type 配置
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 新建文档，插入绘图区，这是插入的 text-at / math-at / document-at 对齐应为 center。
+2. 打开旧文档，在已有的绘图区中对齐方式应该不变，且在 Alignment 菜单中点 Center 应该能生效。
+
+## 4 What
+- 新插入的 text-at / math-at / document-at 默认对齐为 left（document-at 垂直为 top），应改为 center。
+
+## 5 Why
+- 默认对齐不符合「居中」直觉；但环境默认值（`attribute-default-table` / `env_default.cpp`）是渲染回退值，改动会让既有文档在新版本显示错位，破坏版本一致性，且 `graphics-set-property` 对「值=默认值」会移除属性，改默认值还会让 Alignment 菜单点 Center 失效。故应让新插入的对象自身携带 center，而非改环境默认值。
+
+## 6 How
+- 文本标签属性由 per-type 配置机制管理：切到某 type（`graphics-set-mode`）时 `graphics-restore-type-config` 从该 type 的私有存储 `gr-props-<tag>` 读取属性回填到全局 `gr-*`，取不到则填 `"default"`，而 `"default"` 会被 `graphics-set-property` 移除外层绑定。
+- 因此在 `make-graphics` 创建绘图区时，向 init 注入三个 per-type 存储的初值 tuple：
+  - `gr-props-text-at` / `gr-props-math-at`：`("text-at-halign" "center" "text-at-valign" "center")`
+  - `gr-props-document-at`：`("text-at-halign" "center" "doc-at-valign" "center")`
+- 这样切换到文本标签模式时 restore 能取到 center，`graphics-enrich` 把 center 写入新对象，对象自带 `(with ... center ... <text-at>)`。既有文档无此存储绑定，渲染不受影响。


### PR DESCRIPTION
# [0859] 绘图区文本标签默认对齐改为 center

## 1 相关文档
- [0825.md](0825.md) - 绘图模式按图形类型保存属性配置

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-utils.scm` — `make-graphics` 创建绘图区时写入各文本标签 type 的 per-type 配置

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 新建文档，插入绘图区，这是插入的 text-at / math-at / document-at 对齐应为 center。
2. 打开旧文档，在已有的绘图区中对齐方式应该不变，且在 Alignment 菜单中点 Center 应该能生效。

## 4 What
- 新插入的 text-at / math-at / document-at 默认对齐为 left（document-at 垂直为 top），应改为 center。

## 5 Why
- 默认对齐不符合「居中」直觉；但环境默认值（`attribute-default-table` / `env_default.cpp`）是渲染回退值，改动会让既有文档在新版本显示错位，破坏版本一致性，且 `graphics-set-property` 对「值=默认值」会移除属性，改默认值还会让 Alignment 菜单点 Center 失效。故应让新插入的对象自身携带 center，而非改环境默认值。

## 6 How
- 文本标签属性由 per-type 配置机制管理：切到某 type（`graphics-set-mode`）时 `graphics-restore-type-config` 从该 type 的私有存储 `gr-props-<tag>` 读取属性回填到全局 `gr-*`，取不到则填 `"default"`，而 `"default"` 会被 `graphics-set-property` 移除外层绑定。
- 因此在 `make-graphics` 创建绘图区时，向 init 注入三个 per-type 存储的初值 tuple：
  - `gr-props-text-at` / `gr-props-math-at`：`("text-at-halign" "center" "text-at-valign" "center")`
  - `gr-props-document-at`：`("text-at-halign" "center" "doc-at-valign" "center")`
- 这样切换到文本标签模式时 restore 能取到 center，`graphics-enrich` 把 center 写入新对象，对象自带 `(with ... center ... <text-at>)`。既有文档无此存储绑定，渲染不受影响。
