### PR TITLE
[0873] version-compare 支持中文切词

### DIFF
--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -62,9 +62,7 @@
            (stree-str (object->string origin-stree))
           ) ;
       (debug-message "debug-io"
-        (string-append "diff-request: stree=["
-          (substring stree-str 0 (min 500 (string-length stree-str)))
-          "]\n"
+        (string-append "diff-request: stree=[" (herk->utf8 stree-str) "]\n"
         ) ;string-append
       ) ;debug-message
       (diff-cloud-polish stree-str
@@ -82,9 +80,7 @@
           (selection-active?)
         ) ;and
     (debug-message "debug-io"
-      (string-append "diff-predict: suggested=["
-        (substring suggested-str 0 (min 500 (string-length suggested-str)))
-        "]\n"
+      (string-append "diff-predict: suggested=[" (herk->utf8 suggested-str) "]\n"
       ) ;string-append
     ) ;debug-message
     (let ((suggested-stree (catch #t (lambda () (string->object suggested-str)) (lambda args #f))

--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -62,8 +62,7 @@
            (stree-str (object->string origin-stree))
           ) ;
       (debug-message "debug-io"
-        (string-append "diff-request: stree=[" (herk->utf8 stree-str) "]\n"
-        ) ;string-append
+        (string-append "diff-request: stree=[" (herk->utf8 stree-str) "]\n")
       ) ;debug-message
       (diff-cloud-polish stree-str
         (lambda (suggested-str)
@@ -80,8 +79,7 @@
           (selection-active?)
         ) ;and
     (debug-message "debug-io"
-      (string-append "diff-predict: suggested=[" (herk->utf8 suggested-str) "]\n"
-      ) ;string-append
+      (string-append "diff-predict: suggested=[" (herk->utf8 suggested-str) "]\n")
     ) ;debug-message
     (let ((suggested-stree (catch #t (lambda () (string->object suggested-str)) (lambda args #f))
           ) ;suggested-stree

--- a/TeXmacs/progs/version/tests/version-test.scm
+++ b/TeXmacs/progs/version/tests/version-test.scm
@@ -1,0 +1,115 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : version-test.scm
+;; DESCRIPTION : Tests for version-compare (denormalize-string, compare-versions)
+;; COPYRIGHT   : (C) 2026 AcceleratorX
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(check-set-mode! 'report-failed)
+(load "./TeXmacs/progs/version/version-compare.scm")
+
+;; denormalize-string
+;; 把字符串切成 diff 对齐用的 token 列表
+;;
+;; 切词规则
+;; ----
+;; - 空格：独立分隔 token
+;; - ASCII 连续段：一个词 token
+;; - herk 转义 <#XXXX>（中文等非 ASCII 字符的编码形态）：每个转义独立成 token
+;;
+;; 说明
+;; ----
+;; 单元测试本身就是最佳示例
+
+(define (test-denormalize-words)
+  ;; 空串与空格边界（原有行为）
+  (check (denormalize-string "") => '())
+  (check (denormalize-string " ") => '(" "))
+  (check (denormalize-string " a  b ") => '(" " "a" " " " " "b" " "))
+  ;; 纯英文按空格切词（原有行为）
+  (check (denormalize-string "hello brave world") => '("hello" " " "brave" " " "world"))
+  ;; 单个词不拆分
+  (check (denormalize-string "abcd") => '("abcd"))
+) ;define
+
+(define (test-denormalize-herk)
+  ;; 单个 herk 转义
+  (check (denormalize-string "<#4F60>") => '("<#4F60>"))
+  ;; 连续 herk 转义（中文句子），每字一个 token
+  (check (denormalize-string "<#4F60><#597D><#554A><#FF0C>")
+    =>
+    '("<#4F60>" "<#597D>" "<#554A>" "<#FF0C>")
+  ) ;check
+  ;; herk 与英文混排
+  (check (denormalize-string "a<#4F60>b") => '("a" "<#4F60>" "b"))
+  (check (denormalize-string "<#4F60> <#597D>") => '("<#4F60>" " " "<#597D>"))
+  ;; 中文标点同样是独立 token
+  (check (denormalize-string "<#FF0C><#FF1F>") => '("<#FF0C>" "<#FF1F>"))
+) ;define
+
+(define (test-denormalize-herk-edge)
+  ;; 无闭合的 <# 按普通文本处理
+  (check (denormalize-string "a<#4F6") => '("a<#4F6"))
+  ;; < 后非 # 按普通字符处理
+  (check (denormalize-string "a<b") => '("a<b"))
+  ;; 结尾裸 <
+  (check (denormalize-string "a<") => '("a<"))
+) ;define
+
+;; compare-versions（CJK 场景）
+;; herk 编码的中文对做 diff，应对齐到单个转义字符
+;;
+;; 说明
+;; ----
+;; version-get d 0 可取回旧版本、version-get d 1 取回新版本，
+;; diff 结果中 version-both 的数量即变更块数
+
+(define (count-tag t tag)
+  (if (pair? t)
+    (+ (if (eq? (car t) tag) 1 0)
+      (apply + (map (lambda (x) (count-tag x tag)) (cdr t)))
+    ) ;+
+    0
+  ) ;if
+) ;define
+
+(define cjk-old
+  "<#4F60><#597D><#554A><#FF0C><#8BF7><#95EE><#4F60><#5728><#54EA><#91CC><#5BC6><#8DEF><#7684><#FF1F>")
+(define cjk-new
+  "<#4F60><#597D><#554A><#FF0C><#8BF7><#95EE><#4F60><#5728><#54EA><#91CC><#8FF7><#8DEF><#7684><#FF1F>")
+
+(define (test-compare-cjk)
+  ;; 只改一个字符（密->谜）：恰好一个变更块，且新旧版本可完整取回
+  (let ((d (compare-versions cjk-old cjk-new)))
+    (check (count-tag d 'version-both) => 1)
+    (check (version-get d 0) => cjk-old)
+    (check (version-get d 1) => cjk-new)
+  ) ;let
+  ;; 完全相同：无变更
+  (check (compare-versions cjk-old cjk-old) => cjk-old)
+) ;define
+
+(define (test-compare-english)
+  ;; 英文插入一个单词：恰好一个变更块，新旧版本可完整取回
+  (let ((d (compare-versions "hello world" "hello brave world")))
+    (check (count-tag d 'version-both) => 1)
+    (check (version-get d 0) => "hello world")
+    (check (version-get d 1) => "hello brave world")
+  ) ;let
+) ;define
+
+(tm-define (regtest-version)
+  (test-denormalize-words)
+  (test-denormalize-herk)
+  (test-denormalize-herk-edge)
+  (test-compare-cjk)
+  (test-compare-english)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/version/tests/version-test.scm
+++ b/TeXmacs/progs/version/tests/version-test.scm
@@ -34,7 +34,10 @@
   (check (denormalize-string " ") => '(" "))
   (check (denormalize-string " a  b ") => '(" " "a" " " " " "b" " "))
   ;; 纯英文按空格切词（原有行为）
-  (check (denormalize-string "hello brave world") => '("hello" " " "brave" " " "world"))
+  (check (denormalize-string "hello brave world")
+    =>
+    '("hello" " " "brave" " " "world")
+  ) ;check
   ;; 单个词不拆分
   (check (denormalize-string "abcd") => '("abcd"))
 ) ;define
@@ -81,9 +84,12 @@
 ) ;define
 
 (define cjk-old
-  "<#4F60><#597D><#554A><#FF0C><#8BF7><#95EE><#4F60><#5728><#54EA><#91CC><#5BC6><#8DEF><#7684><#FF1F>")
+  "<#4F60><#597D><#554A><#FF0C><#8BF7><#95EE><#4F60><#5728><#54EA><#91CC><#5BC6><#8DEF><#7684><#FF1F>"
+) ;define
+
 (define cjk-new
-  "<#4F60><#597D><#554A><#FF0C><#8BF7><#95EE><#4F60><#5728><#54EA><#91CC><#8FF7><#8DEF><#7684><#FF1F>")
+  "<#4F60><#597D><#554A><#FF0C><#8BF7><#95EE><#4F60><#5728><#54EA><#91CC><#8FF7><#8DEF><#7684><#FF1F>"
+) ;define
 
 (define (test-compare-cjk)
   ;; 只改一个字符（密->谜）：恰好一个变更块，且新旧版本可完整取回

--- a/TeXmacs/progs/version/version-compare.scm
+++ b/TeXmacs/progs/version/version-compare.scm
@@ -59,15 +59,13 @@
 
 ;; herk 编码下中文等字符以 <#XXXX> 转义存在，整串无空格会被当成一个词。
 ;; 每个转义序列切为独立 token，使 CJK 文本按字符对齐；其余仍按空格切词
+
 (define (denormalize-string s)
   (if (== s "")
     (list)
     (with p
       (string-index s #\<)
-      (if (or (not p)
-            (== p (- (string-length s) 1))
-            (!= (string-ref s (+ p 1)) #\#)
-          ) ;or
+      (if (or (not p) (== p (- (string-length s) 1)) (!= (string-ref s (+ p 1)) #\#))
         (denormalize-words s)
         (with q
           (string-index (substring s p (string-length s)) #\>)

--- a/TeXmacs/progs/version/version-compare.scm
+++ b/TeXmacs/progs/version/version-compare.scm
@@ -4,6 +4,7 @@
 ;; MODULE      : version-compare.scm
 ;; DESCRIPTION : comparing two files
 ;; COPYRIGHT   : (C) 2010  Joris van der Hoeven
+;; COPYRIGHT   : (C) 2026 AcceleratorX
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
 ;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
@@ -36,7 +37,7 @@
 ;; Useful subroutines for document comparison
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (denormalize-string s)
+(define (denormalize-words s)
   (if (== s "")
     (list)
     (with d
@@ -44,13 +45,40 @@
       (if (or (not d) (== s " "))
         (list s)
         (let ((h (substring s 0 d))
-              (t (denormalize-string (substring s (+ 1 d) (string-length s))))
+              (t (denormalize-words (substring s (+ 1 d) (string-length s))))
              ) ;
           (cond ((== d 0) (cons " " t))
                 ((== d (- (string-length s) 1)) (list h " "))
                 (else (cons h (cons " " t)))
           ) ;cond
         ) ;let
+      ) ;if
+    ) ;with
+  ) ;if
+) ;define
+
+;; herk 编码下中文等字符以 <#XXXX> 转义存在，整串无空格会被当成一个词。
+;; 每个转义序列切为独立 token，使 CJK 文本按字符对齐；其余仍按空格切词
+(define (denormalize-string s)
+  (if (== s "")
+    (list)
+    (with p
+      (string-index s #\<)
+      (if (or (not p)
+            (== p (- (string-length s) 1))
+            (!= (string-ref s (+ p 1)) #\#)
+          ) ;or
+        (denormalize-words s)
+        (with q
+          (string-index (substring s p (string-length s)) #\>)
+          (if (not q)
+            (denormalize-words s)
+            (append (denormalize-words (substring s 0 p))
+              (list (substring s p (+ p q 1)))
+              (denormalize-string (substring s (+ p q 1) (string-length s)))
+            ) ;append
+          ) ;if
+        ) ;with
       ) ;if
     ) ;with
   ) ;if

--- a/devel/0873.md
+++ b/devel/0873.md
@@ -1,0 +1,27 @@
+# [0873] version-compare 支持中文切词
+
+## 1 相关文档
+- [0872.md](0872.md) - AI Suggestion 自动润色（diff 插件，本任务的主要受益方）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/version/version-compare.scm` — `denormalize-string` 支持 herk 转义逐字切分
+- `TeXmacs/progs/version/tests/version-test.scm` — 新增单测（20 例）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake r version-test
+```
+覆盖：英文空格切词（原有行为）、herk 转义逐字切分、中英混排、无闭合 `<#` / 非 `#` 的 `<` / 结尾裸 `<` 等边界，以及 `compare-versions` 在 CJK 场景下「单字变更恰好产生一个 version-both、新旧版本可经 version-get 完整取回」的功能断言。
+
+### 3.2 非确定性测试（交互验证）
+1. 选中一段中文（例如：`你好，我有点密路了，不知道改怎么走`）按 Tab 触发 AI 润色， diff 支持细粒度对比；
+
+## 4 What
+- `compare-versions` 的切词函数 `denormalize-string` 支持 herk 编码：中文等非 ASCII 字符在 stree 中以 `<#XXXX>` 转义存在，原先整串无空格被当成一个词 token，任何改动都会整句打成 version-both；现在每个转义序列切为独立 token，CJK 文本按字符粒度对齐。
+- AI 润色（diff 插件）与 `Tools -> Versioning` 的版本对比在中文场景下同时受益。
+
+## 5 How
+- 最小改动：原 `denormalize-string` 原样改名为 `denormalize-words`（空格切词逻辑不变），新 `denormalize-string` 只包一层转义切分：找首个 `<#`，切出 `<#...>` 作为独立 token，转义前后的普通文本递归走原逻辑；`<` 后非 `#`、无闭合 `>`、结尾裸 `<` 一律回落为普通文本。
+- 纯英文行为与旧版逐 case 等价（空格边界、连续空格、单字符串），`normalize-strings` 会把相邻字符串 token 无损合并回去。


### PR DESCRIPTION
# [0873] version-compare 支持中文切词

## 1 相关文档
- [0872.md](0872.md) - AI Suggestion 自动润色（diff 插件，本任务的主要受益方）

## 2 任务相关的代码文件
- `TeXmacs/progs/version/version-compare.scm` — `denormalize-string` 支持 herk 转义逐字切分
- `TeXmacs/progs/version/tests/version-test.scm` — 新增单测（20 例）

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake r version-test
```
覆盖：英文空格切词（原有行为）、herk 转义逐字切分、中英混排、无闭合 `<#` / 非 `#` 的 `<` / 结尾裸 `<` 等边界，以及 `compare-versions` 在 CJK 场景下「单字变更恰好产生一个 version-both、新旧版本可经 version-get 完整取回」的功能断言。

### 3.2 非确定性测试（交互验证）
1. 选中一段中文（例如：`你好，我有点密路了，不知道改怎么走`）按 Tab 触发 AI 润色， diff 支持细粒度对比；

## 4 What
- `compare-versions` 的切词函数 `denormalize-string` 支持 herk 编码：中文等非 ASCII 字符在 stree 中以 `<#XXXX>` 转义存在，原先整串无空格被当成一个词 token，任何改动都会整句打成 version-both；现在每个转义序列切为独立 token，CJK 文本按字符粒度对齐。
- AI 润色（diff 插件）与 `Tools -> Versioning` 的版本对比在中文场景下同时受益。

## 5 How
- 最小改动：原 `denormalize-string` 原样改名为 `denormalize-words`（空格切词逻辑不变），新 `denormalize-string` 只包一层转义切分：找首个 `<#`，切出 `<#...>` 作为独立 token，转义前后的普通文本递归走原逻辑；`<` 后非 `#`、无闭合 `>`、结尾裸 `<` 一律回落为普通文本。
- 纯英文行为与旧版逐 case 等价（空格边界、连续空格、单字符串），`normalize-strings` 会把相邻字符串 token 无损合并回去。
