### PR TITLE
[0866] 修复菜单按钮文字慢一拍

### DIFF
--- a/devel/0866.md
+++ b/devel/0866.md
@@ -4,7 +4,7 @@
 - [0853.md](0853.md) - `update_menus` 分类重建与事件优化（回归来源）
 
 ## 2 任务相关的代码文件
-- `src/Edit/Interface/edit_interface.cpp` — after_menu_action 同步全量重建改为 notify THE_MENUS
+- `src/Edit/Interface/edit_interface.cpp` — after_menu_action 与 resume 两处同步全量重建改为 notify THE_MENUS
 
 ## 3 如何测试
 
@@ -19,12 +19,13 @@ xmake r stem
 2. 同理，所有类似的菜单按钮（比如绘图区的对齐方式按钮，之前也慢一拍）都应该得到修复；
 
 ## 4 What
-- `after_menu_action` 不再同步 `update_menus(MENU_ALL)`，改为 `notify_change(THE_MENUS)`，全量重建由随后的 `apply_changes` 在排版后执行。
+- `after_menu_action`、`resume` 不再同步 `update_menus(MENU_ALL)`，均改为 `notify_change(THE_MENUS)`，全量重建由随后的 `apply_changes` 在排版后执行。
 
 ## 5 Why
 - 语言/字体等按钮文字经 `(get-env ...)` 读取 preamble 环境快照 `pre`，`pre` 仅在 `typeset_preamble()`（排版时）刷新；action（如 `change_style`）只改数据不刷 `pre`。
-- 同步重建发生在排版之前，`get-env` 读到旧快照，按钮文字慢一拍；0853 删除 idle 轮询后，排版完成后再无触发点纠正，旧值永久残留。
+- 同步重建发生在排版之前，`get-env` 读到旧快照：菜单点击场景表现为慢一拍；新建文档场景 `pre` 尚为空，落到 `default_env` 的 english，初始按钮显示「English (US)」。
+- 0853 删除 idle 轮询后，排版完成后再无触发点纠正，旧值永久残留。
 
 ## 6 How
 - `apply_changes` 的「Handling menus」段本就有 `env_change & THE_MENUS → update_menus(MENU_ALL)` 分支（原仅 full_screen 使用），位于 `typeset_invalidate_all()`/`typeset()` 之后，此时 `pre` 已刷新，按钮文字即为新值。
-- `windows_delayed_refresh(1)` 保证下一事件循环 tick 即触发 `apply_changes`，勾选态响应仍在同一帧内，不回退 0853 消除的滞后。
+- 菜单点击场景由 `windows_delayed_refresh(1)` 保证下一事件循环 tick 触发；resume 场景自身 notify 了 THE_FOCUS+THE_EXTENTS，attach 后窗口刷新必然触发 `apply_changes`。勾选态响应仍在同一帧内，不回退 0853 消除的滞后。

--- a/devel/0866.md
+++ b/devel/0866.md
@@ -1,0 +1,30 @@
+# [0866] 修复菜单按钮文字慢一拍
+
+## 1 相关文档
+- [0853.md](0853.md) - `update_menus` 分类重建与事件优化（回归来源）
+
+## 2 任务相关的代码文件
+- `src/Edit/Interface/edit_interface.cpp` — after_menu_action 同步全量重建改为 notify THE_MENUS
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 点击主界面 focus 栏的语言按钮，切换为中文，按钮文字应立即显示「中文」；
+2. 同理，所有类似的菜单按钮（比如绘图区的对齐方式按钮，之前也慢一拍）都应该得到修复；
+
+## 4 What
+- `after_menu_action` 不再同步 `update_menus(MENU_ALL)`，改为 `notify_change(THE_MENUS)`，全量重建由随后的 `apply_changes` 在排版后执行。
+
+## 5 Why
+- 语言/字体等按钮文字经 `(get-env ...)` 读取 preamble 环境快照 `pre`，`pre` 仅在 `typeset_preamble()`（排版时）刷新；action（如 `change_style`）只改数据不刷 `pre`。
+- 同步重建发生在排版之前，`get-env` 读到旧快照，按钮文字慢一拍；0853 删除 idle 轮询后，排版完成后再无触发点纠正，旧值永久残留。
+
+## 6 How
+- `apply_changes` 的「Handling menus」段本就有 `env_change & THE_MENUS → update_menus(MENU_ALL)` 分支（原仅 full_screen 使用），位于 `typeset_invalidate_all()`/`typeset()` 之后，此时 `pre` 已刷新，按钮文字即为新值。
+- `windows_delayed_refresh(1)` 保证下一事件循环 tick 即触发 `apply_changes`，勾选态响应仍在同一帧内，不回退 0853 消除的滞后。

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -1340,8 +1340,8 @@ void
 edit_interface_rep::after_menu_action () {
   notify_change (THE_DECORATIONS);
   end_editing ();
-  // 按钮 action 已执行完毕，立即全量重建
-  update_menus (MENU_ALL);
+  // 按钮 action 已执行完毕，apply_changes 排版后全量重建
+  notify_change (THE_MENUS);
   windows_delayed_refresh (1);
 }
 

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -116,7 +116,7 @@ edit_interface_rep::resume () {
   bench_start ("resume");
   got_focus= true;
   // 切 tab / 新建 / 关闭标签均经 resume 触发全量重建
-  update_menus (MENU_ALL);
+  notify_change (THE_MENUS);
   cur_sb    = 2;
   env_change= env_change & (~THE_FREEZE);
   notify_change (THE_FOCUS + THE_EXTENTS);


### PR DESCRIPTION
# [0866] 修复菜单按钮文字慢一拍

## 1 相关文档
- [0853.md](0853.md) - `update_menus` 分类重建与事件优化（回归来源）

## 2 任务相关的代码文件
- `src/Edit/Interface/edit_interface.cpp` — after_menu_action 同步全量重建改为 notify THE_MENUS

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 点击主界面 focus 栏的语言按钮，切换为中文，按钮文字应立即显示「中文」；
2. 同理，所有类似的菜单按钮（比如绘图区的对齐方式按钮，之前也慢一拍）都应该得到修复；

## 4 What
- `after_menu_action` 不再同步 `update_menus(MENU_ALL)`，改为 `notify_change(THE_MENUS)`，全量重建由随后的 `apply_changes` 在排版后执行。

## 5 Why
- 语言/字体等按钮文字经 `(get-env ...)` 读取 preamble 环境快照 `pre`，`pre` 仅在 `typeset_preamble()`（排版时）刷新；action（如 `change_style`）只改数据不刷 `pre`。
- 同步重建发生在排版之前，`get-env` 读到旧快照，按钮文字慢一拍；0853 删除 idle 轮询后，排版完成后再无触发点纠正，旧值永久残留。

## 6 How
- `apply_changes` 的「Handling menus」段本就有 `env_change & THE_MENUS → update_menus(MENU_ALL)` 分支（原仅 full_screen 使用），位于 `typeset_invalidate_all()`/`typeset()` 之后，此时 `pre` 已刷新，按钮文字即为新值。
- `windows_delayed_refresh(1)` 保证下一事件循环 tick 即触发 `apply_changes`，勾选态响应仍在同一帧内，不回退 0853 消除的滞后。
