### PR TITLE
[0861] 修复切换文档模式后 menus 未刷新

### DIFF
--- a/TeXmacs/progs/generic/document-edit.scm
+++ b/TeXmacs/progs/generic/document-edit.scm
@@ -37,6 +37,7 @@
   (:check-mark "v" in-source-mode?)
   (let ((new (if (string=? (get-env "preamble") "true") "false" "true")))
     (init-env "preamble" new)
+    (delayed (:idle 1) (update-menus 'all))
   ) ;let
 ) ;tm-define
 
@@ -447,6 +448,7 @@
           (delayed (:idle 25) (restore-zoom s))
         ) ;else
   ) ;cond
+  (delayed (:idle 1) (update-menus 'all))
 ) ;tm-define
 
 (tm-define (initial-get-page-rendering u)

--- a/devel/0861.md
+++ b/devel/0861.md
@@ -1,0 +1,30 @@
+# [0861] 修复切换文档模式后 menus 未刷新
+
+## 1 相关文档
+- [0853.md](0853.md) — `update_menus` 分类重建与事件优化
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/document-edit.scm` — `toggle-source-mode` 与 `init-page-rendering` 中显式触发异步菜单更新
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 切换至源码区（`Document -> Source -> Edit source tree` 或快捷键 `Ctrl+Shift+O`），观察上方主菜单内容和工具栏图标状态是否已同步变化；
+2. 切换回普通编辑模式，观察主菜单内容和工具栏图标是否同步恢复到普通编辑状态；
+
+## 4 What
+- 在切换至源码区（Source area/Source mode）以及切换文档显示模式（如单页、双页、全景等页面渲染模式）后，主菜单内容与图标栏未自动刷新。
+
+## 5 Why
+- 0853.md 优化中移除了 `update_menus` 的 idle 轮询机制，改由事件驱动和焦点树路径（focus path）变更触发。
+- 在切换至源码区或切换文档显示模式时，光标路径和焦点路径未发生实质变化，因而无法自动触发菜单栏和图标栏的更新。
+
+## 6 How
+- 在 `TeXmacs/progs/generic/document-edit.scm` 的 `toggle-source-mode` 及 `init-page-rendering` 切换逻辑执行完毕后，使用 `(delayed (:idle 1) (update-menus 'all))` 异步显式触发菜单和图标栏全量重建。
+- 由于 `toggle-slideshow-mode`（幻灯片模式）、`toggle-panorama-mode`（全景模式）等多种文档显示/渲染模式切换函数在底层均调用 `init-page-rendering` 来应用具体排版样式，因此在 `init-page-rendering` 统一拦截并异步触发更新可以覆盖绝大多数显示模式切换场景。


### PR DESCRIPTION
# [0861] 修复切换文档模式后 menus 未刷新

## 1 相关文档
- [0853.md](0853.md) — `update_menus` 分类重建与事件优化

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/document-edit.scm` — `toggle-source-mode` 与 `init-page-rendering` 中显式触发异步菜单更新

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 切换至源码区（`Document -> Source -> Edit source tree` 或快捷键 `Ctrl+Shift+O`），观察上方主菜单内容和工具栏图标状态是否已同步变化；
2. 切换回普通编辑模式，观察主菜单内容和工具栏图标是否同步恢复到普通编辑状态；

## 4 What
- 在切换至源码区（Source area/Source mode）以及切换文档显示模式（如单页、双页、全景等页面渲染模式）后，主菜单内容与图标栏未自动刷新。

## 5 Why
- 0853.md 优化中移除了 `update_menus` 的 idle 轮询机制，改由事件驱动和焦点树路径（focus path）变更触发。
- 在切换至源码区或切换文档显示模式时，光标路径和焦点路径未发生实质变化，因而无法自动触发菜单栏和图标栏的更新。

## 6 How
- 在 `TeXmacs/progs/generic/document-edit.scm` 的 `toggle-source-mode` 及 `init-page-rendering` 切换逻辑执行完毕后，使用 `(delayed (:idle 1) (update-menus 'all))` 异步显式触发菜单和图标栏全量重建。
- 由于 `toggle-slideshow-mode`（幻灯片模式）、`toggle-panorama-mode`（全景模式）等多种文档显示/渲染模式切换函数在底层均调用 `init-page-rendering` 来应用具体排版样式，因此在 `init-page-rendering` 统一拦截并异步触发更新可以覆盖绝大多数显示模式切换场景。
