### PR TITLE
[0881] 支持 CJK 扩展区字符的正确识别与渲染

### DIFF
--- a/devel/0881.md
+++ b/devel/0881.md
@@ -1,0 +1,31 @@
+# [0881] 支持 CJK 扩展区字符的正确识别与渲染
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `lolly/lolly/data/unicode.cpp` — 重构并补全 `is_cjk_unified_ideograph_code` 以支持 Extension A–J 等全套 CJK 扩展区，修复十六进制字符串字典序判定逻辑为 `from_hex` 数值比较
+- `lolly/tests/lolly/data/unicode_test.cpp` — 新增覆盖全部 CJK 扩展、标点、边界以及非 CJK 负面测试的单元测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake f --enable_tests=y && xmake test && xmake f --enable_tests=n
+```
+
+### 3.2 非确定性测试（交互验证）
+在文档中粘贴或手动输入 `<#20E4C>` 字符（`𠹌`），能正确路由到 CJK 字体，且能正常渲染。
+
+## 4 What
+- 粘贴或输入 CJK 扩展区汉字（如 `U+20E4C` 即粤语 `𠹌` 字）时，显示为红色的 `<#20E4C>` 占位符。
+- 期望：能自动识别此类 CJK 扩展区及兼容区字符，并成功 fallback 到系统默认的中文字体正常渲染。
+
+## 5 Why
+- 之前 `unicode_get_range` 的 CJK 汉字检测范围极窄，仅硬编码匹配了基本区部分码点（`0x4e00`–`0x9fcc`），未涵盖 CJK Extension A–J 及兼容汉字区等现代扩展块。导致 `unicode_get_range(0x20E4C)` 返回空串，从而无法路由到默认中文字体。
+- `is_cjk_unified_ideographs` 等判定函数错误使用了十六进制字符串字面量进行字典序大小比较（`"4E00" <= r && r <= "9FBF"`），导致 5 位十六进制码点（如 `"20E4C" < "4E00"`，因 `'2' < '4'`）和部分 A 区码点（首位为 `'3' < '4'`）判定全部失效。
+
+## 6 How
+- **抽离公共辅助检测**：实现 `is_cjk_unified_ideograph_code(int code)`，完整、准确支持 CJK 统一汉字基本区、各大扩展区（Extension A–J，含最新 Unicode 17.0）及兼容汉字区。
+- **重构十六进制数值判定**：使用 `from_hex(r)` 先将内部十六进制 cork 字符串码点解析为整数，再进行区间比较，彻底修复了 5 位码点与特殊分区的判定逻辑。
+- **补全测试防护网**：在 `unicode_test.cpp` 中新增了针对标点、基本区、兼容区、Extension A–J 临界点的高密度单元测试及非 CJK 负面边界测试，并验证全部通过。

