### PR TITLE
[2080] 使用 QML 重构版本弹窗

### DIFF
--- a/TeXmacs/progs/doc/help-funcs.scm
+++ b/TeXmacs/progs/doc/help-funcs.scm
@@ -232,6 +232,14 @@
   ) ;with
 ) ;define
 
+(define (show-version-dialog msg url open-website?)
+  (when (cpp-version-dialog (translate "Version") msg)
+    (when open-website?
+      (open-url url)
+    ) ;when
+  ) ;when
+) ;define
+
 ;; 显示Mogan版本信息
 (tm-define (mogan-version)
   (let* ((cur-ver (xmacs-version))
@@ -250,20 +258,22 @@
     (if community?
       ;; 社区版：同时展示社区版和商业版的最新稳定版
       (let ((msg (if community-latest?
-                   (replace (string-append "You are using v%1.\n"
-                              "The latest stable version of Mogan STEM is v%2, "
-                              "and the latest stable version of Liii STEM is v%3."
-                            ) ;string-append
+                   (replace (translate (string-append "You are using v%1.\n"
+                                         "The latest stable version of Mogan STEM is v%2, "
+                                         "and the latest stable version of Liii STEM is v%3."
+                                       ) ;string-append
+                            ) ;translate
                      cur-ver
                      community-ver
                      commercial-ver
                    ) ;replace
-                   (replace (string-append "You are using v%1.\n"
-                              "The latest stable version of Mogan STEM is v%2, "
-                              "and the latest stable version of Liii STEM is v%3.\n"
-                              "Please click OK to visit the official website "
-                              "to download the latest stable version."
-                            ) ;string-append
+                   (replace (translate (string-append "You are using v%1.\n"
+                                         "The latest stable version of Mogan STEM is v%2, "
+                                         "and the latest stable version of Liii STEM is v%3.\n"
+                                         "Please click OK to visit the official website "
+                                         "to download the latest stable version."
+                                       ) ;string-append
+                            ) ;translate
                      cur-ver
                      community-ver
                      commercial-ver
@@ -271,31 +281,27 @@
                  ) ;if
             ) ;msg
            ) ;
-        (if community-latest?
-          (show-message msg (translate "Version"))
-          (show-message-with-callback msg (translate "Version") (lambda x (open-url url)))
-        ) ;if
+        (show-version-dialog msg url (not community-latest?))
       ) ;let
       ;; 商业版：只展示商业版的最新稳定版
       (let ((msg (if commercial-latest?
-                   (replace "You are using v%1, and the latest stable version of Liii STEM is v%2."
+                   (replace (translate "You are using v%1, and the latest stable version of Liii STEM is v%2."
+                            ) ;translate
                      cur-ver
                      commercial-ver
                    ) ;replace
-                   (replace (string-append "You are using v%1, and the latest stable version of Liii STEM is v%2.\n"
-                              "Please click OK to visit the official website "
-                              "to download the latest stable version."
-                            ) ;string-append
+                   (replace (translate (string-append "You are using v%1, and the latest stable version of Liii STEM is v%2.\n"
+                                         "Please click OK to visit the official website "
+                                         "to download the latest stable version."
+                                       ) ;string-append
+                            ) ;translate
                      cur-ver
                      commercial-ver
                    ) ;replace
                  ) ;if
             ) ;msg
            ) ;
-        (if commercial-latest?
-          (show-message msg (translate "Version"))
-          (show-message-with-callback msg (translate "Version") (lambda x (open-url url)))
-        ) ;if
+        (show-version-dialog msg url (not commercial-latest?))
       ) ;let
     ) ;if
   ) ;let*

--- a/TeXmacs/progs/prog/glue-symbols.scm
+++ b/TeXmacs/progs/prog/glue-symbols.scm
@@ -734,6 +734,7 @@
     "cpp-paragraph-format-dialog"
     "cpp-preferences-dialog"
     "cpp-statistics-dialog"
+    "cpp-version-dialog"
     "cpp-rasterize-widget"
     "kill-window"
     "kill-current-window-and-buffer"

--- a/TeXmacs/tests/2080.scm
+++ b/TeXmacs/tests/2080.scm
@@ -1,0 +1,26 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 2080.scm
+;; DESCRIPTION : 「帮助 -> 版本」QML 对话框数据契约测试
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(define (test-version-dialog-contract)
+  (system-setenv "MOGAN_TEST_VERSION_DIALOG" "ok")
+  (check (cpp-version-dialog "Version" "Version information") => #t)
+
+  (system-setenv "MOGAN_TEST_VERSION_DIALOG" "cancel")
+  (check (cpp-version-dialog "Version" "Version information") => #f)
+
+  (system-setenv "MOGAN_TEST_VERSION_DIALOG" "")
+) ;define
+
+(tm-define (test_2080) (test-version-dialog-contract) (check-report))

--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -991,6 +991,7 @@
       <button class="nav-btn" data-target="font">FontSelector.qml</button>
       <button class="nav-btn" data-target="paragraph">ParagraphFormat.qml</button>
       <button class="nav-btn" data-target="statistics">Statistics.qml</button>
+      <button class="nav-btn" data-target="version">Version.qml</button>
       <button class="nav-btn" data-target="preferences">Preferences.qml</button>
       <button class="nav-btn" data-target="confirmRestart">ConfirmRestart.qml</button>
       <div class="sidebar-foot">模拟目标: DialogShell / DialogButtons / EnumCombo / SelectableList / PreviewPane 组合逻辑。</div>
@@ -1321,6 +1322,24 @@
           <code>onClicked -> closeBridge.choose(0)</code>
         </p>
       </section>
+      <section class="panel" id="panel-version">
+        <article class="dialog" style="max-width: 560px;">
+          <h3>Version</h3>
+          <p style="text-align: left; line-height: 1.55; margin: 0;">
+            You are using v2026.2.6.<br>
+            The latest stable version of Mogan STEM is v2026.2.6, and the latest stable version of Liii STEM is v2026.2.6.<br>
+            Please click OK to visit the official website to download the latest stable version.
+          </p>
+          <div class="btn-row" style="margin-top: 20px;">
+            <button class="btn primary" data-log="Version: closeBridge.choose(1)">OK</button>
+          </div>
+        </article>
+        <p class="legend">
+          对应 QML: <code>versionTitle + versionLines + dialogButtons</code>
+          <code>onClicked -> closeBridge.choose(index + 1)</code>
+          <code>Scheme 根据确认结果决定是否打开官网</code>
+        </p>
+      </section>
       <section class="panel" id="panel-preferences">
         <article class="pref-shell">
           <div class="pref-tabs">
@@ -1590,11 +1609,13 @@
         font: document.getElementById('panel-font'),
         paragraph: document.getElementById('panel-paragraph'),
         statistics: document.getElementById('panel-statistics'),
+        version: document.getElementById('panel-version'),
         preferences: document.getElementById('panel-preferences'),
         confirmRestart: document.getElementById('panel-confirm-restart')
       };
 
       const titleMap = {
+        version: 'Version.qml preview',
         confirm: 'ConfirmClose.qml 模拟',
         form: 'FormDialog.qml 模拟',
         font: 'FontSelector.qml 模拟',
@@ -1605,6 +1626,7 @@
       };
 
       const codeMap = {
+        version: 'versionTitle + versionLines + closeBridge.choose(1)',
         confirm: 'dialogMessage + dialogButtons + closeBridge.choose()',
         form: 'formFields + values 收集 + closeBridge.submit(values)',
         font: 'fontBridge 联动: family/style/filter/customize/preview',

--- a/devel/2080.md
+++ b/devel/2080.md
@@ -1,0 +1,25 @@
+# 2080 使用 QML 重构版本弹窗
+
+## What
+
+将“帮助 -> 版本”弹窗由 Scheme 消息框迁移为 `Version.qml`，保留既有版本检查和有更新时跳转官网的业务语义。
+
+## Why
+
+复用 `DialogShell` 与 `DialogButtons` 的 QML 对话框风格，并由 Scheme 按句末组织版本提示，避免自动换行破坏版本号或句末标点。
+
+## How
+
+1. 新增 `Version.qml`，在其中定义 `560 x 220` 的弹窗尺寸，并登记到 `qml/qmldir` 和 `moganqml.qrc`。
+2. 新增 `cpp-version-dialog` glue，将已翻译的标题、句子列表和按钮传入 QML。
+3. 新增 QML 加载、尺寸、Esc 取消及 Scheme/C++ 返回值契约测试。
+
+## Tests
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+xmake r 2080
+xmake b qml_load_test
+xmake r qml_load_test
+```

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -14,8 +14,9 @@
 #include "QTMQmlDialogBridge.hpp"
 #include "QTMQmlDialogInternal.hpp"
 
-#include "analyze.hpp" // occurs
-#include "gui.hpp"     // tm_style_sheet
+#include "analyze.hpp"   // occurs
+#include "converter.hpp" // cork_to_utf8
+#include "gui.hpp"       // tm_style_sheet
 #include "qt_utilities.hpp"
 #include "s7_tm.hpp"     // eval_scheme
 #include "sys_utils.hpp" // lolly: get_env
@@ -63,6 +64,19 @@ translate_buttons (array<string> buttons) {
   for (int i= 0; i < N (buttons); i++)
     out << qt_translate (buttons[i]);
   return out;
+}
+
+static QStringList
+version_message_lines (const string& message) {
+  QStringList lines;
+  int         start= 0;
+  for (int i= 0; i < N (message); i++) {
+    if (message[i] != '\n') continue;
+    lines << utf8_to_qstring (cork_to_utf8 (message (start, i)));
+    start= i + 1;
+  }
+  lines << utf8_to_qstring (cork_to_utf8 (message (start, N (message))));
+  return lines;
 }
 
 /**
@@ -553,6 +567,31 @@ cpp_statistics_dialog (string title, tree items) {
                           &QObject::deleteLater);
       },
       380, 300);
+}
+
+bool
+cpp_version_dialog (string title, string message) {
+  string preset= get_env ("MOGAN_TEST_VERSION_DIALOG");
+  if (preset == "ok") return true;
+  if (preset == "cancel") return false;
+
+  array<string> buttons;
+  buttons << string ("OK");
+  QmlDialogBridge* bridge= nullptr;
+  int              choice= run_qml_dialog (
+      "qrc:/qml/Version.qml", "Version.qml",
+      [&] (QQuickWidget* qw, QDialog& host) {
+        bridge= inject_common_context (qw, host);
+        qw->rootContext ()->setContextProperty (
+            "versionTitle", utf8_to_qstring (cork_to_utf8 (title)));
+        qw->rootContext ()->setContextProperty (
+            "versionLines", version_message_lines (message));
+        qw->rootContext ()->setContextProperty ("dialogButtons",
+                                                             translate_buttons (buttons));
+      },
+      560, 220);
+  delete bridge;
+  return choice == 1;
 }
 
 /**

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -187,7 +187,12 @@ tree cpp_paragraph_format_dialog (int specs_key);
 void cpp_statistics_dialog (string title, tree items);
 
 /**
- * @brief Version QML dialog glue entry.
+ * @brief 显示版本 QML 对话框。
+ *
+ * @param title 已翻译的对话框标题。
+ * @param message 已翻译的版本提示，换行会拆为独立 QML 文本行。
+ * @return 确认返回 true；取消、关闭或加载失败返回 false。
+ * @note MOGAN_TEST_VERSION_DIALOG 用于测试。
  */
 bool cpp_version_dialog (string title, string message);
 

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -187,6 +187,11 @@ tree cpp_paragraph_format_dialog (int specs_key);
 void cpp_statistics_dialog (string title, tree items);
 
 /**
+ * @brief Version QML dialog glue entry.
+ */
+bool cpp_version_dialog (string title, string message);
+
+/**
  * @brief 首选项 QML 对话框的 glue 入口（本地暂存 + OK 一次性提交）。
  * @return 非阻塞 show 路径立即返回空 tree；测试钩子命中时返回 `(tuple "ok")` 供
  * 自动化区分。本地暂存模型：打开时拉一次 meta 建 QML 本地 values 快照、改动只改

--- a/src/Plugins/Qt/moganqml.qrc
+++ b/src/Plugins/Qt/moganqml.qrc
@@ -21,5 +21,6 @@
         <file>qml/ParagraphFormat.qml</file>
         <file>qml/Statistics.qml</file>
         <file>qml/Preferences.qml</file>
+        <file>qml/Version.qml</file>
     </qresource>
 </RCC>

--- a/src/Plugins/Qt/qml/Version.qml
+++ b/src/Plugins/Qt/qml/Version.qml
@@ -1,0 +1,72 @@
+// Version.qml -- 「帮助 -> 版本」模态弹窗。
+//
+// Scheme 侧负责翻译和组织 versionMessage；本组件仅渲染文本并回传确认结果。
+
+import QtQuick
+import "atoms"
+
+DialogShell {
+    id: root
+    implicitWidth: 560
+    implicitHeight: 220
+    implicitMargins: Theme.margin
+
+    property string title: typeof versionTitle !== "undefined" ? versionTitle : ""
+    property var lines: typeof versionLines !== "undefined" ? versionLines : []
+    property var buttonLabels: typeof dialogButtons !== "undefined" ? dialogButtons : []
+
+    onActivate: () => closeBridge.choose(1)
+    Component.onCompleted: forceActiveFocus()
+
+    content: Item {
+        Column {
+            id: body
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.right: parent.right
+            width: parent.width
+            spacing: Theme.pad
+
+            Text {
+                width: body.width
+                text: root.title
+                color: Theme.fg
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 18 * Theme.scaleFactor
+                font.weight: Font.Bold
+                elide: Text.ElideRight
+            }
+
+            Column {
+                id: messageLines
+                objectName: "versionMessageLines"
+                width: parent.width
+                spacing: Theme.gapS
+
+                Repeater {
+                    model: root.lines
+
+                    Text {
+                        required property string modelData
+                        objectName: "versionMessageLine"
+                        width: messageLines.width
+                        text: modelData
+                        color: Theme.fg
+                        horizontalAlignment: Text.AlignLeft
+                        wrapMode: Text.NoWrap
+                        font.pixelSize: Theme.fontBody
+                        lineHeight: 1.35
+                    }
+                }
+            }
+
+            DialogButtons {
+                anchors.horizontalCenter: parent.horizontalCenter
+                buttonLabels: root.buttonLabels
+                onClicked: function (index) {
+                    closeBridge.choose(index + 1);
+                }
+            }
+        }
+    }
+}

--- a/src/Plugins/Qt/qml/qmldir
+++ b/src/Plugins/Qt/qml/qmldir
@@ -5,3 +5,4 @@ FontSelector 1.0 FontSelector.qml
 ParagraphFormat 1.0 ParagraphFormat.qml
 Statistics 1.0 Statistics.qml
 Preferences 1.0 Preferences.qml
+Version 1.0 Version.qml

--- a/src/Scheme/L5/glue_qt.lua
+++ b/src/Scheme/L5/glue_qt.lua
@@ -84,6 +84,15 @@ function main()
                 }
             },
             {
+                scm_name = "cpp-version-dialog",
+                cpp_name = "cpp_version_dialog",
+                ret_type = "bool",
+                arg_list = {
+                    "string",
+                    "string"
+                }
+            },
+            {
                 scm_name = "cpp-preferences-dialog",
                 cpp_name = "cpp_preferences_dialog",
                 ret_type = "tree",

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -31,8 +31,9 @@ class StubBridge : public QObject {
   Q_OBJECT
 public:
   explicit StubBridge (QObject* p= nullptr) : QObject (p) {}
+  int              cancelCount= 0;
   Q_INVOKABLE void choose (int) {}
-  Q_INVOKABLE void cancel () {}
+  Q_INVOKABLE void cancel () { ++cancelCount; }
   Q_INVOKABLE void submit (const QVariantMap&) {}
   Q_INVOKABLE void startMove () {}
 };
@@ -184,6 +185,8 @@ private slots:
   void test_font_selector_loads ();
   void test_paragraph_format_loads ();
   void test_preferences_loads ();
+  void test_version_loads ();
+  void test_version_escape_cancels ();
   void test_statistics_loads ();
 };
 
@@ -334,12 +337,61 @@ TestQmlLoad::test_statistics_loads () {
   QCOMPARE (qw->status (), QQuickWidget::Ready);
 }
 
-#ifdef QTTEXMACS
-QTEST_MAIN (TestQmlLoad)
-#else
-int
-main () {
-  return 0;
+void
+TestQmlLoad::test_version_loads () {
+  QStringList buttons;
+  buttons << "OK";
+
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge* bridge= new StubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->rootContext ()->setContextProperty ("versionTitle", QString ("Version"));
+  QStringList lines;
+  lines << "You are using v2026.2.6."
+        << "The latest stable version is v2026.2.6.";
+  qw->rootContext ()->setContextProperty ("versionLines", lines);
+  qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
+  qw->setSource (QUrl ("qrc:/qml/Version.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  QCOMPARE (qw->rootObject ()->implicitWidth (), 560.0);
+  QCOMPARE (qw->rootObject ()->implicitHeight (), 220.0);
+  QQuickItem* messageLines=
+      qw->rootObject ()->findChild<QQuickItem*> ("versionMessageLines");
+  QVERIFY (messageLines);
+  int messageLineCount= 0;
+  for (QQuickItem* item : messageLines->childItems ())
+    if (item->objectName () == "versionMessageLine") ++messageLineCount;
+  QCOMPARE (messageLineCount, lines.size ());
 }
-#endif
+
+void
+TestQmlLoad::test_version_escape_cancels () {
+  QStringList buttons;
+  buttons << "OK";
+
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge* bridge= new StubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->rootContext ()->setContextProperty ("versionTitle", QString ("Version"));
+  QStringList lines;
+  lines << "Version information";
+  qw->rootContext ()->setContextProperty ("versionLines", lines);
+  qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
+  qw->setSource (QUrl ("qrc:/qml/Version.qml"));
+  host.show ();
+
+  QTRY_VERIFY (qw->rootObject ()->hasActiveFocus ());
+  QTest::keyClick (qw, Qt::Key_Escape);
+  QCOMPARE (bridge->cancelCount, 1);
+}
+
+QTEST_MAIN (TestQmlLoad)
 #include "qml_load_test.moc"


### PR DESCRIPTION
## What

- 将“帮助 -> 版本”弹窗迁移为 QML 实现，保留既有版本检查及官方下载跳转逻辑。
- 统一从 Scheme 按句末拆分版本提示，避免 QML 自动换行产生多余标点。
- 新增版本弹窗的 QML 加载、尺寸、Esc 取消和 Scheme glue 测试。

## How

- 新增 `Version.qml`，复用 `DialogShell` 与 `DialogButtons`，并在页面内定义弹窗尺寸。
- 新增 `cpp-version-dialog` glue，将已翻译文案与按钮传入 QML。
- 注册 QML 资源，不改动 `Theme.qml` 或其他弹窗的基础尺寸约定。

## Tests

- `gf fmt --changed-since=main`
- 改动区段 `clang-format --dry-run --Werror`
- `git diff --check`
- `xmake build stem`
- `xmake run 2080`
- `qml_load_test`（11 passed）