### PR TITLE
[1156] Esperanto 键盘快捷键迁移到 lang 插件

### DIFF
--- a/TeXmacs/packages/customize/language/esperanto.ts
+++ b/TeXmacs/packages/customize/language/esperanto.ts
@@ -21,6 +21,8 @@
   </src-title>>
 
   <assign|language|esperanto>
+
+  <use-module|(lang esperanto-kbd)>
 </body>
 
 <\initial>

--- a/TeXmacs/plugins/lang/progs/lang/esperanto-kbd.scm
+++ b/TeXmacs/plugins/lang/progs/lang/esperanto-kbd.scm
@@ -1,0 +1,29 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : esperanto-kbd.scm
+;; DESCRIPTION : keystrokes for the Esperanto language
+;; COPYRIGHT   : (C) 2017  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (lang esperanto-kbd) (:use (text text-kbd)))
+
+(kbd-map (:mode in-esperanto?)
+ ("c var" "<#109>")
+ ("g var" "<#11D>")
+ ("h var" "<#125>")
+ ("j var" "<#135>")
+ ("s var" "<#15D>")
+ ("u var" "<#16D>")
+ ("C var" "<#108>")
+ ("G var" "<#11C>")
+ ("H var" "<#124>")
+ ("J var" "<#134>")
+ ("S var" "<#15C>")
+ ("U var" "<#16C>")
+) ;kbd-map

--- a/TeXmacs/progs/text/text-kbd.scm
+++ b/TeXmacs/progs/text/text-kbd.scm
@@ -339,21 +339,6 @@
 ;  ("ÿ" "¸"))
 
 (kbd-map
-  (:mode in-esperanto?)
-  ("c var" "<#109>")
-  ("g var" "<#11D>")
-  ("h var" "<#125>")
-  ("j var" "<#135>")
-  ("s var" "<#15D>")
-  ("u var" "<#16D>")
-  ("C var" "<#108>")
-  ("G var" "<#11C>")
-  ("H var" "<#124>")
-  ("J var" "<#134>")
-  ("S var" "<#15C>")
-  ("U var" "<#16C>"))
-
-(kbd-map
   (:mode in-hungarian?)
   ("text:symbol O" "")
   ("text:symbol U" "–")

--- a/devel/1156.md
+++ b/devel/1156.md
@@ -1,0 +1,28 @@
+# 1156 Esperanto 键盘快捷键迁移到 lang 插件
+
+## What
+
+将 `TeXmacs/progs/text/text-kbd.scm` 中 `in-esperanto?` 的 kbd-map 迁移到
+lang 插件 `TeXmacs/plugins/lang/progs/lang/esperanto-kbd.scm`，并在
+`TeXmacs/packages/customize/language/esperanto.ts` 中
+`<use-module|(lang esperanto-kbd)>` 加载。
+
+## Why
+
+语言相关快捷键收敛到 lang 插件统一管理，与 chinese-kbd 的结构保持一致。
+
+## How
+
+- 新增 `plugins/lang/progs/lang/esperanto-kbd.scm`：
+  `(texmacs-module (lang esperanto-kbd) (:use (text text-kbd)))`，
+  内含原 `in-esperanto?` kbd-map（12 条 `x var` → 带帽字母映射）。
+- `text-kbd.scm` 删除对应 kbd-map 块。注意：该文件含编码特殊内容，
+  不可运行 `gf fmt` 格式化。
+- `esperanto.ts` 增加 `<use-module|(lang esperanto-kbd)>`，文档切换为
+  Esperanto 语言时加载快捷键（同 chinese.ts 的模式）。
+
+## 涉及文件
+
+- `TeXmacs/plugins/lang/progs/lang/esperanto-kbd.scm`（新增）
+- `TeXmacs/progs/text/text-kbd.scm`（删除 esperanto kbd-map）
+- `TeXmacs/packages/customize/language/esperanto.ts`（加载模块）


### PR DESCRIPTION
## Summary
- 将 `text-kbd.scm` 中 `in-esperanto?` 的 kbd-map 迁移到 lang 插件 `esperanto-kbd.scm`，与 chinese-kbd 结构保持一致
- `esperanto.ts` 通过 `<use-module|(lang esperanto-kbd)>` 加载快捷键
- 注意：`text-kbd.scm` 含编码特殊内容，本次未对其运行 `gf fmt`（仅格式化新增的 `esperanto-kbd.scm`）

## Test plan
- [ ] 新建文档，Document -> Language 切换为 Esperanto，输入 `c var` 应插入 ĉ
- [ ] 大写 `C var` 应插入 Ĉ，其余 g/h/j/s/u 同理

🤖 Generated with [Claude Code](https://claude.com/claude-code)