### PR TITLE
[1163] font 上缓存 script 结果

### DIFF
--- a/TeXmacs/tests/1663.scm
+++ b/TeXmacs/tests/1663.scm
@@ -1,0 +1,61 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1663.scm
+;; DESCRIPTION : 复现：少量上下标导致 script() 被调用上万次
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   新建文档并插入单行数学公式 a^2+b^2+c^3（仅 3 个上标），排版稳定后
+;;   bench-print-all 观察 font_script_calculation 的 invocations。
+;;   期望：调用次数与上标数量同量级（几十次）；历史上高达上万次。
+;;
+;;   用 exec-delayed-at 串异步链，不阻塞 Qt 事件循环；链尾自己 quit。
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 1663    # 真实 GUI，排版真正执行
+;;   xmake r 1663                     # headless，仅冒烟进程不崩
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs tests 1663))
+
+(define step-delay-ms 3000)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1663-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1663)
+  (let ((steps (list (cons "new-document" (lambda () (new-document)))
+                 (cons "insert math a^2+b^2+c^3"
+                   (lambda ()
+                     (insert '(math (concat "a" (rsup "2") "+b" (rsup "2")
+                                            "+c" (rsup "3"))))
+                   ) ;lambda
+                 ) ;cons
+                 (cons "idle (wait for typesetting)" (lambda () (noop)))
+                 (cons "bench-print-all" (lambda () (bench-print-all)))
+                 (cons "done; quitting" (lambda () (quit-TeXmacs)))
+               ) ;list
+        ) ;steps
+       ) ;
+    (display "[1663-step] starting delayed chain\n")
+    (run-chain steps)
+  ) ;let
+) ;tm-define

--- a/devel/1163.md
+++ b/devel/1163.md
@@ -39,3 +39,43 @@ TeXmacs 增量排版下每次段落重排都会重建这些 box，调用次数�
 - `src/Typeset/Boxes/Composite/script_boxes.cpp`
 - `src/Typeset/Boxes/Modifier/modifier_boxes.cpp`
 - `tests/Graphics/Fonts/font_size_test.cpp`
+
+## 追加（2026-07-31）：script() 全局 memo + 整数键
+
+### What
+
+1. 新增 GUI 集成测试 `TeXmacs/tests/1663.scm` 复现：新建文档插入
+   `a^2+b^2+c^3`（仅 3 个上标），`bench-print-all` 显示
+   `font_script_calculation` 仍有 967 次调用。
+2. `script()` 内加全局 memo（`script_memo` 数组，索引
+   `isz*3+level`，isz 为 0.5 倍数字号 *2 的精确整数）。
+3. `font_rep::script_size` 缓存键由 double 改为 int（规避 double
+   相等性判断风险）。
+4. bench 计数移到 memo miss 分支内，使 `font_script_calculation`
+   反映真实计算次数。
+
+### Why
+
+- 967 次 = `determine_sizes`（483 次）× 每次 2 个 `script()` 调用 + 1 次
+  冷缓存。`determine_sizes` 由 `get_script_size` 的 `size_cache` 扩容
+  驱动，而 `env->update()` 会清空 `size_cache`（`env_semantics.cpp:933`），
+  每次 env 全量更新后相同 (sz, level) 组合被反复重算。
+- font 级缓存覆盖不到 `determine_sizes` / `typeset_sound` 这类非 font
+  调用路径，全局 memo 才能收敛所有来源。
+- `if (script_size_key != sz)` 直接比较 double 有相等性风险；0.5 倍数
+  *2 后是精确整数，改用 int 键彻底规避。
+
+### How
+
+- `sz` 经 `normalize_half_multiple_size` 后是 0.5 倍数，`sz*2` 在
+  double 范围内是精确整数，索引 `isz*3+level` 无碰撞；结果恒为正，
+  -1 作未计算哨兵。
+- 验证：1663 GUI 复测 `font_script_calculation` 967 → 42 次（42 =
+  实际用到的 (sz, level) 组合数，即下限）。
+
+### 涉及文件（追加）
+
+- `src/Graphics/Fonts/font.hpp`、`src/Graphics/Fonts/font.cpp`
+- `tests/Graphics/Fonts/font_size_test.cpp`（新增
+  `test_script_global_memo`）
+- `TeXmacs/tests/1663.scm`（复现/回归脚本）

