### PR TITLE
[0864] Ghost 补全 pre-editing 期间不弹出

### DIFF
--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -162,6 +162,8 @@
       (lambda (res)
         (when (and res
                 (== ghost-serial current)
+                (not-in-tab-cycling?)
+                (not (is-pre-editing))
                 (equal? (cursor-path) ghost-pending-cursor)
                 (not (string=? (car res) ""))
               ) ;and

--- a/devel/0864.md
+++ b/devel/0864.md
@@ -1,0 +1,31 @@
+# [0864] Ghost 补全 pre-editing 期间不弹出
+
+## 1 相关文档
+- [0860.md](0860.md) - Ghost 自动补全
+- [0776.md](0776.md) - 输入法 pre-edit 不同步（`is_pre_editing` 来源）
+
+## 2 任务相关的代码文件
+- `src/Scheme/Glue/glue_editor.lua` — 暴露 `is-pre-editing` glue
+- `TeXmacs/progs/generic/ghost-text.scm` — 回调条件加入 `(not (is-pre-editing))`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 正常输入英文，ghost 应正常弹出；
+2. 用输入法输入中文，在任意时刻的输入过程（pre-editing）中，ghost 不应弹出；
+
+## 4 What
+- ghost 补全结果返回时若用户正处于输入法 pre-editing 阶段，不弹出 ghost。
+
+## 5 Why
+- pre-editing 期间文档尚未提交最终文本，光标位置不稳定，弹出 ghost 会干扰输入。
+
+## 6 How
+- `glue_editor.lua` 暴露已有的 C++ 方法 `is_pre_editing()`（0776 实现，基于 `pre_edit_mark`）为 scheme 函数 `is-pre-editing`。
+- `ghost-text.scm` 回调的 `when` 条件加入 `(not (is-pre-editing))`。

--- a/src/Scheme/Glue/glue_editor.lua
+++ b/src/Scheme/Glue/glue_editor.lua
@@ -1115,6 +1115,11 @@ function main()
                 ret_type = "void"
             },
             {
+                scm_name = "is-pre-editing",
+                cpp_name = "is_pre_editing",
+                ret_type = "bool"
+            },
+            {
                 scm_name = "show-diff-popup",
                 cpp_name = "show_diff_popup",
                 ret_type = "void"


### PR DESCRIPTION
# [0864] Ghost 补全 pre-editing 期间不弹出

## 1 相关文档
- [0860.md](0860.md) - Ghost 自动补全
- [0776.md](0776.md) - 输入法 pre-edit 不同步（`is_pre_editing` 来源）

## 2 任务相关的代码文件
- `src/Scheme/Glue/glue_editor.lua` — 暴露 `is-pre-editing` glue
- `TeXmacs/progs/generic/ghost-text.scm` — 回调条件加入 `(not (is-pre-editing))`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 正常输入英文，ghost 应正常弹出；
2. 用输入法输入中文，在任意时刻的输入过程（pre-editing）中，ghost 不应弹出；

## 4 What
- ghost 补全结果返回时若用户正处于输入法 pre-editing 阶段，不弹出 ghost。

## 5 Why
- pre-editing 期间文档尚未提交最终文本，光标位置不稳定，弹出 ghost 会干扰输入。

## 6 How
- `glue_editor.lua` 暴露已有的 C++ 方法 `is_pre_editing()`（0776 实现，基于 `pre_edit_mark`）为 scheme 函数 `is-pre-editing`。
- `ghost-text.scm` 回调的 `when` 条件加入 `(not (is-pre-editing))`。
