### PR TITLE
[2091] 焦点高亮按 inline 白名单保留蓝色填充，块级结构改用边框

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ tools/loro-server/node_modules/
 tools/loro-server/data/
 # 协作服务端从仓库根运行时产生的测试数据
 /data/
+
+# Reasonix
+reasonix.toml

--- a/TeXmacs/tests/tmu/2091.tmu
+++ b/TeXmacs/tests/tmu/2091.tmu
@@ -1,45 +1,226 @@
-<TMU|<tuple|1.1.0|2026.2.12>>
+<TMU|<tuple|1.1.0|2026.3.0>>
 
 <style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
 
 <\body>
-  <section|绘图区域>
+  <subparagraph|em><em|强调>一般都是斜体
 
-  <with|gr-mode|<tuple|group-edit|edit-props>|gr-frame|<tuple|scale|2cm|<tuple|0.5gw|0.5gh>>|gr-geometry|<tuple|geometry|1par|0.6par>|gr-grid|<tuple|cartesian|<point|0|0>|1>|gr-edit-grid-aspect|<tuple|<tuple|axes|none>|<tuple|1|none>|<tuple|5|none>>|gr-edit-grid|<tuple|cartesian|<point|0|0>|1>|gr-props-text-at|<tuple|text-at-halign|center|text-at-valign|center>|gr-props-math-at|<tuple|text-at-halign|center|text-at-valign|center>|gr-props-document-at|<tuple|text-at-halign|center|doc-at-valign|center>|magnify|2.0|gr-as-visual-grid|off|gr-grid-aspect|<tuple|<tuple|axes|#808080>|<tuple|1|#c0c0c0>|<tuple|5|#e0e0ff>>|gr-grid-aspect-props|<tuple|<tuple|axes|#808080>|<tuple|1|#c0c0c0>|<tuple|5|#e0e0ff>>|<graphics||<rectangle|<point|-3.6|2.2>|<point|-3.4|2.0>>|<rectangle|<point|3.2|-1.8>|<point|3.4|-2.0>>>>
+  <subparagraph|strong><strong|着重>一般都是粗体
 
-  <section|有序列表>
+  <subparagraph|bold><bold|加粗>一般都是粗体
+
+  <dfn|dfn> <dfn|定义>一般都是粗体
+
+  <subparagraph|overline><overline|上划线>
+
+  <subparagraph|underline><underline|下划线>
+
+  <subparagraph|strike-through><strike-through|删除线>
+
+  <subparagraph|math>行内数学 <math|1+2>
+
+  <subparagraph|frac>行内数学里面有分式 <math|<frac|1|2>>
+
+  <subparagraph|sqrt>行内数学里面有根式 <math|<sqrt|x>>
+
+  <subparagraph|long-arrow><math|<long-arrow|\<rubber-rightarrow\>|\<bbb-d\>\<bbb-d\>>>
+
+  <subparagraph|wide> <math|<wide|a bc|\<wide-overbrace\>>+a> <math|<wide|a|\<ddot\>>>
+
+  <subparagraph|abbr><abbr|ABC>
+
+  <subparagraph|rsup>右侧上标 <math|x<rsup|2>>
+
+  <subparagraph|rsub>右侧下标 <math|x<rsub|2>>
+
+  <subparagraph|lsup>左侧上标 <math|<lsup|x>A>
+
+  <subparagraph|rsup>右侧下标 <math|<lsub|y>A>
+
+  <subparagraph|above>顶标 <above|拼音|pinyin>
+
+  <subparagraph|below>底标 <below|拼音|pinyin>
+
+  <subparagraph|really-tiny> <really-tiny|非常小>
+
+  <subparagraph|tiny><tiny|细小>
+
+  <subparagraph|very-tiny> <very-small|很小>
+
+  <subparagraph|small><small|小>
+
+  <subparagraph|normal-size><normal-size|正常大小>
+
+  <subparagraph|large><large|大>
+
+  <subparagraph|very-large><very-large|很大>
+
+  <subparagraph|huge><huge|巨大>
+
+  <subparagraph|very-huge><really-huge|非常大>
+
+  有序列表的每一行的序号会显示焦点的蓝色背景
 
   <\enumerate>
-    <item>答卷前，考生务必用黑色字迹钢笔或签字笔将自己的姓名、考生号、考场号和座位号填写在答题卡上。用2B铅笔将试卷类型（A）填涂在答题卡相应位置上。将条形码横贴在答题卡右上角“条形码粘贴处”。
+    <item>
 
-    <item>作答选择题时，选出每小题答案后，用2B铅笔在答题卡上对应题目选项的答案信息点涂黑；如需改动，用橡皮擦干净后，再选涂其他答案，答案不能答在试卷上。\ 
+    <item>
 
