### PR TITLE
[2080] 版本弹窗改用桥接模式

### DIFF
--- a/devel/2080.md
+++ b/devel/2080.md
@@ -1,5 +1,32 @@
 # 2080 使用 QML 重构版本弹窗
 
+## 2026/08/03 版本弹窗桥接重构
+
+### What
+
+将版本弹窗的标题、文本行、按钮标签与确认动作收敛到
+`VersionDialogBridge`，QML 不再读取多个独立的 context property。
+
+### Why
+
+让版本弹窗遵循其他 QML 对话框的 bridge 模式，明确 C++ 到 QML 的数据与
+交互边界，并避免新增属性继续分散在对话框 glue 中。
+
+### How
+
+1. 新增只读 `VersionDialogBridge`，复用 `QmlDialogBridge` 的关闭、取消和
+   窗口拖动行为。
+2. 在 `cpp_version_dialog` 注入同一个对象为 `closeBridge` 和
+   `versionBridge`；前者供 `DialogShell` 使用，后者供版本弹窗读取模型和确认。
+3. 更新 QML 加载测试的专用 bridge 桩，验证属性绑定、文本行渲染与 Esc 取消。
+
+### 涉及文件
+
+- `src/Plugins/Qt/VersionDialogBridge.hpp`
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `src/Plugins/Qt/qml/Version.qml`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+
 ## What
 
 将“帮助 -> 版本”弹窗由 Scheme 消息框迁移为 `Version.qml`，保留既有版本检查和有更新时跳转官网的业务语义。
