### PR TITLE
[2082] 首页打开文档默认目录

### DIFF
--- a/devel/2082.md
+++ b/devel/2082.md
@@ -1,0 +1,26 @@
+# [2082] 首页打开文档默认目录
+
+## 相关文档
+- [Issue #4140](https://github.com/MoganLab/mogan/issues/4140) - PDF 导出和预览默认目录
+
+## 任务相关的代码文件
+- `src/Plugins/Qt/QTMHomePage.cpp`
+
+## 如何测试
+```powershell
+xmake b stem
+xmake run stem
+```
+
+在首页选择“打开文档”，确认文件选择器初始目录为 `Documents/LiiiSTEM`；目录不存在时应自动创建。
+
+## 2026/08/04 首页打开文档默认目录
+
+### What
+首页“打开文档”文件选择器默认打开 `Documents/LiiiSTEM`。
+
+### Why
+首页入口不应因最近文档或空白文档状态而打开不同目录。
+
+### How
+使用 Qt 的 Documents 位置构造 `LiiiSTEM` 目录，必要时创建该目录，并将其作为文件选择器的初始路径。

--- a/src/Plugins/Qt/QTMHomePage.cpp
+++ b/src/Plugins/Qt/QTMHomePage.cpp
@@ -29,6 +29,7 @@
 #include <QPointer>
 #include <QPushButton>
 #include <QResizeEvent>
+#include <QStandardPaths>
 #include <QStringList>
 #include <QStyleOption>
 #include <QTimer>
@@ -746,16 +747,17 @@ QTMHomePage::createDocumentWithStyle (const QString& styleId) {
   }
 
   if (styleId == "open") {
-    if (!recentDocs_.isEmpty ()) {
-      QString dir= QFileInfo (recentDocs_.first ().filePath).absolutePath ();
-      eval_scheme (
-          "(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
-          "(system->url " *
-          qt_scheme_quote_utf8 (dir) * "))");
+    QString docsDir=
+        QStandardPaths::writableLocation (QStandardPaths::DocumentsLocation);
+    if (docsDir.isEmpty ()) {
+      docsDir= QStandardPaths::writableLocation (QStandardPaths::HomeLocation);
     }
-    else {
-      eval_scheme ("(open-document)");
-    }
+    docsDir= QDir (docsDir).filePath ("LiiiSTEM");
+    if (!QDir (docsDir).exists ()) QDir ().mkpath (docsDir);
+
+    eval_scheme ("(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
+                 "(system->url " *
+                 qt_scheme_quote_utf8 (docsDir) * "))");
     return;
   }
 


### PR DESCRIPTION
## What
- 首页“打开文档”默认打开 `Documents/LiiiSTEM`。
- 目录不存在时自动创建。

## Why
- 首页入口不再受最近文档目录或空白文档状态影响。

## Test
- `gf fmt --changed-since=main`
- `clang-format --dry-run --Werror src/Plugins/Qt/QTMHomePage.cpp`
- `xmake b -y stem`