### PR TITLE
[0875] Diff 弹窗跟随光标刷新位置

### DIFF
--- a/devel/0875.md
+++ b/devel/0875.md
@@ -1,0 +1,32 @@
+# [0875] Diff 弹窗跟随光标刷新位置
+
+## 1 相关文档
+- [0872.md](0872.md) - AI Suggestion 自动润色（diff 插件）
+- [0860.md](0860.md) - Ghost 自动补全
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_simple_widget.cpp` — `send` 的 `SLOT_CURSOR` 与 `SLOT_SCROLL_POSITION` 分支：可见 popup 直接 `updatePosition()`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 选中文本按 Tab 触发 diff，出现弹窗后点工具栏「Go to next similar tag」或 `Ctrl+PageUp/Down`，弹窗跟随到新光标位置；
+2. 触发 diff 后手动点击按钮接收/拒绝，弹窗跟随到新光标位置；
+3. 触发 diff 后滚动页面，弹窗跟随到新光标位置；
+
+## 4 What
+- 点击工具栏按钮/菜单命令（如 Go to next similar tag）移动光标后，diff 弹窗位置刷新到当前光标旁，而非停在旧位置。
+
+## 5 Why
+- popup 位置取自 `canvas->cursorPos()` 缓存，该缓存仅在 `SLOT_CURSOR` 处由 `send_cursor()`（排版重算后，异步）更新。
+- `diff-text.scm` 的 `diff-check-popup` 用 `(delayed (:idle 0))`，下一 tick 即 hide/show；工具栏按钮触发的光标跳转其重排版 + `SLOT_CURSOR` 跨多个 tick，`idle 0` 时缓存仍为旧值，弹窗用旧坐标 show，表现为「消失后又在旧位置重现」。
+
+## 6 How
+- 在 `qt_simple_widget_rep::send` 的 `SLOT_CURSOR`（`cursorPos` 刚刷新处）与 `SLOT_SCROLL_POSITION`（origin 刚更新处）分支，对可见的 ghost/diff popup 直接调用 `updatePosition()`，位置始终基于最新坐标，彻底绕开 scheme 侧 idle 0 时序竞争。
+- `isVisible()` 为假时短路，零额外开销。

--- a/src/Plugins/Qt/qt_simple_widget.cpp
+++ b/src/Plugins/Qt/qt_simple_widget.cpp
@@ -246,6 +246,11 @@ qt_simple_widget_rep::send (slot s, blackbox val) {
     qp-= QPoint (sz.width () / 2, sz.height () / 2);
     // NOTE: adjust because child is centered
     scrollarea ()->setOrigin (qp);
+    // origin 变化会改变 popup 全局坐标映射，及时刷新 popup
+    if (ghostTextPopup && ghostTextPopup->isVisible ())
+      ghostTextPopup->updatePosition ();
+    if (diffTextPopup && diffTextPopup->isVisible ())
+      diffTextPopup->updatePosition ();
   } break;
 
   case SLOT_ZOOM_FACTOR: {
@@ -278,6 +283,11 @@ qt_simple_widget_rep::send (slot s, blackbox val) {
     check_type<coord2> (val, s);
     coord2 p= open_box<coord2> (val);
     canvas ()->setCursorPos (to_qpoint (p));
+    // 光标坐标在此刷新，及时刷新 popup
+    if (ghostTextPopup && ghostTextPopup->isVisible ())
+      ghostTextPopup->updatePosition ();
+    if (diffTextPopup && diffTextPopup->isVisible ())
+      diffTextPopup->updatePosition ();
 #ifdef Q_OS_LINUX
     QInputMethod* im= QGuiApplication::inputMethod ();
     if (im) im->update (Qt::ImCursorRectangle);


### PR DESCRIPTION
# [0875] Diff 弹窗跟随光标刷新位置

## 1 相关文档
- [0872.md](0872.md) - AI Suggestion 自动润色（diff 插件）
- [0860.md](0860.md) - Ghost 自动补全

## 2 任务相关的代码文件
- `src/Plugins/Qt/qt_simple_widget.cpp` — `send` 的 `SLOT_CURSOR` 与 `SLOT_SCROLL_POSITION` 分支：可见 popup 直接 `updatePosition()`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 选中文本按 Tab 触发 diff，出现弹窗后点工具栏「Go to next similar tag」或 `Ctrl+PageUp/Down`，弹窗跟随到新光标位置；
2. 触发 diff 后手动点击按钮接收/拒绝，弹窗跟随到新光标位置；
3. 触发 diff 后滚动页面，弹窗跟随到新光标位置；

## 4 What
- 点击工具栏按钮/菜单命令（如 Go to next similar tag）移动光标后，diff 弹窗位置刷新到当前光标旁，而非停在旧位置。

## 5 Why
- popup 位置取自 `canvas->cursorPos()` 缓存，该缓存仅在 `SLOT_CURSOR` 处由 `send_cursor()`（排版重算后，异步）更新。
- `diff-text.scm` 的 `diff-check-popup` 用 `(delayed (:idle 0))`，下一 tick 即 hide/show；工具栏按钮触发的光标跳转其重排版 + `SLOT_CURSOR` 跨多个 tick，`idle 0` 时缓存仍为旧值，弹窗用旧坐标 show，表现为「消失后又在旧位置重现」。

## 6 How
- 在 `qt_simple_widget_rep::send` 的 `SLOT_CURSOR`（`cursorPos` 刚刷新处）与 `SLOT_SCROLL_POSITION`（origin 刚更新处）分支，对可见的 ghost/diff popup 直接调用 `updatePosition()`，位置始终基于最新坐标，彻底绕开 scheme 侧 idle 0 时序竞争。
- `isVisible()` 为假时短路，零额外开销。
