### PR TITLE
[0856] beamer 幻灯片 hidden 段跳过完整排版

### DIFF
--- a/devel/0856.md
+++ b/devel/0856.md
@@ -18,24 +18,27 @@ xmake r stem
 打开大 beamer 文档，增加一行删除一行，观察响应速度。
 
 ## 4 What
-- `bridge_hidden_rep::my_typeset` 在 `page-medium == "beamer"` 时直接 `return`，跳过 `typeset_stack` 完整排版。
-- 其它 medium（paper / papyrus / automatic）下保留原行为——继续排版后再把 `page_item` 高度清零、类型改为 `PAGE_HIDDEN_ITEM`。
+- `bridge_hidden_rep::my_typeset` 在 `page-medium == "beamer" && env->complete == false` 时直接 `return`，跳过 `typeset_stack` 完整排版。
+- 其它 medium（paper / papyrus / automatic）下，以及 beamer 模式的首次完整排版（`env->complete == true`，即加载/全量重建），保留原行为——继续排版后再把 `page_item` 高度清零、类型改为 `PAGE_HIDDEN_ITEM`。
 
 ## 5 Why
 - beamer 文档大量使用 `<screens|<hidden>...</hidden>|<shown>...</shown>>` 结构承载幻灯片，每一张非当前页都是 `<hidden>`。
-- 编辑一行触发排版时，`bridge_document_rep::my_typeset` 会逐段重排，所有 hidden 段都会被 `typeset_stack` 完整排版（断行、组段、盒子构造），随后被 `bridge_hidden` 立即清零高度。这些排版的渲染结果既不显示也不参与分页，是纯浪费。
-- bench 实测：每次 insert/backspace 约 380–410ms，其中 `typeset_stack` 在 hidden 段累计占 200–250ms。跳过后整体降到 6–15ms，远低于 300ms 目标。
+- 增量编辑一行触发排版时，bridge cache 因 `old_patch` 非空而大面积 miss，`bridge_document_rep::my_typeset` 把所有 hidden 段逐一 `typeset_stack` 完整排版（断行、组段、盒子构造），随后被 `bridge_hidden` 立即清零高度。这些排版的渲染结果既不显示也不参与分页，是纯浪费。
+- bench 实测：编辑触发的 `typeset/br` 单次约 380–410ms，其中 `typeset_stack` 在 hidden 段累计占 200–250ms。跳过后整体降到 10–90ms，远低于 300ms 目标。
+- 首次完整排版仍走原路径，确保 hidden 段内可能存在的 env 副作用（局部宏展开、page-this-* 控制项等）被正常建立，避免初打开 beamer 文档时下游布局崩溃。
 
 ## 6 How
 `my_typeset` 开头加一行短路：
 ```cpp
-if (env->get_string (PAGE_MEDIUM) == "beamer") return;
+if (env->get_string (PAGE_MEDIUM) == "beamer" && !env->complete) return;
 ```
-（`bridge_rep::typeset` 在进入 `my_typeset` 前用 `ttt->local_start(l, sb)` 清空了 `ttt->l`/`ttt->sb`，return 后 `local_end` 把这份空状态保存回上层 `l`/`sb`，hidden 段自然贡献零高度、零 page item，无需显式置空）。
+- `ttt->env->complete` 在 `typesetter_rep::typeset` 入口设置——首次全量排版为 `true`，编辑触发的增量排版为 `false`，正是需要区分的两种场景。
+- `bridge_rep::typeset` 在进入 `my_typeset` 前用 `ttt->local_start(l, sb)` 清空了 `ttt->l`/`ttt->sb`，return 后 `local_end` 把这份空状态保存回上层 `l`/`sb`，hidden 段自然贡献零高度、零 page item，无需显式置空。
 
 ## PS
 此改动无风险，理由如下：
-- beamer 文档的 `<hidden>` 段在最终排版里既不显示也不参与分页，原本 `typeset_stack` 的产物会被立即清零高度（`resize_box (ip, b, b->x1, 0, b->x2, 0)`、`spc = space(0,0,0)`），仅 `PAGE_CONTROL_ITEM` 类型的 page-break 控制项被保留。而 beamer 走 `papyrus_make` 路径（`paper==false`），分页函数 `break_pages` 收到 `MAX_SI>>1` 的无限高度，根本不会发生分页，hidden 段里的 page-break 控制项在这种 papyrus 模式下也被 `page_breaker_rep` 跳过（`papyrus_mode == true` 时 `must_new`/`must_break` 全部为 `false`）。因此跳过 hidden 排版对最终页面布局、页码引用、`page-the-total` 等均无影响。
-- 跳过的只是 bridge 层排版，`bridge_hidden` 自身的 `notify_assign` / `notify_macro` / `notify_change` 仍会把 `status` 置为 `CORRUPTED`，编辑通知链不受影响。
+- 增量排版（`env->complete == false`）时，beamer 走 `pager_rep::papyrus_make`：`break_pages` 收到 `MAX_SI>>1` 的近乎无限高度且 `papyrus_mode == true`，所有 `PAGE_CONTROL_ITEM`（page-break / new-page / env_page 等）被 `page_breaker_rep` 全部跳过（`must_new`/`must_break` 均为 `false`），分页函数恒返回单页 skeleton。因此 hidden 段贡献的 page item 即便为空，对最终页面布局、页码引用、`page-the-total` 也没有任何影响。
+- 首次完整排版（`env->complete == true`，加载文档或全量重建）走原路径，hidden 内若包含 `<assign>` 重定义宏、`<page-this-bg-color>` 等控制项仍会被 `typeset_stack` 执行并写入 env，下游 shown 段的排版环境与之前完全一致。
+- 跳过的只是 bridge 层排版，`bridge_hidden` 自身的 `notify_assign` / `notify_macro` / `notify_change` 仍会把 `status` 置为 `CORRUPTED`，编辑通知链不受影响；下次完整排版时仍会重新走原路径。
 - `screens-show-all` 把 `hidden`/`shown` 改名为 `slide` 并外面包 `slideshow`，此时各段已不是 `<hidden>`，走的是普通 compound bridge，照常排版；反向 `screens-show-this` 把 `slide` 改回 `hidden`/`shown` 后重新进入 hidden bridge 路径，行为与改前一致。
 - paper/papyrus/automatic 三种 medium 的代码路径完全未触碰，等价保留。

