### PR TITLE
[0876] 提交选中对象后不再进入文本区

### DIFF
--- a/TeXmacs/progs/graphics/graphics-object.scm
+++ b/TeXmacs/progs/graphics/graphics-object.scm
@@ -764,7 +764,7 @@
     (for (o sketch0)
       (with layer
         layer-of-last-removed-object
-        (sketch-toggle (path->tree (graphics-group-insert-bis o group-mode?)))
+        (sketch-toggle (path->tree (graphics-group-insert-bis o #f)))
         (if (not (list? layer)) (set! layer-of-last-removed-object layer))
       ) ;with
     ) ;for

--- a/devel/0876.md
+++ b/devel/0876.md
@@ -1,0 +1,33 @@
+# [0876] 提交选中对象后不再进入文本区
+
+## 1 相关文档
+- [0822.md](0822.md) - 方向键微移选中对象（暴露问题：nudge text-at 后光标进入文本）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-object.scm` — `sketch-commit` 提交时固定 `go-into=#f`，不再把光标放进 text-at
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 在绘图区插入文本（text-at、math-at、document-at），之后输入一些字符；
+2. 在进入属性编辑模式，选中后按方向键微移，或鼠标拖动后松开，光标不会进入文本区，后续方向键仍然可以微移选中对象；
+3. 只有在同一个模式，左键单击才可以进入文本区，光标才会进入文本区；
+
+## 4 What
+- 选中 text-at 后按方向键微移、或鼠标拖动 text-at 松开提交后，光标会进入文本区，导致后续方向键绑定失效、误在文本内移动。
+
+## 5 Why
+- `sketch-commit`（拖动/nudge/group/ungroup/paste/绘制完成提交的通用路径）插入对象时调 `graphics-group-insert-bis o group-mode?`，group-edit 模式下 `go-into=#t`，对 text-at 会把光标 `go-to` 到文本内容起始处。
+- 光标进入文本后 `inside_graphics(true)`（即 `in-graphics?`）因路径经过 graphical_text 返回 false，`in-active-graphics?` 随之为假，graphics 的方向键 `kbd-map` 绑定失效，回退到 generic `kbd-left/right` 在文本内移动。
+
+## 6 How
+- 进入文本只由两条独立入口负责，均不依赖 `sketch-commit` 的 `go-into`：
+  - 新建 text-at：`object_create` 走 `object-set! 'new` → `graphics-group-insert`（仍 `go-into=#t`），并用 `(cDr (cursor-path))` 精确定位 document；
+  - 文本工具点击已有 text-at：`edit_left-button`（edit 模式）直接 `go-to` 文本内。
+- 故 `sketch-commit` 中固定传 `go-into=#f`，提交仅做几何/结构调整，光标留在 graphics 层。`group-mode?` 变量仍保留，用于其下游 `current-obj` 的设置。


### PR DESCRIPTION
# [0876] 提交选中对象后不再进入文本区

## 1 相关文档
- [0822.md](0822.md) - 方向键微移选中对象（暴露问题：nudge text-at 后光标进入文本）

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-object.scm` — `sketch-commit` 提交时固定 `go-into=#f`，不再把光标放进 text-at

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 在绘图区插入文本（text-at、math-at、document-at），之后输入一些字符；
2. 在进入属性编辑模式，选中后按方向键微移，或鼠标拖动后松开，光标不会进入文本区，后续方向键仍然可以微移选中对象；
3. 只有在同一个模式，左键单击才可以进入文本区，光标才会进入文本区；

## 4 What
- 选中 text-at 后按方向键微移、或鼠标拖动 text-at 松开提交后，光标会进入文本区，导致后续方向键绑定失效、误在文本内移动。

## 5 Why
- `sketch-commit`（拖动/nudge/group/ungroup/paste/绘制完成提交的通用路径）插入对象时调 `graphics-group-insert-bis o group-mode?`，group-edit 模式下 `go-into=#t`，对 text-at 会把光标 `go-to` 到文本内容起始处。
- 光标进入文本后 `inside_graphics(true)`（即 `in-graphics?`）因路径经过 graphical_text 返回 false，`in-active-graphics?` 随之为假，graphics 的方向键 `kbd-map` 绑定失效，回退到 generic `kbd-left/right` 在文本内移动。

## 6 How
- 进入文本只由两条独立入口负责，均不依赖 `sketch-commit` 的 `go-into`：
  - 新建 text-at：`object_create` 走 `object-set! 'new` → `graphics-group-insert`（仍 `go-into=#t`），并用 `(cDr (cursor-path))` 精确定位 document；
  - 文本工具点击已有 text-at：`edit_left-button`（edit 模式）直接 `go-to` 文本内。
- 故 `sketch-commit` 中固定传 `go-into=#f`，提交仅做几何/结构调整，光标留在 graphics 层。`group-mode?` 变量仍保留，用于其下游 `current-obj` 的设置。