-    <item>非选择题必须用黑色字迹的钢笔或签字笔作答，答案必须写在答题卡各题目指定区域内相应位置上；如需改动，先划掉原来的答案，然后再写上新答案；不准使用铅笔和涂改液，不按以上要求作答无效。\ 
-
-    <item>考生必须保持答题卡的整洁。考试结束后，将试卷和答题卡一并交回。\ 
+    <item>
   </enumerate>
+
+  无序列表的每一行也会显示焦点的蓝色背景
+
+  <\itemize>
+    <item>
+
+    <item>
+
+    <item>
+  </itemize>
+
+  <section|没有蓝色背景>
+
+  <\big-table|<tabular|<tformat|<cwith|1|-1|1|-1|cell-hyphen|t>|<twith|table-hyphen|y>|<table|<row|<\cell>
+    1
+  </cell>|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>>|<row|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>>|<row|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>|<\cell>
+    \;
+  </cell>|<\cell>
+    1
+  </cell>>>>>>
+    \;
+  </big-table>
+
+  <\equation*>
+    <matrix|<tformat|<cwith|1|-1|1|-1|cell-hyphen|t>|<table|<row|<\cell>
+      1
+    </cell>|<\cell>
+      \;
+    </cell>>|<row|<\cell>
+      \;
+    </cell>|<\cell>
+      1
+    </cell>>>>>
+  </equation*>
+
+  <with|gr-mode|point|gr-frame|<tuple|scale|2cm|<tuple|0.5gw|0.5gh>>|gr-geometry|<tuple|geometry|1par|0.6par>|gr-grid|<tuple|cartesian|<point|0|0>|1>|gr-edit-grid-aspect|<tuple|<tuple|axes|none>|<tuple|1|none>|<tuple|5|none>>|gr-edit-grid|<tuple|cartesian|<point|0|0>|1>|gr-props-text-at|<tuple|text-at-halign|center|text-at-valign|center>|gr-props-math-at|<tuple|text-at-halign|center|text-at-valign|center>|gr-props-document-at|<tuple|text-at-halign|center|doc-at-valign|center>|magnify|2.0|gr-as-visual-grid|off|gr-grid-aspect|<tuple|<tuple|axes|#808080>|<tuple|1|#c0c0c0>|<tuple|5|#e0e0ff>>|gr-grid-aspect-props|<tuple|<tuple|axes|#808080>|<tuple|1|#c0c0c0>|<tuple|5|#e0e0ff>>|<graphics||<point|-1|1>|<point|0|0>|<point|1|-1>>>
 </body>
 
 <\initial>
   <\collection>
     <associate|page-screen-margin|false>
-    <associate|stem-doc-id|3DDAAEC1-7F73-4170-8AAF-21E632650F70>
+    <associate|preamble|false>
   </collection>
 </initial>
 
 <\references>
   <\collection>
     <associate|auto-1|<tuple|1|?>>
+    <associate|auto-10|<tuple|10|?>>
+    <associate|auto-11|<tuple|11|?>>
+    <associate|auto-12|<tuple|12|?>>
+    <associate|auto-13|<tuple|13|?>>
+    <associate|auto-14|<tuple|14|?>>
+    <associate|auto-15|<tuple|15|?>>
+    <associate|auto-16|<tuple|16|?>>
+    <associate|auto-17|<tuple|17|?>>
+    <associate|auto-18|<tuple|18|?>>
+    <associate|auto-19|<tuple|19|?>>
     <associate|auto-2|<tuple|2|?>>
+    <associate|auto-20|<tuple|20|?>>
+    <associate|auto-21|<tuple|21|?>>
+    <associate|auto-22|<tuple|22|?>>
+    <associate|auto-23|<tuple|23|?>>
+    <associate|auto-24|<tuple|24|?>>
+    <associate|auto-25|<tuple|25|?>>
+    <associate|auto-26|<tuple|26|?>>
+    <associate|auto-27|<tuple|27|?>>
+    <associate|auto-28|<tuple|1|?>>
+    <associate|auto-29|<tuple|1|?>>
+    <associate|auto-3|<tuple|3|?>>
+    <associate|auto-4|<tuple|4|?>>
+    <associate|auto-5|<tuple|5|?>>
+    <associate|auto-6|<tuple|6|?>>
+    <associate|auto-7|<tuple|7|?>>
+    <associate|auto-8|<tuple|8|?>>
+    <associate|auto-9|<tuple|9|?>>
   </collection>
 </references>
 
 <\auxiliary>
   <\collection>
     <\associate|toc>
-      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|1<space|2spc>绘图区域><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-1><vspace|0.5fn>
+      <with|par-left|<quote|4tab>|em<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-1>>
 
