### PR TITLE
[1160] 绘图模式新增快捷键 e 继续插入上一次对象

### DIFF
--- a/TeXmacs/progs/graphics/graphics-env.scm
+++ b/TeXmacs/progs/graphics/graphics-env.scm
@@ -43,6 +43,7 @@
           (multiselecting #f)
           (preselected #f)
           (layer-of-last-removed-object #f)
+          (last-inserted-type #f)
          ) ;
   ) ;slots
   (props ((current-x (f2s (get-graphical-x)))
@@ -114,6 +115,7 @@
     (state-set! st 'multiselecting multiselecting)
     (state-set! st 'preselected preselected)
     (state-set! st 'current-path current-path)
+    (state-set! st 'last-inserted-type last-inserted-type)
     st
   ) ;with
 ) ;tm-define
@@ -148,6 +150,7 @@
   (set! multiselecting (state-ref st 'multiselecting))
   (set! preselected (state-ref st 'preselected))
   (set! current-path (state-ref st 'current-path))
+  (set! last-inserted-type (state-ref st 'last-inserted-type))
 ) ;tm-define
 
 ;; State stack (2)
@@ -231,6 +234,7 @@
   (set! preselected #f)
   (set! current-path #f)
   (set! layer-of-last-removed-object #f)
+  (set! last-inserted-type #f)
 ) ;tm-define
 
 (tm-define (graphics-init-state)
@@ -596,3 +600,7 @@
 ) ;tm-define
 
 (tm-define (set-cursor-style-now) (set-cursor-style the-current-cursor-style))
+
+(tm-define (graphics-remember-inserted-type val) (set! last-inserted-type val))
+
+(tm-define (graphics-last-inserted-type) last-inserted-type)

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -140,6 +140,7 @@
  ("t" (graphics-set-origin "0gw" "1gh"))
  ("l" (graphics-set-origin "0gw" "0.5gh"))
  ("b" (graphics-set-origin "0gw" "0gh"))
+ ("e" (graphics-resume-last-insert))
  ("#" (graphics-toggle-grid))
  ("!" (open-plots-editor "scheme" "default" ""))
  ("left" (graphics-arrow-left))
@@ -210,6 +211,7 @@
     "l"
     "b"
     "t"
+    "e"
     "left"
     "right"
     "down"
@@ -237,6 +239,17 @@
   (cond ((string-occurs? "-" key) (key-press key))
         ((in? key graphics-keys) (key-press key))
   ) ;cond
+) ;tm-define
+
+;; 按下 e：从更改属性模式切回上一次插入对象的插入模式
+(tm-define (graphics-resume-last-insert)
+  (:mode in-active-graphics?)
+  (and-with last
+    (graphics-last-inserted-type)
+    (when (equal? (graphics-mode) '(group-edit edit-props))
+      (graphics-set-mode last)
+    ) ;when
+  ) ;and-with
 ) ;tm-define
 
 (tm-define (mouse-drop-event x y obj)

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -1138,6 +1138,7 @@
       (graphics-set-property "gr-mode" `(tuple ,@(map symbol->string val)))
       (when (func? val 'edit 1)
         (graphics-restore-type-config (cadr val))
+        (graphics-remember-inserted-type val)
       ) ;when
       (graphics-enter-mode (graphics-mode) val)
     ) ;begin

--- a/devel/1160.md
+++ b/devel/1160.md
@@ -1,0 +1,39 @@
+# 1160 绘图模式新增快捷键 e 继续插入上一次的对象
+
+## What
+
+在绘图模式中，绘制结束（进入"更改属性模式" `(group-edit edit-props)`）
+之后，按 `e` 键重新进入上一次插入对象的插入模式，可继续插入同类型对象。
+
+例如：画折线（`(edit spline)`）画好之后自动进入更改属性模式，按 `e`
+即切回 `(edit spline)`，可继续画下一条折线。
+
+## Why
+
+绘制完一个对象后，用户常常想连续插入多个同类型对象。当前需要从工具栏/
+菜单重新点选插入类型，操作链长。新增 `e` 快捷键一键回到上次插入模式，
+提升绘图效率。
+
+`e` 取自 "edit/insert again"，且当前 `graphics-kbd.scm` 中字母键 `c/t/l/b`
+已被占用，`e` 未被占用。
+
+## How
+
+- `TeXmacs/progs/graphics/graphics-env.scm`：新增状态变量
+  `last-inserted-type`（初始 `#f`），加入 `define-state` 的 slots 与
+  `graphics-state-get`/`graphics-state-set`/`graphics-set-default-state-except-sticky-point`
+  的存取，保证 undo/redo 一致。
+- `TeXmacs/progs/graphics/graphics-main.scm`：在 `graphics-set-mode`
+  中，当 `val` 形如 `(edit <type>)` 时，记录 `(set! last-inserted-type val)`。
+- `TeXmacs/progs/graphics/graphics-kbd.scm`：
+  - `kbd-map` 增加 `("e" (graphics-resume-last-insert))`。
+  - `graphics-keys` 列表加入 `"e"`，让 `keyboard-press` 派发到 `kbd-map`。
+  - 新增 `(tm-define (graphics-resume-last-insert) ...)`：当处于
+    `(group-edit edit-props)` 且 `last-inserted-type` 非空时，调用
+    `(graphics-set-mode last-inserted-type)` 切回插入模式；否则 no-op。
+
+## 涉及文件
+
+- `TeXmacs/progs/graphics/graphics-env.scm`
+- `TeXmacs/progs/graphics/graphics-main.scm`
+- `TeXmacs/progs/graphics/graphics-kbd.scm`


### PR DESCRIPTION
## Summary
- 绘图结束后进入更改属性模式 `(group-edit edit-props)` 时，按 `e` 可切回上一次插入对象的插入模式，继续插入同类型对象（如画完折线按 e 继续画折线）
- 新增状态 `last-inserted-type`，`graphics-set-mode` 进入 `(edit <type>)` 时记录
- `graphics-kbd.scm` 绑定 `e` → `graphics-resume-last-insert`，并加入 `graphics-keys` 派发表

## Test plan
- [ ] 进入绘图模式，插入一条折线（spline），绘制完成后自动进入更改属性模式
- [ ] 按 `e`，确认切回 spline 插入模式可继续画线
- [ ] 切换其它类型（line/circle/rectangle）后按 `e`，确认回到最近一次插入的类型
- [ ] 未插入过任何对象时按 `e`，确认无异常（no-op）

🤖 Generated with [Claude Code](https://claude.com/claude-code)