### PR TITLE
[1178] julia 插件清理：精简 init-julia.scm 的 use-modules

### DIFF
--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -11,34 +11,43 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(use-modules (dynamic session-edit) (binary julia))
+(use-modules (binary julia))
+
+(lazy-format (data julia) julia)
 
 (define (julia-serialize lan t)
-  (let* ((u (pre-serialize lan t))
-         (s (texmacs->utf8raw (stree->tree u))))
-    (string-append s "\n<EOF>\n")))
+  (with u
+    (pre-serialize lan t)
+    (with s (texmacs->utf8raw (stree->tree u)) (string-append s "\n<EOF>\n"))
+  ) ;with
+) ;define
 
 (define (julia-entry)
-  (url->system (string->url
-    (if (url-exists? "$TEXMACS_HOME_PATH/plugins/julia/bin/julia.jl")
-        "$TEXMACS_HOME_PATH/plugins/julia/bin/julia.jl"
-        "$TEXMACS_PATH/plugins/julia/bin/julia.jl"))))
+  (url->system (string->url (if (url-exists? "$TEXMACS_HOME_PATH/plugins/julia/bin/julia.jl")
+                              "$TEXMACS_HOME_PATH/plugins/julia/bin/julia.jl"
+                              "$TEXMACS_PATH/plugins/julia/bin/julia.jl"
+                            ) ;if
+               ) ;string->url
+  ) ;url->system
+) ;define
 
 (define (julia-launcher)
-  (let* ((boot (string-quote (julia-entry)))
-         (cmd  (url->system (find-binary-julia))))
+  (let* ((boot (string-quote (julia-entry))) (cmd (url->system (find-binary-julia))))
     (if (or (os-win32?) (os-mingw?))
-        (string-append cmd " " boot)
-        (string-append "env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH " cmd " " boot))))
+      (string-append cmd " " boot)
+      (string-append "env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH " cmd " " boot)
+    ) ;if
+  ) ;let*
+) ;define
 
 (plugin-configure julia
   (:require (has-binary-julia?))
   (:serializer ,julia-serialize)
   (:launch ,(julia-launcher))
   (:tab-completion #t)
-  (:session "Julia"))
-
-(lazy-format (data julia) julia)
+  (:session "Julia")
+) ;plugin-configure
 
 (when (supports-julia?)
-  (plugin-input-converters julia))
+  (plugin-input-converters julia)
+) ;when

--- a/devel/1178.md
+++ b/devel/1178.md
@@ -1,0 +1,21 @@
+# 1178 插件 init 清理
+
+## 2026-08-07 精简 init-julia.scm 的 use-modules
+
+### What
+- 从 `use-modules` 中移除 `(dynamic session-edit)`，仅保留 `(binary julia)`
+- `lazy-format` 提前到 `use-modules` 之后（与 init-python.scm 结构一致）
+- 全文按项目 scheme 风格重排（`gf fmt`）
+
+### Why
+减少插件初始化时加载的模块数，提升 julia 插件加载性能。init-julia.scm 中
+用到的 `pre-serialize`（`utils/plugins/plugin-cmd.scm`）、
+`plugin-input-converters`（`utils/plugins/plugin-convert.scm`，由
+`init-research.scm` 核心加载）、`texmacs->utf8raw` 均来自核心模块，不依赖
+`(dynamic session-edit)`。
+
+沿用 2e2342450（[1176] python 插件清理）的模式；julia 没有 python-menus
+那样的空菜单模块，无需删文件。
+
+### 涉及文件
+- `TeXmacs/plugins/julia/progs/init-julia.scm`


### PR DESCRIPTION
## What
- 从 `use-modules` 中移除 `(dynamic session-edit)`，仅保留 `(binary julia)`
- `lazy-format` 提前到 `use-modules` 之后（与 init-python.scm 结构一致）
- 全文按项目 scheme 风格重排（`gf fmt`）

## Why
减少插件初始化时加载的模块数，提升 julia 插件加载性能。init-julia.scm 用到的 `pre-serialize`（`utils/plugins/plugin-cmd.scm`）、`plugin-input-converters`（`utils/plugins/plugin-convert.scm`，由 `init-research.scm` 核心加载）、`texmacs->utf8raw` 均来自核心模块，不依赖 `(dynamic session-edit)`。

沿用 2e2342450（[1176] python 插件清理）的模式；julia 没有空菜单模块，无需删文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)