### PR TITLE
[2081] 修复数学模式下字母 T 的 Tab 循环问题

### DIFF
--- a/devel/2081.md
+++ b/devel/2081.md
@@ -1,0 +1,40 @@
+# [2081] 修复数学模式下字母 T 的 Tab 循环问题
+
+## 相关文档
+
+- [Issue #3030](https://github.com/MoganLab/mogan/issues/3030) - 问题描述
+- [PR #2805](https://github.com/MoganLab/mogan/pull/2805) - `box_widget` 字体渲染方式参考
+
+## 任务相关的代码文件
+
+- `src/Texmacs/Window/tm_button.cpp`
+
+## 如何测试
+
+1. 进入数学模式并输入 `T`。
+2. 连续按 `Tab` 浏览全部候选。
+3. 确认最后两个候选显示为完整符号，而不是红色的内部符号名称。
+4. 确认选中最后两个候选后，插入结果与候选预览一致。
+
+## 如何提交
+
+```bash
+gf fmt --changed-since=main
+xmake build smart_font_test
+xmake build stem
+git diff --check
+```
+
+## 2026/08/03 修复组合乘号候选的显示异常
+
+### What
+
+修复 Tab 循环菜单中 `<lefttimesthree>` 和 `<righttimesthree>` 的渲染。
+
+### Why
+
+Tab 循环菜单默认使用传统数学字体渲染候选。这两个组合符号只在智能字体模拟层中定义，因此默认字体会回退为红色的内部名称。
+
+### How
+
+参考 #2805，让 `box_widget` 使用智能字体渲染数学候选。针对 `<lefttimesthree>` 和 `<righttimesthree>`，在同一条预览渲染路径上适当增大字号并下移字形，使同组候选在视觉上大小、基线协调。

--- a/src/Texmacs/Window/tm_button.cpp
+++ b/src/Texmacs/Window/tm_button.cpp
@@ -253,9 +253,12 @@ box_widget (scheme_tree p, string s, color col, bool trans, bool ink) {
   if ((n >= 5) && is_atomic (p[4])) sz= as_int (p[4]);
   if ((n >= 6) && is_atomic (p[5])) dpi= as_int (p[5]);
   if ((n >= 7) && is_atomic (p[6])) dw= as_int (p[6]);
-  font fn= find_font (family, fn_class, series, shape, sz, dpi);
+  bool adjust= s == "<lefttimesthree>" || s == "<righttimesthree>";
+  font fn= smart_font (family, fn_class, series, shape, adjust ? 1.15 * sz : sz,
+                       dpi);
   box  b = text_box (decorate (), 0, s, fn, col);
   if (ink) b= resize_box (decorate (), b, b->x3, b->y3, b->x4, b->y4, true);
+  if (adjust) b= shift_box (decorate (), b, 0, -fn->wfn / 16);
   return box_widget (b, trans, dw);
 }
 


### PR DESCRIPTION
## What

- 修复数学模式下字母 `T` 的 Tab 循环菜单中，最后两个组合乘号候选显示为红色内部符号名称的问题。
- 调整 `<lefttimesthree>` 和 `<righttimesthree>` 的预览字号与基线，使其与同组候选在视觉上协调。

## How

- 参考 #2805，让 `box_widget` 使用 `smart_font` 渲染候选符号。
- 仅对两个组合乘号候选放大字号并下移渲染盒，不影响其他候选。

## Tests

- `gf fmt --changed-since=main`
- `clang-format --dry-run --Werror src/Texmacs/Window/tm_button.cpp`
- `git diff --check`
- `xmake build smart_font_test`
- `xmake build stem`

Fixes #3030