### PR TITLE
[1162] markdown 快捷键迁移到 text-kbd-utf8 并迁入 keyboard 插件

### DIFF
--- a/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
+++ b/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
@@ -17,7 +17,7 @@
 (lazy-keyboard (generic generic-kbd) always?)
 (lazy-keyboard (generic search-kbd))
 (lazy-keyboard (text text-kbd) in-text?)
-(lazy-keyboard (text text-kbd-utf8) in-text?)
+(lazy-keyboard (keyboard text-kbd-utf8) in-text?)
 (lazy-keyboard (math math-kbd) in-math?)
 (lazy-keyboard (math math-sem-edit) in-sem-math?)
 (lazy-keyboard (prog prog-kbd) in-prog?)

--- a/TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm
+++ b/TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (text text-kbd-utf8)
+(texmacs-module (keyboard text-kbd-utf8)
   (:use (generic generic-kbd)
     (utils edit auto-close)
     (text text-edit)
@@ -29,6 +29,26 @@
  ("- > var" "->")
  ("< -" "<#2190>")
  ("< - var" "<less>-")
+) ;kbd-map
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Markdown style shortcuts
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(kbd-map (:mode in-text?)
+ ("# # var" (make 'section))
+ ("# # # var" (make 'subsection))
+ ("# # # # var" (make 'subsubsection))
+ ("` ` ` var" (make 'verbatim-code))
+ ("* * var" (make-with "font-series" "bold"))
+ ("* var" (make-with "font-shape" "italic"))
+ ("- space" (make-tmlist-if-line-start 'itemize "- "))
+ ("+ space" (make-tmlist-if-line-start 'itemize "+ "))
+ ("+ var" (make-tmlist 'itemize))
+ ("1 . space" (make-tmlist-if-line-start 'enumerate "1. "))
+ ("1 . var" (make-tmlist 'enumerate))
+ ("[ ] var" (make 'hlink))
+ ("[ ] var var" (make 'slink))
 ) ;kbd-map
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/progs/text/text-kbd.scm
+++ b/TeXmacs/progs/text/text-kbd.scm
@@ -60,21 +60,6 @@
   ("/ /" "//")
   ("/ / var" (make 'deleted))
 
-  ;; Markdown Style Shortcuts
-  ("# # var" (make 'section))
-  ("# # # var" (make 'subsection))
-  ("# # # # var" (make 'subsubsection))
-  ("` ` ` var" (make 'verbatim-code))
-  ("* * var" (make-with "font-series" "bold"))
-  ("* var" (make-with "font-shape" "italic"))
-  ("- space" (make-tmlist-if-line-start 'itemize "- "))
-  ("+ space" (make-tmlist-if-line-start 'itemize "+ "))
-  ("+ var" (make-tmlist 'itemize))
-  ("1 . space" (make-tmlist-if-line-start 'enumerate "1. "))
-  ("1 . var" (make-tmlist 'enumerate))
-  ("[ ] var" (make 'hlink))
-  ("[ ] var var" (make 'slink))
-
   ("space var" (make 'nbsp))
   ("space var var" (make-space "1em"))
   ("_" "_")

--- a/devel/1162.md
+++ b/devel/1162.md
@@ -1,0 +1,46 @@
+# 1162 markdown 快捷键迁移与 text-kbd-utf8 迁入 keyboard 插件
+
+## What
+
+1. 将 `TeXmacs/progs/text/text-kbd.scm` 中 `;; Markdown Style Shortcuts`
+   注释下的 13 条绑定（原 64-76 行）迁移到 `text-kbd-utf8.scm`。
+2. 将 `TeXmacs/progs/text/text-kbd-utf8.scm` 迁移到 keyboard 插件
+   `TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm`，模块名由
+   `(text text-kbd-utf8)` 改为 `(keyboard text-kbd-utf8)`，
+   `plugins/keyboard/progs/init-keyboard.scm` 中的 `lazy-keyboard`
+   同步更新。
+
+## Why
+
+- markdown 风格快捷键 RHS 全是 scheme 调用（`make` / `make-with` /
+  `make-tmlist`），无 cork 字节，本就属于 UTF-8 安全的绑定，从 cork
+  编码的 text-kbd.scm 迁出后可摆脱该文件的编码约束。
+- keyboard 插件已存在（`plugins/keyboard/progs/init-keyboard.scm` 统一
+  登记各模式 lazy-keyboard），text-kbd-utf8.scm 是纯快捷键定义文件，
+  收敛进 keyboard 插件与 lang 插件管理语言快捷键（1156-1159）的方向
+  一致。
+
+## How
+
+- `text-kbd.scm` **精确删除 63-77 行**（`;; Markdown Style Shortcuts`
+  注释 + 13 条绑定 + 尾随空行）。该文件是 **cork 编码**，禁用
+  `gf fmt`，删除用 `sed '63,77d'` 按行号完成，不触碰其它字节。
+- `git mv` text-kbd-utf8.scm 到 `plugins/keyboard/progs/keyboard/`，
+  模块头改为 `(keyboard text-kbd-utf8)`，`(:use ...)` 保持不变
+  （`make-tmlist` / `make-tmlist-if-line-start` 在 `(text text-edit)`
+  中定义，已 import）。13 条 markdown 绑定并入文件头部
+  `(:mode in-text?)` 的 kbd-map。
+- `init-keyboard.scm` 中
+  `(lazy-keyboard (text text-kbd-utf8) in-text?)` 改为
+  `(lazy-keyboard (keyboard text-kbd-utf8) in-text?)`，加载顺序不变
+  （仍在 text-kbd 之后），kbd-map 相对优先级不受影响。
+
+## 涉及文件
+
+- `devel/1162.md`（本文档）
+- `TeXmacs/progs/text/text-kbd.scm`（删 13 条绑定）
+- `TeXmacs/progs/text/text-kbd-utf8.scm` →
+  `TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm`（移动 +
+  模块改名 + 并入 markdown 绑定）
+- `TeXmacs/plugins/keyboard/progs/init-keyboard.scm`（lazy-keyboard
+  路径更新）


### PR DESCRIPTION
## Summary
- `text-kbd.scm` 中 13 条 markdown 风格快捷键（`# # var` 建 section、`- space` 建行首 itemize 等）迁移到 `text-kbd-utf8.scm`；RHS 全是 scheme 调用、无 cork 字节，迁出后摆脱 cork 编码文件的约束
- `text-kbd-utf8.scm` 从 `TeXmacs/progs/text/` 迁入 keyboard 插件 `TeXmacs/plugins/keyboard/progs/keyboard/`，模块名改为 `(keyboard text-kbd-utf8)`，`init-keyboard.scm` 的 lazy-keyboard 同步更新，加载顺序与 kbd-map 优先级不变

## Test plan
- [ ] 文本模式输入 `# # var` 生成 section，`# # # var` 生成 subsection
- [ ] 行首输入 `- space` / `+ space` / `1 . space` 生成 itemize / enumerate
- [ ] `` ` ` ` var `` 生成 verbatim-code，`* var` / `* * var` 切换 italic / bold
- [ ] `[ ] var` 生成 hlink，`[ ] var var` 生成 slink
- [ ] 原有 utf8 绑定（`<`、`>`、`- >`、希腊字母、`text ;` 注释）不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)