-      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|2<space|2spc>有序列表><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-2><vspace|0.5fn>
+      <with|par-left|<quote|4tab>|strong<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-2>>
+
+      <with|par-left|<quote|4tab>|bold<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-3>>
+
+      <with|par-left|<quote|4tab>|overline<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-4>>
+
+      <with|par-left|<quote|4tab>|underline<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-5>>
+
+      <with|par-left|<quote|4tab>|strike-through<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-6>>
+
+      <with|par-left|<quote|4tab>|math<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-7>>
+
+      <with|par-left|<quote|4tab>|frac<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-8>>
+
+      <with|par-left|<quote|4tab>|sqrt<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-9>>
+
+      <with|par-left|<quote|4tab>|long-arrow<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-10>>
+
+      <with|par-left|<quote|4tab>|wide<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-11>>
+
+      <with|par-left|<quote|4tab>|abbr<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-12>>
+
+      <with|par-left|<quote|4tab>|rsup<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-13>>
+
+      <with|par-left|<quote|4tab>|rsub<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-14>>
+
+      <with|par-left|<quote|4tab>|lsup<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-15>>
+
+      <with|par-left|<quote|4tab>|rsup<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-16>>
+
+      <with|par-left|<quote|4tab>|above<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-17>>
+
+      <with|par-left|<quote|4tab>|below<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-18>>
+
+      <with|par-left|<quote|4tab>|really-tiny<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-19>>
+
+      <with|par-left|<quote|4tab>|tiny<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-20>>
+
+      <with|par-left|<quote|4tab>|very-tiny<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-21>>
+
+      <with|par-left|<quote|4tab>|small<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-22>>
+
+      <with|par-left|<quote|4tab>|normal-size<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-23>>
+
+      <with|par-left|<quote|4tab>|large<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-24>>
+
+      <with|par-left|<quote|4tab>|very-large<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-25>>
+
+      <with|par-left|<quote|4tab>|huge<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-26>>
+
+      <with|par-left|<quote|4tab>|very-huge<datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-27>>
     </associate>
   </collection>
 </auxiliary>

--- a/devel/2091.md
+++ b/devel/2091.md
@@ -191,3 +191,22 @@ MSVC 的重载解析不认这个转换序列，模板版本
 已验证：最小用例在 `g++ -std=c++17 -pedantic-errors` 下，无 `OS_WIN`
 时保持原报错行为、定义 `OS_WIN` 时编译通过；`xmake b stem` 增量编译
 通过。
+
+## 2026/08/05 改写：白名单初始化直接用 hashset 的 << 链式插入
+
+### What
+移除 `array<string>` 中转与 `#ifdef OS_WIN` 的 `const char*` 重载补丁，
+改为 `tags << string ("strong") << ... << string ("subparagraph")`
+逐个显式构造 `string` 后链式插入 `hashset`。
+
+### Why
+`hashset` 自带 `operator<< (hashset<T>&, T)`（hashset.ipp:129），
+`string` 显式构造后模板推导 `T=string` 成功，全平台无歧义；不再依赖
+「字符串字面量 → char*」的弃用转换（GCC 的 `-Wwrite-strings` 告警随之
+消失），MSVC 亦无需任何条件编译补丁。`array` 中转与 `const char*`
+重载（无论是否限 `OS_WIN`）均不再需要。
+
+### How
+- `is_inline_focus_tag`：`array<string> init; init << ...; for (...) tags->insert (init[i])`
+  替换为 `tags << string (...) << ...` 链式。
+- 删除文件局部 `operator<< (array<string>&, const char*)` 及 `#ifdef OS_WIN` 块。

--- a/devel/2091.md
+++ b/devel/2091.md
@@ -164,3 +164,26 @@ GRAPHICS / enumerate* / itemize* / 表格的硬编码分流全部移除，
 - `call` 前加 `static bool scripts_edit_loaded` 一次性守卫，首次调用时
   `use-modules` 主动加载（沿用 edit_cursor.cpp / image_files.cpp 等处
   的既有模式）。CLI 前端仍由 `#ifndef MOGAN_CLI` 整体排除，不受影响。
+
+## 2026/08/05 修复：Windows 构建失败（array<string> 追加字符串字面量）
+
+### What
+`is_inline_focus_tag` 白名单初始化 `init << "strong"` 在 Windows/MSVC 下
+编译失败（C2676），Linux/GCC 正常。
+
+### Why
+lolly 的 `array.hpp` 只为 `array<string>` 提供了
+`operator<< (array<string>&, char*)`（非 const）重载，而字符串字面量是
+`const char*`。GCC 将「字面量 → char*」视为弃用转换，仅告警通过；
+MSVC 的重载解析不认这个转换序列，模板版本
+`operator<< (array<T>&, T)` 又因 `T` 推导冲突（`string` vs `const char*`）
+失败，最终无可用重载报 C2676。`src/Data/Convert/Texmacs/upgradetm.cpp`
+此前已踩过同一坑（其 `operator<< (array<string>&, const char*)` 正是为此）。
+
+### How
+在 `is_inline_focus_tag` 前新增文件局部
+`static array<string>& operator<< (array<string>&, const char*)`，
+转发到 `a << string (x)`，与 `upgradetm.cpp:4191` 同款写法。加完后
+`const char*` 实参在 GCC 与 MSVC 下都精确匹配该重载，跨平台通过。
+已验证：最小用例在 `g++ -std=c++17 -pedantic-errors`（模拟 MSVC 严格
+模式）下编译通过；`xmake b stem` 增量编译通过。

