### PR TITLE
[0863] Ghost 补全按右方向键到文档末主动触发

### DIFF
--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -122,7 +122,7 @@
 ;; Model evaluation
 ;; =============================================================================
 
-(tm-define (trigger-ghost-text)
+(tm-define (trigger-ghost-text dl-time)
   (when (ghost-enable?)
     (when ghost-active?
       (ignore-ghost)

--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -129,7 +129,7 @@
     ) ;when
     (set! ghost-serial (+ ghost-serial 1))
     (let ((current ghost-serial))
-      (delayed (:idle 500)
+      (delayed (:idle dl-time)
         (when (and (== ghost-serial current)
                 (not-in-tab-cycling?)
                 (or (in-text?) (in-math?))
@@ -256,13 +256,23 @@
 (tm-define (kbd-insert s)
   (former s)
   (when (not-in-tab-cycling?)
-    (trigger-ghost-text)
+    (trigger-ghost-text 500)
   ) ;when
 ) ;tm-define
 
 (tm-define (keyboard-press key time)
   (set! last-key-press key)
-  (former key time)
+  (when (== key "right")
+    (let ((before (cursor-path)))
+      (former key time)
+      (when (equal? (cursor-path) before)
+        (trigger-ghost-text 0)
+      ) ;when
+    ) ;let
+  ) ;when
+  (when (!= key "right")
+    (former key time)
+  ) ;when
 ) ;tm-define
 
 (tm-define (keyboard-press key time)

--- a/devel/0863.md
+++ b/devel/0863.md
@@ -1,0 +1,29 @@
+# [0863] Ghost 补全按右方向键到文档末主动触发
+
+## 1 相关文档
+- [0860.md](0860.md) - Ghost 自动补全
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/ghost-text.scm` — `keyboard-press` 拦截 right 键检测文档末；`trigger-ghost-text` 增加 `dl-time` 参数支持立即触发
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在文档末按右方向键，应立即触发 ghost 补全；
+2. 在文档中间按右方向键，光标正常右移，且不触发补全；
+
+## 4 What
+- 用户按右方向键但光标已在文档末（未移动）时，主动触发 ghost 补全。
+
+## 5 Why
+- 文档末按 right 无任何效果，用户可能在"要求"补全；利用这个无效按键主动触发，提升交互自然度。
+
+## 6 How
+- `trigger-ghost-text` 增加 `dl-time` 参数：`kbd-insert` 传 `500`（防抖），手动触发传 `0`（立即）。
+- `keyboard-press` 拦截 right 键：记录按下前的 `cursor-path`，`(former)` 后比较——未变则说明光标在文档末，调 `(trigger-ghost-text 0)` 立即触发。


### PR DESCRIPTION
# [0863] Ghost 补全按右方向键到文档末主动触发

## 1 相关文档
- [0860.md](0860.md) - Ghost 自动补全

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/ghost-text.scm` — `keyboard-press` 拦截 right 键检测文档末；`trigger-ghost-text` 增加 `dl-time` 参数支持立即触发

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在文档末按右方向键，应立即触发 ghost 补全；
2. 在文档中间按右方向键，光标正常右移，且不触发补全；

## 4 What
- 用户按右方向键但光标已在文档末（未移动）时，主动触发 ghost 补全。

## 5 Why
- 文档末按 right 无任何效果，用户可能在"要求"补全；利用这个无效按键主动触发，提升交互自然度。

## 6 How
- `trigger-ghost-text` 增加 `dl-time` 参数：`kbd-insert` 传 `500`（防抖），手动触发传 `0`（立即）。
- `keyboard-press` 拦截 right 键：记录按下前的 `cursor-path`，`(former)` 后比较——未变则说明光标在文档末，调 `(trigger-ghost-text 0)` 立即触发。
