### PR TITLE
[2090] 修复文档背景图片选择不生效

### DIFF
--- a/TeXmacs/tests/tmu/2090.tmu
+++ b/TeXmacs/tests/tmu/2090.tmu
@@ -1,0 +1,11 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\initial>
+  <\collection>
+    <associate|bg-color|<pattern|/home/da/git/mogan/TeXmacs/misc/images/stem-512.png|100%|100%>>
+    <associate|page-screen-margin|false>
+    <associate|stem-doc-id|E973E011-57F4-4570-8B5D-2BA1813203C0>
+  </collection>
+</initial>

--- a/devel/2090.md
+++ b/devel/2090.md
@@ -1,0 +1,85 @@
+# [2090] 文档背景色选择图片无法生效
+
+## 1 任务相关的代码文件
+- `src/Graphics/Renderer/brush.cpp` — `make_brush(tree, int)` 的 PATTERN 参数校验
+- `src/Graphics/Renderer/renderer.cpp` — `clear_pattern` 按 PATTERN 树平铺绘制背景
+- `TeXmacs/progs/generic/pattern-selector.scm` — 背景图片选择器，生成 3 参数 pattern
+- `tests/Graphics/Renderer/brush_test.cpp` — 回归测试
+
+## 2 如何测试
+
+### 2.1 单元测试
+```bash
+xmake b brush_test && xmake r brush_test
+```
+
+### 2.2 交互验证
+1. 文档 -> 颜色 -> 背景色 -> 图片，打开背景图片选择器；
+2. 点放大镜图标选择一张本地图片，Ok 后文档背景平铺显示该图片。
+
+## 3 What
+文档 -> 颜色 -> 背景色 -> 图片，选择图片并 Ok 后，文档背景没有任何变化。
+
+## 4 Why
+背景图片选择器生成的 pattern 是 3 参数形式 `(pattern image w h)`。
+[201_72]（a089a5dad）为修复导言区未定义颜色变量导致的 crash，给
+`make_brush(tree, int)` 加了防御性校验，但误将合法条件收紧为
+`N(p) == 4`，3 参数 pattern 被静默降级为 `no_brush`，
+`edit_interface_rep::draw_background` 拿不到有效画刷，背景不再绘制。
+
+## 5 How
+- `make_brush` 的 PATTERN 校验由 `N(p) != 4` 放宽为 `N(p) < 3`：
+  3 参数（无叠加色，默认 white）恢复合法；不足 3 参数（缺 w/h，
+  `clear_pattern` 会读 `p[1]`/`p[2]`，正是原 crash 场景）仍回退
+  `no_brush`。
+- 第 4 参数仅在 `is_atomic(p[3])` 时才作为叠加色名传给 `named_color`，
+  避免 4 参数带效果树（如 `eff-recolor`）时对复合树取 `as_string`。
+
+## 6 涉及文件
+- `src/Graphics/Renderer/brush.cpp`
+- `tests/Graphics/Renderer/brush_test.cpp`（新增）
+
+## 7 遗留问题调研记录
+
+### 7.1 背景图片路径存的是绝对路径（不改）
+设置背景图片时，文档里存的是绝对路径（如
+`<associate|bg-color|<pattern|/home/da/xxx.png|100%|100%>>`）。
+`tm-pattern`（`TeXmacs/progs/kernel/gui/menu-define.scm:787`）第二分支
+本可通过 `url->delta-unix`（`TeXmacs/progs/kernel/library/base.scm:394`，
+相对于 `buffer-get-master` 计算）存相对路径，但绝对路径不走该分支。
+结论：维持现状，不改。
+
+### 7.2 路径编码问题（tm 非 unicode，tmu 是 unicode）
+文档树中文件路径的既有约定是 **cork 编码**（`<#56FE>` 转义，纯 ASCII）：
+
+- 写入（插入图片）：`src/Edit/Modify/edit_text.cpp:375`
+  `utf8_to_cork (as_string (image, URL_STANDARD))`
+- 读取（图片排版）：`src/Typeset/Concat/concat_active.cpp:444`
+  `url_system (cork_to_utf8 (image_tree->label))`
+- 读取（include）：`src/Typeset/Env/env_exec.cpp:121`
+  `url_unix (cork_to_utf8 (exec_string (t[0])))`
+
+而背景图片链路两侧都不符合约定：
+
+- scheme 写入侧存的是 UTF-8：`pattern-selector.scm` 的 `set-name`
+  （约 70 行）→ `tm-pattern` 写入树
+- C++ 读取侧两处都没做 `cork_to_utf8`：
+  - `src/Typeset/Env/env_exec.cpp:2056`（`exec_pattern`）
+  - `src/Graphics/Renderer/brush.cpp` `get_pattern_url()`（约 108 行）
+
+tmu 格式下 pattern 第一个参数（图片链接）以 UTF-8 原样落盘
+（`moebius/Data/Convert/tmu.cpp:646` 只转义 `\ < | >` 和空格；
+读取侧 `tmu.cpp:312` 按 UTF-8 逐字符 decode）。
+
+实测（headless）：
+- `(utf8->cork "图")` → `<#56FE>`；`(cork->utf8 "图")`（输入已是 UTF-8）
+  → 乱码 `å¾`
+- 因此读侧加 `cork_to_utf8` 与写侧存 cork 必须配对修改；单独加读侧会把
+  tmu 的 UTF-8 标签转成乱码
+- cork 形式路径（含 `<#xx>`）经过 `tm-pattern` 的
+  `url->system`/`url-tail`/`url->delta-unix` 不会被 `#` 截断，安全
+- 兼容两种编码的启发式 helpers：`src/Data/String/wencoding.cpp:64`
+  （`looks_utf8`），参考 `qt_utilities.cpp:449` 的 `to_qstring`
+- 注意：选择器预览直接用 `global-pattern-color` 渲染，若只在 Ok 时
+  编码，中文路径的预览会破；要编需在 `set-name` 编。ASCII 路径经
+  `utf8->cork` 是恒等变换，不影响内置 pattern

