### PR TITLE
[1169] emoji 绘制路径 drawImage 崩溃：崩溃分析 + 三层防御性判空

### DIFF
--- a/devel/1169.md
+++ b/devel/1169.md
@@ -1,0 +1,127 @@
+# [1169] 修复 emoji 绘制路径 drawImage 崩溃
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_picture.cpp`（draw_picture:147，崩溃点）
+- `src/Plugins/Qt/qt_renderer.cpp`（draw:612，draw_emoji 调用点）
+- `src/Graphics/Renderer/renderer.cpp`（draw_emoji:487）
+- `src/Graphics/Pictures/scalable.cpp`（scalable_image_rep::draw:70）
+- `src/Graphics/Pictures/picture.cpp`（picture 缓存：cached_load_picture:229）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+# ASan 构建复现崩溃（先 xmake clean -a 避免陈旧对象），获取精确 UAF 报告
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+分析并修复 releasedbg 下彩色 emoji 绘制路径的段错误：
+`qt_renderer_rep::draw_picture` 向 QPainter 提交 QImage 时，
+Qt 内 `QImage::devicePixelRatio()` 崩溃。
+
+## 6 Why
+崩溃栈顶在 Qt 库（`QRasterPaintEngine::drawImage` → `QImage::devicePixelRatio`），
+需要定位是 mogan 侧传入了非法 QImage 还是 Qt 问题。
+
+## 7 How
+
+### 7.1 崩溃分析过程
+
+**addr2line 符号化**（releasedbg 有内联，中间帧归属有偏差，首尾帧与 Qt 帧自洽）：
+
+```
+0x3dc583  clean_exit_on_signal            init_texmacs.cpp:144   ← SIGSEGV 处理函数，非崩溃点
+0x4dd525  qt_renderer_rep::draw_picture   qt_picture.cpp:147     ← painter->drawImage(..., pict->pict)
+0x79ed5b  scalable/picture 析构（内联误判） scalable.hpp:46         ← 实为 scalable_image_rep::draw 内联帧
+0x39bc45  qt_renderer_rep::draw           qt_renderer.cpp:612    ← if (draw_emoji (...))
+0x4d69e9  resource_ptr::operator->        lolly resource.hpp:42  ← 上层排版调用
+```
+
+坐实的调用链：
+
+```
+qt_renderer_rep::draw (qt_renderer.cpp:612)
+  → renderer_rep::draw_emoji (renderer.cpp:487)
+    → draw_scalable → scalable_image_rep::draw (scalable.cpp:70)
+      → cached_load_picture (picture.cpp:229)
+      → qt_renderer_rep::draw_picture (qt_picture.cpp:147)
+        → QPainter::drawImage → QRasterPaintEngine::drawImage
+          → QImage::devicePixelRatio  ← 崩溃
+```
+
+**崩溃指令级定位**：反汇编 libQt6Gui.so.6 的 `QImage::devicePixelRatio()`：
+
+```asm
+16ff24:  mov    0x10(%rdi),%rax     ; rax = QImage::d
+16ff28:  test   %rax,%rax
+16ff2b:  je     +0x18              ; d==nullptr 则返回 1.0（空 QImage 安全）
+16ff2d:  movsd  0x18(%rax),%xmm0   ; ← +0xd，崩溃指令：读 d->devicePixelRatio
+```
+
+关键结论：**`d` 不是 nullptr（空指针检查已通过），但指向已释放/未映射内存**。
+不是「画了空 QImage」，而是 `pict->pict` 的 d 是野指针——
+`qt_picture_rep` 被提前释放（UAF）或堆被破坏。
+
+**触发条件**（`draw_emoji`，renderer.cpp:487）：
+
+1. `is_emoji_character(char_code)` 为真（unicode 区间判定为 "emoji"）；
+2. 字体 face 带 CBDT 彩色 emoji 位图表；
+3. `ft_get_char_index` 命中非零 glyph id；
+4. CBDT 表取出 PNG 数据 → `load_scalable_image(url_ramdisc(png_data))` → 走 picture 双层缓存。
+
+### 7.2 可疑点（按嫌疑排序）
+
+1. **picture 双层缓存的生命周期**：`picture_cache`（picture.cpp:151，存 `picture`）
+   + `qt_pic_cache`（qt_picture.cpp:341，存裸 `QImage*`）。
+   `picture_cache_clean()` / `picture_cache_reset()` 清缓存并
+   `qt_clean_picture_cache()` **delete 掉 QImage***。QImage 隐式共享理论上安全，
+   但缓存清理与 `draw_emoji` 的 static `emoji_cache`（renderer.cpp:488，常驻不析构）
+   存在时序窗口，是 UAF 首要嫌疑。
+2. **堆破坏**：`shrink()`/glyph 处理若越界写，同样会让 QImage 的 d 变野，
+   此时 emoji 路径只是受害者。
+3. 中间帧 0x79ed5b 符号化为析构函数，大概率是内联误判，
+   但不能完全排除崩溃在 picture/scalable 析构链上。
+
+### 7.3 顺带发现的相邻问题（非本次崩溃点）
+
+- `draw_emoji`（renderer.cpp:502）`fn->get(char_code)` 返回 nil glyph 时未判空
+  直接 `shrink(pre_gl, ...)`；正常路径 qt_renderer.cpp:635 有判空。
+- qt_renderer.cpp:610 声明了从未使用的 `static hashmap<index_type, picture> emoji_cache;` 死代码。
+
+### 7.4 下一步
+
+1. ASan 构建复现，拿精确 UAF/堆破坏报告；
+2. 审查 `picture_cache_reset/clean` 与 static `emoji_cache` 的交互时序；
+3. 补 `draw_emoji` 的 nil glyph 判空，删 qt_renderer.cpp:610 死代码。
+
+## 8 改动记录
+
+### 2026-08-05 draw_picture 最底层防御性判空
+
+**What**：在 `qt_renderer_rep::draw_picture`（qt_picture.cpp:139）入口加防御：
+`is_nil (p)` 直接返回；`get_handle()` 为 NULL 或 `pict->pict.isNull()` 直接返回。
+
+**Why**：崩溃栈显示 drawImage 提交的 QImage 失效。判空能挡住 nil picture、
+解码失败的空 QImage（如 CBDT PNG 加载失败）等路径；但对 d 为野指针的
+UAF 场景防不住（`isNull()` 本身也要读 d），真正修复依赖 ASan 定位缓存时序。
+
+**How**：最底层单点防御，不改上层调用链，保持行为最小侵入。
+
+**涉及文件**：`src/Plugins/Qt/qt_picture.cpp`

--- a/devel/1169.md
+++ b/devel/1169.md
@@ -137,3 +137,15 @@ UAF 场景防不住（`isNull()` 本身也要读 d），真正修复依赖 ASan 
 nil glyph 进 `shrink` 可能越界写，正是让 QImage d 变野的候选根因之一。
 
 **涉及文件**：`src/Graphics/Renderer/renderer.cpp`
+
+### 2026-08-05 scalable_image_rep::draw nil picture 判空
+
+**What**：`scalable_image_rep::draw`（scalable.cpp:76）在 `cached_load_picture`
+之后补 `if (is_nil (pict)) return;`。
+
+**Why**：第二次判空后崩溃依旧（栈同址 qt_picture.cpp:149）。补齐调用链上
+最后一处未判空的 picture 传递点。三层判空（draw_emoji → scalable::draw →
+draw_picture）已全覆盖，若仍复现则根因必为 UAF/堆破坏而非空值传递，
+需转 ASan 定位。
+
+**涉及文件**：`src/Graphics/Pictures/scalable.cpp`

--- a/devel/1169.md
+++ b/devel/1169.md
@@ -125,3 +125,15 @@ UAF 场景防不住（`isNull()` 本身也要读 d），真正修复依赖 ASan 
 **How**：最底层单点防御，不改上层调用链，保持行为最小侵入。
 
 **涉及文件**：`src/Plugins/Qt/qt_picture.cpp`
+
+### 2026-08-05 draw_emoji nil glyph 判空
+
+**What**：`renderer_rep::draw_emoji`（renderer.cpp:504）在 `fn->get(char_code)`
+之后、`shrink` 之前补 `if (is_nil (pre_gl)) return false;`。
+
+**Why**：第一次判空（draw_picture）后仍复现同样崩溃（栈偏移 0x4dd525→0x4dd568，
+崩溃点同址），证实 `isNull()` 只比较 `d==nullptr` 不解引用，野指针防不住。
+正常字符路径（qt_renderer.cpp:635）有 nil glyph 判空，emoji 路径缺失；
+nil glyph 进 `shrink` 可能越界写，正是让 QImage d 变野的候选根因之一。
+
+**涉及文件**：`src/Graphics/Renderer/renderer.cpp`

--- a/src/Graphics/Pictures/scalable.cpp
+++ b/src/Graphics/Pictures/scalable.cpp
@@ -76,6 +76,7 @@ public:
     }
     picture pict=
         cached_load_picture (u, w / ren->pixel, h / ren->pixel, eff, px, false);
+    if (is_nil (pict)) return;
     ren->draw_picture (pict, x, y, alpha);
   }
 };

--- a/src/Graphics/Renderer/renderer.cpp
+++ b/src/Graphics/Renderer/renderer.cpp
@@ -501,7 +501,8 @@ renderer_rep::draw_emoji (int char_code, font_glyphs fn, SI x, SI y) {
   // Calculate emoji size
   SI    xo, yo;
   glyph pre_gl= fn->get (char_code);
-  glyph gl    = shrink (pre_gl, std_shrinkf, std_shrinkf, xo, yo);
+  if (is_nil (pre_gl)) return false;
+  glyph gl= shrink (pre_gl, std_shrinkf, std_shrinkf, xo, yo);
   int   w= gl->width, h= gl->height;
   if (is_printer ()) {
     w= pre_gl->width, h= pre_gl->height;

--- a/src/Plugins/Qt/qt_picture.cpp
+++ b/src/Plugins/Qt/qt_picture.cpp
@@ -137,9 +137,11 @@ native_picture (int w, int h, int ox, int oy) {
 
 void
 qt_renderer_rep::draw_picture (picture p, SI x, SI y, int alpha) {
+  if (is_nil (p)) return;
   p                   = as_qt_picture (p);
   qt_picture_rep* pict= (qt_picture_rep*) p->get_handle ();
-  int             x0= pict->ox, y0= pict->h - 1 - pict->oy;
+  if (pict == NULL || pict->pict.isNull ()) return;
+  int x0= pict->ox, y0= pict->h - 1 - pict->oy;
   decode (x, y);
   qreal old_opacity= painter->opacity ();
   painter->setOpacity (qreal (alpha) / qreal (255));


### PR DESCRIPTION
## Summary
- 崩溃分析（addr2line + Qt 反汇编定位）：emoji CBDT 路径 `draw_picture` 提交 QImage 时 `QImage::d` 为野指针（非空但已失效），调用链 `qt_renderer_rep::draw` → `draw_emoji` → `scalable_image_rep::draw` → `draw_picture` → `QPainter::drawImage`
- `draw_picture` 防御性判空：nil picture / null QImage 直接返回
- `draw_emoji` 补 nil glyph 判空（与正常字符路径 qt_renderer.cpp:635 对齐）
- `scalable_image_rep::draw` 补 nil picture 判空
- 完整分析过程见 devel/1169.md

## 说明
三层判空为防御性修复。若崩溃仍复现，根因为 UAF/堆破坏（`QImage::d` 被覆写），需 ASan 复现定位缓存时序问题（`picture_cache_clean`/`qt_clean_picture_cache` 与 `draw_emoji` static `emoji_cache` 的交互窗口）。

## Test plan
- [x] `gf fmt --changed-since=main`
- [x] `xmake b stem` 构建通过
- [ ] ASan 构建复现验证（进行中）