### PR TITLE
[1164] 移除 get_script_size 与 script 热路径上的 bench 埋点

### DIFF
--- a/devel/1164.md
+++ b/devel/1164.md
@@ -1,0 +1,39 @@
+# 1164 get_script_size 性能优化
+
+## What
+
+移除 `edit_env_rep::get_script_size` 与 `script()` 热路径上的
+`bench_start` / `bench_cumul` 埋点，并为其补充行为锁定单元测试。
+
+## Why
+
+实测单次排版 `get_script_size` 被调用 97802 次、累计 228 ms（约 2.3 µs/次）。
+该函数体本身只是 `size_cache` 的 O(1) 数组查询（约几十 ns），耗时几乎全部
+来自埋点本身：每次调用构造 `string` 字面量并对 `hashmap<string, uint32_t>`
+做约 8 次哈希查找（见 `lolly/lolly/system/timer.cpp` 的 `timer_start` /
+`timer_cumul`）。`script()`（`src/Graphics/Fonts/font.cpp`）同样被
+`script_boxes`、`modifier_boxes`、`concat_animate` 等热路径直接调用，存在
+相同问题。
+
+## How
+
+1. TDD：先新增 `tests/Typeset/Env/env_script_size_test.cpp`，锁定
+   `get_script_size` 现有行为——default 尺寸表（回退 `script()` 公式）、
+   tuple 尺寸表（`all` / 精确尺寸 / `*ratio` / 整数项）、level 越界回退、
+   0.5 倍数归一化、`size_cache` 增长与复用。测试在改动前全部通过。
+2. 删除 `get_script_size`（`src/Typeset/Env/env_semantics.cpp`）与
+   `script()`（`src/Graphics/Fonts/font.cpp`）中的 bench 埋点，函数体逻辑
+   保持不变。
+3. `determine_sizes` 的埋点保留：它仅在缓存填充时调用（每个字号一次），
+   开销可忽略，保留后仍可用于观测缓存填充成本。
+
+验证：`env_script_size_test`（5 例）、`font_size_test`（19 例）、
+`smart_font_test`（20 例）、`env_length_test`、`table_performance_test`
+全部通过；`xmake b stem` 构建通过。改动后 bench 日志中不再出现
+`get_script_size` / `font_script_calculation`，即开销已消除。
+
+## 涉及文件
+
+- `src/Typeset/Env/env_semantics.cpp`：移除 `get_script_size` 的 bench 埋点
+- `src/Graphics/Fonts/font.cpp`：移除 `script()` 的 bench 埋点
+- `tests/Typeset/Env/env_script_size_test.cpp`：新增行为锁定测试