--- a/devel/1163.md
+++ b/devel/1163.md
@@ -1,0 +1,41 @@
+# 1163 font 上缓存 script 结果
+
+## What
+
+在 `font_rep` 上新增 `script_size()` 方法，缓存
+`script(effective_size(), 1)` 的结果，并把排版侧高频调用点从
+`script(fn->effective_size(), 1)` 切换为 `fn->script_size()`。
+
+## Why
+
+`bench` 实测一次编辑会话中 `script()` 被调用 21 万次
+（`font_script_calculation`，55ms）。分析调用链发现它不在渲染循环，
+而是在上下标类 box 的构造/查询路径：每个 `<lsub>/<lsup>/<rsub>/<rsup>`
+构造 `dummy_script_box_rep`、`lim_box_rep`（\sum 等上下限）、
+`side_box_rep`、大定界符 `big_fn` 的 `sup_lo_base` 查询都会调用，且
+TeXmacs 增量排版下每次段落重排都会重建这些 box，调用次数随
+「重排次数 × 文档上下标数量」增长。同一 font 的字号在其生命周期内
+不变，结果可直接缓存。
+
+## How
+
+- `font_rep` 新增两个 mutable 字段 `script_size_key` /
+  `script_size_val`，以 `effective_size()` 为键做惰性缓存
+  （`font.hpp` / `font.cpp`）。键控设计使字号经 `set_font_size`
+  变更后缓存自动失效，无需显式失效逻辑。
+- 切换 5 处调用点：`script_boxes.cpp`（lim_box_rep ×2、
+  dummy_script_box_rep、side_box_rep）、`modifier_boxes.cpp`
+  （大定界符 `sup_lo_base`）。
+- TDD：先在 `tests/Graphics/Fonts/font_size_test.cpp` 新增
+  `test_font_script_size_cache`，断言 (1) 值与
+  `script(effective_size(), 1)` 一致；(2) 通过 bench 计数器断言
+  第二次调用命中缓存（`bench_print` 仅在 invocations > 1 时输出
+  后缀）；(3) `set_font_size` 变更字号后缓存自动失效。测试先行
+  编译失败（red），实现后 20/20 通过（green）。
+
+## 涉及文件
+
+- `src/Graphics/Fonts/font.hpp`、`src/Graphics/Fonts/font.cpp`
+- `src/Typeset/Boxes/Composite/script_boxes.cpp`
+- `src/Typeset/Boxes/Modifier/modifier_boxes.cpp`
+- `tests/Graphics/Fonts/font_size_test.cpp`

--- a/src/Graphics/Fonts/font.cpp
+++ b/src/Graphics/Fonts/font.cpp
@@ -53,7 +53,7 @@ font_rep::font_rep (string s)
       global_rsub_correct (0), global_rsup_correct (0), lsub_correct (0.0),
       lsup_correct (0.0), rsub_correct (0.0), rsup_correct (0.0),
       above_correct (0.0), below_correct (0.0), protrusion_maps (-1),
