### PR TITLE
[1174] keyboard 快捷键模块加载性能观测

### DIFF
--- a/TeXmacs/plugins/code/progs/prog/prog-kbd.scm
+++ b/TeXmacs/plugins/code/progs/prog/prog-kbd.scm
@@ -20,6 +20,7 @@
     (code cpp-edit)
   ) ;:use
 ) ;texmacs-module
+(debug-message "keyboard" "(prog prog-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode in-prog?)
  ("cmd i" (program-indent #f))
@@ -45,3 +46,4 @@
  ("- -" "--")
  ("- - -" "---")
 ) ;kbd-map
+(debug-message "keyboard" "(prog prog-kbd): kbd-map registered\n")

--- a/TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm
+++ b/TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm
@@ -19,6 +19,7 @@
     (various comment-widgets)
   ) ;:use
 ) ;texmacs-module
+(debug-message "keyboard" "(keyboard text-kbd-utf8): registering kbd-map ...\n")
 
 (kbd-map (:mode in-text?)
  ("<" "<less>")
@@ -122,3 +123,4 @@
  ("std ;" (make-folded-comment "comment"))
  ("std /" (make-unfolded-comment "comment"))
 ) ;kbd-map
+(debug-message "keyboard" "(keyboard text-kbd-utf8): kbd-map registered\n")