--- a/src/Graphics/Renderer/brush.cpp
+++ b/src/Graphics/Renderer/brush.cpp
@@ -143,13 +143,15 @@ make_brush (color c) {
  * @brief 根据颜色描述树创建画刷对象。
  * @param p 画刷输入描述，支持两种形态：
  *   - 原子树：颜色名，例如 "red"、"#ff0000"、"none"。
- *   - 复合树：PATTERN(image, w, h, color)，当前实现要求 N(p) == 4。
+ *   - 复合树：PATTERN(image, w, h) 或 PATTERN(image, w, h, color)，
+ *     要求 N(p) >= 3（clear_pattern 会读取 p[1]/p[2]）。
  *     - p[0]：pattern 资源标识（通常是图片路径，必须为原子）。
  *     - p[1]：宽度表达式（例如 "20"、"100%"）。
  *     - p[2]：高度表达式（例如 "20"、"100%"）。
- *     - p[3]：叠加颜色名（传给 named_color，与 a 一起决定最终颜色）。
+ *     - p[3]：可选，叠加颜色名（传给 named_color，与 a 一起决定最终颜色）。
  *   示例：
  *   - p = "blue"
+ *   - p = (PATTERN "paper.png" "100%" "100%")
  *   - p = (PATTERN "paper.png" "100%" "100%" "white")
  * @param a 透明度 alpha，通常取值范围 [0, 255]。
  */
@@ -162,18 +164,18 @@ make_brush (tree p, int a) {
   }
   else {
     // 防御性处理：复合树必须是合法 PATTERN 结构。
-    // 否则继续解包可能在访问 pattern[1]/pattern[2]/pattern[3] 时触发异常。
+    // 否则继续解包可能在访问 pattern[1]/pattern[2] 时触发异常。
     // - L (p) != PATTERN：节点类型不对
-    // - N (p) != 4：参数个数不对（后续会读取 p[3]）
+    // - N (p) < 3：缺宽度/高度参数（绘制时会读取 p[1]/p[2]）
     // - !is_atomic (p[0])：资源标识形态不对（应为原子）
     // - as_string (p[0]) == "" || "{}"：资源标识为空或占位
-    if (L (p) != moebius::PATTERN || N (p) != 4 || !is_atomic (p[0]))
+    if (L (p) != moebius::PATTERN || N (p) < 3 || !is_atomic (p[0]))
       return tm_new<no_brush_rep> ();
     // p[0] 为空串或 "{}" 时直接回退 no_brush，避免后续取图路径异常。
     if (as_string (p[0]) == "" || as_string (p[0]) == "{}")
       return tm_new<no_brush_rep> ();
     color c= white;
-    c      = named_color (as_string (p[3]), a);
+    if (N (p) >= 4 && is_atomic (p[3])) c= named_color (as_string (p[3]), a);
     return tm_new<pattern_brush_rep> (c, p, a);
   }
 }

