### PR TITLE
[1068] 确认 U+25B0/U+25B1 无物理字体覆盖

### DIFF
--- a/TeXmacs/tests/1068.scm
+++ b/TeXmacs/tests/1068.scm
@@ -1,0 +1,61 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1068.scm
+;; DESCRIPTION : 集成测试：U+25B0/U+25B1（平行四边形）无物理字体覆盖。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   [1068] 钉死事实：U+25B0（black parallelogram）、U+25B1（white
+;;   parallelogram）目前没有任何物理字体覆盖——仓库自带虚拟字体
+;;   （emu-*.vfn）与常见系统字体均无对应字形。
+;;
+;;   断言走 physical-font-for-string（真实排版路径，移植自 da/1166/font）：
+;;   把字符串放进临时文档排版，取叶子盒 smart font 再按字符下钻到实际物理
+;;   子字体，返回其 res_name；无覆盖时落到 error 字体，res_name 以
+;;   "error-" 开头。
+;;
+;;   后续为这两个字符补齐渲染方案（如虚拟字体合成）后，本测试应翻红，
+;;   提示把期望从 error 字体更新为新方案的实际物理字体。
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r 1068                     # headless，同步断言全量执行
+;;   MOGAN_TEST_GUI=1 xmake r 1068    # 真实 GUI，同样同步执行
+;;
+;; 注意：本测试全程同步（physical-font-for-string 是同步 bridge），
+;; headless 与 GUI 模式都会真正执行断言。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY whatsoever. For details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(import (liii unicode))
+
+(check-set-mode! 'report-failed)
+
+;; 码位 -> tm 内部字符串（cork；超出 cork 的由 utf8->cork 转 <#XXXX>）。
+(define (codepoint->tmstring n)
+  (utf8->cork (utf8-string (integer->char n))))
+
+;; res_name 以 "error-" 开头：无字体覆盖的占位字体。
+(define (error-font? f)
+  (and (> (string-length f) 6)
+       (string=? (substring f 0 6) "error-")))
+
+(tm-define (test_1068)
+  ;; 前置：默认环境为文本模式（与 1166 同一排版入口）。
+  (check (get-env "mode") => "text")
+  (check (get-env "font") => "roman")
+
+  ;; 对照组：ASCII 'A' 有物理字体覆盖（随仓库分发的 Cork 字体）。
+  (check (physical-font-for-string "A") => "ec:ecrm10@600")
+
+  ;; 事实：两个平行四边形码位均无物理字体覆盖，落到 error 字体。
+  (check-true (error-font? (physical-font-for-string (codepoint->tmstring #x25B0))))
+  (check-true (error-font? (physical-font-for-string (codepoint->tmstring #x25B1))))
+
+  (check-report)
+  (quit-TeXmacs)
+) ;tm-define

--- a/devel/1068.md
+++ b/devel/1068.md
@@ -1,0 +1,59 @@
+# [1068] 确认 U+25B0/U+25B1 无物理字体覆盖
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- da/1166/font 分支 - physical-font-for-string 的出处
+
+## 2 任务相关的代码文件
+- src/Graphics/Fonts/font.hpp / font.cpp（`font_rep::get_subfont` 默认实现）
+- src/Graphics/Fonts/smart_font.hpp / smart_font.cpp（`smart_font_rep::get_subfont` 下钻）
+- src/Edit/editor.hpp（`physical_font_for_string` 虚方法）
+- src/Edit/Editor/edit_typeset.hpp / edit_typeset.cpp（实现）
+- src/Scheme/Glue/glue_editor.lua（`physical-font-for-string` glue 声明）
+- TeXmacs/tests/1068.scm（集成测试）
+- TeXmacs/langs/encoding/tmuniversaltounicode.scm（25B0/25B1 编码表位置，未改动）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r 1068                     # headless，同步断言全量执行
+MOGAN_TEST_GUI=1 xmake r 1068    # 真实 GUI，同样同步执行
+```
+
+### 3.2 非确定性测试（文档验证）
+- 在文档中输入 `<#25B0>`、`<#25B1>`（平行四边形），观察渲染为 error 占位
+  而非真实字形。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+xmake b stem
+xmake r 1068
+```
+
+## 5 What
+确认事实：U+25B0（black parallelogram）、U+25B1（white parallelogram）目前
+没有任何物理字体覆盖，排版落到 error 占位字体。
+
+1. 从 da/1166/font 移植 `physical-font-for-string` glue（真实排版路径量
+   字符的叶子物理字体 res_name）
+2. 新增 TeXmacs/tests/1068.scm，断言两个码位解析到 error 字体
+   （res_name 以 "error-" 开头）
+
+## 6 Why
+平行四边形字符（U+25B0/U+25B1）在 tmuniversaltounicode.scm 中已有编码
+表项，但仓库自带虚拟字体（emu-*.vfn）与常见系统字体均无对应字形。在为
+其补齐渲染方案（如虚拟字体合成）之前，先用集成测试钉死「当前无物理字
+体覆盖」这一事实，后续修复后该测试应随之翻红、提示更新。
+
+## 7 How
+- 测试不走 font-supports? 式的逐字体扫描，而是复用 1166 的真实排版路径：
+  `physical-font-for-string` 把字符串放进临时文档排版，取叶子盒的
+  smart font，再经 `get_subfont` 按字符下钻到实际物理子字体，返回其
+  res_name；无覆盖时底层是 error font，res_name 以 "error-" 开头。
+- glue 只能绑编辑器方法（glue 规则自动加 `get_current_editor()->` 前缀），
+  故实现挂在 edit_typeset_rep 上，声明进 glue_editor.lua。

--- a/src/Edit/Editor/edit_typeset.cpp
+++ b/src/Edit/Editor/edit_typeset.cpp
@@ -17,12 +17,14 @@
 #include "file.hpp"
 #include "iterator.hpp"
 #include "merge_sort.hpp"
+#include "new_document.hpp"
 #include "new_style.hpp"
 #include "observers.hpp"
 #include "tm_buffer.hpp"
 #include "tm_timer.hpp"
 #include "tree_modify.hpp"
 #include "tree_observer.hpp"
+#include "typesetter.hpp"
 #include <climits>
 
 using namespace moebius;
@@ -615,6 +617,37 @@ edit_typeset_rep::get_init_value (string var) {
 string
 edit_typeset_rep::get_env_string (string var) {
   return as_string (get_env_value (var));
+}
+
+static font
+find_leaf_font (box b) {
+  if (is_nil (b)) return font ();
+  if (b->get_type () == TEXT_BOX) return b->get_leaf_font ();
+  int n= N (b);
+  for (int i= 0; i < n; i++) {
+    font f= find_leaf_font (b[i]);
+    if (!is_nil (f)) return f;
+  }
+  return font ();
+}
+
+string
+edit_typeset_rep::physical_font_for_string (string s) {
+  // 复用 print_snippet 的临时文档排版路径，量真实排版结果：
+  // 叶子物理字体的 res_name；字符无字体覆盖时为 "error-" 前缀
+  path temp_root= new_document ();
+  temp_root << 0;
+  assign (subtree (et, temp_root), tree (s));
+  typeset_prepare ();
+  env->style_init_env ();
+  env->update ();
+  box b= typeset_as_box (env, tree (s), reverse (temp_root));
+  delete_document (path_up (temp_root));
+  font fn= find_leaf_font (b);
+  if (is_nil (fn)) return "";
+  // 文本盒挂的是 smart font，需按字符下钻到实际物理子字体
+  font sub= fn->get_subfont (s);
+  return is_nil (sub) ? string ("") : sub->res_name;
 }
 
 string

--- a/src/Edit/Editor/edit_typeset.hpp
+++ b/src/Edit/Editor/edit_typeset.hpp
@@ -79,6 +79,7 @@ public:
   color    get_env_color (string var_name);
   color    get_init_color (string var_name);
   language get_env_language ();
+  string   physical_font_for_string (string s);
   int      get_page_count ();
   string   get_page_number_text (int page_index);
   int      get_current_page ();

--- a/src/Edit/editor.hpp
+++ b/src/Edit/editor.hpp
@@ -320,6 +320,7 @@ public:
   virtual color         get_env_color (string var_name)                   = 0;
   virtual color         get_init_color (string var_name)                  = 0;
   virtual language      get_env_language ()                               = 0;
+  virtual string        physical_font_for_string (string s)               = 0;
   virtual int           get_page_count ()                                 = 0;
   virtual string        get_page_number_text (int page_index)             = 0;
   virtual int           get_current_page ()                               = 0;

--- a/src/Graphics/Fonts/font.cpp
+++ b/src/Graphics/Fonts/font.cpp
@@ -552,6 +552,12 @@ use_poor_rubber (font fn) {
 }
 
 font
+font_rep::get_subfont (string s) {
+  (void) s;
+  return font (this);
+}
+
+font
 font_rep::make_rubber_font (font fn) {
   string name= locase_all (fn->res_name);
   if (starts (name, "stix-") || starts (name, "stix,") ||

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -148,6 +148,7 @@ struct font_rep : rep<font> {
   void copy_math_pars (font fn);
 
   virtual font make_rubber_font (font base);
+  virtual font get_subfont (string s);
   virtual bool supports (string c)               = 0;
   virtual void get_extents (string s, metric& ex)= 0;
   virtual void get_extents (string s, metric& ex, bool ligf);

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -868,6 +868,17 @@ smart_font_rep::advance (string s, int& pos, string& r, int& nr) {
   }
 }
 
+font
+smart_font_rep::get_subfont (string s) {
+  int    pos= 0, nr= -1;
+  string r;
+  advance (s, pos, r, nr);
+  if (nr < 0 || nr >= N (fn)) return font ();
+  maybe_initialize_font (nr);
+  if (is_nil (fn[nr])) return font ();
+  return fn[nr]->get_subfont (r);
+}
+
 bool
 is_italic_font (string master) {
   return contains (string ("italic"), master_features (master));

--- a/src/Graphics/Fonts/smart_font.hpp
+++ b/src/Graphics/Fonts/smart_font.hpp
@@ -125,6 +125,7 @@ struct smart_font_rep : font_rep {
   int  adjusted_dpi (string fam, string var, string ser, string sh, int att);
 
   font make_rubber_font (font base) override;
+  font get_subfont (string s) override;
 
   bool   supports (string c);
   void   get_extents (string s, metric& ex);

--- a/src/Scheme/Glue/glue_editor.lua
+++ b/src/Scheme/Glue/glue_editor.lua
@@ -390,6 +390,14 @@ function main()
                 }
             },
             {
+                scm_name = "physical-font-for-string",
+                cpp_name = "physical_font_for_string",
+                ret_type = "string",
+                arg_list = {
+                    "string"
+                }
+            },
+            {
                 scm_name = "get-env-tree",
                 cpp_name = "get_env_value",
                 ret_type = "tree",


### PR DESCRIPTION
## Summary
- 移植 da/1166/font 的 physical-font-for-string glue（真实排版路径取字符的叶子物理字体 res_name）：font/smart_font 新增 get_subfont 下钻，edit_typeset 新增 physical_font_for_string，glue_editor.lua 加声明
- 新增集成测试 TeXmacs/tests/1068.scm，断言 U+25B0（black parallelogram）、U+25B1（white parallelogram）均无物理字体覆盖、落到 error- 前缀占位字体；对照组 'A' -> ec:ecrm10@600
- 后续为这两个字符补齐渲染方案（如虚拟字体合成）后，本测试应翻红提示更新期望

## Test plan
- [x] xmake b stem
- [x] xmake r 1068（headless，5 correct, 0 failed）
- [ ] MOGAN_TEST_GUI=1 xmake r 1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)