### PR TITLE
[0869] Ghost 接受后自动触发下一次补全

### DIFF
--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -231,6 +231,7 @@
   (ghost-remove-node! #t)
   (interrupt-shortcut)
   (ghost-feedback 'accept)
+  (trigger-ghost-text 0)
 ) ;tm-define
 
 (tm-define (reject-ghost)

--- a/devel/0869.md
+++ b/devel/0869.md
@@ -1,0 +1,21 @@
+# [0869] Ghost 接受后自动触发下一次补全
+
+## 1 相关文档
+- [0860.md](0860.md) - Ghost 自动补全
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/ghost-text.scm` — 按右方向键且光标未移动时立即触发 ghost
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在用户接受一次 ghost 补全后，自动触发下一次 ghost 补全；
+
+## 4 What
+- 按右方向键且光标未移动时，立即触发 Ghost 自动补全（即 `(trigger-ghost-text 0)`）。


### PR DESCRIPTION
# [0869] Ghost 接受后自动触发下一次补全

## 1 相关文档
- [0860.md](0860.md) - Ghost 自动补全

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/ghost-text.scm` — 按右方向键且光标未移动时立即触发 ghost

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在用户接受一次 ghost 补全后，自动触发下一次 ghost 补全；

## 4 What
- 按右方向键且光标未移动时，立即触发 Ghost 自动补全（即 `(trigger-ghost-text 0)`）。
