### PR TITLE
[1169] 修复数学模式工具栏按钮点击崩溃及字符渲染错误

### DIFF
--- a/devel/1169.md
+++ b/devel/1169.md
@@ -4,10 +4,11 @@
 - [dddd.md](dddd.md) - 任务文档模板
 
 ## 2 任务相关的代码文件
+- `src/Graphics/Renderer/renderer.cpp`（`draw_emoji` unchecked 强转修复）
 - `src/Plugins/Qt/qt_picture.cpp`（`as_qt_picture` 修复）
 - `src/Plugins/Qt/qt_picture.hpp`（补充 `as_qt_picture` 声明）
 - `src/Plugins/MuPDF/mupdf_picture.cpp`（`mupdf_picture_rep::get_type()` 返回 `picture_native`）
-- `src/Graphics/Renderer/renderer.cpp`（`draw_emoji`，崩溃触发路径之一）
+- `src/Data/String/unicode.cpp` / `lolly/lolly/data/unicode.cpp`（emoji 码位区间判定）
 - `tests/Plugins/Qt/qt_picture_test.cpp`（新增回归测试）
 
 ## 3 崩溃定位过程（日志分析）
@@ -39,6 +40,22 @@ addr2line -Cfe build/linux/x86_64/releasedbg/moganstem \
 
 ### 3.3 根因
 
+根因有两个，叠加导致「crash → 修复后显示错误字符」的现象。
+
+**根因 A：`draw_emoji` 对 font_glyphs 的 unchecked 强转（错字符 + 野指针）**
+
+`renderer_rep::draw_emoji`（renderer.cpp:490）原本直接
+`static_cast<tt_font_glyphs_rep*> (fn.rep)`。但数学模式工具栏按钮的符号经
+poor/virtual 字体包装（如 `poor_bold_font_rep::draw_fixed` 里
+`ren->draw (c, fng)` 的 `fng` 是 `bolden()` 包装后的 glyphs），并不是
+`tt_font_glyphs_rep`。符号码位落在 emoji 区间（unicode.cpp 的
+`unicode_get_range` 把 U+2600–26FF、U+2700–27BF 等划为 "emoji"，数学符号
+如 ✖ U+2716、➗ U+2797 均在列）时进入 `draw_emoji`，强转后按错误偏移读
+`face`/`cbdt_table`：轻则拿到错误的字体数据渲染出**错误的 emoji 位图**
+（用户看到「显示的字符不是正确的字符」），重则野指针直接段错误。
+
+**根因 B：`as_qt_picture` 信任 `picture_native` 类型标签（drawImage 段错误）**
+
 `QImage::devicePixelRatio` 崩在 `this` 非法，说明传入 `drawImage` 的
 `QImage&` 是野引用。`draw_picture` 里：
 
@@ -58,7 +75,7 @@ picture 原样放行，随后 C 风格强转成 `qt_picture_rep*`，按错误偏
 野 `QImage`，`drawImage` 解引用即段错误。
 
 凡经 `cached_load_picture` 进入 Qt 渲染器的图片都会踩中该问题（文档内嵌
-图片、emoji 位图等）；本次是点击含彩色 emoji（CBDT 字体）的工具按钮时，
+图片、emoji 位图等）；本次是点击数学模式工具栏按钮时，
 `draw_emoji` → `load_scalable_image` 路径触发。
 
 ## 4 如何测试
@@ -92,22 +109,29 @@ gf fmt --changed-since=main
 
 ## 6 What
 
-1. 修复 `as_qt_picture`：USE_MUPDF_RENDERER 构建下改用 `dynamic_cast`
+1. 修复 `draw_emoji` 的 unchecked 强转：`static_cast<tt_font_glyphs_rep*>`
+   改为 `dynamic_cast`，非 TrueType glyphs（数学模式经 poor/virtual 字体
+   包装的符号）直接返回 false 走正常字形渲染，不再误入 emoji 位图路径。
+2. 修复 `as_qt_picture`：USE_MUPDF_RENDERER 构建下改用 `dynamic_cast`
    区分 `qt_picture_rep` 与 `mupdf_picture_rep`，不再信任
    `picture_native` 类型标签。