--- a/tests/Graphics/Renderer/brush_test.cpp
+++ b/tests/Graphics/Renderer/brush_test.cpp
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * MODULE     : brush_test.cpp
+ * DESCRIPTION: 回归测试 make_brush 对 PATTERN 树的参数个数校验。
+ *              [201_72] 的防御性修复曾要求 N(p)==4，导致背景图片选择器
+ *              生成的 3 参数 pattern（pattern image w h）被静默降级为
+ *              no_brush，文档背景图片不显示（[2090]）。
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "base.hpp"
+#include "brush.hpp"
+
+#include <QtTest/QtTest>
+#include <moebius/tree_label.hpp>
+
+using namespace moebius;
+
+class TestBrush : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_atomic_color ();
+  void test_pattern_three_args ();
+  void test_pattern_four_args ();
+  void test_malformed_patterns ();
+};
+
+void
+TestBrush::test_atomic_color () {
+  QCOMPARE (brush (tree ("red"))->get_type (), brush_color);
+  QCOMPARE (brush (tree ("none"))->get_type (), brush_none);
+  QCOMPARE (brush (tree (""))->get_type (), brush_none);
+}
+
+void
+TestBrush::test_pattern_three_args () {
+  tree p (PATTERN, "paper.png", "100%", "100%");
+  QCOMPARE (brush (p)->get_type (), brush_pattern);
+}
+
+void
+TestBrush::test_pattern_four_args () {
+  tree p (PATTERN, "paper.png", "100%", "100%", "white");
+  QCOMPARE (brush (p)->get_type (), brush_pattern);
+}
+
+void
+TestBrush::test_malformed_patterns () {
+  // 缺宽度/高度参数：绘制时会读取 p[1]/p[2]，必须回退 no_brush
+  QCOMPARE (brush (tree (PATTERN))->get_type (), brush_none);
+  QCOMPARE (brush (tree (PATTERN, "paper.png"))->get_type (),
+            brush_none);
+  QCOMPARE (brush (tree (PATTERN, "paper.png", "100%"))->get_type (),
+            brush_none);
+  // 资源标识为空或为占位符
+  QCOMPARE (brush (tree (PATTERN, "", "100%", "100%"))->get_type (),
+            brush_none);
+  QCOMPARE (brush (tree (PATTERN, "{}", "100%", "100%"))->get_type (),
+            brush_none);
+  // 非 PATTERN 复合树
+  QCOMPARE (brush (tree (DOCUMENT, "a"))->get_type (), brush_none);
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestBrush)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "brush_test.moc"

--- a/tests/Graphics/Renderer/brush_test.cpp
+++ b/tests/Graphics/Renderer/brush_test.cpp
@@ -54,8 +54,7 @@ void
 TestBrush::test_malformed_patterns () {
   // 缺宽度/高度参数：绘制时会读取 p[1]/p[2]，必须回退 no_brush
   QCOMPARE (brush (tree (PATTERN))->get_type (), brush_none);
-  QCOMPARE (brush (tree (PATTERN, "paper.png"))->get_type (),
-            brush_none);
+  QCOMPARE (brush (tree (PATTERN, "paper.png"))->get_type (), brush_none);
   QCOMPARE (brush (tree (PATTERN, "paper.png", "100%"))->get_type (),
             brush_none);
   // 资源标识为空或为占位符


### PR DESCRIPTION
## Summary
- 文档 -> 颜色 -> 背景色 -> 图片，选择图片后背景不显示。根因：[201_72] 给 `make_brush` 加的防御性校验误将合法 PATTERN 收紧为 `N(p)==4`，而背景图片选择器生成的是 3 参数 pattern `(pattern image w h)`，被静默降级为 `no_brush`。放宽为 `N(p)>=3`（缺 w/h 仍回退 `no_brush`，保留原 crash 修复）。
- 新增 `tests/Graphics/Renderer/brush_test.cpp` 回归测试（原子颜色、3/4 参数 pattern、畸形 pattern 共 6 项）。
- `devel/2090.md` 记录修复说明及遗留问题调研（背景图片路径为绝对路径——维持现状不改；路径 cork/UTF-8 编码链路分析——tm 非 unicode、tmu 为 unicode，读写两侧需配对修改，本次不动）。

## Test plan
- [x] `xmake b brush_test && xmake r brush_test`（6 项全过）
- [x] `TeXmacs/tests/tmu/2090.tmu` 手工验证：设置背景图片后文档背景平铺显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)