### PR TITLE
[1160] 绘图模式 e 快捷键切换到当前选中对象的插入模式

### DIFF
--- a/TeXmacs/progs/graphics/graphics-env.scm
+++ b/TeXmacs/progs/graphics/graphics-env.scm
@@ -43,7 +43,6 @@
           (multiselecting #f)
           (preselected #f)
           (layer-of-last-removed-object #f)
-          (last-inserted-type #f)
          ) ;
   ) ;slots
   (props ((current-x (f2s (get-graphical-x)))
@@ -115,7 +114,6 @@
     (state-set! st 'multiselecting multiselecting)
     (state-set! st 'preselected preselected)
     (state-set! st 'current-path current-path)
-    (state-set! st 'last-inserted-type last-inserted-type)
     st
   ) ;with
 ) ;tm-define
@@ -150,7 +148,6 @@
   (set! multiselecting (state-ref st 'multiselecting))
   (set! preselected (state-ref st 'preselected))
   (set! current-path (state-ref st 'current-path))
-  (set! last-inserted-type (state-ref st 'last-inserted-type))
 ) ;tm-define
 
 ;; State stack (2)
@@ -234,7 +231,6 @@
   (set! preselected #f)
   (set! current-path #f)
   (set! layer-of-last-removed-object #f)
-  (set! last-inserted-type #f)
 ) ;tm-define
 
 (tm-define (graphics-init-state)
@@ -600,7 +596,3 @@
 ) ;tm-define
 
 (tm-define (set-cursor-style-now) (set-cursor-style the-current-cursor-style))
-
-(tm-define (graphics-remember-inserted-type val) (set! last-inserted-type val))
-
-(tm-define (graphics-last-inserted-type) last-inserted-type)

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -239,15 +239,40 @@
   ) ;cond
 ) ;tm-define
 
-;; 按下 e：从更改属性模式切回上一次插入对象的插入模式
+;; 有对应插入模式 (edit <tag>) 的对象 tag（见 graphics-menu.scm 的插入菜单）
+
+(define graphics-insertable-tags
+  '(point line
+     cline
+     spline
+     smooth
+     bezier
+     cspline
+     csmooth
+     cbezier
+     std-arc-counterclockwise
+     sector-counterclockwise
+     circle
+     ellipse
+     hyperbola
+     parabola
+     rectangle
+     text-at
+     math-at
+     document-at)
+) ;define
+
+;; 按下 e：从更改属性模式切换到当前选中对象对应的插入模式
 (tm-define (graphics-resume-last-insert)
   (:mode in-active-graphics?)
-  (and-with last
-    (graphics-last-inserted-type)
-    (when (equal? (graphics-mode) '(group-edit edit-props))
-      (graphics-set-mode last)
-    ) ;when
-  ) ;and-with
+  (when (and (== (graphics-mode) '(group-edit edit-props)) (== (length (sketch-get)) 1))
+    (with obj
+      (stree-radical (tree->stree (car (sketch-get))))
+      (when (and (pair? obj) (in? (car obj) graphics-insertable-tags))
+        (graphics-set-mode `(edit ,(car obj)))
+      ) ;when
+    ) ;with
+  ) ;when
 ) ;tm-define
 
 (tm-define (mouse-drop-event x y obj)

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -1138,7 +1138,6 @@
       (graphics-set-property "gr-mode" `(tuple ,@(map symbol->string val)))
       (when (func? val 'edit 1)
         (graphics-restore-type-config (cadr val))
-        (graphics-remember-inserted-type val)
       ) ;when
       (graphics-enter-mode (graphics-mode) val)
     ) ;begin

--- a/devel/1160.md
+++ b/devel/1160.md
@@ -3,15 +3,16 @@
 ## What
 
 在绘图模式中，绘制结束（进入"更改属性模式" `(group-edit edit-props)`）
-之后，按 `e` 键重新进入上一次插入对象的插入模式，可继续插入同类型对象。
+之后，按 `e` 键切换到当前选中对象对应的插入模式，可继续插入同类型对象。
 
-例如：画折线（`(edit spline)`）画好之后自动进入更改属性模式，按 `e`
-即切回 `(edit spline)`，可继续画下一条折线。
+例如：画折线（`(edit spline)`）画好之后自动进入更改属性模式并选中该
+折线，按 `e` 即切回 `(edit spline)`，可继续画下一条折线。选中一个已有
+对象按 `e`，同样进入该类对象的插入模式。
 
 ## Why
 
 绘制完一个对象后，用户常常想连续插入多个同类型对象。当前需要从工具栏/
-菜单重新点选插入类型，操作链长。新增 `e` 快捷键一键回到上次插入模式，
+菜单重新点选插入类型，操作链长。新增 `e` 快捷键一键回到对应的插入模式，
 提升绘图效率。
 
 `e` 取自 "edit/insert again"，且当前 `graphics-kbd.scm` 中字母键 `c/t/l/b`
@@ -19,21 +20,20 @@
 
 ## How
 
-- `TeXmacs/progs/graphics/graphics-env.scm`：新增状态变量
-  `last-inserted-type`（初始 `#f`），加入 `define-state` 的 slots 与
-  `graphics-state-get`/`graphics-state-set`/`graphics-set-default-state-except-sticky-point`
-  的存取，保证 undo/redo 一致。
-- `TeXmacs/progs/graphics/graphics-main.scm`：在 `graphics-set-mode`
-  中，当 `val` 形如 `(edit <type>)` 时，记录 `(set! last-inserted-type val)`。
 - `TeXmacs/progs/graphics/graphics-kbd.scm`：
   - `kbd-map` 增加 `("e" (graphics-resume-last-insert))`。
   - `graphics-keys` 列表加入 `"e"`，让 `keyboard-press` 派发到 `kbd-map`。
+  - 新增 `graphics-insertable-tags` 白名单：与 `graphics-menu.scm` 插入
+    菜单中 `(edit <tag>)` 模式一一对应的对象 tag。
   - 新增 `(tm-define (graphics-resume-last-insert) ...)`：当处于
-    `(group-edit edit-props)` 且 `last-inserted-type` 非空时，调用
-    `(graphics-set-mode last-inserted-type)` 切回插入模式；否则 no-op。
+    `(group-edit edit-props)` 且恰好选中一个对象时，取该对象
+    `(stree-radical (tree->stree (car (sketch-get))))` 的 tag，若在
+    白名单内则 `(graphics-set-mode `(edit ,tag))` 切换到对应插入模式；
+    否则 no-op。
+- 模式直接由当前选中对象推导，无需 `set!` 记录上一次插入类型（初版
+  `last-inserted-type` 状态变量已移除，`graphics-env.scm` /
+  `graphics-main.scm` 恢复无额外状态）。
 
 ## 涉及文件
 
-- `TeXmacs/progs/graphics/graphics-env.scm`
-- `TeXmacs/progs/graphics/graphics-main.scm`
 - `TeXmacs/progs/graphics/graphics-kbd.scm`


### PR DESCRIPTION
## Summary
- 按下 `e`：在 `(group-edit edit-props)` 模式下，由当前选中对象的 tag 推导插入模式并切换（如选中折线 → `(edit spline)`），不再用 `set!` 记录上一次插入类型
- 移除初版的 `last-inserted-type` 状态变量及 `graphics-remember-inserted-type` / `graphics-last-inserted-type`，`graphics-env.scm` / `graphics-main.scm` 恢复无额外状态
- 新增 `graphics-insertable-tags` 白名单，与插入菜单的 `(edit <tag>)` 一一对应；未选中/多选/白名单外对象时 no-op

## Test plan
- [x] `xmake b stem` 构建通过
- [x] headless 启动冒烟正常
- [ ] GUI 手测：画完折线后按 `e` 继续画折线；选中已有圆按 `e` 进入 `(edit circle)`；多选时按 `e` 无反应

🤖 Generated with [Claude Code](https://claude.com/claude-code)