### PR TITLE
[2082] 首页的 打开文档 功能过滤临时目录

### DIFF
--- a/devel/2082.md
+++ b/devel/2082.md
@@ -12,7 +12,25 @@ xmake b stem
 xmake run stem
 ```
 
-在首页选择“打开文档”，确认文件选择器初始目录为 `Documents/LiiiSTEM`；目录不存在时应自动创建。
+在首页选择“打开文档”，验证最近文档目录时：
+
+1. 最近文档路径不包含 `.lolly`，文件选择器沿用其所在目录。
+2. 最近文档路径包含 `.lolly`，文件选择器打开 `Documents/LiiiSTEM`；目录不存在时自动创建。
+3. 没有最近文档时，首页沿用原有的 `open-document` 行为。
+
+## 2026/08/04 临时预览目录回退
+
+### What
+首页“打开文档”保留最近文档目录作为默认目录；最近文档路径包含 `.lolly` 时，改为打开 `Documents/LiiiSTEM`。
+
+### Why
+PDF 预览文件位于进程临时目录，不能作为后续文件选择器的默认目录。
+
+### How
+检查最近文档的完整路径；仅在其包含 `.lolly` 时，用 Qt Documents 位置构造 `LiiiSTEM` 目录，其他分支保持上游原有行为。
+
+### 涉及文件
+- `src/Plugins/Qt/QTMHomePage.cpp`
 
 ## 2026/08/04 首页打开文档默认目录
 

--- a/src/Plugins/Qt/QTMHomePage.cpp
+++ b/src/Plugins/Qt/QTMHomePage.cpp
@@ -747,17 +747,27 @@ QTMHomePage::createDocumentWithStyle (const QString& styleId) {
   }
 
   if (styleId == "open") {
-    QString docsDir=
-        QStandardPaths::writableLocation (QStandardPaths::DocumentsLocation);
-    if (docsDir.isEmpty ()) {
-      docsDir= QStandardPaths::writableLocation (QStandardPaths::HomeLocation);
+    if (!recentDocs_.isEmpty ()) {
+      QString filePath             = recentDocs_.first ().filePath;
+      QString dir                  = QFileInfo (filePath).absolutePath ();
+      bool    isTemporaryPreviewDir= filePath.contains (".lolly");
+      if (isTemporaryPreviewDir) {
+        dir= QStandardPaths::writableLocation (
+            QStandardPaths::DocumentsLocation);
+        if (dir.isEmpty ()) {
+          dir= QStandardPaths::writableLocation (QStandardPaths::HomeLocation);
+        }
+        dir= QDir (dir).filePath ("LiiiSTEM");
+        if (!QDir (dir).exists ()) QDir ().mkpath (dir);
+      }
+      eval_scheme (
+          "(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
+          "(system->url " *
+          qt_scheme_quote_utf8 (dir) * "))");
     }
-    docsDir= QDir (docsDir).filePath ("LiiiSTEM");
-    if (!QDir (docsDir).exists ()) QDir ().mkpath (docsDir);
-
-    eval_scheme ("(choose-file load-buffer \"Load file\" \"action_open\" \"\" "
-                 "(system->url " *
-                 qt_scheme_quote_utf8 (docsDir) * "))");
+    else {
+      eval_scheme ("(open-document)");
+    }
     return;
   }
 


### PR DESCRIPTION
## What
- 保留首页打开文档时最近文档目录的上游逻辑。
- 最近文档完整路径包含 `.lolly` 时，回退到 `Documents/LiiiSTEM`。

## Why
PDF 预览文件位于进程临时目录，不应成为后续文件选择器的默认目录。

## Test
- `gf fmt --changed-since=main`
- `clang-format --dry-run --Werror src/Plugins/Qt/QTMHomePage.cpp`
- `git diff --check`
- `xmake b -y stem`