--- a/src/Graphics/Fonts/font.cpp
+++ b/src/Graphics/Fonts/font.cpp
@@ -577,8 +577,7 @@ rubber_font (font base) {
 
 double
 script (double sz, int level) {
-  bench_start ("font_script_calculation");
-
+  // 热路径（每个上下标盒子都会调用）：bench 计时开销远超函数体，勿在此埋点
   sz= normalize_half_multiple_size (sz);
 
   if (level < 0) level= 0;
@@ -587,7 +586,6 @@ script (double sz, int level) {
     sz= (sz * 2.0 + 2.0) / 3.0; // 浮点除法，保持精度
 
   // 输出可能不是0.5倍数，但这是设计允许的
-  bench_cumul ("font_script_calculation");
   return sz;
 }
 

--- a/src/Typeset/Env/env_semantics.cpp
+++ b/src/Typeset/Env/env_semantics.cpp
@@ -528,9 +528,8 @@ determine_sizes (tree szt, double sz) {
 
 double
 edit_env_rep::get_script_size (double sz, int level) {
-  bench_start ("get_script_size");
-  double result= 0.0;
-
+  // 热路径（单次排版数万次）：bench 计时的 string
+  // 哈希开销远超函数体，勿在此埋点
   sz= normalize_half_multiple_size (sz);
   // 将0.5倍数转换为整数索引（乘以2）
   int isz= (int) (sz * 2.0);
@@ -540,11 +539,8 @@ edit_env_rep::get_script_size (double sz, int level) {
     size_cache << determine_sizes (math_font_sizes, xsz);
   }
   array<double>& a (size_cache[isz]);
-  if (level < N (a)) result= a[level];
-  else result= a[N (a) - 1];
-
-  bench_cumul ("get_script_size");
-  return result;
+  if (level < N (a)) return a[level];
+  return a[N (a) - 1];
 }
 
 /******************************************************************************

--- a/tests/Typeset/Env/env_script_size_test.cpp
+++ b/tests/Typeset/Env/env_script_size_test.cpp
@@ -1,0 +1,129 @@
+
+/******************************************************************************
+ * MODULE     : env_script_size_test.cpp
+ * DESCRIPTION: behavior-locking tests for edit_env_rep::get_script_size
+ * COPYRIGHT  : (C) 2026  Da Shen
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "Metafont/load_tex.hpp"
+#include "base.hpp"
+#include "data_cache.hpp"
+#include "env.hpp"
+#include "sys_utils.hpp"
+#include "tm_sys_utils.hpp"
+#include <QtTest/QtTest>
+#include <cmath>
+#include <moebius/drd/drd_std.hpp>
+
+using namespace moebius;
+using moebius::drd::std_drd;
+
+class TestEnvScriptSize : public QObject {
+  Q_OBJECT
+
+private:
+  drd_info*             drd;
+  hashmap<string, tree> h1, h2, h3, h4, h5, h6;
+
+  bool     close (double a, double b) { return fabs (a - b) < 1e-9; }
+  edit_env make_env ();
+  edit_env make_env (tree sizes);
+
+private slots:
+  void initTestCase ();
+  void default_table ();
+  void normalize_half_multiple ();
+  void tuple_all_table ();
+  void tuple_exact_size_table ();
+  void cache_growth_and_reuse ();
+};
+
+void
+TestEnvScriptSize::initTestCase () {
+  init_lolly ();
+  init_texmacs_home_path ();
+  cache_initialize ();
+  init_tex ();
+  moebius::drd::init_std_drd ();
+  drd= tm_new<drd_info> ("none", std_drd);
+}
+
+edit_env
+TestEnvScriptSize::make_env () {
+  return edit_env (*drd, "none", h1, h2, h3, h4, h5, h6);
+}
+
+edit_env
+TestEnvScriptSize::make_env (tree sizes) {
+  edit_env env        = make_env ();
+  env->math_font_sizes= sizes;
+  env->size_cache     = array<array<double>> ();
+  return env;
+}
+
+void
+TestEnvScriptSize::default_table () {
+  edit_env env= make_env ("default");
+  double   s1 = (10.0 * 2.0 + 2.0) / 3.0;
+  double   s2 = (s1 * 2.0 + 2.0) / 3.0;
+  QVERIFY (close (env->get_script_size (10.0, 0), 10.0));
+  QVERIFY (close (env->get_script_size (10.0, 1), s1));
+  QVERIFY (close (env->get_script_size (10.0, 2), s2));
+  // level 超出缓存级别数时回退到最后一级
+  QVERIFY (close (env->get_script_size (10.0, 3), s2));
+  QVERIFY (close (env->get_script_size (10.0, 100), s2));
+}
+
+void
+TestEnvScriptSize::normalize_half_multiple () {
+  edit_env env= make_env ("default");
+  QVERIFY (close (env->get_script_size (10.3, 0), 10.5));
+  QVERIFY (close (env->get_script_size (10.24, 0), 10.0));
+  QVERIFY (close (env->get_script_size (10.26, 0), 10.5));
+}
+
+void
+TestEnvScriptSize::tuple_all_table () {
+  edit_env env= make_env (tree (TUPLE, tree (TUPLE, tree ("all"), tree ("*0.8"),
+                                             tree ("*0.6"), tree ("7"))));
+  QVERIFY (close (env->get_script_size (10.0, 0), 10.0));
+  QVERIFY (close (env->get_script_size (10.0, 1), 8.0));
+  QVERIFY (close (env->get_script_size (10.0, 2), 6.0));
+  QVERIFY (close (env->get_script_size (10.0, 3), 7.0));
+  QVERIFY (close (env->get_script_size (10.0, 4), 7.0));
+  QVERIFY (close (env->get_script_size (12.0, 1), 10.0));
+}
+
+void
+TestEnvScriptSize::tuple_exact_size_table () {
+  edit_env env= make_env (tree (TUPLE, tree (TUPLE, tree ("12"), tree ("*0.5")),
+                                tree (TUPLE, tree ("all"), tree ("*0.7"))));
+  // sz=12 命中精确尺寸条目；sz=10 落到 all 条目
+  QVERIFY (close (env->get_script_size (12.0, 1), 6.0));
+  QVERIFY (close (env->get_script_size (10.0, 1), 7.0));
+}
+
+void
+TestEnvScriptSize::cache_growth_and_reuse () {
+  edit_env env= make_env ("default");
+  // isz=20：填充索引 0..20
+  QVERIFY (close (env->get_script_size (10.0, 0), 10.0));
+  QCOMPARE (N (env->size_cache), 21);
+  // 已缓存的尺寸不再增长
+  double s1= (5.0 * 2.0 + 2.0) / 3.0;
+  QVERIFY (close (env->get_script_size (5.0, 1), s1));
+  QCOMPARE (N (env->size_cache), 21);
+  // 半尺寸 10.5 -> isz=21，缓存继续增长
+  QVERIFY (close (env->get_script_size (10.5, 0), 10.5));
+  QCOMPARE (N (env->size_cache), 22);
+  // 重复调用结果一致
+  QVERIFY (
+      close (env->get_script_size (10.0, 1), env->get_script_size (10.0, 1)));
+}
+
+QTEST_MAIN (TestEnvScriptSize)
+#include "env_script_size_test.moc"


### PR DESCRIPTION
## Summary
- 实测 `get_script_size` 单次排版调用 97802 次、累计 228 ms（约 2.3 µs/次），其中绝大部分开销来自 `bench_start`/`bench_cumul` 埋点本身（每次调用构造 `string` + 约 8 次 `hashmap<string, uint32_t>` 哈希查找），函数体仅为 `size_cache` 的 O(1) 数组查询（约几十 ns）
- 移除 `edit_env_rep::get_script_size` 与 `script()`（被 `script_boxes`/`modifier_boxes`/`concat_animate` 等热路径直接调用）中的 bench 埋点，函数逻辑不变
- `determine_sizes` 仅在缓存填充时调用（每个字号一次），保留其埋点用于观测缓存填充成本
- 新增 `tests/Typeset/Env/env_script_size_test.cpp` 行为锁定测试（TDD：改动前全部通过）：default 尺寸表回退 `script()` 公式、tuple 尺寸表（all/精确尺寸/`*ratio`/整数项）、level 越界回退、0.5 倍数归一化、`size_cache` 增长与复用

## Test plan
- [x] `xmake r env_script_size_test`（新增 5 例全过）
- [x] `xmake r font_size_test`（19 例全过）
- [x] `xmake r smart_font_test`（20 例全过）
- [x] `xmake r env_length_test`、`xmake r table_performance_test` 全过
- [x] `xmake b stem` 构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)