-2. MuPDF picture 走快速转换：直接把 `fz_pixmap` 采样按行 memcpy 成
+3. MuPDF picture 走快速转换：直接把 `fz_pixmap` 采样按行 memcpy 成
    `QImage`（n=4 对应 `Format_RGBA8888_Premultiplied`，n=3 对应
    `Format_RGB888`），其它格式回退到逐像素 `copy_from`。
-3. `qt_picture.hpp` 补充 `as_qt_picture` 函数声明（原本只有定义、无声明）。
-4. 新增 `tests/Plugins/Qt/qt_picture_test.cpp` 回归测试。
+4. `qt_picture.hpp` 补充 `as_qt_picture` 函数声明（原本只有定义、无声明）。
+5. 新增 `tests/Plugins/Qt/qt_picture_test.cpp` 回归测试。
 
 ## 7 Why
 
-USE_MUPDF_RENDERER 构建中 MuPDF picture 与 Qt picture 共用
-`picture_native` 类型标签，`as_qt_picture` 的
+数学模式工具栏按钮的符号经 poor/virtual 字体包装后 font_glyphs 不再是
+`tt_font_glyphs_rep`，`draw_emoji` 的强转按错误偏移读 `face`，渲染出
+错误的 emoji 位图（字符不对）甚至野指针崩溃；这是「不该进入 emoji 路径
+却进入」的直接原因。此外 USE_MUPDF_RENDERER 构建中 MuPDF picture 与
+Qt picture 共用 `picture_native` 类型标签，`as_qt_picture` 的
 `get_type() == picture_native` 快速路径会把 MuPDF picture 误判为 Qt
 picture，后续 `(qt_picture_rep*) get_handle()` 强转产生非法 `QImage`
-引用，`QPainter::drawImage` 一访问即段错误。
+引用，`QPainter::drawImage` 一访问即段错误——emoji 路径正常进入时
+（如文档正文 emoji）也会崩，所以这条路径本身也要修。
 
 ## 8 How
 
@@ -118,6 +142,10 @@ picture，后续 `(qt_picture_rep*) get_handle()` 强转产生非法 `QImage`
 `QImage::Format_RGBA8888_Premultiplied` / `Format_RGB888` 内存布局一致，
 逐行 memcpy 即可完成零逐像素开销的转换；通道数不匹配时回退到原有
 `copy_from` 逐像素路径，保证任意 picture 类型都有正确结果。
+
+`draw_emoji` 侧：`fn.rep` 在 renderer.cpp 中本就可访问，直接
+`dynamic_cast<tt_font_glyphs_rep*>`，为 NULL 或 face/CBDT 表缺失时
+返回 false，调用方（qt/mupdf/pdf 渲染器）回落到普通字形绘制。
 
 注意：QtTest 的 moc 不处理 `USE_MUPDF_RENDERER` 宏，测试槽位声明不能
 放在 `#ifdef` 里（否则 moc 生成的元对象缺少该槽，用例被静默跳过），