--- a/devel/2091.md
+++ b/devel/2091.md
@@ -184,9 +184,10 @@ MSVC 的重载解析不认这个转换序列，模板版本
 在 `is_inline_focus_tag` 前新增文件局部
 `static array<string>& operator<< (array<string>&, const char*)`，
 转发到 `a << string (x)`，与 `upgradetm.cpp:4191` 同款写法。该重载
-**仅在 Windows 生效**（`#ifdef _WIN32` 包裹）：MSVC 下 `const char*`
+**仅在 Windows 生效**（`#ifdef OS_WIN` 包裹，宏由 xmake
+`set_configvar` 定义于 build/config.h）：MSVC 下 `const char*`
 实参精确匹配它，编译通过；其余平台维持原行为不变（GCC 仍走 lolly 的
 `char*` 重载、仅弃用转换告警）。
-已验证：最小用例在 `g++ -std=c++17 -pedantic-errors` 下，无 `_WIN32`
-时保持原报错行为、定义 `_WIN32` 时编译通过；`xmake b stem` 增量编译
+已验证：最小用例在 `g++ -std=c++17 -pedantic-errors` 下，无 `OS_WIN`
+时保持原报错行为、定义 `OS_WIN` 时编译通过；`xmake b stem` 增量编译
 通过。

--- a/devel/2091.md
+++ b/devel/2091.md
@@ -26,14 +26,18 @@ xmake b stem
    预期只显示边框高亮，画布无半透明蓝色背景填充、内容不被遮挡。
 3. 光标点击进入「有序列表」一节的 enumerate 条目：
    预期整个 enumerate 环境只显示边框高亮，无整片蓝色背景填充。
-4. 在文档中插入一个无框表格（tabular），光标点击进入单元格：
+4. 光标点击进入「无序列表」一节的 itemize 条目：
+   预期整个 itemize 环境只显示边框高亮，无整片蓝色背景填充。
+5. 在文档中插入一个无框表格（tabular），光标点击进入单元格：
    预期表格只显示边框高亮，无蓝色背景填充；且开启
    「编辑 -> 首选项 -> 其他 -> 显示表格单元格」后，无框表格的灰色细线
    （单元格辅助线）仍然完整显示。
 5. 再插入一个有框表格（block），光标进入单元格：预期同样只显示边框
    高亮，表格自身的边框正常显示。
-6. 对照检查：光标进入普通段落文字时，焦点结构仍显示蓝色背景填充
-   （确认只影响绘图区、enumerate 和表格，不影响其他结构）。
+6. 行内标签对照：光标进入 strong/em 等行内标签文字时，仍显示蓝色背景
+   填充（确认白名单生效）。
+7. 普通段落对照：光标进入普通段落文字时，只显示边框高亮，无蓝色背景
+   填充（白名单方案下非 inline 结构一律不填充）。
 
 ## 2026/08/04 绘图区焦点高亮改为边框
 
@@ -91,3 +95,72 @@ env_rects 绘制（见 0150/0113），与非递归分支的 foc_rects 填充相�
   `path_inside_table (et, path_up (tp))`，与 `inside_graphics (false)`
   同样基于全局光标状态。实测确认：基于 p 的版本填充未被去掉，基于 tp
   后修复。
