### PR TITLE
[2090] 临时禁用文档背景色图片入口

### DIFF
--- a/TeXmacs/progs/generic/document-menu.scm
+++ b/TeXmacs/progs/generic/document-menu.scm
@@ -936,7 +936,6 @@
  ("Palette" (interactive-background set-background '()))
  ("Pattern" (open-pattern-selector set-background "1cm"))
  ("Gradient" (open-gradient-selector set-background))
- ("Picture" (open-background-picture-selector set-background))
  ("Other" (init-interactive-env "bg-color"))
 ) ;menu-bind
 

--- a/devel/2090.md
+++ b/devel/2090.md
@@ -83,3 +83,19 @@ tmu 格式下 pattern 第一个参数（图片链接）以 UTF-8 原样落盘
 - 注意：选择器预览直接用 `global-pattern-color` 渲染，若只在 Ok 时
   编码，中文路径的预览会破；要编需在 `set-name` 编。ASCII 路径经
   `utf8->cork` 是恒等变换，不影响内置 pattern
+
+## 8 临时禁用文档背景图片入口（2026-08-05）
+
+### 8.1 What
+文档 -> 颜色 -> 背景色 -> 图片 菜单项暂时下线，后续会重新设计背景图片支持。
+
+### 8.2 Why
+现有背景图片链路存在路径编码等遗留问题（见 7.2），先隐藏入口，
+避免用户踩坑；底层 `open-background-picture-selector` 保留，
+表格单元格背景等其它入口不受影响。
+
+### 8.3 How
+删除 `document-background-color-menu` 中的 `("Picture" ...)` 一行。
+
+### 8.4 涉及文件
+- `TeXmacs/progs/generic/document-menu.scm`


### PR DESCRIPTION
## Summary
- 文档 -> 颜色 -> 背景色 -> 图片 菜单项暂时下线，后续会重新设计背景图片支持
- 仅删除 `document-background-color-menu` 中的 `("Picture" ...)` 一行；底层 `open-background-picture-selector` 保留，表格单元格背景等其它入口不受影响

## Test plan
- [ ] 打开 文档 -> 颜色 -> 背景色 菜单，确认无「图片」项，其余项（Palette/Pattern/Gradient/Other）正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)