### PR TITLE
[0874] Diff 树锚点（tree pin）与 serial 拦截

### DIFF
--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -44,11 +44,23 @@
 ;; State variables for Diff Text
 ;; =============================================================================
 
+(define diff-serial 0)
+
 (define diff-active? #f)
 
 (tm-define (is-diff-active?) diff-active?)
 
 (tm-define (diff-enable?) (defined? 'diff-cloud-polish))
+
+;; 树锚点（tree pin）：触发时把选区两端点所在的树节点钉住，
+;; 树引用随编辑自动追踪，选区取消/光标移动后仍能找回原区域
+
+(define (diff-pin->path pin offset)
+  ;; 锚点节点存活则重建「当前路径 + 原偏移」，节点被删（区域已移除）返回 #f
+  (let ((p (tree->path pin)))
+    (if (pair? p) (append p (list offset)) #f)
+  ) ;let
+) ;define
 
 ;; =============================================================================
 ;; Diff Text core control flow
@@ -56,9 +68,16 @@
 
 (tm-define (trigger-diff-text)
   (when (diff-enable?)
-    (let* ((sel (selection-tree))
+    (set! diff-serial (+ diff-serial 1))
+    (let* ((current diff-serial)
+           (sel (selection-tree))
            (origin-stree (tree->stree sel))
-           (pre-cur (cursor-path))
+           (p1 (selection-get-start))
+           (p2 (selection-get-end))
+           (pin1 (path->tree (cDr p1)))
+           (pin2 (path->tree (cDr p2)))
+           (off1 (cAr p1))
+           (off2 (cAr p2))
            (stree-str (object->string origin-stree))
           ) ;
       (debug-message "debug-io"
@@ -66,42 +85,51 @@
       ) ;debug-message
       (diff-cloud-polish stree-str
         (lambda (suggested-str)
-          (diff-apply-suggestion origin-stree suggested-str pre-cur)
+          (diff-apply-suggestion current origin-stree suggested-str pin1 off1 pin2 off2)
         ) ;lambda
       ) ;diff-cloud-polish
     ) ;let*
   ) ;when
 ) ;tm-define
 
-(define (diff-apply-suggestion origin-stree suggested-str pre-cur)
-  (when (and (string? suggested-str)
-          (not (string=? suggested-str ""))
-          (selection-active?)
-        ) ;and
-    (debug-message "debug-io"
-      (string-append "diff-predict: suggested=[" (herk->utf8 suggested-str) "]\n")
-    ) ;debug-message
-    (let ((suggested-stree (catch #t (lambda () (string->object suggested-str)) (lambda args #f))
-          ) ;suggested-stree
-         ) ;
-      (when suggested-stree
-        (let ((pre-grain (get-preference "versioning grain")))
-          ;; 设为字符级精度 "detailed"；其余选项："block" (块级)、"rough" (粗粒度)
-          (set-preference "versioning grain" "detailed")
-          (let* ((diff-stree (compare-versions origin-stree suggested-stree))
-                 (diff-tree (stree->tree diff-stree))
-                ) ;
-            (clipboard-cut "primary")
-            (insert diff-tree)
-            (go-to pre-cur)
-            (diff-scan-next)
-          ) ;let*
-          ;; 还原精度
-          (set-preference "versioning grain" pre-grain)
-        ) ;let
-      ) ;when
-    ) ;let
-  ) ;when
+(define (diff-apply-suggestion current origin-stree suggested-str pin1 off1 pin2 off2)
+  (let ((new-p1 (diff-pin->path pin1 off1)) (new-p2 (diff-pin->path pin2 off2)))
+    (when (and (== current diff-serial)
+            (string? suggested-str)
+            (not (string=? suggested-str ""))
+          ) ;and
+      (if (and new-p1 new-p2)
+        (begin
+          (debug-message "debug-io"
+            (string-append "diff-predict: suggested=[" (herk->utf8 suggested-str) "]\n")
+          ) ;debug-message
+          (let ((suggested-stree (catch #t (lambda () (string->object suggested-str)) (lambda args #f))
+                ) ;suggested-stree
+               ) ;
+            (when suggested-stree
+              (let ((pre-grain (get-preference "versioning grain")))
+                ;; 设为字符级精度 "detailed"；其余选项："block" (块级)、"rough" (粗粒度)
+                (set-preference "versioning grain" "detailed")
+                (let* ((diff-stree (compare-versions origin-stree suggested-stree))
+                       (diff-tree (stree->tree diff-stree))
+                      ) ;
+                  ;; 经树锚点重建选区，与当前活跃选区无关
+                  (selection-set new-p1 new-p2)
+                  (clipboard-cut "primary")
+                  (insert diff-tree)
+                  (go-to new-p1)
+                  (diff-scan-next)
+                ) ;let*
+                ;; 还原精度
+                (set-preference "versioning grain" pre-grain)
+              ) ;let
+            ) ;when
+          ) ;let
+        ) ;begin
+        (debug-message "debug-io" "diff-predict: dropped (region deleted)\n")
+      ) ;if
+    ) ;when
+  ) ;let
 ) ;define
 
 (tm-define (accept-diff)

--- a/devel/0874.md
+++ b/devel/0874.md
@@ -1,0 +1,24 @@
+# [0874] Diff 树锚点（tree pin）与 serial 拦截
+
+## 1 相关文档
+- [0872.md](0872.md) - AI Suggestion 自动润色（diff 插件）
+- [0860.md](0860.md) - Ghost 自动补全（serial 校验的来源）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/diff-text.scm` — 触发时树锚点钉住选区两端点，回调时重建选区落盘；serial 拦截过期请求
+
+## 3 如何测试
+1. 选中一段文字按 Tab 后点击空白处取消选区，或者继续其他段落的编辑，请求回来后建议应仍落在原区域（diff 视图正常出现）；
+2. 选中一段文字按 Tab 后在该段**中间**增删改若干行文字，请求回来后应覆盖该段的修改，显示修改前的文本与 AI 润色的 diff；
+3. 选中一段文字按 Tab 后把该段**删除**，请求回来后文档无变化，`debug-io` 输出 `diff-predict: dropped (region deleted)`；
+4. 快速连按两次 Tab（可选不同选区），应只有最后一次触发的建议生效；
+
+## 4 What
+- 树锚点（tree pin）：按 Tab 触发润色请求后，即使选区被取消、光标移走或区域前方文本被编辑，请求回来时建议仍能精确落在原选区；原区域被整块删除则静默丢弃。
+- serial 拦截：连续触发时只有最后一次请求的结果生效，旧请求的结果回来即丢弃（同 ghost）。
+
+## 5 How
+- 树锚点：触发时取选区两端点光标路径 `p1/p2`，以 `(path->tree (cDr p))` 钉住端点所在树节点、以 `(cAr p)` 记录节点内偏移。TeXmacs 的树引用是文档内的活引用，节点随编辑自动追踪（前方增删导致 path 平移时仍指向原节点）。回调时 `(tree->path pin)` 求节点当前路径、拼回原偏移重建 `new-p1/new-p2`，再 `(selection-set new-p1 new-p2)` 程序化重选，后续 cut + insert diff tree 流程不变；不再检查 `(selection-active?)`。
+- 丢弃条件：任一锚点节点已脱离文档（`tree->path` 返回 `#f`，即区域被删除）时静默丢弃，并输出 debug 日志。
+- 已知取舍：请求在途时若用户在选区**内部**编辑文本，节点内偏移可能失效，建议会覆盖用户编辑（可用 undo 回退）。
+- serial：`diff-serial` 全局计数器，触发时递增并捕获 `current`，回调首道闸 `(== current diff-serial)`，不匹配即静默丢弃。serial 管「哪个请求有效」（时序），tree pin 管「落到哪里」（位置），两层互不耦合。


### PR DESCRIPTION
# [0874] Diff 树锚点（tree pin）与 serial 拦截

## 1 相关文档
- [0872.md](0872.md) - AI Suggestion 自动润色（diff 插件）
- [0860.md](0860.md) - Ghost 自动补全（serial 校验的来源）

## 2 任务相关的代码文件
- `TeXmacs/progs/generic/diff-text.scm` — 触发时树锚点钉住选区两端点，回调时重建选区落盘；serial 拦截过期请求

## 3 如何测试
1. 选中一段文字按 Tab 后点击空白处取消选区，或者继续其他段落的编辑，请求回来后建议应仍落在原区域（diff 视图正常出现）；
2. 选中一段文字按 Tab 后在该段**中间**增删改若干行文字，请求回来后应覆盖该段的修改，显示修改前的文本与 AI 润色的 diff；
3. 选中一段文字按 Tab 后把该段**删除**，请求回来后文档无变化，`debug-io` 输出 `diff-predict: dropped (region deleted)`；
4. 快速连按两次 Tab（可选不同选区），应只有最后一次触发的建议生效；

## 4 What
- 树锚点（tree pin）：按 Tab 触发润色请求后，即使选区被取消、光标移走或区域前方文本被编辑，请求回来时建议仍能精确落在原选区；原区域被整块删除则静默丢弃。
- serial 拦截：连续触发时只有最后一次请求的结果生效，旧请求的结果回来即丢弃（同 ghost）。

## 5 How
- 树锚点：触发时取选区两端点光标路径 `p1/p2`，以 `(path->tree (cDr p))` 钉住端点所在树节点、以 `(cAr p)` 记录节点内偏移。TeXmacs 的树引用是文档内的活引用，节点随编辑自动追踪（前方增删导致 path 平移时仍指向原节点）。回调时 `(tree->path pin)` 求节点当前路径、拼回原偏移重建 `new-p1/new-p2`，再 `(selection-set new-p1 new-p2)` 程序化重选，后续 cut + insert diff tree 流程不变；不再检查 `(selection-active?)`。
- 丢弃条件：任一锚点节点已脱离文档（`tree->path` 返回 `#f`，即区域被删除）时静默丢弃，并输出 debug 日志。
- 已知取舍：请求在途时若用户在选区**内部**编辑文本，节点内偏移可能失效，建议会覆盖用户编辑（可用 undo 回退）。
- serial：`diff-serial` 全局计数器，触发时递增并捕获 `current`，回调首道闸 `(== current diff-serial)`，不匹配即静默丢弃。serial 管「哪个请求有效」（时序），tree pin 管「落到哪里」（位置），两层互不耦合。
