### PR TITLE
[0862] Ghost 补全行首不触发

### DIFF
--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -134,6 +134,7 @@
                 (not-in-tab-cycling?)
                 (or (in-text?) (in-math?))
                 (in-editor-buffer?)
+                (not-at-line-start?)
               ) ;and
           (generate-ghost-text current)
         ) ;when
@@ -236,6 +237,14 @@
 
 (define (not-in-tab-cycling?)
   (not (== last-key-press "tab"))
+) ;define
+
+(define (not-at-line-start?)
+  (let* ((ctx (ghost-collect-context)) (prefix (car ctx)))
+    (and (not (string=? prefix ""))
+      (not (char=? (string-ref prefix (- (string-length prefix) 1)) #\newline))
+    ) ;and
+  ) ;let*
 ) ;define
 
 (define (in-editor-buffer?)

--- a/devel/0862.md
+++ b/devel/0862.md
@@ -1,0 +1,28 @@
+# [0862] Ghost 补全行首不触发
+
+## 1 相关文档
+- [0860.md](0860.md) - Ghost 自动补全
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/ghost-text.scm` — `trigger-ghost-text` 的 delayed 条件加入 `not-at-line-start?` 检查
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在空行行首不应触发 ghost 补全；
+2. 在已有行上换行后，光标在行首不应触发 ghost 补全；
+
+## 4 What
+- 光标在行首时不应触发 ghost 补全，避免无意义请求。
+
+## 5 Why
+- 行首时 prefix 为空或仅以换行结尾，模型缺乏上下文，补全质量低且浪费请求。
+
+## 6 How
+- 在 `trigger-ghost-text` 的 `delayed (:idle 500)` 条件中加入 `not-at-line-start?`：该函数通过 `ghost-collect-context` 取 prefix，当 prefix 为空或以换行结尾时返回 `#f`，阻止触发。


### PR DESCRIPTION
# [0862] Ghost 补全行首不触发

## 1 相关文档
- [0860.md](0860.md) - Ghost 自动补全

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/ghost-text.scm` — `trigger-ghost-text` 的 delayed 条件加入 `not-at-line-start?` 检查

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在空行行首不应触发 ghost 补全；
2. 在已有行上换行后，光标在行首不应触发 ghost 补全；

## 4 What
- 光标在行首时不应触发 ghost 补全，避免无意义请求。

## 5 Why
- 行首时 prefix 为空或仅以换行结尾，模型缺乏上下文，补全质量低且浪费请求。

## 6 How
- 在 `trigger-ghost-text` 的 `delayed (:idle 500)` 条件中加入 `not-at-line-start?`：该函数通过 `ghost-collect-context` 取 prefix，当 prefix 为空或以换行结尾时返回 `#f`，阻止触发。
