### PR TITLE
[1157] Spanish 键盘快捷键迁移到 lang 插件

### DIFF
--- a/TeXmacs/packages/customize/language/spanish.ts
+++ b/TeXmacs/packages/customize/language/spanish.ts
@@ -21,6 +21,8 @@
   </src-title>>
 
   <assign|language|spanish>
+
+  <use-module|(lang spanish-kbd)>
 </body>
 
 <\initial>

--- a/TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm
+++ b/TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm
@@ -1,0 +1,23 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : spanish-kbd.scm
+;; DESCRIPTION : keystrokes for the Spanish language
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (lang spanish-kbd) (:use (text text-kbd)))
+
+(kbd-map (:mode in-spanish?)
+ ("! var" "<#A1>")
+ ("? var" "<#BF>")
+ ("! `" "<#A1>")
+ ("? `" "<#BF>")
+ ("! accent:grave" "<#A1>")
+ ("? accent:grave" "<#BF>")
+) ;kbd-map

--- a/TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm
+++ b/TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm
@@ -18,6 +18,4 @@
  ("? var" "<#BF>")
  ("! `" "<#A1>")
  ("? `" "<#BF>")
- ("! accent:grave" "<#A1>")
- ("? accent:grave" "<#BF>")
 ) ;kbd-map

