### PR TITLE
[1154] 列表函数性能优化：cDr/cDDr/cDDDr/cADr 改走 C 层实现

### DIFF
--- a/TeXmacs/progs/kernel/library/list-test.scm
+++ b/TeXmacs/progs/kernel/library/list-test.scm
@@ -1,0 +1,174 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : list-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：kernel 列表工具函数（cDr 等）。
+;;               无 GUI，headless 可跑。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r list-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/kernel/library/list.scm")
+
+;; cDr：移除列表最后一个元素。
+
+(define (test-cdr-basic)
+  (check (cDr '(1 2 3)) => '(1 2))
+  (check (cDr '(a b)) => '(a))
+  (check (cDr '(a)) => '())
+) ;define
+
+;; 元素本身可以是任意类型（嵌套列表、字符串、布尔），cDr 只看顶层结构。
+
+(define (test-cdr-mixed-elements)
+  (check (cDr '((a b) (c d))) => '((a b)))
+  (check (cDr '("x" 1 (a) #t)) => '("x" 1 (a)))
+) ;define
+
+;; 纯函数：不修改入参，且返回新列表（后续 set-car! 不影响原列表）。
+
+(define (test-cdr-pure)
+  (let* ((l (list 1 2 3))
+         (r (cDr l)))
+    (check l => '(1 2 3))
+    (set-car! r 99)
+    (check l => '(1 2 3))
+  ) ;let*
+) ;define
+
+;; 空列表无最后一个元素可移除，抛 out-of-range（list-drop-right 语义）。
+
+(define (test-cdr-empty-errors)
+  (check-catch 'out-of-range (cDr '()))
+) ;define
+
+;; cDDr/cDDDr：移除列表末尾 2/3 个元素。
+
+(define (test-cddr-basic)
+  (check (cDDr '(1 2 3 4)) => '(1 2))
+  (check (cDDr '(1 2)) => '())
+  (check (cDDDr '(1 2 3 4)) => '(1))
+  (check (cDDDr '(1 2 3)) => '())
+) ;define
+
+;; 纯函数：返回新列表，set-car! 结果不影响原列表。
+
+(define (test-cddr-pure)
+  (let* ((l (list 1 2 3 4))
+         (r (cDDr l)))
+    (set-car! r 99)
+    (check l => '(1 2 3 4))
+  ) ;let*
+) ;define
+
+;; 长度不足 k 时抛 out-of-range。
+
+(define (test-cddr-errors)
+  (check-catch 'out-of-range (cDDr '(1)))
+  (check-catch 'out-of-range (cDDDr '(1 2)))
+) ;define
+
+;; cADr：取倒数第二个元素。
+
+(define (test-cadr-star-basic)
+  (check (cADr '(1 2 3)) => 2)
+  (check (cADr '(1 2)) => 1)
+  (check (cADr '("a" "b" "c")) => "b")
+) ;define
+
+;; 列表不足两个元素时抛 out-of-range。
+
+(define (test-cadr-star-errors)
+  (check-catch 'out-of-range (cADr '(1)))
+  (check-catch 'out-of-range (cADr '()))
+) ;define
+
+;; list-head：取列表前 k 个元素（g_take 的 C 实现）。
+
+(define (test-list-head-basic)
+  (check (list-head '(1 2 3) 2) => '(1 2))
+  (check (list-head '(1 2 3) 3) => '(1 2 3))
+  (check (list-head '(1 2 3) 0) => '())
+  (check (list-head '((a b) (c d) e) 2) => '((a b) (c d)))
+) ;define
+
+;; 纯函数：返回新列表，set-car! 结果不影响原列表。
+
+(define (test-list-head-pure)
+  (let* ((l (list 1 2 3))
+         (r (list-head l 2)))
+    (set-car! r 99)
+    (check l => '(1 2 3))
+  ) ;let*
+) ;define
+
+;; 边界：k 为负、非整数、超出长度、对非列表取非零个，均抛 wrong-type-arg。
+
+(define (test-list-head-errors)
+  (check-catch 'wrong-type-arg (list-head '(1 2 3) -1))
+  (check-catch 'wrong-type-arg (list-head '(1 2 3) 4))
+  (check-catch 'wrong-type-arg (list-head '(1 2 3) 1.5))
+  (check-catch 'wrong-type-arg (list-head 'a 1))
+) ;define
+
+;; list-drop-right：移除列表末尾 k 个元素（g_drop_right 的 C 实现）。
+
+(define (test-list-drop-right-basic)
+  (check (list-drop-right '(1 2 3 4) 1) => '(1 2 3))
+  (check (list-drop-right '(1 2 3 4) 2) => '(1 2))
+  (check (list-drop-right '(1 2) 2) => '())
+  (check (list-drop-right '(1 2 3) 0) => '(1 2 3))
+  (check (list-drop-right '() 0) => '())
+  (check (list-drop-right '((a b) (c d) e) 1) => '((a b) (c d)))
+) ;define
+
+;; 纯函数：返回新列表（k=0 时也是拷贝），set-car! 结果不影响原列表。
+
+(define (test-list-drop-right-pure)
+  (let* ((l (list 1 2 3))
+         (r (list-drop-right l 1)))
+    (set-car! r 99)
+    (check l => '(1 2 3))
+  ) ;let*
+  (let* ((l (list 1 2 3))
+         (r (list-drop-right l 0)))
+    (set-car! r 99)
+    (check l => '(1 2 3))
+  ) ;let*
+) ;define
+
+;; 边界：k 为负、超出长度抛 out-of-range；k 非整数、lst 非列表抛 wrong-type-arg。
+
+(define (test-list-drop-right-errors)
+  (check-catch 'out-of-range (list-drop-right '(1 2 3) -1))
+  (check-catch 'out-of-range (list-drop-right '(1 2 3) 4))
+  (check-catch 'out-of-range (list-drop-right '() 1))
+  (check-catch 'wrong-type-arg (list-drop-right '(1 2 3) 1.5))
+  (check-catch 'wrong-type-arg (list-drop-right 'a 1))
+) ;define
+
+(tm-define (regtest-list)
+  (test-cdr-basic)
+  (test-cdr-mixed-elements)
+  (test-cdr-pure)
+  (test-cdr-empty-errors)
+  (test-cddr-basic)
+  (test-cddr-pure)
+  (test-cddr-errors)
+  (test-cadr-star-basic)
+  (test-cadr-star-errors)
+  (test-list-head-basic)
+  (test-list-head-pure)
+  (test-list-head-errors)
+  (test-list-drop-right-basic)
+  (test-list-drop-right-pure)
+  (test-list-drop-right-errors)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/library/list-test.scm
+++ b/TeXmacs/progs/kernel/library/list-test.scm
@@ -35,8 +35,7 @@
 ;; 纯函数：不修改入参，且返回新列表（后续 set-car! 不影响原列表）。
 
 (define (test-cdr-pure)
-  (let* ((l (list 1 2 3))
-         (r (cDr l)))
+  (let* ((l (list 1 2 3)) (r (cDr l)))
     (check l => '(1 2 3))
     (set-car! r 99)
     (check l => '(1 2 3))
@@ -61,8 +60,7 @@
 ;; 纯函数：返回新列表，set-car! 结果不影响原列表。
 
 (define (test-cddr-pure)
-  (let* ((l (list 1 2 3 4))
-         (r (cDDr l)))
+  (let* ((l (list 1 2 3 4)) (r (cDDr l)))
     (set-car! r 99)
     (check l => '(1 2 3 4))
   ) ;let*
@@ -102,8 +100,7 @@
 ;; 纯函数：返回新列表，set-car! 结果不影响原列表。
 
 (define (test-list-head-pure)
-  (let* ((l (list 1 2 3))
-         (r (list-head l 2)))
+  (let* ((l (list 1 2 3)) (r (list-head l 2)))
     (set-car! r 99)
     (check l => '(1 2 3))
   ) ;let*
@@ -132,13 +129,11 @@
 ;; 纯函数：返回新列表（k=0 时也是拷贝），set-car! 结果不影响原列表。
 
 (define (test-list-drop-right-pure)
-  (let* ((l (list 1 2 3))
-         (r (list-drop-right l 1)))
+  (let* ((l (list 1 2 3)) (r (list-drop-right l 1)))
     (set-car! r 99)
     (check l => '(1 2 3))
   ) ;let*
-  (let* ((l (list 1 2 3))
-         (r (list-drop-right l 0)))
+  (let* ((l (list 1 2 3)) (r (list-drop-right l 0)))
     (set-car! r 99)
     (check l => '(1 2 3))
   ) ;let*

--- a/TeXmacs/progs/kernel/library/list.scm
+++ b/TeXmacs/progs/kernel/library/list.scm
@@ -76,21 +76,21 @@
 
 (define-public (cAr l) "Get last element of @l." (car (last-pair l)))
 
-(define-public (cDr l)
-  "Remove last element from @l."
-  (reverse (cdr (reverse l)))
-) ;define-public
+(define-public (cDr l) "Remove last element from @l." (list-drop-right l 1))
 
-(define-public (cADr l) "Get before last element of @l." (cadr (reverse l)))
+(define-public (cADr l)
+  "Get before last element of @l."
+  (car (list-take-right l 2))
+) ;define-public
 
 (define-public (cDDr l)
   "Remove two last elements from @l"
-  (reverse (cddr (reverse l)))
+  (list-drop-right l 2)
 ) ;define-public
 
 (define-public (cDDDr l)
-  "Remove two last elements from @l"
-  (reverse (cdddr (reverse l)))
+  "Remove three last elements from @l"
+  (list-drop-right l 3)
 ) ;define-public
 
 (define-public (cDdr l) "Remove first and last elements from @l" (cDr (cdr l)))

--- a/devel/1154.md
+++ b/devel/1154.md
@@ -1,0 +1,47 @@
+# [1154] cDr 单元测试与性能优化
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/kernel/library/list.scm` - cDr 定义所在
+- `TeXmacs/progs/kernel/library/list-test.scm` - 单元测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem && xmake r list-test
+```
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+
+1. 为 `cDr`/`cDDr`/`cDDDr`/`cADr` 补单元测试，锁定行为契约。
+2. 为 `list-head`（`g_take`）、`list-drop-right`（`g_drop_right`）两个 C 实现
+   的封装补单元测试。
+3. 性能优化（去 scheme 层双 `reverse`，改走 C 层单遍历）：
+   - `cDr` → `(list-drop-right l 1)`
+   - `cDDr` → `(list-drop-right l 2)`
+   - `cDDDr` → `(list-drop-right l 3)`
+   - `cADr` → `(car (list-take-right l 2))`（`g_take_right` 返回子列表，零拷贝）
+
+## 6 Why
+
+原实现均为 scheme 层 `reverse` + 截断 + `reverse`，2 次遍历 + 约 2n 次 cons
+分配（一半立即变垃圾）。`g_drop_right`/`g_take_right` 是 C 层 lead-lag 双指针
+单遍历，只分配结果所需的 cons。
+
+行为变化：长度不足时错误 key 由 `wrong-type-arg` 变为 `out-of-range`
+（`take_right_lead` 的语义），均属抛错，仅 key 不同。
+
+## 7 How
+
+先补测试锁定契约（正常值、纯函数性、边界错误 key），跑旧实现确认错误 key
+用例如期失败，再替换实现至全绿。cADr 注意取的是 `car` 而非 `cadr`
+（take-right 2 的末两位里前一个是倒数第二）。


### PR DESCRIPTION
## Summary
- `cDr`/`cDDr`/`cDDDr` 由 scheme 层双 `reverse`（2 次遍历 + ~2n cons 分配）改为 `list-drop-right`（`g_drop_right` C 层 lead-lag 单遍历）
- `cADr` 由 `(cadr (reverse l))` 改为 `(car (list-take-right l 2))`，`g_take_right` 返回子列表零拷贝
- 新增 `TeXmacs/progs/kernel/library/list-test.scm`（42 项）：覆盖上述函数及 `list-head`/`list-drop-right` 的正常值、纯函数性、边界错误 key
- 行为变化：长度不足时错误 key 由 `wrong-type-arg` 变为 `out-of-range`（均抛错，仅 key 不同）

## Test plan
- [x] `xmake b stem && xmake r list-test` — 42 correct, 0 failed
- [x] 先写测试对旧实现验证错误 key 用例如期失败，再改实现至全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)