### PR TITLE
[0877] 修复选中文本框缩放时的两处 crash

### DIFF
--- a/TeXmacs/progs/graphics/graphics-ghost.scm
+++ b/TeXmacs/progs/graphics/graphics-ghost.scm
@@ -22,7 +22,7 @@
     (let* ((obj (stree-radical (car (sketch-get1)))) (pts (cdr obj)))
       (let loop
         ((i 0) (res '()))
-        (if (< i current-point-no)
+        (if (< i (min current-point-no (length pts)))
           (let ((p (list-ref pts i)))
             (if (and (pair? p) (== (car p) 'point))
               (loop (+ i 1) (cons (cdr p) res))

--- a/TeXmacs/progs/graphics/graphics-group.scm
+++ b/TeXmacs/progs/graphics/graphics-group.scm
@@ -127,13 +127,18 @@
 ) ;define
 
 (define (group-zoom x y)
-  (with h
-    (/ (point-norm (sub-point `(,x ,y) `(,group-bary-x ,group-bary-y)))
-      (point-norm (sub-point `(,group-first-x ,group-first-y) `(,group-bary-x
-                                                                ,group-bary-y))
-      ) ;point-norm
-    ) ;/
-    (lambda (o) (traverse-transform o (zoom-point group-bary-x group-bary-y h)))
+  (with denom
+    (point-norm (sub-point `(,group-first-x ,group-first-y) `(,group-bary-x
+                                                              ,group-bary-y))
+    ) ;point-norm
+    ;; 首点与重心重合时缩放比例无定义（如单锚点 text-at），保持原大小避免除零
+    (with h
+      (if (< denom 1e-9)
+        1.0
+        (/ (point-norm (sub-point `(,x ,y) `(,group-bary-x ,group-bary-y))) denom)
+      ) ;if
+      (lambda (o) (traverse-transform o (zoom-point group-bary-x group-bary-y h)))
+    ) ;with
   ) ;with
 ) ;define
 

--- a/devel/0877.md
+++ b/devel/0877.md
@@ -1,0 +1,31 @@
+# [0877] 修复选中文本框缩放时的两处 crash
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/graphics/graphics-group.scm` — `group-zoom` 分母为零时回退 `h=1.0`
+- `TeXmacs/progs/graphics/graphics-ghost.scm` — `graphics-get-all-previous-points` 按 `pts` 实际长度截断遍历
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+1. 插入文本框后缩放该对象，不会出现任何报错，且绘图区不会 crash。
+
+## 4 What
+- 插入文本框后选中缩放工具拖动缩放，报 `division by zero, (/ ... 0.0)`；
+- 同场景下鼠标在绘图区移动，报 `list-ref second argument, 2, is out of range`。
+
+## 5 Why
+- text-at 只有一个锚点，`store-important-points` 算出的重心等于该锚点；缩放起点（鼠标按下处）若与之重合，`group-zoom` 的分母 `point-norm(first - bary)` 为 0。
+- `graphics-get-all-previous-points` 用 `current-point-no` 作下标索引 `(sketch-get1)` 对象的子节点；group-edit 下该变量残留为绘制时的陈旧值，而 sketch 装的是点数更少的 text-at，导致越界。
+
+## 6 How
+- `group-zoom`：取出分母 `denom`，`(< denom 1e-9)` 时（首点与重心重合，缩放比例无定义）取 `h=1.0`，对象保持原大小，避免除零；正常路径算法与返回值完全不变。
+- `graphics-get-all-previous-points`：循环上限由 `current-point-no` 改为 `(min current-point-no (length pts))`，按 `pts` 实际长度截断；收集逻辑、返回结构不变，仅丢弃越界下标，下游 C++ 侧 `N(t_prev) >= 2` 的检查自然过滤退化情形。


### PR DESCRIPTION
# [0877] 修复选中文本框缩放时的两处 crash

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `TeXmacs/progs/graphics/graphics-group.scm` — `group-zoom` 分母为零时回退 `h=1.0`
- `TeXmacs/progs/graphics/graphics-ghost.scm` — `graphics-get-all-previous-points` 按 `pts` 实际长度截断遍历

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）
1. 插入文本框后缩放该对象，不会出现任何报错，且绘图区不会 crash。

## 4 What
- 插入文本框后选中缩放工具拖动缩放，报 `division by zero, (/ ... 0.0)`；
- 同场景下鼠标在绘图区移动，报 `list-ref second argument, 2, is out of range`。

## 5 Why
- text-at 只有一个锚点，`store-important-points` 算出的重心等于该锚点；缩放起点（鼠标按下处）若与之重合，`group-zoom` 的分母 `point-norm(first - bary)` 为 0。
- `graphics-get-all-previous-points` 用 `current-point-no` 作下标索引 `(sketch-get1)` 对象的子节点；group-edit 下该变量残留为绘制时的陈旧值，而 sketch 装的是点数更少的 text-at，导致越界。

## 6 How
- `group-zoom`：取出分母 `denom`，`(< denom 1e-9)` 时（首点与重心重合，缩放比例无定义）取 `h=1.0`，对象保持原大小，避免除零；正常路径算法与返回值完全不变。
- `graphics-get-all-previous-points`：循环上限由 `current-point-no` 改为 `(min current-point-no (length pts))`，按 `pts` 实际长度截断；收集逻辑、返回结构不变，仅丢弃越界下标，下游 C++ 侧 `N(t_prev) >= 2` 的检查自然过滤退化情形。
