### PR TITLE
[0880] 修复符号菜单按钮 crash

### DIFF
--- a/devel/0880.md
+++ b/devel/0880.md
@@ -1,0 +1,32 @@
+# [0880] 修复符号菜单按钮 crash
+
+## 1 相关文档
+- [2081](2081.md) - 修复数学模式下字母 T 的 Tab 循环问题
+
+## 2 任务相关的代码文件
+- `src/Texmacs/Window/tm_button.cpp` — `box_widget` 字体选择改为 `find_font` 优先、仅当主字体不含该符号字形时回退 `smart_font`
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r stem
+```
+
+### 3.2 非确定性测试（交互验证）
+
+
+## 4 What
+- 符号工具栏按钮 $\infty$ 若直接用 `smart_font` 渲染，点击后段错误（SIGSEGV）；若用 `find_font`，则平行四边形等需智能回退的符号渲染不出。
+- 期望：符号按钮既不崩溃、符号不消失，又能让 `<parallelogram>` 这类主字体无字形的符号正常渲染。
+
+## 5 Why
+- `box_widget` 的字体描述为 `(roman mr medium normal …)`，`mr` 是数学字体族，但 `shape=normal`。
+- `find_font` 返回主字体（roman TrueType）的 `unicode_font`，直接查 cmap 用矢量字形，稳定可靠，覆盖 ♣♥♠♦ 等绝大多数符号；但主字体不含 `<parallelogram>`(U+25B1)，渲染不出。
+- `smart_font` 在 `shape=normal` 下 `math_kind=0`：数学符号栈（special/emu-bracket 子字体）不加载；且 `resolve()` 把 emoji 范围(U+2600–U+27BF)符号（花色/音符/天体等）回退到带 CBDT 位图的 emoji 字体，走 `draw_emoji`→ramdisc PNG→`draw_picture` 路径，在该上下文渲染 QImage 时段错误。
+- 即 `smart_font` 牺牲了普通符号的稳定渲染去换取少数符号的智能回退，得不偿失；`find_font` 则对需要回退的符号无能为力。两者各有缺口。
+
+## 6 How
+- `box_widget` 默认用 `find_font`（主字体矢量字形，稳定）。仅当 `find_font` 返回 nil 或 `supports(s)` 为假（主字体不含该符号字形，如 `<parallelogram>`）时，才回退到 `smart_font` 走 0878 的智能回退。
+- ♣♥♠♦ 等绝大多数符号走 find_font，既不崩溃也不消失；`<parallelogram>` 等少数符号走 smart_font，由 0878 的 Geometric 回退正常渲染。

--- a/src/Texmacs/Window/tm_button.cpp
+++ b/src/Texmacs/Window/tm_button.cpp
@@ -253,12 +253,11 @@ box_widget (scheme_tree p, string s, color col, bool trans, bool ink) {
   if ((n >= 5) && is_atomic (p[4])) sz= as_int (p[4]);
   if ((n >= 6) && is_atomic (p[5])) dpi= as_int (p[5]);
   if ((n >= 7) && is_atomic (p[6])) dw= as_int (p[6]);
-  bool adjust= s == "<lefttimesthree>" || s == "<righttimesthree>";
-  font fn= smart_font (family, fn_class, series, shape, adjust ? 1.15 * sz : sz,
-                       dpi);
-  box  b = text_box (decorate (), 0, s, fn, col);
+  font fn= find_font (family, fn_class, series, shape, sz, dpi);
+  if (is_nil (fn) || !fn->supports (s))
+    fn= smart_font (family, fn_class, series, shape, sz, dpi);
+  box b= text_box (decorate (), 0, s, fn, col);
   if (ink) b= resize_box (decorate (), b, b->x3, b->y3, b->x4, b->y4, true);
-  if (adjust) b= shift_box (decorate (), b, 0, -fn->wfn / 16);
   return box_widget (b, trans, dw);
 }
 


### PR DESCRIPTION
# [0880] 修复符号菜单按钮 crash

## 1 相关文档
- [2081](2081.md) - 修复数学模式下字母 T 的 Tab 循环问题

## 2 任务相关的代码文件
- `src/Texmacs/Window/tm_button.cpp` — `box_widget` 字体选择改为 `find_font` 优先、仅当主字体不含该符号字形时回退 `smart_font`

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
xmake r stem
```

### 3.2 非确定性测试（交互验证）


## 4 What
- 符号工具栏按钮 $\infty$ 若直接用 `smart_font` 渲染，点击后段错误（SIGSEGV）；若用 `find_font`，则平行四边形等需智能回退的符号渲染不出。
- 期望：符号按钮既不崩溃、符号不消失，又能让 `<parallelogram>` 这类主字体无字形的符号正常渲染。

## 5 Why
- `box_widget` 的字体描述为 `(roman mr medium normal …)`，`mr` 是数学字体族，但 `shape=normal`。
- `find_font` 返回主字体（roman TrueType）的 `unicode_font`，直接查 cmap 用矢量字形，稳定可靠，覆盖 ♣♥♠♦ 等绝大多数符号；但主字体不含 `<parallelogram>`(U+25B1)，渲染不出。
- `smart_font` 在 `shape=normal` 下 `math_kind=0`：数学符号栈（special/emu-bracket 子字体）不加载；且 `resolve()` 把 emoji 范围(U+2600–U+27BF)符号（花色/音符/天体等）回退到带 CBDT 位图的 emoji 字体，走 `draw_emoji`→ramdisc PNG→`draw_picture` 路径，在该上下文渲染 QImage 时段错误。
- 即 `smart_font` 牺牲了普通符号的稳定渲染去换取少数符号的智能回退，得不偿失；`find_font` 则对需要回退的符号无能为力。两者各有缺口。

## 6 How
- `box_widget` 默认用 `find_font`（主字体矢量字形，稳定）。仅当 `find_font` 返回 nil 或 `supports(s)` 为假（主字体不含该符号字形，如 `<parallelogram>`）时，才回退到 `smart_font` 走 0878 的智能回退。
- ♣♥♠♦ 等绝大多数符号走 find_font，既不崩溃也不消失；`<parallelogram>` 等少数符号走 smart_font，由 0878 的 Geometric 回退正常渲染。