+
+## 2026/08/05 子任务：itemize 焦点关闭蓝色填充
+
+### What
+`compute_env_rects` 非递归分支的 outlines 分流条件追加 itemize 系列标签
+（itemize、itemize-dot、itemize-minus、itemize-arrow 等，标签名以
+"itemize" 开头），与 enumerate 一致改用边框。`2091.tmu` 增加
+「无序列表」一节用于手动验证。
+
+### Why
+无序列表与有序列表场景相同：条目多、覆盖面积大，整片蓝色填充干扰明显。
+
+### How
+- 原 `starts (label, "enumerate")` 条件扩展为
+  `starts (label, "enumerate") || starts (label, "itemize")`。
+
+## 2026/08/05 重构：按 inline 标签白名单决定是否保留蓝色填充
+
+### What
+`compute_env_rects` 的焦点填充策略反转：默认对所有结构只画边框
+（outlines），仅白名单内的 inline 标签（strong、em、dfn、samp、name、
+person、abbr、acronym、kbd、var、tt、verbatim、cite*、math、rsub、
+rsup、hlink、slink、action、item、cell、around、around*、sqrt、frac、
+frac*、dfrac、tfrac、cfrac、above、below、lsub、lsup、strike-through、
+underline、bold、really-tiny、
+tiny、very-small、normal-size、small、large、very-large、huge、really-huge、
+overline、long-arrow、wide、paragraph、subparagraph）保留半透明蓝色填充
+（thicken）。白名单用 `hashset<string>` 实现
+（`is_inline_focus_tag`）。原先针对
+GRAPHICS / enumerate* / itemize* / 表格的硬编码分流全部移除，
+`path_inside_table` 辅助函数随之删除；绘图区、列表、表格等块级结构
+不在白名单内，自然走边框路径，视觉效果与之前子任务一致。普通段落文字
+也不再显示蓝色填充，只显示边框。
+
+### Why
+逐个硬编码非 inline 标签是无底洞（绘图区、enumerate、itemize、表格……
+还有 equation、section 等无数块级结构）。需求本质是「inline tag 保留
+蓝色、非 inline tag 隐藏蓝色」。DRD 目前没有可查询的 inline/block
+属性（moebius 的 tag_info 预留了 block 标志位但未实现，`with-like`
+只是近似代理），故按用户决策用白名单显式指定 inline 标签。
+
+### How
+- 新增文件局部 `is_inline_focus_tag (tree st)`：`static hashset<string>`
+  惰性初始化白名单，`contains (as_string (L (st)))` 查询。
+- `compute_env_rects` 非递归分支：白名单命中 → `thicken`，否则 →
+  `outlines`。
+- `apply_changes` 处注释同步更新。
+- `2091.tmu` 增加「无序列表」一节；测试步骤 6/7 改为行内标签（保留蓝色）
+  与普通段落（只画边框）的对照检查。
+
+## 2026/08/05 修复：打开含绘图区文档报 unbound variable graphics-notify-extents
+
+### What
+打开 `2091.tmu`（含绘图区）时报
+`;unbound variable graphics-notify-extents`。在
+`notify_graphics_extents`（src/Typeset/Concat/concat_graphics.cpp）
+首次回调前主动 `eval ("(use-modules (dynamic scripts-edit))")`，
+一次性加载模块。
+
+### Why
+`graphics-notify-extents` 定义在 `(dynamic scripts-edit)`，该模块只经
+菜单链（`lazy-menu (dynamic scripts-menu) ...`）惰性加载；打开含绘图区
+的文档时排版器先触发回调，模块尚未加载，scheme 侧报未绑定。属加载顺序
+问题，与焦点高亮改动无关，但由本任务的测试文档暴露。
+
+### How
+- `call` 前加 `static bool scripts_edit_loaded` 一次性守卫，首次调用时
+  `use-modules` 主动加载（沿用 edit_cursor.cpp / image_files.cpp 等处
+  的既有模式）。CLI 前端仍由 `#ifndef MOGAN_CLI` 整体排除，不受影响。

--- a/devel/2091.md
+++ b/devel/2091.md
@@ -183,7 +183,10 @@ MSVC 的重载解析不认这个转换序列，模板版本
 ### How
 在 `is_inline_focus_tag` 前新增文件局部
 `static array<string>& operator<< (array<string>&, const char*)`，
-转发到 `a << string (x)`，与 `upgradetm.cpp:4191` 同款写法。加完后
-`const char*` 实参在 GCC 与 MSVC 下都精确匹配该重载，跨平台通过。
-已验证：最小用例在 `g++ -std=c++17 -pedantic-errors`（模拟 MSVC 严格
-模式）下编译通过；`xmake b stem` 增量编译通过。
+转发到 `a << string (x)`，与 `upgradetm.cpp:4191` 同款写法。该重载
+**仅在 Windows 生效**（`#ifdef _WIN32` 包裹）：MSVC 下 `const char*`
+实参精确匹配它，编译通过；其余平台维持原行为不变（GCC 仍走 lolly 的
+`char*` 重载、仅弃用转换告警）。
+已验证：最小用例在 `g++ -std=c++17 -pedantic-errors` 下，无 `_WIN32`
+时保持原报错行为、定义 `_WIN32` 时编译通过；`xmake b stem` 增量编译
+通过。

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -599,6 +599,14 @@ correct_adjacent_horizontal (rectangles& rs1, rectangles& rs2) {
   rs2->item->x1= mid;
 }
 