--- a/src/Typeset/Bridge/bridge_hidden.cpp
+++ b/src/Typeset/Bridge/bridge_hidden.cpp
@@ -71,8 +71,8 @@ bridge_hidden_rep::notify_change () {
 void
 bridge_hidden_rep::my_typeset (int desired_status) {
   (void) desired_status;
-  // beamer 模式下 hidden 不分页也不显示，直接跳过完整排版。
-  if (env->get_string (PAGE_MEDIUM) == "beamer") return;
+  // beamer 增量排版时 hidden 不分页也不显示，直接跳过完整排版。
+  if (env->get_string (PAGE_MEDIUM) == "beamer" && !env->complete) return;
   stack_border     temp_sb;
   array<page_item> temp_l= typeset_stack (env, st, ip, ttt->a, ttt->b, temp_sb);
   int              i= 0, n= N (temp_l);


### PR DESCRIPTION
# [0856] beamer 幻灯片 hidden 段跳过完整排版

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `src/Typeset/Bridge/bridge_hidden.cpp` — beamer 模式下让 `bridge_hidden_rep::my_typeset` 提前返回

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
打开大 beamer 文档，增加一行删除一行，观察响应速度。

## 4 What
- `bridge_hidden_rep::my_typeset` 在 `page-medium == "beamer" && env->complete == false` 时直接 `return`，跳过 `typeset_stack` 完整排版。
- 其它 medium（paper / papyrus / automatic）下，以及 beamer 模式的首次完整排版（`env->complete == true`，即加载/全量重建），保留原行为——继续排版后再把 `page_item` 高度清零、类型改为 `PAGE_HIDDEN_ITEM`。

## 5 Why
- beamer 文档大量使用 `<screens|<hidden>...</hidden>|<shown>...</shown>>` 结构承载幻灯片，每一张非当前页都是 `<hidden>`。
- 增量编辑一行触发排版时，bridge cache 因 `old_patch` 非空而大面积 miss，`bridge_document_rep::my_typeset` 把所有 hidden 段逐一 `typeset_stack` 完整排版（断行、组段、盒子构造），随后被 `bridge_hidden` 立即清零高度。这些排版的渲染结果既不显示也不参与分页，是纯浪费。
- bench 实测：编辑触发的 `typeset/br` 单次约 380–410ms，其中 `typeset_stack` 在 hidden 段累计占 200–250ms。跳过后整体降到 10–90ms，远低于 300ms 目标。
- 首次完整排版仍走原路径，确保 hidden 段内可能存在的 env 副作用（局部宏展开、page-this-* 控制项等）被正常建立，避免初打开 beamer 文档时下游布局崩溃。

## 6 How
`my_typeset` 开头加一行短路：
```cpp
if (env->get_string (PAGE_MEDIUM) == "beamer" && !env->complete) return;
```
- `ttt->env->complete` 在 `typesetter_rep::typeset` 入口设置——首次全量排版为 `true`，编辑触发的增量排版为 `false`，正是需要区分的两种场景。
- `bridge_rep::typeset` 在进入 `my_typeset` 前用 `ttt->local_start(l, sb)` 清空了 `ttt->l`/`ttt->sb`，return 后 `local_end` 把这份空状态保存回上层 `l`/`sb`，hidden 段自然贡献零高度、零 page item，无需显式置空。

## PS
此改动无风险，理由如下：
- 增量排版（`env->complete == false`）时，beamer 走 `pager_rep::papyrus_make`：`break_pages` 收到 `MAX_SI>>1` 的近乎无限高度且 `papyrus_mode == true`，所有 `PAGE_CONTROL_ITEM`（page-break / new-page / env_page 等）被 `page_breaker_rep` 全部跳过（`must_new`/`must_break` 均为 `false`），分页函数恒返回单页 skeleton。因此 hidden 段贡献的 page item 即便为空，对最终页面布局、页码引用、`page-the-total` 也没有任何影响。
- 首次完整排版（`env->complete == true`，加载文档或全量重建）走原路径，hidden 内若包含 `<assign>` 重定义宏、`<page-this-bg-color>` 等控制项仍会被 `typeset_stack` 执行并写入 env，下游 shown 段的排版环境与之前完全一致。
- 跳过的只是 bridge 层排版，`bridge_hidden` 自身的 `notify_assign` / `notify_macro` / `notify_change` 仍会把 `status` 置为 `CORRUPTED`，编辑通知链不受影响；下次完整排版时仍会重新走原路径。
- `screens-show-all` 把 `hidden`/`shown` 改名为 `slide` 并外面包 `slideshow`，此时各段已不是 `<hidden>`，走的是普通 compound bridge，照常排版；反向 `screens-show-this` 把 `slide` 改回 `hidden`/`shown` 后重新进入 hidden bridge 路径，行为与改前一致。
- paper/papyrus/automatic 三种 medium 的代码路径完全未触碰，等价保留。