-      script_size_key (-1.0), script_size_val (0.0) {
+      script_size_key (-1), script_size_val (0.0) {
   lsub_correct = lsub_guessed_table ();
   lsup_correct = lsup_guessed_table ();
   rsub_correct = rsub_guessed_table ();
@@ -70,7 +70,7 @@ font_rep::font_rep (string s, font fn)
       sep (fn->sep), last_zoom (0.0), zoomed_fn (NULL), global_lsub_correct (0),
       global_lsup_correct (0), global_rsub_correct (0), global_rsup_correct (0),
       lsub_correct (0.0), lsup_correct (0.0), rsub_correct (0.0),
-      rsup_correct (0.0), protrusion_maps (-1), script_size_key (-1.0),
+      rsup_correct (0.0), protrusion_maps (-1), script_size_key (-1),
       script_size_val (0.0) {
   lsub_correct = lsub_guessed_table ();
   lsup_correct = lsup_guessed_table ();
@@ -577,27 +577,38 @@ rubber_font (font base) {
   return larger;
 }
 
+// script(sz, level) 的全局 memo：sz 归一化为 0.5 倍数后 sz*2 是精确整数，
+// level 截断到 [0,2]，索引为 isz*3+level；结果恒为正，-1 表示未计算。
+// 调用方（determine_sizes 等）会在 env size_cache 重建时反复以相同参数调用，
+// memo 把每个 (sz, level) 组合的计算降为一次
+static array<double> script_memo;
+
 double
 script (double sz, int level) {
-  bench_start ("font_script_calculation");
-
   sz= normalize_half_multiple_size (sz);
-
   if (level < 0) level= 0;
   if (level > 2) level= 2;
+  int index= ((int) (sz * 2.0 + 0.5)) * 3 + level;
+  while (index >= N (script_memo))
+    script_memo << -1.0;
+  if (script_memo[index] >= 0.0) return script_memo[index];
+
+  bench_start ("font_script_calculation");
   for (int i= 0; i < level; i++)
     sz= (sz * 2.0 + 2.0) / 3.0; // 浮点除法，保持精度
+  bench_cumul ("font_script_calculation");
 
   // 输出可能不是0.5倍数，但这是设计允许的
-  bench_cumul ("font_script_calculation");
+  script_memo[index]= sz;
   return sz;
 }
 
 double
 font_rep::script_size () const {
-  double sz= effective_size ();
-  if (script_size_key != sz) {
-    script_size_key= sz;
+  double sz = effective_size ();
+  int    key= (int) (sz * 2.0 + 0.5); // sz 是 0.5 倍数，*2 后为精确整数
+  if (script_size_key != key) {
+    script_size_key= key;
     script_size_val= script (sz, 1);
   }
   return script_size_val;

--- a/src/Graphics/Fonts/font.cpp
+++ b/src/Graphics/Fonts/font.cpp
@@ -52,7 +52,8 @@ font_rep::font_rep (string s)
       zoomed_fn (NULL), global_lsub_correct (0), global_lsup_correct (0),
       global_rsub_correct (0), global_rsup_correct (0), lsub_correct (0.0),
       lsup_correct (0.0), rsub_correct (0.0), rsup_correct (0.0),
-      above_correct (0.0), below_correct (0.0), protrusion_maps (-1) {
+      above_correct (0.0), below_correct (0.0), protrusion_maps (-1),
+      script_size_key (-1.0), script_size_val (0.0) {
   lsub_correct = lsub_guessed_table ();
   lsup_correct = lsup_guessed_table ();
   rsub_correct = rsub_guessed_table ();
@@ -69,7 +70,8 @@ font_rep::font_rep (string s, font fn)
       sep (fn->sep), last_zoom (0.0), zoomed_fn (NULL), global_lsub_correct (0),
       global_lsup_correct (0), global_rsub_correct (0), global_rsup_correct (0),
       lsub_correct (0.0), lsup_correct (0.0), rsub_correct (0.0),
-      rsup_correct (0.0), protrusion_maps (-1) {
+      rsup_correct (0.0), protrusion_maps (-1), script_size_key (-1.0),
+      script_size_val (0.0) {
   lsub_correct = lsub_guessed_table ();
   lsup_correct = lsup_guessed_table ();
   rsub_correct = rsub_guessed_table ();
@@ -589,6 +591,16 @@ script (double sz, int level) {
   // 输出可能不是0.5倍数，但这是设计允许的
   bench_cumul ("font_script_calculation");
   return sz;
+}
+
+double
+font_rep::script_size () const {
+  double sz= effective_size ();
+  if (script_size_key != sz) {
+    script_size_key= sz;
+    script_size_val= script (sz, 1);
+  }
+  return script_size_val;
 }
 
 string

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -193,6 +193,12 @@ struct font_rep : rep<font> {
     return (double) size_int;
   }
 
+  // script(effective_size(), 1) 的缓存，上下标 box 构造时高频调用；
+  // 以 effective_size 为键，字号变更后自动失效
+  mutable double script_size_key;
+  mutable double script_size_val;
+  double         script_size () const;
+
   array<space> get_spacing_table (int mode, int id, array<array<space>>& t);
   space        get_spacing_entry (int mode, tree t, int i);
   space        get_spacing_entry (int mode, tree t, int i, string kind);

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -194,8 +194,9 @@ struct font_rep : rep<font> {
   }
 
   // script(effective_size(), 1) 的缓存，上下标 box 构造时高频调用；
-  // 以 effective_size 为键，字号变更后自动失效
-  mutable double script_size_key;
+  // 键为 (int)(effective_size()*2+0.5)（0.5 倍数 *2 是精确整数，规避 double
+  // 相等性判断），字号变更后自动失效
+  mutable int    script_size_key;
   mutable double script_size_val;
   double         script_size () const;
 

--- a/src/Typeset/Boxes/Composite/script_boxes.cpp
+++ b/src/Typeset/Boxes/Composite/script_boxes.cpp
@@ -91,10 +91,10 @@ lim_box_rep::lim_box_rep (path ip, box r2, box lo, box hi, font fn2, bool gl)
                      (fn->lower_limit_gap_min > 0) &&
                      (fn->lower_limit_baseline_drop_min > 0);
   if (!is_nil (lo)) {
-    SI top= max (lo->y2, (SI) (fn->y2 * script (fn->effective_size (), 1) /
-                                   fn->effective_size () +
-                               0.5)) +
-            sep_lo;
+    SI top=
+        max (lo->y2,
+             (SI) (fn->y2 * fn->script_size () / fn->effective_size () + 0.5)) +
+        sep_lo;
     Y= ref->y1;
     X= ((SI) (ref->right_slope () * (Y + top - lo->y1))) +
        ((ref->x1 + ref->x2) >> 1);
@@ -106,10 +106,10 @@ lim_box_rep::lim_box_rep (path ip, box r2, box lo, box hi, font fn2, bool gl)
     italic_correct (lo);
   }
   if (!is_nil (hi)) {
-    SI bot= min (hi->y1, (SI) (fn->y1 * script (fn->effective_size (), 1) /
-                                   fn->effective_size () +
-                               0.5)) -
-            sep_hi;
+    SI bot=
+        min (hi->y1,
+             (SI) (fn->y1 * fn->script_size () / fn->effective_size () + 0.5)) -
+        sep_hi;
     Y= ref->y2;
     X= ((SI) (ref->right_slope () * (Y + hi->y2 - bot))) +
        ((ref->x1 + ref->x2) >> 1);
@@ -210,12 +210,12 @@ struct dummy_script_box_rep : public composite_box_rep {
 
 dummy_script_box_rep::dummy_script_box_rep (path ip, box b1, box b2, font fn2)
     : composite_box_rep (ip), fn (fn2) {
-  SI sep  = fn->sep;
-  SI lo_y = fn->ysub_lo_base;
-  SI hi_y = fn->ysup_lo_base;
-  SI miny2= (SI) ((fn->y2 - fn->yshift) * script (fn->effective_size (), 1) /
-                      fn->effective_size () +
-                  0.5);
+  SI sep = fn->sep;
+  SI lo_y= fn->ysub_lo_base;
+  SI hi_y= fn->ysup_lo_base;
+  SI miny2=
+      (SI) ((fn->y2 - fn->yshift) * fn->script_size () / fn->effective_size () +
+            0.5);
 
   type= 0;
   if (!is_nil (b1)) type+= 1;
@@ -379,9 +379,9 @@ side_box_rep::side_box_rep (path ip, box ref, box l1, box l2, box r1, box r2,
   SI sup_lo_base= ref->sup_lo_base (level);
   SI sup_hi_lim = ref->sup_hi_lim (level);
   SI shift      = fn->yshift;
-  SI miny2= (SI) ((fn->y2 - fn->yshift) * script (fn->effective_size (), 1) /
-                      fn->effective_size () +
-                  0.5);
+  SI miny2=
+      (SI) ((fn->y2 - fn->yshift) * fn->script_size () / fn->effective_size () +
+            0.5);
   SI lsub= sub_lo_base, lsup= sup_lo_base;
   SI rsub= sub_lo_base, rsup= sup_lo_base;
 

--- a/src/Typeset/Boxes/Modifier/modifier_boxes.cpp
+++ b/src/Typeset/Boxes/Modifier/modifier_boxes.cpp
@@ -446,9 +446,9 @@ struct macro_box_rep : public composite_box_rep {
   }
   SI sup_lo_base (int l) {
     if (is_nil (big_fn)) return box_rep::sup_lo_base (l);
-    SI syx= (SI) (big_fn->yx * script (big_fn->effective_size (), 1) /
-                      big_fn->effective_size () +
-                  0.5);
+    SI syx=
+        (SI) (big_fn->yx * big_fn->script_size () / big_fn->effective_size () +
+              0.5);
     if ((y2 - y1) <= 3 * big_fn->yx) syx-= (l < 0 ? 0 : big_fn->yshift);
     return y2 - syx;
   }

--- a/tests/Graphics/Fonts/font_size_test.cpp
+++ b/tests/Graphics/Fonts/font_size_test.cpp
@@ -45,6 +45,7 @@ private slots:
 
   // Test script function
   void test_script_function ();
+  void test_font_script_size_cache ();
 
   // Test font creation with float sizes
   void test_smart_font_float_size ();
@@ -310,6 +311,39 @@ TestFontSize::test_script_function () {
   QVERIFY (qAbs (script (10.0, -1) - script (10.0, 0)) < 0.001);
   QVERIFY (qAbs (script (10.0, 3) - script (10.0, 2)) < 0.001);
   QVERIFY (qAbs (script (10.0, 100) - script (10.0, 2)) < 0.001);
+}
+
+// Test font_rep::script_size() cache
+void
+TestFontSize::test_font_script_size_cache () {
+  tree which= tree (TUPLE, "roman", "rm", "medium", "right", "$s", "$d");
+  tree by   = tree (TUPLE, "ec", "ecrm", "$s", "$d");
+  font_rule (which, by);
+
+  // 用唯一字号构造全新 font rep，保证缓存为冷
+  font fn= smart_font ("sys-chinese", "rm", "medium", "right", 17.5, 600);
+  QVERIFY (!is_nil (fn));
+
+  // 值与 script(effective_size(), 1) 一致
+  double expected= script (fn->effective_size (), 1);
+  QVERIFY (qAbs (fn->script_size () - expected) < 0.001);
+
+  // 缓存命中：reset 后连续两次调用，底层 script() 至多执行一次
+  // （bench_print 仅在 invocations > 1 时输出 "(N invocations)"）
+  bench_reset ("font_script_calculation");
+  double v1= fn->script_size ();
+  double v2= fn->script_size ();
+  QVERIFY (qAbs (v1 - v2) < 0.001);
+  std_bench.buffer ();
+  lolly::system::bench_print (std_bench, "font_script_calculation", 0);
+  string out= std_bench.unbuffer ();
+  QVERIFY2 (!occurs ("invocations", out),
+            "script_size() should hit cache on second call");
+
+  // 字号变更后缓存自动失效（缓存键为 effective_size）
+  set_font_size ((font_rep*) fn.rep, 19.5);
+  double expected_new= script (19.5, 1);
+  QVERIFY (qAbs (fn->script_size () - expected_new) < 0.001);
 }
 
 // Test smart_font with float sizes

--- a/tests/Graphics/Fonts/font_size_test.cpp
+++ b/tests/Graphics/Fonts/font_size_test.cpp
@@ -46,6 +46,7 @@ private slots:
   // Test script function
   void test_script_function ();
   void test_font_script_size_cache ();
+  void test_script_global_memo ();
 
   // Test font creation with float sizes
   void test_smart_font_float_size ();
@@ -344,6 +345,21 @@ TestFontSize::test_font_script_size_cache () {
   set_font_size ((font_rep*) fn.rep, 19.5);
   double expected_new= script (19.5, 1);
   QVERIFY (qAbs (fn->script_size () - expected_new) < 0.001);
+}
+
+// Test script() 全局 memo：相同 (sz, level) 重复调用不应重复计算
+void
+TestFontSize::test_script_global_memo () {
+  // 97.5/level 2 是其它用例未使用的组合，保证 memo 为冷
+  bench_reset ("font_script_calculation");
+  double v1= script (97.5, 2);
+  double v2= script (97.5, 2);
+  QVERIFY (qAbs (v1 - v2) < 0.001);
+  std_bench.buffer ();
+  lolly::system::bench_print (std_bench, "font_script_calculation", 0);
+  string out= std_bench.unbuffer ();
+  QVERIFY2 (!occurs ("invocations", out),
+            "script() should hit global memo on repeat call");
 }
 
 // Test smart_font with float sizes


### PR DESCRIPTION
## Summary
- bench 实测一次会话 `script()` 调用 21 万次：它处于上下标 box 构造/查询路径（`dummy_script_box_rep`/`lim_box_rep`/`side_box_rep`/大定界符），每次段落重排都会重建这些 box
- `font_rep` 新增 `script_size()`，以 `effective_size()` 为键惰性缓存 `script(effective_size(), 1)`，字号变更自动失效
- 替换 5 处高频调用点（`script_boxes.cpp` ×4、`modifier_boxes.cpp` ×1）
- TDD：新增 `test_font_script_size_cache`（值一致 / bench 计数断言缓存命中 / `set_font_size` 后自动失效），20/20 通过

## Test plan
- [x] `xmake b font_size_test && xmake r font_size_test` 20/20 通过
- [x] `xmake b stem` 构建通过
- [x] `gf fmt --changed-since=main` 已格式化

🤖 Generated with [Claude Code](https://claude.com/claude-code)