--- a/TeXmacs/progs/text/text-kbd.scm
+++ b/TeXmacs/progs/text/text-kbd.scm
@@ -348,17 +348,6 @@
   ("text:symbol o var" "¯"))
 
 (kbd-map
-  (:mode in-spanish?)
-  ("°" "Ω")
-  ("ø" "æ")
-  ("! var" "Ω")
-  ("? var" "æ")
-  ("! `" "Ω")
-  ("? `" "æ")
-  ("! accent:grave" "Ω")
-  ("? accent:grave" "æ"))
-
-(kbd-map
   (:mode in-polish?)
   ("text:symbol a" "°")
   ("text:symbol A" "Å")

--- a/TeXmacs/tests/1157.scm
+++ b/TeXmacs/tests/1157.scm
@@ -1,0 +1,76 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1157.scm
+;; DESCRIPTION : 纯逻辑回归测试：spanish kbd-map 迁移到 lang 插件后，相关
+;;               cork 编码契约不变。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   [1157] 把 text-kbd.scm 中 in-spanish? 的 kbd-map 迁移到
+;;   lang/spanish-kbd.scm。迁移前该 kbd-map 的 LHS/RHS 用 cork 编码字节写
+;;   死在 text-kbd.scm（cork 文件，不可 gf fmt）；迁移到 UTF-8 新文件后，
+;;   必须用 <#XXXX> 转义重建完全等价的字节序列。本测试钉死迁移前后必须
+;;   成立的 cork↔utf8 转换契约，任一字节映射回退都会红。
+;;
+;;   覆盖 spanish kbd-map 的 8 条映射所涉及的全部 cork 字节：
+;;     * cork 0xBD = U+00A1 ¡ (exclamdown, 倒感叹号)
+;;     * cork 0xBE = U+00BF ¿ (questiondown, 倒问号)
+;;     * 顺带验证 cork 0xFF = U+00DF ß、cork 0xA1 = U+0105 ą（同为 text-kbd.scm
+;;       里出现的字节，确保我们没把 LHS 0xA1 错当 ¡）。
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r 1157
+;;
+;;   纯逻辑（headless 即跑断言），无需 MOGAN_TEST_GUI。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;; 直接键入 spanish 倒感叹号 / 倒问号时，Qt 层把 UTF-8 交上来，handle_keypress
+;; 用 utf8->cork 转成内部 cork 字节再去匹配 kbd-map。两条直接按键映射
+;; （"¡"→"¡"、"¿"→"¿"）的 LHS 由此路径产生。
+(define (test-spanish-direct-keys-utf8-to-cork)
+  ;; "¡" U+00A1 → cork 0xBD（单字节）。
+  (check (string-length (utf8->cork "¡")) => 1)
+  (check (char->integer (string-ref (utf8->cork "¡") 0)) => #xBD)
+  ;; "¿" U+00BF → cork 0xBE（单字节）。
+  (check (string-length (utf8->cork "¿")) => 1)
+  (check (char->integer (string-ref (utf8->cork "¿") 0)) => #xBE)
+) ;define
+
+;; kbd-map 的 RHS（插入串）在 .scm 里直接写 cork 字节，最终走 cork->utf8
+;; 渲染。倒感叹号 / 倒问号的插入字符必须分别解出 U+00A1 / U+00BF。
+(define (test-spanish-insertion-cork-to-utf8)
+  (check (cork->utf8 "\xBD") => "¡")
+  (check (cork->utf8 "\xBE") => "¿")
+) ;define
+
+;; 双向往返自反：spanish kbd-map 涉及的两个字符 utf8->cork->utf8 不丢信息。
+(define (test-spanish-roundtrip)
+  (check (cork->utf8 (utf8->cork "¡")) => "¡")
+  (check (cork->utf8 (utf8->cork "¿")) => "¿")
+) ;define
+
+;; text-kbd.scm 里其它 cork 字节也用同样的字节直写——这里顺带钉死几个
+;; 高频点，确保我们的编码模型一致（不把 LHS 0xA1 误读成 ¡）。
+(define (test-other-cork-bytes-in-text-kbd)
+  ;; cork 0xFF = ß（germandbls，"sz" 与 "text:symbol s" 的 RHS）。
+  (check (cork->utf8 "\xFF") => "ß")
+  ;; cork 0xA1 = ą（a with ogonek，U+0105），不是 ¡。
+  (check (cork->utf8 "\xA1") => "ą")
+) ;define
+
+(tm-define (test_1157)
+  (test-spanish-direct-keys-utf8-to-cork)
+  (test-spanish-insertion-cork-to-utf8)
+  (test-spanish-roundtrip)
+  (test-other-cork-bytes-in-text-kbd)
+  (check-report)
+) ;tm-define

--- a/devel/1157.md
+++ b/devel/1157.md
@@ -1,0 +1,88 @@
+# 1157 Spanish 键盘快捷键迁移到 lang 插件
+
+## What
+
+将 `TeXmacs/progs/text/text-kbd.scm` 中 `in-spanish?` 的 kbd-map（8 条快捷键）
+迁移到 lang 插件 `TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm`，并在
+`TeXmacs/packages/customize/language/spanish.ts` 中
+`<use-module|(lang spanish-kbd)>` 加载。
+
+## Why
+
+语言相关快捷键收敛到 lang 插件统一管理，与 esperanto-kbd / chinese-kbd 的
+结构保持一致（见 1156）。
+
+## How
+
+- 新增 `plugins/lang/progs/lang/spanish-kbd.scm`：
+  `(texmacs-module (lang spanish-kbd) (:use (text text-kbd)))`，
+  内含原 `in-spanish?` kbd-map（8 条映射，见下表）。
+- `text-kbd.scm` 删除对应 kbd-map 块。注意：该文件为 cork 编码，
+  不可运行 `gf fmt` 格式化。
+- `spanish.ts` 增加 `<use-module|(lang spanish-kbd)>`，文档切换为
+  Spanish 语言时加载快捷键。
+
+8 条快捷键（cork 编码字节 `0xBD` = ¡，`0xBE` = ¿）：
+
+| 按键序列 | 插入字符 |
+|----------|----------|
+| `¡`（直接按键） | ¡ |
+| `¿`（直接按键） | ¿ |
+| `!` `Tab` | ¡ |
+| `?` `Tab` | ¿ |
+| `!` `` ` `` | ¡ |
+| `?` `` ` `` | ¿ |
+| `!` `accent:grave`（死键重音） | ¡ |
+| `?` `accent:grave`（死键重音） | ¿ |
+
+注：`var` 即 `Tab` 键（`prefix-kbd.scm` 中 `set-variant-keys "tab" "S-tab"`）。
+
+## 如何测试
+
+迁移后行为应与迁移前完全一致，故测试等价于回归验证这 8 个快捷键在
+Spanish 语言下仍按预期触发，且其他语言下不再触发。
+
+### 直接输入 `¡` / `¿`（快捷键 #1/#2）
+
+在 KDE 系统下把键盘布局切换为西班牙键盘：
+- 按 `=` 键直接打出 `¡`（倒感叹号）
+- 按 `Shift =` 直接打出 `¿`（倒问号）
+
+切到 Spanish 语言后，在 Mogan 文本里按这两个物理键，应分别插入 `¡`/`¿`。
+（在其他语言下也会回显，但这两条本就属于直接字符回显，不受迁移影响。）
+
+### 组合键序列（快捷键 #3–#8）
+
+前置：启动 Mogan，新建文档，通过菜单「文档 → 语言 → Spanish」将文档语言
+切换为西班牙语（`in-spanish?` 生效，需处于文本模式）。逐条按键并检查
+文档中插入的字符：
+
+| # | 按键序列 | 预期结果 |
+|---|----------|----------|
+| 3 | `!` 然后 `Tab` | `¡` |
+| 4 | `?` 然后 `Tab` | `¿` |
+| 5 | `!` 然后反引号 `` ` `` | `¡` |
+| 6 | `?` 然后反引号 `` ` `` | `¿` |
+| 7 | `!` 然后死键重音 `accent:grave` | `¡` |
+| 8 | `?` 然后死键重音 `accent:grave` | `¿` |
+
+回归：把文档语言切回 English（或其他语言）重复 #3–#8，确认不再触发
+转换（快捷键已从全局 text-kbd 移除，仅随 Spanish 语言包加载）。
+
+### cork 编码契约（自动化）
+
+`TeXmacs/tests/1157.scm` 用 `utf8->cork`/`cork->utf8` 钉死了这 8 条映射
+涉及的全部 cork 字节契约：
+
+```
+xmake b stem && xmake r 1157
+```
+
+纯逻辑、headless 即跑断言，验证 `¡`↔cork `0xBD`、`¿`↔cork `0xBE` 等关键
+转换不变（10 个 check 全过即契约成立）。
+
+## 涉及文件
+
+- `TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm`（新增）
+- `TeXmacs/progs/text/text-kbd.scm`（删除 spanish kbd-map）
+- `TeXmacs/packages/customize/language/spanish.ts`（加载模块）

--- a/devel/1157.md
+++ b/devel/1157.md
@@ -2,10 +2,16 @@
 
 ## What
 
-将 `TeXmacs/progs/text/text-kbd.scm` 中 `in-spanish?` 的 kbd-map（8 条快捷键）
-迁移到 lang 插件 `TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm`，并在
+将 `TeXmacs/progs/text/text-kbd.scm` 中 `in-spanish?` 的 kbd-map 迁移
+到 lang 插件 `TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm`，并在
 `TeXmacs/packages/customize/language/spanish.ts` 中
 `<use-module|(lang spanish-kbd)>` 加载。
+
+原 text-kbd.scm 的 spanish 块共 8 条绑定，其中 2 条死键路径
+（`! accent:grave` / `? accent:grave`）经 GUI 实测无法生效（死键事件
+派发的 key 名与 LHS 不匹配，改 `grave` 亦然），本次迁移**不保留**这两条，
+只迁移可用的 6 条。直接按键 `¡`/`¿`（原 #1/#2）由 Qt 直接回显，不需要
+kbd-map 绑定，也不迁移。
 
 ## Why
 
@@ -16,42 +22,37 @@
 
 - 新增 `plugins/lang/progs/lang/spanish-kbd.scm`：
   `(texmacs-module (lang spanish-kbd) (:use (text text-kbd)))`，
-  内含原 `in-spanish?` kbd-map（8 条映射，见下表）。
-- `text-kbd.scm` 删除对应 kbd-map 块。注意：该文件为 cork 编码，
-  不可运行 `gf fmt` 格式化。
+  内含 4 条组合键映射（`! var` / `? var` / `` ! ` `` / `` ? ` ``）。
+  RHS 用 `<#A1>`/`<#BF>` 转义避免 cork 字节直写。
+- `text-kbd.scm` 删除整个原 `in-spanish?` kbd-map 块（含失效的死键
+  绑定，一并清理）。注意：该文件为 cork 编码，不可运行 `gf fmt`。
 - `spanish.ts` 增加 `<use-module|(lang spanish-kbd)>`，文档切换为
   Spanish 语言时加载快捷键。
 
-8 条快捷键（cork 编码字节 `0xBD` = ¡，`0xBE` = ¿）：
+4 条迁移后的组合键（cork 编码字节 `0xBD` = ¡，`0xBE` = ¿）：
 
 | 按键序列 | 插入字符 |
 |----------|----------|
-| `¡`（直接按键） | ¡ |
-| `¿`（直接按键） | ¿ |
 | `!` `Tab` | ¡ |
 | `?` `Tab` | ¿ |
 | `!` `` ` `` | ¡ |
 | `?` `` ` `` | ¿ |
-| `!` `accent:grave`（死键重音） | ¡ |
-| `?` `accent:grave`（死键重音） | ¿ |
 
 注：`var` 即 `Tab` 键（`prefix-kbd.scm` 中 `set-variant-keys "tab" "S-tab"`）。
 
 ## 如何测试
 
-迁移后行为应与迁移前完全一致，故测试等价于回归验证这 8 个快捷键在
-Spanish 语言下仍按预期触发，且其他语言下不再触发。
+迁移后行为应与迁移前可用的部分完全一致。
 
-### 直接输入 `¡` / `¿`（快捷键 #1/#2）
+### 直接输入 `¡` / `¿`
 
 在 KDE 系统下把键盘布局切换为西班牙键盘：
 - 按 `=` 键直接打出 `¡`（倒感叹号）
 - 按 `Shift =` 直接打出 `¿`（倒问号）
 
-切到 Spanish 语言后，在 Mogan 文本里按这两个物理键，应分别插入 `¡`/`¿`。
-（在其他语言下也会回显，但这两条本就属于直接字符回显，不受迁移影响。）
+这条由 Qt 直接回显，不需要 kbd-map 绑定，任何语言下都工作。
 
-### 组合键序列（快捷键 #3–#8）
+### 组合键序列
 
 前置：启动 Mogan，新建文档，通过菜单「文档 → 语言 → Spanish」将文档语言
 切换为西班牙语（`in-spanish?` 生效，需处于文本模式）。逐条按键并检查
@@ -59,20 +60,18 @@ Spanish 语言下仍按预期触发，且其他语言下不再触发。
 
 | # | 按键序列 | 预期结果 |
 |---|----------|----------|
-| 3 | `!` 然后 `Tab` | `¡` |
-| 4 | `?` 然后 `Tab` | `¿` |
-| 5 | `!` 然后反引号 `` ` `` | `¡` |
-| 6 | `?` 然后反引号 `` ` `` | `¿` |
-| 7 | `!` 然后死键重音 `accent:grave` | `¡` |
-| 8 | `?` 然后死键重音 `accent:grave` | `¿` |
+| 1 | `!` 然后 `Tab` | `¡` |
+| 2 | `?` 然后 `Tab` | `¿` |
+| 3 | `!` 然后反引号 `` ` `` | `¡` |
+| 4 | `?` 然后反引号 `` ` `` | `¿` |
 
-回归：把文档语言切回 English（或其他语言）重复 #3–#8，确认不再触发
+回归：把文档语言切回 English（或其他语言）重复上述序列，确认不再触发
 转换（快捷键已从全局 text-kbd 移除，仅随 Spanish 语言包加载）。
 
 ### cork 编码契约（自动化）
 
-`TeXmacs/tests/1157.scm` 用 `utf8->cork`/`cork->utf8` 钉死了这 8 条映射
-涉及的全部 cork 字节契约：
+`TeXmacs/tests/1157.scm` 用 `utf8->cork`/`cork->utf8` 钉死了 spanish
+相关 cork 字节契约：
 
 ```
 xmake b stem && xmake r 1157


### PR DESCRIPTION
## Summary

延续 #4111（Esperanto 迁移），把 `in-spanish?` 的 kbd-map 从
`TeXmacs/progs/text/text-kbd.scm` 收敛到 lang 插件
`TeXmacs/plugins/lang/progs/lang/spanish-kbd.scm`，并在
`TeXmacs/packages/customize/language/spanish.ts` 中加载。

## 改动

- **新增** `plugins/lang/progs/lang/spanish-kbd.scm`：4 条组合键映射
  （`! var` / `? var` / `` ! ` `` / `` ? ` ``）；RHS 用 `<#A1>`/`<#BF>`
  转义避免 cork 字节直写。
- **删除** `text-kbd.scm` 中的 `in-spanish?` kbd-map 块（字节级精确删除，
  该文件是 cork 编码，不能跑 `gf fmt`）。
- **修改** `spanish.ts`：增加 `<use-module|(lang spanish-kbd)>`，文档
  切到 Spanish 语言时加载快捷键（同 `esperanto.ts` 模式）。
- **新增** `TeXmacs/tests/1157.scm`：纯逻辑回归，用 `utf8->cork` /
  `cork->utf8` 钉死 spanish 相关 cork 字节契约（`¡`↔`0xBD`、`¿`↔`0xBE`
  等 10 个 check），headless 秒级反馈。

## 未迁移的绑定

原 text-kbd.scm 的 spanish 块共 8 条，其中：
- **直接按键 `¡`/`¿`（2 条）**：由 Qt 直接回显，不需要 kbd-map 绑定。
- **死键路径 `! accent:grave` / `? accent:grave`（2 条）**：GUI 实测无法
  生效（死键事件派发的 key 名与 LHS 不匹配，改 `grave` 亦然），本次移除，
  不保留失效绑定。

## 4 个快捷键

| # | 按键序列 | 结果 |
|---|----------|------|
| 1 | `!` 然后 `Tab` | `¡` |
| 2 | `?` 然后 `Tab` | `¿` |
| 3 | `!` 然后反引号 `` ` `` | `¡` |
| 4 | `?` 然后反引号 `` ` `` | `¿` |

直接输入 `¡`/`¿`：KDE 西班牙键盘下 `=` → `¡`，`Shift =` → `¿`（Qt 直接
回显，任何语言都工作）。

## Test plan

- [x] `xmake b stem && xmake r 1157` → 10 correct, 0 failed
- [x] GUI 手测：`! var` / `? var` 在 Spanish 语言下正常产生 `¡`/`¿`
- [ ] GUI 手测：`` ! ` `` / `` ? ` `` 在 Spanish 语言下正常产生 `¡`/`¿`
- [ ] 回归：文档语言切回 English，上述组合键不再触发转换

🤖 Generated with [Claude Code](https://claude.com/claude-code)