--- a/devel/1169.md
+++ b/devel/1169.md
@@ -1,0 +1,124 @@
+# [1169] 修复 Qt 渲染器绘制 MuPDF picture 时的段错误
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_picture.cpp`（`as_qt_picture` 修复）
+- `src/Plugins/Qt/qt_picture.hpp`（补充 `as_qt_picture` 声明）
+- `src/Plugins/MuPDF/mupdf_picture.cpp`（`mupdf_picture_rep::get_type()` 返回 `picture_native`）
+- `src/Graphics/Renderer/renderer.cpp`（`draw_emoji`，崩溃触发路径之一）
+- `tests/Plugins/Qt/qt_picture_test.cpp`（新增回归测试）
+
+## 3 崩溃定位过程（日志分析）
+
+### 3.1 方法：addr2line 解析 backtrace
+
+崩溃时进程打印的 C++ backtrace 只有地址。releasedbg 构建带调试符号，
+直接用 `addr2line -Cfe` 把 `moganstem(+0x...)` 的偏移解析成函数与行号：
+
+```bash
+addr2line -Cfe build/linux/x86_64/releasedbg/moganstem \
+  0x3dc203 0x4dd1a5 0x79e45b 0x39b8b5 0x4d6669 0x9fa3c5 ...
+```
+
+### 3.2 解析结果
+
+| 偏移 | 位置 |
+|------|------|
+| 0x3dc203 | `clean_exit_on_signal`（init_texmacs.cpp:144，信号处理器） |
+| 0x4dd1a5 | `qt_renderer_rep::draw_picture`（qt_picture.cpp:147，`painter->drawImage`） |
+| 0x79e45b / 0x39b8b5 | `picture`/`scalable` 内联帧（releasedbg -O2 内联归属噪声） |
+| 0x4d6669 | `qt_renderer_rep::draw`（qt_renderer.cpp:612，即 `draw_emoji` 调用点，被内联） |
+| 顶层 Qt 帧 | `QRasterPaintEngine::drawImage` → `QImage::devicePixelRatio` 崩溃 |
+
+调用链：点击 QToolButton → `box_widget_rep::handle_repaint`
+（tm_button.cpp:172）→ box 重绘 → `font_rep::draw` →
+`qt_renderer_rep::draw` → `draw_emoji` → `draw_scalable` →
+`scalable_image_rep::draw` → `qt_renderer_rep::draw_picture` → 崩溃。
+
+### 3.3 根因
+
+`QImage::devicePixelRatio` 崩在 `this` 非法，说明传入 `drawImage` 的
+`QImage&` 是野引用。`draw_picture` 里：
+
+```cpp
+p                   = as_qt_picture (p);                      // 期望转成 qt picture
+qt_picture_rep* pict= (qt_picture_rep*) p->get_handle ();
+painter->drawImage (x - x0, y - y0, pict->pict);              // pict 实际不是 qt_picture_rep
+```
+
+本构建 `USE_MUPDF_RENDERER` 恒为真（`xmake/options.lua` 里
+`set_config("mupdf", true)` 强制开启），`load_picture` 是 MuPDF 版本
+（mupdf_picture.cpp:711），返回 `mupdf_picture_rep`。而
+`mupdf_picture_rep::get_type()` 与 `qt_picture_rep` 一样返回
+`picture_native`（mupdf_picture.cpp:44），导致 `as_qt_picture` 的
+快速路径 `if (pic->get_type () == picture_native) return pic;` 把 MuPDF
+picture 原样放行，随后 C 风格强转成 `qt_picture_rep*`，按错误偏移读出
+野 `QImage`，`drawImage` 解引用即段错误。
+
+凡经 `cached_load_picture` 进入 Qt 渲染器的图片都会踩中该问题（文档内嵌
+图片、emoji 位图等）；本次是点击含彩色 emoji（CBDT 字体）的工具按钮时，
+`draw_emoji` → `load_scalable_image` 路径触发。
+
+## 4 如何测试
+
+### 4.1 确定性测试（单元测试）
+
+```bash
+xmake b qt_picture_test && xmake r qt_picture_test
+```
+
+`test_as_qt_picture_converts_mupdf_picture` 构造 MuPDF native picture，
+断言 `as_qt_picture` 转换结果是真正的 `qt_picture_rep` 且像素一致。
+已验证：修复前该用例在 dynamic_cast 断言处失败，修复后通过。
+
+### 4.2 非确定性测试（GUI 验证）
+
+```bash
+xmake b stem && xmake r stem
+```
+
+打开 Mogan，点击含 emoji 的工具按钮（原崩溃场景），不再段错误；
+文档中插入图片可正常显示。
+
+## 5 如何提交
+
+```bash
+xmake b stem
+xmake b qt_picture_test && xmake r qt_picture_test
+gf fmt --changed-since=main
+```
+
+## 6 What
+
+1. 修复 `as_qt_picture`：USE_MUPDF_RENDERER 构建下改用 `dynamic_cast`
+   区分 `qt_picture_rep` 与 `mupdf_picture_rep`，不再信任
+   `picture_native` 类型标签。
+2. MuPDF picture 走快速转换：直接把 `fz_pixmap` 采样按行 memcpy 成
+   `QImage`（n=4 对应 `Format_RGBA8888_Premultiplied`，n=3 对应
+   `Format_RGB888`），其它格式回退到逐像素 `copy_from`。
+3. `qt_picture.hpp` 补充 `as_qt_picture` 函数声明（原本只有定义、无声明）。
+4. 新增 `tests/Plugins/Qt/qt_picture_test.cpp` 回归测试。
+
+## 7 Why
+
+USE_MUPDF_RENDERER 构建中 MuPDF picture 与 Qt picture 共用
+`picture_native` 类型标签，`as_qt_picture` 的
+`get_type() == picture_native` 快速路径会把 MuPDF picture 误判为 Qt
+picture，后续 `(qt_picture_rep*) get_handle()` 强转产生非法 `QImage`
+引用，`QPainter::drawImage` 一访问即段错误。
+
+## 8 How
+
+`picture` 智能指针的 `rep` 成员是私有的，通过 `pic.operator->()` 取
+原始指针做 `dynamic_cast`（项目已启用 RTTI，qt_renderer.cpp 中已有
+先例）。识别为 `mupdf_picture_rep` 时，fz_pixmap 采样为 RGB(A)
+预乘格式（见 mupdf_picture.hpp 头部注释），与
+`QImage::Format_RGBA8888_Premultiplied` / `Format_RGB888` 内存布局一致，
+逐行 memcpy 即可完成零逐像素开销的转换；通道数不匹配时回退到原有
+`copy_from` 逐像素路径，保证任意 picture 类型都有正确结果。
+
+注意：QtTest 的 moc 不处理 `USE_MUPDF_RENDERER` 宏，测试槽位声明不能
+放在 `#ifdef` 里（否则 moc 生成的元对象缺少该槽，用例被静默跳过），
+只能把 `#ifdef` 放在函数体内。

