### PR TITLE
[0868] 纸张类型改变/collab协同时，更新菜单

### DIFF
--- a/devel/0868.md
+++ b/devel/0868.md
@@ -1,0 +1,33 @@
+# [0868] 纸张类型改变/collab协同时，更新菜单
+
+## 1 相关文档
+- [0866.md](0866.md) - 修复菜单按钮文字慢一拍（THE_MENUS 推迟重建机制）
+- [0853.md](0853.md) - `update_menus` 分类重建与事件优化
+
+## 2 任务相关的代码文件
+- `src/Edit/Editor/edit_typeset.cpp` — init_env / init_default 追加 notify THE_MENUS
+- `src/Edit/Modify/edit_collab.cpp` — apply_remote_meta 有变更时追加 notify THE_MENUS
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 直接执行 Scheme `(init-page-type "b5")`（不经菜单），纸张按钮文字应立即变为 B5；
+2. collab 协同中，对端改变纸张类型或切换文档语言，本端应立即跟随；
+
+## 4 What
+- `init_env` / `init_default` 修改 env 变量时，在 `notify_change(THE_ENVIRONMENT)` 之后追加 `notify_change(THE_MENUS)`。
+- collab `apply_remote_meta` 回写远端 meta（style/initial/final/attachments/project）有变更时，追加 `notify_change(THE_MENUS)`。
+
+## 5 Why
+- 直接执行 Scheme（如 `(init-page-type "b5")`）或键盘路径不经 `after_menu_action`，`init_env` 此前只 notify THE_ENVIRONMENT，无人通知菜单重建，按钮文字（读 `init` 哈希表，数据已是新值）停留旧值。
+- collab 远端改纸张/语言走 meta section 回写：`set_init` 整体setter 绕过 `init_env`、`change_style` 只 notify THE_ENVIRONMENT，本端页面重排正常但按钮文字 stale。
+
+## 6 How
+- THE_MENUS 为幂等位，下一帧 `apply_changes` 在排版后执行 `update_menus(MENU_ALL)`（0866 建立的机制），读到新值；连续多次 init-env（如 init-page-type 三连写）合并为一次重建。
+- `init_env` 是 scheme `(init-env ...)` 的唯一 C++ 漏斗，在此处通知可覆盖 scheme/键盘/插件等所有不过 after_menu_action 的路径；`full-screen-mode` 提前 return（全屏路径自行通知 THE_MENUS）。

--- a/src/Edit/Editor/edit_typeset.cpp
+++ b/src/Edit/Editor/edit_typeset.cpp
@@ -1029,6 +1029,7 @@ edit_typeset_rep::init_env (string var, tree by) {
       var != ZOOM_FACTOR)
     require_save ();
   notify_change (THE_ENVIRONMENT);
+  notify_change (THE_MENUS);
 #ifdef LORO_ENABLED
   mirror_meta_if_active ("initial");
 #endif
@@ -1041,6 +1042,7 @@ edit_typeset_rep::init_default (string var) {
   if (stydef->contains (var)) pre (var)= stydef[var];
   else pre->reset (var);
   notify_change (THE_ENVIRONMENT);
+  notify_change (THE_MENUS);
 #ifdef LORO_ENABLED
   mirror_meta_if_active ("initial");
 #endif

--- a/src/Edit/Modify/edit_collab.cpp
+++ b/src/Edit/Modify/edit_collab.cpp
@@ -297,6 +297,7 @@ edit_main_rep::apply_remote_meta () {
   }
   if (changed) {
     notify_change (THE_ENVIRONMENT);
+    notify_change (THE_MENUS);
     typeset_invalidate_env ();
   }
 }


### PR DESCRIPTION
# [0868] 纸张类型改变/collab协同时，更新菜单

## 1 相关文档
- [0866.md](0866.md) - 修复菜单按钮文字慢一拍（THE_MENUS 推迟重建机制）
- [0853.md](0853.md) - `update_menus` 分类重建与事件优化

## 2 任务相关的代码文件
- `src/Edit/Editor/edit_typeset.cpp` — init_env / init_default 追加 notify THE_MENUS
- `src/Edit/Modify/edit_collab.cpp` — apply_remote_meta 有变更时追加 notify THE_MENUS

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 直接执行 Scheme `(init-page-type "b5")`（不经菜单），纸张按钮文字应立即变为 B5；
2. collab 协同中，对端改变纸张类型或切换文档语言，本端应立即跟随；

## 4 What
- `init_env` / `init_default` 修改 env 变量时，在 `notify_change(THE_ENVIRONMENT)` 之后追加 `notify_change(THE_MENUS)`。
- collab `apply_remote_meta` 回写远端 meta（style/initial/final/attachments/project）有变更时，追加 `notify_change(THE_MENUS)`。

## 5 Why
- 直接执行 Scheme（如 `(init-page-type "b5")`）或键盘路径不经 `after_menu_action`，`init_env` 此前只 notify THE_ENVIRONMENT，无人通知菜单重建，按钮文字（读 `init` 哈希表，数据已是新值）停留旧值。
- collab 远端改纸张/语言走 meta section 回写：`set_init` 整体setter 绕过 `init_env`、`change_style` 只 notify THE_ENVIRONMENT，本端页面重排正常但按钮文字 stale。

## 6 How
- THE_MENUS 为幂等位，下一帧 `apply_changes` 在排版后执行 `update_menus(MENU_ALL)`（0866 建立的机制），读到新值；连续多次 init-env（如 init-page-type 三连写）合并为一次重建。
- `init_env` 是 scheme `(init-env ...)` 的唯一 C++ 漏斗，在此处通知可覆盖 scheme/键盘/插件等所有不过 after_menu_action 的路径；`full-screen-mode` 提前 return（全屏路径自行通知 THE_MENUS）。