--- a/lolly/lolly/data/unicode.cpp
+++ b/lolly/lolly/data/unicode.cpp
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 #include "unicode.hpp"
+#include "numeral.hpp"
 #include "tbox/tbox.h"
 
 namespace lolly {
@@ -95,6 +96,18 @@ decode_from_utf8 (string_u8 s, int& i) {
   return code;
 }
 
+static bool
+is_cjk_unified_ideograph_code (int code) {
+  return (code >= 0x4e00 && code <= 0x9fff) ||   // CJK 统一汉字基本区
+         (code >= 0x3400 && code <= 0x4dbf) ||   // CJK 统一汉字扩展区 A
+         (code >= 0x20000 && code <= 0x2a6df) || // CJK 统一汉字扩展区 B
+         (code >= 0x2a700 && code <= 0x2b81f) || // CJK 统一汉字扩展区 C & D
+         (code >= 0x2b820 && code <= 0x2ee5f) || // CJK 统一汉字扩展区 E, F & I
+         (code >= 0x30000 && code <= 0x3347f) || // CJK 统一汉字扩展区 G, H & J
+         (code >= 0xf900 && code <= 0xfaff) ||   // CJK 兼容表意文字
+         (code >= 0x2f800 && code <= 0x2fa1f);   // CJK 兼容表意文字补充区
+}
+
 string
 unicode_get_range (int code) {
   if (code <= 0x7f) return "ascii";
@@ -102,9 +115,11 @@ unicode_get_range (int code) {
   else if (code >= 0x380 && code <= 0x3ff) return "greek";
   else if (code >= 0x400 && code <= 0x4ff) return "cyrillic";
   else if (code >= 0x2460 && code <= 0x24ff) return "enclosed_alphanumerics";
-  else if (code >= 0x3000 && code <= 0x303f) return "cjk";
-  else if (code >= 0x4e00 && code <= 0x9fcc) return "cjk";
-  else if (code >= 0xff00 && code <= 0xffef) return "cjk";
+  else if (code >= 0x3000 && code <= 0x303f) return "cjk"; // CJK 符号和标点
+  else if (is_cjk_unified_ideograph_code (code))
+    return "cjk"; // CJK 统一汉字及各大扩展、兼容区
+  else if (code >= 0xff00 && code <= 0xffef)
+    return "cjk"; // 半角和全角形式标点与字符
   else if (code >= 0x3040 && code <= 0x309F) return "hiragana";
   else if (code >= 0xac00 && code <= 0xd7af) return "hangul";
   else if (code >= 0x2000 && code <= 0x23ff) return "mathsymbols";
@@ -140,8 +155,9 @@ is_cjk_unified_ideographs (string s) {
       i        = i + 2;
       while (i < n && s[i] != '>')
         i++;
-      string r= s (start, i);
-      if ("4E00" <= r && r <= "9FBF") continue;
+      string r   = s (start, i);
+      int    code= from_hex (r);
+      if (is_cjk_unified_ideograph_code (code)) continue;
       else return false;
     }
     else {
@@ -159,8 +175,9 @@ has_cjk_unified_ideographs (string s) {
       i        = i + 2;
       while (i < n && s[i] != '>')
         i++;
-      string r= s (start, i);
-      if ("4E00" <= r && r <= "9FBF") return true;
+      string r   = s (start, i);
+      int    code= from_hex (r);
+      if (is_cjk_unified_ideograph_code (code)) return true;
       else continue;
     }
     else {

--- a/lolly/tests/lolly/data/unicode_test.cpp
+++ b/lolly/tests/lolly/data/unicode_test.cpp
@@ -26,13 +26,98 @@ TEST_CASE ("unicode_get_range") {
   string_eq (unicode_get_range ((int) 'a'), "ascii");
   string_eq (unicode_get_range (0x2460), "enclosed_alphanumerics"); // ①
   string_eq (unicode_get_range (0x24ff), "enclosed_alphanumerics"); // ⓿
+
+  // CJK range tests (including unified ideographs, compatibility, symbols, and
+  // half/fullwidth)
+  string_eq (unicode_get_range (0x3000),
+             "cjk"); // CJK Symbols & Punctuation Start
+  string_eq (unicode_get_range (0x303f),
+             "cjk"); // CJK Symbols & Punctuation End
+  string_eq (unicode_get_range (0xff00),
+             "cjk"); // Halfwidth & Fullwidth Forms Start
+  string_eq (unicode_get_range (0xffef),
+             "cjk"); // Halfwidth & Fullwidth Forms End
+
+  // CJK Unified Ideographs and Extensions
+  string_eq (unicode_get_range (0x4e00),
+             "cjk"); // Unified Ideographs Base Start
+  string_eq (unicode_get_range (0x9fff), "cjk");  // Unified Ideographs Base End
+  string_eq (unicode_get_range (0x3400), "cjk");  // Extension A Start
+  string_eq (unicode_get_range (0x4dbf), "cjk");  // Extension A End
+  string_eq (unicode_get_range (0x20000), "cjk"); // Extension B Start
+  string_eq (unicode_get_range (0x2a6df), "cjk"); // Extension B End
+  string_eq (unicode_get_range (0x2a700), "cjk"); // Extension C Start
+  string_eq (unicode_get_range (0x2b81f), "cjk"); // Extension D End
+  string_eq (unicode_get_range (0x2b820), "cjk"); // Extension E Start
+  string_eq (unicode_get_range (0x2ee5f), "cjk"); // Extension I End
+  string_eq (unicode_get_range (0x30000), "cjk"); // Extension G Start
+  string_eq (unicode_get_range (0x3347f),
+             "cjk"); // Extension J End (Unicode 17.0)
+  string_eq (unicode_get_range (0xf900),
+             "cjk"); // Compatibility Ideographs Start
+  string_eq (unicode_get_range (0xfaff), "cjk"); // Compatibility Ideographs End
+  string_eq (unicode_get_range (0x2f800),
+             "cjk"); // Compatibility Ideographs Supplement Start
+  string_eq (unicode_get_range (0x2fa1f),
+             "cjk"); // Compatibility Ideographs Supplement End
+
+  // Non-CJK boundaries
+  string_eq (unicode_get_range (0x33f0), ""); // Outside Extension A / CJK
+  string_eq (unicode_get_range (0x4dc0), ""); // Outside Unified Ideographs Base
+  string_eq (unicode_get_range (0x2a6e0), ""); // Outside Extension B
+  string_eq (unicode_get_range (0x2fa20),
+             ""); // Outside Compatibility Supplement
+  string_eq (unicode_get_range (0x33480), ""); // Outside Extension J
 }
 
 TEST_CASE ("cjk_unified_ideographs") {
+  // CJK Unified Ideographs Base (e.g., 中)
   CHECK (is_cjk_unified_ideographs ("<#4E2D>"));
   CHECK (has_cjk_unified_ideographs ("<#4E2D>"));
   CHECK (has_cjk_unified_ideographs ("bib-<#4E2D>"));
   CHECK (!is_cjk_unified_ideographs ("bib-<#4E2D>"));
+
+  // Extension A
+  CHECK (is_cjk_unified_ideographs ("<#3400>"));
+  CHECK (is_cjk_unified_ideographs ("<#4DBF>"));
+
+  // Extension B (e.g., 𠹌)
+  CHECK (is_cjk_unified_ideographs ("<#20E4C>"));
+  CHECK (has_cjk_unified_ideographs ("<#20E4C>"));
+  CHECK (has_cjk_unified_ideographs ("bib-<#20E4C>"));
+  CHECK (!is_cjk_unified_ideographs ("bib-<#20E4C>"));
+  CHECK (is_cjk_unified_ideographs ("<#20000>"));
+  CHECK (is_cjk_unified_ideographs ("<#2A6DF>"));
+
+  // Extension C & D
+  CHECK (is_cjk_unified_ideographs ("<#2A700>"));
+  CHECK (is_cjk_unified_ideographs ("<#2B81F>"));
+
+  // Extension E, F & I
+  CHECK (is_cjk_unified_ideographs ("<#2B820>"));
+  CHECK (is_cjk_unified_ideographs ("<#2EE5F>"));
+
+  // Extension G, H & J
+  CHECK (is_cjk_unified_ideographs ("<#30000>"));
+  CHECK (is_cjk_unified_ideographs ("<#3347F>"));
+
+  // Compatibility Ideographs
+  CHECK (is_cjk_unified_ideographs ("<#F900>"));
+  CHECK (is_cjk_unified_ideographs ("<#FAFF>"));
+  CHECK (is_cjk_unified_ideographs ("<#2F800>"));
+  CHECK (is_cjk_unified_ideographs ("<#2FA1F>"));
+
+  // Non-CJK / Boundaries (Should fail)
+  CHECK (!is_cjk_unified_ideographs (
+      "<#3000>")); // CJK Symbol/Punctuation is not a unified ideograph
+  CHECK (!is_cjk_unified_ideographs (
+      "<#FF00>")); // Half/Fullwidth is not a unified ideograph
+  CHECK (!is_cjk_unified_ideographs ("<#4DC0>"));  // Outside Base
+  CHECK (!is_cjk_unified_ideographs ("<#2A6E0>")); // Outside Ext B
+  CHECK (!is_cjk_unified_ideographs (
+      "<#2FA20>")); // Outside Compatibility Supplement
+  CHECK (!is_cjk_unified_ideographs ("<#33480>")); // Outside Ext J
+  CHECK (!is_cjk_unified_ideographs ("<#1FFFF>")); // Invalid
 }
 
 #if defined(OS_MINGW) || defined(OS_WIN)


### PR DESCRIPTION
# [0881] 支持 CJK 扩展区字符的正确识别与渲染

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板

## 2 任务相关的代码文件
- `lolly/lolly/data/unicode.cpp` — 重构并补全 `is_cjk_unified_ideograph_code` 以支持 Extension A–J 等全套 CJK 扩展区，修复十六进制字符串字典序判定逻辑为 `from_hex` 数值比较
- `lolly/tests/lolly/data/unicode_test.cpp` — 新增覆盖全部 CJK 扩展、标点、边界以及非 CJK 负面测试的单元测试

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake f --enable_tests=y && xmake test && xmake f --enable_tests=n
```

### 3.2 非确定性测试（交互验证）
在文档中粘贴或手动输入 `<#20E4C>` 字符（`𠹌`），能正确路由到 CJK 字体，且能正常渲染。

## 4 What
- 粘贴或输入 CJK 扩展区汉字（如 `U+20E4C` 即粤语 `𠹌` 字）时，显示为红色的 `<#20E4C>` 占位符。
- 期望：能自动识别此类 CJK 扩展区及兼容区字符，并成功 fallback 到系统默认的中文字体正常渲染。

## 5 Why
- 之前 `unicode_get_range` 的 CJK 汉字检测范围极窄，仅硬编码匹配了基本区部分码点（`0x4e00`–`0x9fcc`），未涵盖 CJK Extension A–J 及兼容汉字区等现代扩展块。导致 `unicode_get_range(0x20E4C)` 返回空串，从而无法路由到默认中文字体。
- `is_cjk_unified_ideographs` 等判定函数错误使用了十六进制字符串字面量进行字典序大小比较（`"4E00" <= r && r <= "9FBF"`），导致 5 位十六进制码点（如 `"20E4C" < "4E00"`，因 `'2' < '4'`）和部分 A 区码点（首位为 `'3' < '4'`）判定全部失效。

## 6 How
- **抽离公共辅助检测**：实现 `is_cjk_unified_ideograph_code(int code)`，完整、准确支持 CJK 统一汉字基本区、各大扩展区（Extension A–J，含最新 Unicode 17.0）及兼容汉字区。
- **重构十六进制数值判定**：使用 `from_hex(r)` 先将内部十六进制 cork 字符串码点解析为整数，再进行区间比较，彻底修复了 5 位码点与特殊分区的判定逻辑。
- **补全测试防护网**：在 `unicode_test.cpp` 中新增了针对标点、基本区、兼容区、Extension A–J 临界点的高密度单元测试及非 CJK 负面边界测试，并验证全部通过。