--- a/src/Graphics/Renderer/renderer.cpp
+++ b/src/Graphics/Renderer/renderer.cpp
@@ -486,9 +486,11 @@ renderer_rep::draw_scalable (scalable im, SI x, SI y, int alpha) {
 bool
 renderer_rep::draw_emoji (int char_code, font_glyphs fn, SI x, SI y) {
   static hashmap<index_type, scalable> emoji_cache;
-  // Cast to TrueType font glyphs representation
-  auto tt_font= static_cast<tt_font_glyphs_rep*> (fn.rep);
-  if (is_nil (tt_font->face) || is_nil (tt_font->face->cbdt_table)) {
+  // fn 可能是 poor/virtual 字体的 glyphs（如数学模式的加粗符号经
+  // poor_bold 包装），并非 tt_font_glyphs_rep，强转会读到野 face
+  auto tt_font= dynamic_cast<tt_font_glyphs_rep*> (fn.rep);
+  if (tt_font == NULL || is_nil (tt_font->face) ||
+      is_nil (tt_font->face->cbdt_table)) {
     return false;
   }
 

--- a/src/Plugins/Qt/qt_picture.cpp
+++ b/src/Plugins/Qt/qt_picture.cpp
@@ -22,6 +22,12 @@
 #include "scheme.hpp"
 #include "tm_file.hpp"
 
+#ifdef USE_MUPDF_RENDERER
+#include "mupdf_picture.hpp"
+#endif
+
+#include <cstring>
+
 #include <QObject>
 #include <QPaintDevice>
 #include <QPainter>
@@ -84,7 +90,27 @@ qt_picture (const QImage& im, int ox, int oy) {
 
 picture
 as_qt_picture (picture pic) {
+#ifdef USE_MUPDF_RENDERER
+  // mupdf_picture_rep 同样上报 picture_native，类型标签无法区分两种
+  // native picture，必须按实际 rep 类型判断，否则强转会读到非法 QImage
+  if (dynamic_cast<qt_picture_rep*> (pic.operator->()) != NULL) return pic;
+  if (mupdf_picture_rep* mp=
+          dynamic_cast<mupdf_picture_rep*> (pic.operator->())) {
+    fz_pixmap* pix= mp->pix;
+    QImage     qimg;
+    if (pix->n == 4)
+      qimg= QImage (mp->w, mp->h, QImage::Format_RGBA8888_Premultiplied);
+    else if (pix->n == 3) qimg= QImage (mp->w, mp->h, QImage::Format_RGB888);
+    if (!qimg.isNull ()) {
+      const uchar* src= fz_pixmap_samples (mupdf_context (), pix);
+      for (int y= 0; y < mp->h; y++)
+        memcpy (qimg.scanLine (y), src + y * pix->stride, mp->w * pix->n);
+      return qt_picture (qimg, mp->ox, mp->oy);
+    }
+  }
+#else
   if (pic->get_type () == picture_native) return pic;
+#endif
   picture ret= qt_picture (
       QImage (pic->get_width (), pic->get_height (), QImage::Format_ARGB32),
       pic->get_origin_x (), pic->get_origin_y ());

--- a/src/Plugins/Qt/qt_picture.hpp
+++ b/src/Plugins/Qt/qt_picture.hpp
@@ -38,6 +38,7 @@ public:
 
 QImage* get_image (url u, int w, int h, tree eff, SI pixel);
 picture qt_picture (const QImage& im, int ox, int oy);
+picture as_qt_picture (picture pic);
 QImage* xpm_image (url file_name);
 QPixmap qt_load_svg_icon (url file_name);
 QIcon   qt_load_icon (url file_name);

--- a/tests/Plugins/Qt/qt_picture_test.cpp
+++ b/tests/Plugins/Qt/qt_picture_test.cpp
@@ -34,20 +34,20 @@ void
 TestQtPicture::test_as_qt_picture_keeps_qt_picture () {
   picture p= qt_picture (QImage (3, 2, QImage::Format_ARGB32), 1, 1);
   picture q= as_qt_picture (p);
-  QVERIFY (dynamic_cast<qt_picture_rep*> (q.operator-> ()) != NULL);
-  QCOMPARE (q.operator-> (), p.operator-> ());
+  QVERIFY (dynamic_cast<qt_picture_rep*> (q.operator->()) != NULL);
+  QCOMPARE (q.operator->(), p.operator->());
 }
 
 void
 TestQtPicture::test_as_qt_picture_converts_mupdf_picture () {
 #ifdef USE_MUPDF_RENDERER
   picture p= native_picture (3, 2, 1, 1);
-  QVERIFY (dynamic_cast<mupdf_picture_rep*> (p.operator-> ()) != NULL);
+  QVERIFY (dynamic_cast<mupdf_picture_rep*> (p.operator->()) != NULL);
   p->set_pixel (0, 0, 0xFFFF0000);
 
   picture q= as_qt_picture (p);
   // 转换结果必须是真正的 qt_picture_rep，drawImage 才不会踩野指针
-  QVERIFY (dynamic_cast<qt_picture_rep*> (q.operator-> ()) != NULL);
+  QVERIFY (dynamic_cast<qt_picture_rep*> (q.operator->()) != NULL);
   QCOMPARE (q->get_width (), 3);
   QCOMPARE (q->get_height (), 2);
   QCOMPARE (q->get_origin_x (), 1);

--- a/tests/Plugins/Qt/qt_picture_test.cpp
+++ b/tests/Plugins/Qt/qt_picture_test.cpp
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * MODULE     : qt_picture_test.cpp
+ * DESCRIPTION: USE_MUPDF_RENDERER 构建下，mupdf_picture_rep 与 qt_picture_rep
+ *              的 get_type() 同为 picture_native，as_qt_picture 必须按实际
+ *              rep 类型区分并完成像素转换，否则 qt_renderer_rep::draw_picture
+ *              对 get_handle() 的强转产生非法 QImage 引用导致段错误
+ *              （见 devel/1169.md）。
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "base.hpp"
+#include "qt_picture.hpp"
+
+#ifdef USE_MUPDF_RENDERER
+#include "mupdf_picture.hpp"
+#endif
+
+#include <QtTest/QtTest>
+
+class TestQtPicture : public QObject {
+  Q_OBJECT
+private slots:
+  void init () { init_lolly (); }
+  void cleanup () { cleanup_qt_top_level_widgets (); }
+  void test_as_qt_picture_keeps_qt_picture ();
+  void test_as_qt_picture_converts_mupdf_picture ();
+};
+
+void
+TestQtPicture::test_as_qt_picture_keeps_qt_picture () {
+  picture p= qt_picture (QImage (3, 2, QImage::Format_ARGB32), 1, 1);
+  picture q= as_qt_picture (p);
+  QVERIFY (dynamic_cast<qt_picture_rep*> (q.operator-> ()) != NULL);
+  QCOMPARE (q.operator-> (), p.operator-> ());
+}
+
+void
+TestQtPicture::test_as_qt_picture_converts_mupdf_picture () {
+#ifdef USE_MUPDF_RENDERER
+  picture p= native_picture (3, 2, 1, 1);
+  QVERIFY (dynamic_cast<mupdf_picture_rep*> (p.operator-> ()) != NULL);
+  p->set_pixel (0, 0, 0xFFFF0000);
+
+  picture q= as_qt_picture (p);
+  // 转换结果必须是真正的 qt_picture_rep，drawImage 才不会踩野指针
+  QVERIFY (dynamic_cast<qt_picture_rep*> (q.operator-> ()) != NULL);
+  QCOMPARE (q->get_width (), 3);
+  QCOMPARE (q->get_height (), 2);
+  QCOMPARE (q->get_origin_x (), 1);
+  QCOMPARE (q->get_origin_y (), 1);
+  QCOMPARE (q->get_pixel (0, 0), p->get_pixel (0, 0));
+  QCOMPARE (q->get_pixel (-1, -1), p->get_pixel (-1, -1));
+#endif
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestQtPicture)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "qt_picture_test.moc"


### PR DESCRIPTION
## Summary
- 修复 `renderer_rep::draw_emoji` 对 `font_glyphs` 的 unchecked `static_cast<tt_font_glyphs_rep*>`：数学模式工具栏符号经 poor/virtual 字体包装后并非 `tt_font_glyphs_rep`，码位落在 emoji 区间（U+2600–26FF、U+2700–27BF）时强转按错误偏移读 `face`，渲染出错误字符甚至野指针崩溃。改用 `dynamic_cast`，非 TrueType glyphs 直接返回 false 走正常字形渲染
- 修复 `as_qt_picture` 信任 `picture_native` 类型标签：USE_MUPDF_RENDERER 构建下 MuPDF picture 同样上报 `picture_native`，被误判为 Qt picture 后强转产生野 `QImage`，`QPainter::drawImage` 解引用即段错误。改用 `dynamic_cast` 区分，MuPDF picture 直接按行 memcpy `fz_pixmap` 采样完成转换
- 新增 `tests/Plugins/Qt/qt_picture_test.cpp` 回归测试（已验证修复前失败、修复后通过）
- 任务文档：devel/1169.md（含 addr2line 崩溃定位过程与根因分析）

## Test plan
- [x] `xmake b stem` 构建通过
- [x] `xmake b qt_picture_test && xmake r qt_picture_test` 4 用例全过
- [x] 回归有效性：临时还原旧逻辑后 `test_as_qt_picture_converts_mupdf_picture` 按预期失败
- [ ] GUI 验证：点击数学模式工具栏按钮，确认不再崩溃且显示正确数学字形

🤖 Generated with [Claude Code](https://claude.com/claude-code)