@@ -18,7 +45,9 @@
 
 ```bash
 gf fmt --changed-since=main
+clang-format --dry-run --Werror -- src/Plugins/Qt/VersionDialogBridge.hpp src/Plugins/Qt/QTMQmlDialog.cpp tests/Plugins/Qt/qml_load_test.cpp
 xmake b stem
+xmake install stem
 xmake r 2080
 xmake b qml_load_test
 xmake r qml_load_test

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -13,6 +13,7 @@
 #include "PreferencesBridge.hpp"
 #include "QTMQmlDialogBridge.hpp"
 #include "QTMQmlDialogInternal.hpp"
+#include "VersionDialogBridge.hpp"
 
 #include "analyze.hpp"   // occurs
 #include "converter.hpp" // cork_to_utf8
@@ -123,14 +124,19 @@ setup_frameless_qml_host (QDialog& d) {
  * QObject parent，不会被宿主 QDialog 析构带走，以便 form 型 exec 后取
  * results()）。
  */
-static QmlDialogBridge*
-inject_common_context (QQuickWidget* qw, QDialog& host) {
+static void
+inject_common_context_properties (QQuickWidget* qw, QObject* close_bridge) {
   bool isDark=
       occurs ("dark", tm_style_sheet) || occurs ("liii-night", tm_style_sheet);
-  QmlDialogBridge* bridge= new QmlDialogBridge (&host);
-  qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("closeBridge", close_bridge);
   qw->rootContext ()->setContextProperty ("dpScale", DpiUtils::scaleFactor ());
   qw->rootContext ()->setContextProperty ("isDark", isDark);
+}
+
+static QmlDialogBridge*
+inject_common_context (QQuickWidget* qw, QDialog& host) {
+  QmlDialogBridge* bridge= new QmlDialogBridge (&host);
+  inject_common_context_properties (qw, bridge);
   return bridge;
 }
 
@@ -577,17 +583,15 @@ cpp_version_dialog (string title, string message) {
 
   array<string> buttons;
   buttons << string ("OK");
-  QmlDialogBridge* bridge= nullptr;
-  int              choice= run_qml_dialog (
+  VersionDialogBridge* bridge= nullptr;
+  int                  choice= run_qml_dialog (
       "qrc:/qml/Version.qml", "Version.qml",
       [&] (QQuickWidget* qw, QDialog& host) {
-        bridge= inject_common_context (qw, host);
-        qw->rootContext ()->setContextProperty (
-            "versionTitle", utf8_to_qstring (cork_to_utf8 (title)));
-        qw->rootContext ()->setContextProperty (
-            "versionLines", version_message_lines (message));
-        qw->rootContext ()->setContextProperty ("dialogButtons",
-                                                             translate_buttons (buttons));
+        bridge= new VersionDialogBridge (
+            &host, utf8_to_qstring (cork_to_utf8 (title)),
+            version_message_lines (message), translate_buttons (buttons));
+        inject_common_context_properties (qw, bridge);
+        qw->rootContext ()->setContextProperty ("versionBridge", bridge);
       },
       560, 220);
   delete bridge;

--- a/src/Plugins/Qt/VersionDialogBridge.hpp
+++ b/src/Plugins/Qt/VersionDialogBridge.hpp
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * MODULE      : VersionDialogBridge.hpp
+ * DESCRIPTION : Data and actions exposed to the Version QML dialog.
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+#ifndef VERSION_DIALOG_BRIDGE_HPP
+#define VERSION_DIALOG_BRIDGE_HPP
+
+#include "QTMQmlDialogBridge.hpp"
+
+#include <QString>
+#include <QStringList>
+
+class VersionDialogBridge : public QmlDialogBridge {
+  Q_OBJECT
+  Q_PROPERTY (QString title READ title CONSTANT)
+  Q_PROPERTY (QStringList lines READ lines CONSTANT)
+  Q_PROPERTY (QStringList buttonLabels READ buttonLabels CONSTANT)
+
+public:
+  VersionDialogBridge (QDialog* host, const QString& title,
+                       const QStringList& lines,
+                       const QStringList& button_labels)
+      : QmlDialogBridge (host), m_title (title), m_lines (lines),
+        m_buttonLabels (button_labels) {}
+
+  QString     title () const { return m_title; }
+  QStringList lines () const { return m_lines; }
+  QStringList buttonLabels () const { return m_buttonLabels; }
+
+  Q_INVOKABLE void confirm () { choose (QDialog::Accepted); }
+
+private:
+  QString     m_title;
+  QStringList m_lines;
+  QStringList m_buttonLabels;
+};
+
+#endif // defined VERSION_DIALOG_BRIDGE_HPP

--- a/src/Plugins/Qt/qml/Version.qml
+++ b/src/Plugins/Qt/qml/Version.qml
@@ -11,11 +11,11 @@ DialogShell {
     implicitHeight: 220
     implicitMargins: Theme.margin
 
-    property string title: typeof versionTitle !== "undefined" ? versionTitle : ""
-    property var lines: typeof versionLines !== "undefined" ? versionLines : []
-    property var buttonLabels: typeof dialogButtons !== "undefined" ? dialogButtons : []
+    property string title: versionBridge.title
+    property var lines: versionBridge.lines
+    property var buttonLabels: versionBridge.buttonLabels
 
-    onActivate: () => closeBridge.choose(1)
+    onActivate: () => versionBridge.confirm()
     Component.onCompleted: forceActiveFocus()
 
     content: Item {
@@ -63,9 +63,7 @@ DialogShell {
             DialogButtons {
                 anchors.horizontalCenter: parent.horizontalCenter
                 buttonLabels: root.buttonLabels
-                onClicked: function (index) {
-                    closeBridge.choose(index + 1);
-                }
+                onClicked: versionBridge.confirm()
             }
         }
     }

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -38,6 +38,27 @@ public:
   Q_INVOKABLE void startMove () {}
 };
 
+class VersionStubBridge : public QObject {
+  Q_OBJECT
+  Q_PROPERTY (QString title READ title CONSTANT)
+  Q_PROPERTY (QStringList lines READ lines CONSTANT)
+  Q_PROPERTY (QStringList buttonLabels READ buttonLabels CONSTANT)
+
+public:
+  explicit VersionStubBridge (QObject* p= nullptr) : QObject (p) {}
+  QString     title () const { return QString ("Version"); }
+  QStringList lines () const {
+    return {"You are using v2026.2.6.",
+            "The latest stable version is v2026.2.6."};
+  }
+  QStringList buttonLabels () const { return {"OK"}; }
+
+  int              cancelCount= 0;
+  Q_INVOKABLE void confirm () {}
+  Q_INVOKABLE void cancel () { ++cancelCount; }
+  Q_INVOKABLE void startMove () {}
+};
+
 // live 弹窗（FontSelector / ParagraphFormat）bridge 占位：加载阶段 QML 顶层会调
 // 一批 uiLabels/meta/currentXxx/requestXxx 取初始值，桩统一返回空（空串/空
 // list/空 map）， 仅保证文档能实例化、不验证交互语义。
@@ -339,22 +360,14 @@ TestQmlLoad::test_statistics_loads () {
 
 void
 TestQmlLoad::test_version_loads () {
-  QStringList buttons;
-  buttons << "OK";
-
-  QDialog       host;
-  QQuickWidget* qw= new QQuickWidget (&host);
+  QDialog            host;
+  QQuickWidget*      qw    = new QQuickWidget (&host);
+  VersionStubBridge* bridge= new VersionStubBridge (qw);
   qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
-  StubBridge* bridge= new StubBridge (qw);
   qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("versionBridge", bridge);
   qw->rootContext ()->setContextProperty ("dpScale", 1.0);
   qw->rootContext ()->setContextProperty ("isDark", false);
-  qw->rootContext ()->setContextProperty ("versionTitle", QString ("Version"));
-  QStringList lines;
-  lines << "You are using v2026.2.6."
-        << "The latest stable version is v2026.2.6.";
-  qw->rootContext ()->setContextProperty ("versionLines", lines);
-  qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
   qw->setSource (QUrl ("qrc:/qml/Version.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
   QCOMPARE (qw->rootObject ()->implicitWidth (), 560.0);
@@ -365,26 +378,19 @@ TestQmlLoad::test_version_loads () {
   int messageLineCount= 0;
   for (QQuickItem* item : messageLines->childItems ())
     if (item->objectName () == "versionMessageLine") ++messageLineCount;
-  QCOMPARE (messageLineCount, lines.size ());
+  QCOMPARE (messageLineCount, bridge->lines ().size ());
 }
 
 void
 TestQmlLoad::test_version_escape_cancels () {
-  QStringList buttons;
-  buttons << "OK";
-
-  QDialog       host;
-  QQuickWidget* qw= new QQuickWidget (&host);
+  QDialog            host;
+  QQuickWidget*      qw    = new QQuickWidget (&host);
+  VersionStubBridge* bridge= new VersionStubBridge (qw);
   qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
-  StubBridge* bridge= new StubBridge (qw);
   qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("versionBridge", bridge);
   qw->rootContext ()->setContextProperty ("dpScale", 1.0);
   qw->rootContext ()->setContextProperty ("isDark", false);
-  qw->rootContext ()->setContextProperty ("versionTitle", QString ("Version"));
-  QStringList lines;
-  lines << "Version information";
-  qw->rootContext ()->setContextProperty ("versionLines", lines);
-  qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
   qw->setSource (QUrl ("qrc:/qml/Version.qml"));
   host.show ();
 


### PR DESCRIPTION
## What

- 将版本弹窗的 QML 模型与交互收敛到专用 VersionDialogBridge。
- 保持既有 Scheme glue、阻塞模态、Esc 取消和窗口拖动语义。

## How

- VersionDialogBridge 继承 QmlDialogBridge，提供只读标题、文本行、按钮标签和 confirm 动作。
- cpp_version_dialog 将同一个 bridge 注入为 closeBridge 与 versionBridge，DialogShell 和 Version.qml 分别使用各自的协议。
- 更新 QML 加载测试的专用 bridge 桩，覆盖属性绑定、文本行渲染和 Esc 取消。

## Tests

- gf fmt --changed-since=main
- clang-format --dry-run --Werror
- git diff --check
- xmake build qml_load_test
- xmake run qml_load_test
- xmake build stem
- xmake install stem
- xmake run 2080 (2 correct, 0 failed)