--- a/TeXmacs/progs/doc/apidoc-kbd.scm
+++ b/TeXmacs/progs/doc/apidoc-kbd.scm
@@ -14,6 +14,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (doc apidoc-kbd) (:use (doc apidoc-widgets)))
+(debug-message "keyboard" "(doc apidoc-kbd): registering kbd-map ...\n")
 
 (tm-define (macro-popup-help)
   (:synopsis "Pops up the help window for the innermost TeXmacs macro")
@@ -26,3 +27,4 @@
 (kbd-map (:require (and developer-mode? (not (in-prog-scheme?))))
  ("A-F1" (macro-popup-help))
 ) ;kbd-map
+(debug-message "keyboard" "(doc apidoc-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/doc/tmdoc-kbd.scm
+++ b/TeXmacs/progs/doc/tmdoc-kbd.scm
@@ -12,9 +12,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (doc tmdoc-kbd) (:use (text text-kbd)))
+(debug-message "keyboard" "(doc tmdoc-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode in-manual?)
  ("S-F7" (make 'scm))
  ("C-F7" (make 'scm-arg))
  ("M-F7" (make 'scm-code))
 ) ;kbd-map
+(debug-message "keyboard" "(doc tmdoc-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/dynamic/calc-kbd.scm
+++ b/TeXmacs/progs/dynamic/calc-kbd.scm
@@ -12,6 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (dynamic calc-kbd) (:use (math math-kbd) (dynamic calc-table)))
+(debug-message "keyboard" "(dynamic calc-kbd): registering kbd-map ...\n")
 
 (kbd-map (:require (inside? 'calc-table))
  (", ," (make 'cell-commas))
@@ -33,3 +34,4 @@
  ("C-!" (calc-solutions #f))
  ("C-?" (calc-solutions #t))
 ) ;kbd-map
+(debug-message "keyboard" "(dynamic calc-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/dynamic/fold-kbd.scm
+++ b/TeXmacs/progs/dynamic/fold-kbd.scm
@@ -14,6 +14,7 @@
 (texmacs-module (dynamic fold-kbd)
   (:use (generic generic-kbd) (dynamic fold-edit))
 ) ;texmacs-module
+(debug-message "keyboard" "(dynamic fold-kbd): registering kbd-map ...\n")
 
 (define (reset-buffer-players)
   (players-set-elapsed (buffer-tree) 0.0)
@@ -47,3 +48,4 @@
  ("F10" (screens-switch-to :previous))
  ("F11" (screens-switch-to :next))
 ) ;kbd-map
+(debug-message "keyboard" "(dynamic fold-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/dynamic/scripts-kbd.scm
+++ b/TeXmacs/progs/dynamic/scripts-kbd.scm
@@ -14,6 +14,7 @@
 (texmacs-module (dynamic scripts-kbd)
   (:use (math math-kbd) (dynamic scripts-edit))
 ) ;texmacs-module
+(debug-message "keyboard" "(dynamic scripts-kbd): registering kbd-map ...\n")
 
 (kbd-map ("script *" (make 'script-eval))
  ("script !" (make-script-input))
@@ -26,3 +27,4 @@
  ("std \\" (insert-go-to '(converter-eval "latex" "") '(1 0)))
  ("std \\ var" (insert-go-to '(converter-input "latex" "" "") '(1 0)))
 ) ;kbd-map
+(debug-message "keyboard" "(dynamic scripts-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/education/edu-kbd.scm
+++ b/TeXmacs/progs/education/edu-kbd.scm
@@ -12,6 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (education edu-kbd) (:use (education edu-edit)))
+(debug-message "keyboard" "(education edu-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode in-edu-text?)
  ("text c" (make-mc 'mc))
@@ -30,3 +31,4 @@
  (". . ." (make 'gap))
  (". . . ." (make 'gap-wide))
 ) ;kbd-map
+(debug-message "keyboard" "(education edu-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -29,6 +29,7 @@
     (doc help-funcs)
   ) ;:use
 ) ;texmacs-module
+(debug-message "keyboard" "(generic generic-kbd): registering kbd-map ...\n")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; General shortcuts for all modes
@@ -835,3 +836,4 @@
 
 (kbd-apply-magic-paste-shortcut)
 ;; added for convenience
+(debug-message "keyboard" "(generic generic-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/generic/search-kbd.scm
+++ b/TeXmacs/progs/generic/search-kbd.scm
@@ -11,6 +11,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (generic search-kbd) (:use (generic search-widgets)))
+(debug-message "keyboard" "(generic search-kbd): registering kbd-map ...\n")
 
 (kbd-map (:require (inside-search-or-replace-buffer?))
  ("std ?" (make 'select-region))
@@ -45,3 +46,4 @@
    ) ;replace-all
  ) ;
 ) ;kbd-map
+(debug-message "keyboard" "(generic search-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/graphics/graphics-kbd.scm
+++ b/TeXmacs/progs/graphics/graphics-kbd.scm
@@ -19,6 +19,7 @@
     (graphics graphics-edit)
   ) ;:use
 ) ;texmacs-module
+(debug-message "keyboard" "(graphics graphics-kbd): registering kbd-map ...\n")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Various contexts
@@ -434,3 +435,4 @@
 (kbd-map (:mode inside-graphical-over-under?)
  ("C-*" (graphics-toggle-over-under))
 ) ;kbd-map
+(debug-message "keyboard" "(graphics graphics-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -691,9 +691,9 @@
       (if (url-exists? u)
         (with fname
           (url-materialize u "r")
-          (debug-message "debug-std" (string-append "Loading plugin " name "\n"))
+          (debug-message "plugin" (string-append "(" name "): loading plugin ...\n"))
           (load fname)
-          (debug-message "debug-std" (string-append "Loaded plugin " name "\n"))
+          (debug-message "plugin" (string-append "(" name "): plugin loaded\n"))
         ) ;with
       ) ;if
       (if (plugin-all-initialized?) (plugin-save-setup))

--- a/TeXmacs/progs/link/link-kbd.scm
+++ b/TeXmacs/progs/link/link-kbd.scm
@@ -18,6 +18,7 @@
     (link link-extract)
   ) ;:use
 ) ;texmacs-module
+(debug-message "keyboard" "(link link-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode with-linking-tool?)
  ("link L" (make-locus))
@@ -35,3 +36,4 @@
  ("link i" (build-locus-page))
  ("link e" (interactive build-environment-page))
 ) ;kbd-map
+(debug-message "keyboard" "(link link-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -19,6 +19,7 @@
     (table table-edit)
   ) ;:use
 ) ;texmacs-module
+(debug-message "keyboard" "(math math-kbd): registering kbd-map ...\n")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Bypassing the pre-edit mechanism
@@ -3039,3 +3040,4 @@
 (kbd-map (:require (inside? 'eqnarray*))
  ("C-&" (eqnarray->equation (tree-innermost 'eqnarray*)))
 ) ;kbd-map
+(debug-message "keyboard" "(math math-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/source/source-kbd.scm
+++ b/TeXmacs/progs/source/source-kbd.scm
@@ -14,6 +14,7 @@
 (texmacs-module (source source-kbd)
   (:use (generic generic-kbd) (source source-edit))
 ) ;texmacs-module
+(debug-message "keyboard" "(source source-kbd): registering kbd-map ...\n")
 
 (kbd-map ("altcmd )" (make-style-with "src-compact" "none"))
  ("altcmd (" (make-style-with "src-compact" "all"))
@@ -88,3 +89,4 @@
  ("special ," (make 'unquote))
  ("special ?" (make 'if))
 ) ;kbd-map
+(debug-message "keyboard" "(source source-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/table/table-kbd.scm
+++ b/TeXmacs/progs/table/table-kbd.scm
@@ -14,6 +14,7 @@
 (texmacs-module (table table-kbd)
   (:use (generic generic-kbd) (table table-edit))
 ) ;texmacs-module
+(debug-message "keyboard" "(table table-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode in-table?)
  ("table N" "" "New table (t: tabular, b: block)")
@@ -123,3 +124,4 @@
  ("table s" (interactive cell-set-span))
  ("table j" (cell-set-span-selection))
 ) ;kbd-map
+(debug-message "keyboard" "(table table-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/texmacs/keyboard/prefix-kbd.scm
+++ b/TeXmacs/progs/texmacs/keyboard/prefix-kbd.scm
@@ -17,6 +17,7 @@
 	(texmacs texmacs tm-server)
 	(texmacs texmacs tm-files)
 	(generic generic-edit)))
+(debug-message "keyboard" "(texmacs keyboard prefix-kbd): registering kbd-map ...\n")
 
 (set-variant-keys "tab" "S-tab")
 
@@ -382,3 +383,4 @@
 (kbd-map
   (:mode in-prog?)
   ("prog" "" "TeXmacs command"))
+(debug-message "keyboard" "(texmacs keyboard prefix-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/text/text-kbd.scm
+++ b/TeXmacs/progs/text/text-kbd.scm
@@ -15,6 +15,7 @@
   (:use (generic generic-kbd)
         (utils edit auto-close)
         (text text-edit)))
+(debug-message "keyboard" "(text text-kbd): registering kbd-map ...\n")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special symbols in text mode
@@ -438,3 +439,4 @@
 (kbd-map
   (:mode in-std?)
   ("std @" (go-to-section-title)))
+(debug-message "keyboard" "(text text-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/utils/automate/auto-kbd.scm
+++ b/TeXmacs/progs/utils/automate/auto-kbd.scm
@@ -12,6 +12,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (utils automate auto-kbd) (:use (utils automate auto-tmfs)))
+(debug-message "keyboard"
+  "(utils automate auto-kbd): registering kbd-map ...\n"
+) ;debug-message
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Keyboard shortcuts
@@ -34,3 +37,4 @@
  ("O u t" (make-inline-output))
  ("$ $" (make-output-string))
 ) ;kbd-map
+(debug-message "keyboard" "(utils automate auto-kbd): kbd-map registered\n")

--- a/TeXmacs/progs/version/version-kbd.scm
+++ b/TeXmacs/progs/version/version-kbd.scm
@@ -14,6 +14,7 @@
 (texmacs-module (version version-kbd)
   (:use (generic generic-kbd) (version version-compare))
 ) ;texmacs-module
+(debug-message "keyboard" "(version version-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode with-versioning-tool?)
  ("version home" (version-first-difference))
@@ -44,3 +45,4 @@
   (:require (and (tree-is-buffer? t) (in-versioning?)))
   (version-retain 'current)
 ) ;tm-define
+(debug-message "keyboard" "(version version-kbd): kbd-map registered\n")

--- a/devel/1174.md
+++ b/devel/1174.md
@@ -1,0 +1,80 @@
+# 1174 keyboard 快捷键模块加载性能观测
+
+## What
+
+给 `init-keyboard.scm` 中 `lazy-keyboard` 注册的 19 个快捷键模块
+（`math/math-sem-edit.scm` 无 `kbd-map`，除外）各加两条
+`debug-message`（`keyboard` 通道），仿照 mogan 仓库
+`plugins/keyboard/progs/keyboard/emoji.scm` 的风格：
+
+- 模块加载开始时（`texmacs-module` 之后）：
+  `(<模块名>): registering kbd-map ...`
+- 模块加载完成时（文件末尾）：`(<模块名>): kbd-map registered`
+
+## Why
+
+`init-keyboard.scm` 末尾的 `(lazy-keyboard-force #t)` 在 init 阶段就
+同步 `module-provide` 全部模块，`lazy-keyboard` 的延迟（`delayed
+(:idle 250)`）与 mode 门控均被旁路，懒加载名存实亡。启动时这批模块
+到底花多少时间、哪个是大头，之前没有数据。在模块内部埋点（而不是在
+`init-keyboard.scm` 的 `lazy-keyboard` 调用处）才能量到每个模块真实
+的加载耗时。
+
+## How
+
+- 用 Python 脚本统一插入：按括号平衡定位 `texmacs-module` 表单结束行，
+  其后插入 registering 消息；文件末尾追加 registered 消息。
+- **`text/text-kbd.scm` 是 latin-1 编码**（含 4 个 `0xff` 字节，即
+  `ß`），该文件用 latin-1 读写，处理前后 `0xff` 计数不变（4 → 4），
+  文件长度差恰为两行新增。其余 18 个文件均为 UTF-8。
+- **`(generic search-kbd)` 的特殊性**：注册时无 mode 参数，
+  `lazy-keyboard-do` 的 `for-each` 空转，从不进入
+  `lazy-keyboard-waiting`（故 force 时 `waiting=19` 而非 20），只能靠
+  `delayed (:idle 250)` 延迟加载，不在本次 force 日志里。
+
+## 性能数据（2026-08-06 实测，启动日志时间戳）
+
+`lazy-keyboard-force` 全程 **~675ms**（36.859 → 37.534），各模块
+`registering` → `registered` 耗时：
+
+| 模块 | 耗时 |
+|------|------|
+| **math math-kbd** | **382ms（占 57%）** |
+| text text-kbd | 37ms |
+| generic generic-kbd | 25ms |
+| table table-kbd | 14ms |
+| source source-kbd | 9ms |
+| keyboard text-kbd-utf8 | 8ms |
+| graphics graphics-kbd | 8ms |
+| texmacs keyboard prefix-kbd | 7ms |
+| prog prog-kbd | 4ms |
+| 其余 10 个 | 0–3ms |
+
+- 模块本体合计 ~510ms；模块间空隙（`module-provide` 定位文件 +
+  `:use` 依赖加载）合计 ~160ms。
+- **结论**：`math-kbd.scm`（3041 行）一家占 382ms，是唯一值得优化
+  的目标（拆分文件或对其恢复真正的懒加载）；其余 18 个模块合计不到
+  300ms，直接加载没有问题。
+
+## 涉及文件
+
+- `devel/1174.md`（本文档）
+- `TeXmacs/progs/utils/automate/auto-kbd.scm`
+- `TeXmacs/progs/texmacs/keyboard/prefix-kbd.scm`
+- `TeXmacs/progs/generic/generic-kbd.scm`
+- `TeXmacs/progs/generic/search-kbd.scm`
+- `TeXmacs/progs/text/text-kbd.scm`（latin-1，禁 `gf fmt`）
+- `TeXmacs/plugins/keyboard/progs/keyboard/text-kbd-utf8.scm`
+- `TeXmacs/progs/math/math-kbd.scm`
+- `TeXmacs/plugins/code/progs/prog/prog-kbd.scm`
+- `TeXmacs/progs/source/source-kbd.scm`
+- `TeXmacs/progs/table/table-kbd.scm`
+- `TeXmacs/progs/graphics/graphics-kbd.scm`
+- `TeXmacs/progs/education/edu-kbd.scm`
+- `TeXmacs/progs/dynamic/fold-kbd.scm`
+- `TeXmacs/progs/dynamic/scripts-kbd.scm`
+- `TeXmacs/progs/dynamic/calc-kbd.scm`
+- `TeXmacs/progs/doc/tmdoc-kbd.scm`
+- `TeXmacs/progs/doc/apidoc-kbd.scm`
+- `TeXmacs/progs/link/link-kbd.scm`
+- `TeXmacs/progs/version/version-kbd.scm`

--- a/devel/1174.md
+++ b/devel/1174.md
@@ -2,14 +2,19 @@
 
 ## What
 
-给 `init-keyboard.scm` 中 `lazy-keyboard` 注册的 19 个快捷键模块
-（`math/math-sem-edit.scm` 无 `kbd-map`，除外）各加两条
-`debug-message`（`keyboard` 通道），仿照 mogan 仓库
-`plugins/keyboard/progs/keyboard/emoji.scm` 的风格：
+1. 给 `init-keyboard.scm` 中 `lazy-keyboard` 注册的 19 个快捷键模块
+   （`math/math-sem-edit.scm` 无 `kbd-map`，除外）各加两条
+   `debug-message`（`keyboard` 通道），仿照 mogan 仓库
+   `plugins/keyboard/progs/keyboard/emoji.scm` 的风格：
 
-- 模块加载开始时（`texmacs-module` 之后）：
-  `(<模块名>): registering kbd-map ...`
-- 模块加载完成时（文件末尾）：`(<模块名>): kbd-map registered`
+   - 模块加载开始时（`texmacs-module` 之后）：
+     `(<模块名>): registering kbd-map ...`
+   - 模块加载完成时（文件末尾）：`(<模块名>): kbd-map registered`
+
+2. 插件加载日志（`tm-plugins.scm` 的 `plugin-initialize`）改为同样
+   风格：通道由 `debug-std` 改为 `plugin`，消息为
+   `(<插件名>): loading plugin ...` / `(<插件名>): plugin loaded`，
+   时间戳之差即单个插件的加载耗时。
 
 ## Why
 
@@ -78,3 +83,4 @@
 - `TeXmacs/progs/doc/apidoc-kbd.scm`
 - `TeXmacs/progs/link/link-kbd.scm`
 - `TeXmacs/progs/version/version-kbd.scm`
+- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`（插件加载日志改风格）


### PR DESCRIPTION
## What

给 `init-keyboard.scm` 中 `lazy-keyboard` 注册的 19 个快捷键模块各加两条 `debug-message`（`keyboard` 通道），仿照 emoji.scm 的风格：模块加载开始/完成时各一条。

## Why

`(lazy-keyboard-force #t)` 在 init 阶段同步加载全部模块，懒加载名存实亡。埋点实测各模块加载耗时，定位启动性能大头。

## 实测数据

`lazy-keyboard-force` 全程 ~675ms：

| 模块 | 耗时 |
|------|------|
| **math math-kbd** | **382ms（占 57%）** |
| text text-kbd | 37ms |
| generic generic-kbd | 25ms |
| 其余 16 个 | 0–14ms |

结论：`math-kbd.scm`（3041 行）是唯一值得优化的目标。

## 注意

- `text/text-kbd.scm` 是 latin-1 编码，已确认 4 个 `0xff` 字节未被破坏
- `math/math-sem-edit.scm` 无 `kbd-map`，未加日志
- `(generic search-kbd)` 注册时无 mode 参数，不进 `lazy-keyboard-waiting`，不受 force 影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)