+// lolly 的 array.hpp 只提供了 operator<< (array<string>&, char*)，字符串
+// 字面量是 const char*，GCC 靠弃用转换容忍（仅告警），MSVC 则直接编译
+// 失败（C2676）。与 upgradetm.cpp 相同的做法，补一个 const char* 重载。
+static array<string>&
+operator<< (array<string>& a, const char* x) {
+  return a << string (x);
+}
+
 // 保留蓝色焦点填充的 inline 标签白名单：其余结构（段落、列表、表格、
 // 绘图区等块级标签）一律只画边框，避免大面积蓝色填充遮挡内容
 // （Issue #2091）。DRD 目前没有 inline/block 属性可查询，故显式列举。

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -603,7 +603,7 @@ correct_adjacent_horizontal (rectangles& rs1, rectangles& rs2) {
 // 字面量是 const char*。GCC 靠弃用转换容忍（仅告警），而 MSVC 的重载解析
 // 不认该转换序列，直接编译失败（C2676），故仅在 Windows 上补 const char*
 // 重载（与 upgradetm.cpp 同款），其余平台维持原行为。
-#ifdef _WIN32
+#ifdef OS_WIN
 static array<string>&
 operator<< (array<string>& a, const char* x) {
   return a << string (x);

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -599,17 +599,6 @@ correct_adjacent_horizontal (rectangles& rs1, rectangles& rs2) {
   rs2->item->x1= mid;
 }
 
-// lolly 的 array.hpp 只提供了 operator<< (array<string>&, char*)，字符串
-// 字面量是 const char*。GCC 靠弃用转换容忍（仅告警），而 MSVC 的重载解析
-// 不认该转换序列，直接编译失败（C2676），故仅在 Windows 上补 const char*
-// 重载（与 upgradetm.cpp 同款），其余平台维持原行为。
-#ifdef OS_WIN
-static array<string>&
-operator<< (array<string>& a, const char* x) {
-  return a << string (x);
-}
-#endif
-
 // 保留蓝色焦点填充的 inline 标签白名单：其余结构（段落、列表、表格、
 // 绘图区等块级标签）一律只画边框，避免大面积蓝色填充遮挡内容
 // （Issue #2091）。DRD 目前没有 inline/block 属性可查询，故显式列举。
@@ -618,59 +607,23 @@ is_inline_focus_tag (tree st) {
   if (!is_compound (st)) return false;
   static hashset<string> tags;
   if (N (tags) == 0) {
-    array<string> init;
-    init << "strong"
-         << "em"
-         << "dfn"
-         << "samp"
-         << "name"
-         << "person"
-         << "abbr"
-         << "acronym"
-         << "kbd"
-         << "var"
-         << "tt"
-         << "verbatim"
-         << "cite*"
-         << "math"
-         << "rsub"
-         << "rsup"
-         << "hlink"
-         << "slink"
-         << "action"
-         << "item"
-         << "cell"
-         << "around"
-         << "around*"
-         << "sqrt"
-         << "frac"
-         << "frac*"
-         << "dfrac"
-         << "tfrac"
-         << "cfrac"
-         << "above"
-         << "lsub"
-         << "lsup"
-         << "strike-through"
-         << "underline"
-         << "bold"
-         << "below"
-         << "really-tiny"
-         << "tiny"
-         << "very-small"
-         << "normal-size"
-         << "large"
-         << "very-large"
-         << "huge"
-         << "really-huge"
-         << "overline"
-         << "small"
-         << "long-arrow"
-         << "wide"
-         << "paragraph"
-         << "subparagraph";
-    for (int i= 0; i < N (init); i++)
-      tags->insert (init[i]);
+    tags << string ("strong") << string ("em") << string ("dfn")
+         << string ("samp") << string ("name") << string ("person")
+         << string ("abbr") << string ("acronym") << string ("kbd")
+         << string ("var") << string ("tt") << string ("verbatim")
+         << string ("cite*") << string ("math") << string ("rsub")
+         << string ("rsup") << string ("hlink") << string ("slink")
+         << string ("action") << string ("item") << string ("cell")
+         << string ("around") << string ("around*") << string ("sqrt")
+         << string ("frac") << string ("frac*") << string ("dfrac")
+         << string ("tfrac") << string ("cfrac") << string ("above")
+         << string ("lsub") << string ("lsup") << string ("strike-through")
+         << string ("underline") << string ("bold") << string ("below")
+         << string ("really-tiny") << string ("tiny") << string ("very-small")
+         << string ("normal-size") << string ("large") << string ("very-large")
+         << string ("huge") << string ("really-huge") << string ("overline")
+         << string ("small") << string ("long-arrow") << string ("wide")
+         << string ("paragraph") << string ("subparagraph");
   }
   return tags->contains (as_string (L (st)));
 }

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -600,12 +600,15 @@ correct_adjacent_horizontal (rectangles& rs1, rectangles& rs2) {
 }
 
 // lolly 的 array.hpp 只提供了 operator<< (array<string>&, char*)，字符串
-// 字面量是 const char*，GCC 靠弃用转换容忍（仅告警），MSVC 则直接编译
-// 失败（C2676）。与 upgradetm.cpp 相同的做法，补一个 const char* 重载。
+// 字面量是 const char*。GCC 靠弃用转换容忍（仅告警），而 MSVC 的重载解析
+// 不认该转换序列，直接编译失败（C2676），故仅在 Windows 上补 const char*
+// 重载（与 upgradetm.cpp 同款），其余平台维持原行为。
+#ifdef _WIN32
 static array<string>&
 operator<< (array<string>& a, const char* x) {
   return a << string (x);
 }
+#endif
 
 // 保留蓝色焦点填充的 inline 标签白名单：其余结构（段落、列表、表格、
 // 绘图区等块级标签）一律只画边框，避免大面积蓝色填充遮挡内容

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -607,24 +607,58 @@ is_inline_focus_tag (tree st) {
   if (!is_compound (st)) return false;
   static hashset<string> tags;
   if (N (tags) == 0) {
-    const char* init[]= {"strong",      "em",          "dfn",
-                         "samp",        "name",        "person",
-                         "abbr",        "acronym",     "kbd",
-                         "var",         "tt",          "verbatim",
-                         "cite*",       "math",        "rsub",
-                         "rsup",        "hlink",       "slink",
-                         "action",      "item",        "cell",
-                         "around",      "around*",     "sqrt",
-                         "frac",        "frac*",       "dfrac",
-                         "tfrac",       "cfrac",       "above",
-                         "lsub",        "lsup",        "strike-through",
-                         "underline",   "bold",        "below",
-                         "really-tiny", "tiny",        "very-small",
-                         "normal-size", "large",       "very-large",
-                         "huge",        "really-huge", "overline",
-                         "small",       "long-arrow",  "wide",
-                         "paragraph",   "subparagraph"};
-    for (int i= 0; i < (int) (sizeof (init) / sizeof (init[0])); i++)
+    array<string> init;
+    init << "strong"
+         << "em"
+         << "dfn"
+         << "samp"
+         << "name"
+         << "person"
+         << "abbr"
+         << "acronym"
+         << "kbd"
+         << "var"
+         << "tt"
+         << "verbatim"
+         << "cite*"
+         << "math"
+         << "rsub"
+         << "rsup"
+         << "hlink"
+         << "slink"
+         << "action"
+         << "item"
+         << "cell"
+         << "around"
+         << "around*"
+         << "sqrt"
+         << "frac"
+         << "frac*"
+         << "dfrac"
+         << "tfrac"
+         << "cfrac"
+         << "above"
+         << "lsub"
+         << "lsup"
+         << "strike-through"
+         << "underline"
+         << "bold"
+         << "below"
+         << "really-tiny"
+         << "tiny"
+         << "very-small"
+         << "normal-size"
+         << "large"
+         << "very-large"
+         << "huge"
+         << "really-huge"
+         << "overline"
+         << "small"
+         << "long-arrow"
+         << "wide"
+         << "paragraph"
+         << "subparagraph";
+    for (int i= 0; i < N (init); i++)
       tags->insert (init[i]);
   }
   return tags->contains (as_string (L (st)));

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -15,6 +15,7 @@
 #include "data_cache.hpp"
 #include "file.hpp"
 #include "gui.hpp" // for gui_interrupted
+#include "hashset.hpp"
 #include "message.hpp"
 #include "new_view.hpp"
 #include "observers.hpp"
@@ -598,15 +599,35 @@ correct_adjacent_horizontal (rectangles& rs1, rectangles& rs2) {
   rs2->item->x1= mid;
 }
 
-// 光标（tp 的父路径）位于表格（TABLE/SUBTABLE）内部时返回 true
+// 保留蓝色焦点填充的 inline 标签白名单：其余结构（段落、列表、表格、
+// 绘图区等块级标签）一律只画边框，避免大面积蓝色填充遮挡内容
+// （Issue #2091）。DRD 目前没有 inline/block 属性可查询，故显式列举。
 static bool
-path_inside_table (tree et, path p) {
-  while (!is_nil (p)) {
-    tree st= subtree (et, p);
-    if (is_func (st, TABLE) || is_func (st, SUBTABLE)) return true;
-    p= path_up (p);
+is_inline_focus_tag (tree st) {
+  if (!is_compound (st)) return false;
+  static hashset<string> tags;
+  if (N (tags) == 0) {
+    const char* init[]= {"strong",      "em",          "dfn",
+                         "samp",        "name",        "person",
+                         "abbr",        "acronym",     "kbd",
+                         "var",         "tt",          "verbatim",
+                         "cite*",       "math",        "rsub",
+                         "rsup",        "hlink",       "slink",
+                         "action",      "item",        "cell",
+                         "around",      "around*",     "sqrt",
+                         "frac",        "frac*",       "dfrac",
+                         "tfrac",       "cfrac",       "above",
+                         "lsub",        "lsup",        "strike-through",
+                         "underline",   "bold",        "below",
+                         "really-tiny", "tiny",        "very-small",
+                         "normal-size", "large",       "very-large",
+                         "huge",        "really-huge", "overline",
+                         "small",       "long-arrow",  "wide",
+                         "paragraph",   "subparagraph"};
+    for (int i= 0; i < (int) (sizeof (init) / sizeof (init[0])); i++)
+      tags->insert (init[i]);
   }
-  return false;
+  return tags->contains (as_string (L (st)));
 }
 
 void
@@ -777,18 +798,11 @@ edit_interface_rep::compute_env_rects (path p, rectangles& rs, bool recurse) {
       if (N (focus_get ()) >= N (p))
         if (!recurse || get_preference ("show full context") == "on") {
           if (recurse) rs << outlines (sel->rs, pixel);
-          // 光标位于绘图区（graphics 上下文，含 with 包裹的画布）、enumerate
-          // 环境或表格内部时改用边框而非半透明背景填充：避免画布被覆盖；
-          // enumerate 条目通常较多、表格整片蓝色填充干扰明显（Issue #2091）。
-          // 表格内 CELL/ROW/TABLE/TFORMAT 均走上方 skip 分支，填充实际落在
-          // 表格外层节点（如 tabular 宏），故表格判断基于光标路径 tp 而非 p。
-          // 表格的灰色细线由上方 recurse 分支（env_rects）绘制，不受影响。
-          else if (is_func (st, GRAPHICS) || inside_graphics (false) ||
-                   (is_compound (st) &&
-                    starts (as_string (L (st)), "enumerate")) ||
-                   path_inside_table (et, path_up (tp)))
-            rs << outlines (sel->rs, pixel);
-          else rs << thicken (sel->rs, 0, 2 * pixel);
+          // 仅 inline 标签白名单保留半透明蓝色填充，其余结构（段落、
+          // 列表、表格、绘图区等）一律只画边框（Issue #2091）。
+          else if (is_inline_focus_tag (st))
+            rs << thicken (sel->rs, 0, 2 * pixel);
+          else rs << outlines (sel->rs, pixel);
         }
     }
     set_access_mode (old_mode);
@@ -1148,9 +1162,9 @@ edit_interface_rep::apply_changes () {
       ;
     else pp= path_up (pp);
     if (full_context || table_cells) compute_env_rects (pp, env_rects, true);
-    // 光标处于绘图区时仍计算 foc_rects，但在 compute_env_rects 内部
-    // 会对 GRAPHICS 节点改用边框（outlines）而非背景填充（thicken），
-    // 以避免画布被半透明色覆盖影响视觉。
+    // 光标处于绘图区时仍计算 foc_rects；焦点填充样式在 compute_env_rects
+    // 内部分流：仅 inline 标签白名单用背景填充（thicken），其余结构
+    // （含绘图区）一律改用边框（outlines），避免大面积遮挡内容。
     if (show_focus && (!semantic_flag || !semantic_only))
       compute_env_rects (pp, foc_rects, false);
     if (env_rects != old_env_rects) {

--- a/src/Typeset/Concat/concat_graphics.cpp
+++ b/src/Typeset/Concat/concat_graphics.cpp
@@ -60,6 +60,13 @@ notify_graphics_extents (tree t, point lbot, point rtop) {
       // scripts-edit.scm，经菜单链 lazy-load；无 UI 的 CLI 前端不加载它，
       // 故用条件编译在 CLI 下排除该回调（Qt/ImGui 照常）。
 #ifndef MOGAN_CLI
+      // 文档打开时菜单链尚未触发 lazy-load，先主动加载模块，
+      // 避免 graphics-notify-extents 未绑定（Issue #2091）
+      static bool scripts_edit_loaded= false;
+      if (!scripts_edit_loaded) {
+        eval ("(use-modules (dynamic scripts-edit))");
+        scripts_edit_loaded= true;
+      }
       call ("graphics-notify-extents", args);
 #endif
     }


### PR DESCRIPTION
## Summary
- 焦点高亮策略反转：默认对所有结构只画边框（outlines），仅 `is_inline_focus_tag` 白名单（`hashset<string>`）内的 inline 标签保留半透明蓝色填充（thicken）
- 移除原先针对 GRAPHICS / enumerate* / 表格的硬编码分流及 `path_inside_table` 辅助函数
- 修复打开含绘图区文档时报 `unbound variable graphics-notify-extents`：回调前 `use-modules` 主动加载 `(dynamic scripts-edit)`（加载顺序问题）
- `TeXmacs/tests/tmu/2091.tmu` 增加无序列表与行内标签手动验证用例

## Test plan
- [x] `xmake b stem` 编译通过
- [ ] 打开 `TeXmacs/tests/tmu/2091.tmu`，光标进入绘图区/有序列表/无序列表：只显示边框高亮，无蓝色填充
- [ ] 光标进入 strong/em 等行内标签：仍显示蓝色背景填充
- [ ] 打开含绘图区文档不再报 `graphics-notify-extents` 未绑定

🤖 Generated with [Claude Code](https://claude.com/claude-code)