### PR TITLE
[1177] lazy-keyboard-force 空队列短路，消除每次按键的空转开销

### DIFF
--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -53,27 +53,30 @@
 ) ;define
 
 (tm-define (lazy-keyboard-force . opt)
-  (debug-message "debug-std"
-    (string-append "lazy-keyboard-force called, opt="
-      (object->string opt)
-      ", waiting="
-      (number->string (length lazy-keyboard-waiting))
-      "\n"
-    ) ;string-append
-  ) ;debug-message
-  (set! lazy-force-all? (or lazy-force-all? (nnull? opt)))
-  (when (not lazy-force-busy?)
-    (set! lazy-force-busy? #t)
-    (let* ((l1 (reverse lazy-keyboard-waiting)) (l2 (lazy-keyboard-force-do l1)))
-      (set! lazy-keyboard-waiting (reverse l2))
-      (set! lazy-force-busy? #f)
-      (when (null? lazy-keyboard-waiting)
-        (set! lazy-force-all? #f)
-      ) ;when
-      (when (and lazy-force-all? (nnull? lazy-keyboard-waiting))
-        (lazy-keyboard-force #t)
-      ) ;when
-    ) ;let*
+  ;; 等待队列为空且非强制时直接返回，避免每次查表都白走一趟
+  (when (or (nnull? opt) (nnull? lazy-keyboard-waiting))
+    (debug-message "debug-std"
+      (string-append "lazy-keyboard-force called, opt="
+        (object->string opt)
+        ", waiting="
+        (number->string (length lazy-keyboard-waiting))
+        "\n"
+      ) ;string-append
+    ) ;debug-message
+    (set! lazy-force-all? (or lazy-force-all? (nnull? opt)))
+    (when (not lazy-force-busy?)
+      (set! lazy-force-busy? #t)
+      (let* ((l1 (reverse lazy-keyboard-waiting)) (l2 (lazy-keyboard-force-do l1)))
+        (set! lazy-keyboard-waiting (reverse l2))
+        (set! lazy-force-busy? #f)
+        (when (null? lazy-keyboard-waiting)
+          (set! lazy-force-all? #f)
+        ) ;when
+        (when (and lazy-force-all? (nnull? lazy-keyboard-waiting))
+          (lazy-keyboard-force #t)
+        ) ;when
+      ) ;let*
+    ) ;when
   ) ;when
 ) ;tm-define
 

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -1,0 +1,207 @@
+# 1177 kbd-map 工作原理详解
+
+## 概述
+
+`kbd-map` 是 Mogan 快捷键系统的核心宏，定义在
+`TeXmacs/progs/kernel/gui/kbd-define.scm`。它把「按键序列 → 命令」的绑定
+注册进全局哈希表，供 C++ 键盘事件处理在按键到达时查询。整个系统分两层：
+
+- **Scheme 层（本任务重点）**：`kbd-map` / `kbd-wildcards` / `kbd-commands`
+  三个宏负责定义期的注册；三张全局哈希表负责存储；`kbd-find-key-binding`
+  负责带条件求值的查询。
+- **C++ 层**：`edit_interface_rep::key_press` / `try_shortcut`
+  （`src/Edit/Interface/edit_keyboard.cpp`）驱动按键序列的累积与派发；
+  `tm_config_rep::get_keycomb`（`src/Texmacs/Server/tm_config.cpp`）
+  做通配符改写后回调 Scheme 查表。
+
+## 定义期：`kbd-map` 宏的展开与注册
+
+### 宏展开链
+
+```
+(kbd-map (:mode in-math?) ("C-a" (foo) "help") ...)
+  └─ kbd-map-body          ; 解析头部选项，产出 (kbd-binding ...) 列表
+      ├─ 头部 (:mode m)     → kbd-add-condition：把模式谓词符号追加到 conds
+      ├─ 头部 (:require e)  → 包成 (lambda () e) 追加到 conds
+      ├─ 头部 (:profile p)  → has-look-and-feel? 不匹配则整块丢弃
+      └─ 每条绑定           → kbd-map-one 生成：
+          (kbd-binding (list conds...) key cmd help)
+```
+
+要点（`kbd-define.scm:345-386`）：
+
+- `conds` 是**条件列表**，元素最终是零参闭包（thunk）。`:mode in-math?`
+  的符号在 `kbd-binding` 执行时被求值——因为 `texmacs-mode` 定义模式时
+  用 `set-symbol-procedure!` 给 `in-math?` 符号绑了过程
+  （`tm-modes.scm:46-47`），所以求值结果就是一个 thunk。
+- `kbd-map-one` 区分两种 action：
+  - action 是**字符串** → 该键是「字面量插入」绑定（shorthand），
+    生成 `(kbd-binding conds key "插入串" help)`；
+  - action 是**代码** → 包成 `(lambda () action ...)` 命令闭包。
+- 条件中的 `kind` 参数（`ctx-add-condition` 的第一个参数）目前被忽略，
+  条件只是简单 append（`tm-define.scm:20-23`）。
+
+### 注册时处理：`kbd-binding`
+
+`kbd-binding`（`kbd-define.scm:331-339`）依次做三件事：
+
+1. **`kbd-pre-rewrite`**：C++ 函数（glue 于 `glue_server.lua:49`），
+   用 pre-wildcards 表改写键名。这是把 `math:bold a`、`std c` 这类
+   「虚拟前缀」展开成真实按键的地方（见下文通配符一节）。
+2. **`kbd-sub-bindings`**：对多键序列（含空格的 key，如 `"emacs c x"`），
+   为每个中间前缀补一条「原样回显」绑定。例如绑定 `"a b c"` 时，若
+   `"a"`、`"a b"` 尚无绑定，则分别绑定为插入字符串 `"a"`、`"a b"`
+   （`kbd-append` 负责把 `<`、`>` 转义为 `<less>`、`<gtr>`）。
+   这让用户在输长序列的中间击键能看到字面回显，配合 `sh_mark`
+   机制在序列完成时回滚替换（见执行期）。
+3. **`kbd-insert-key-binding`**：真正写表。
+
+### 三张全局表
+
+`kbd-insert-key-binding`（`kbd-define.scm:159-170`）维护三张表：
+
+| 表 | 键 → 值 | 用途 |
+|---|---|---|
+| `kbd-map-table` | key → ctx 列表，元素为 `(conds cmd help)` | 正向查询（按键找命令） |
+| `kbd-inv-table` | 命令源码 → ctx 列表，元素为 `(conds key)` | 带模式的反向查询（菜单显示当前模式下的快捷键，`kbd-find-inv-binding`） |
+| `kbd-rev-table` | 命令字符串 → key 列表（无模式） | 无模式反向查询（`kbd-find-rev-binding`） |
+
+其中 `kbd-source` 会对命令闭包取 `promise-source`，使同一逻辑命令的
+不同闭包实例在 inv/rev 表中归并到同一个源码键上。
+
+写表前先调 `kbd-delete-key-binding2` 删除同 conds 的旧绑定（同键同条件
+覆盖语义）。删除时通过 `ctx-find` 精确匹配 conds，再从三张表同步移除。
+
+### ctx 列表：上下文重载
+
+ctx 结构由 `tm-define.scm:25-56` 提供，本质是 **alist**，新绑定 cons
+在头部（后定义优先）：
+
+- `ctx-insert`：`(cons (cons conds data) ctx)` —— O(1) 头插。
+- `ctx-resolve`：线性扫描，`and-apply` 依次调用每个条件 thunk
+  （按键当下求值），第一个全部条件为真的条目胜出。
+- `ctx-find` / `ctx-remove`：用 `==` 对 conds 列表做**结构相等**匹配，
+  用于覆盖/删除。
+
+因此同一个键（如 `return`）可以在不同模式（文本、表格、数学）下各有
+绑定，运行时按当前上下文解析出唯一胜者。
+
+## 通配符（wildcards）：虚拟前缀的改写
+
+`kbd-wildcards`（`kbd-define.scm:84-110`）把规则经 glue
+`insert-kbd-wildcard` 写入 C++ 的两个 `hashmap<string,tree>`：
+`pre_kbd_wildcards` / `post_kbd_wildcards`（`tm_config.cpp`）。
+
+- **pre 表**：定义期 `kbd-pre-rewrite` 使用——把绑定里的虚拟前缀
+  （如 `math:bold`、`std`、`emacs`）展开成真实按键（如 `F6`、`C-`）。
+  见 `prefix-kbd.scm` 的大量规则；同一虚拟前缀可按 look-and-feel
+  （emacs/gnome/macos/windows）映射到不同物理键。
+- **post 表**：运行期 `kbd-post-rewrite` / `get_keycomb` 使用——
+  把用户实际按下的键改写回虚拟前缀再查表（如 `S-C-` 归一为 `C-S-`，
+  `tab` 归一为 `var`）。
+
+C++ 侧 `apply_wildcards`（`tm_config.cpp:66-90`）做**最长子串优先**的
+迭代改写：对每个长度从长到短扫描子串（边界必须是空格或 `-`），命中则
+替换并递归。规则的 `left`/`right` 标志（`kbd-wildcards` 条目的第 3、4
+个元素）控制是否要求出现在序列首/尾。
+
+## 执行期：一次按键的完整链路
+
+```
+Qt keyEvent
+  └─ handle_keypress (edit_keyboard.cpp:438)     ; utf8→cork、特殊字符预处理
+      └─ call("keyboard-press") → (key-press key)   (kbd-handlers.scm:25)
+          └─ key_press (edit_keyboard.cpp:274)
+              ├─ pre-edit / 语音输入分流
+              ├─ new_sh = sh_s + " " + key         ; 累积多键序列
+              └─ try_shortcut(new_sh) (edit_keyboard.cpp:109)
+                  └─ sv->get_keycomb (tm_config.cpp:161)
+                      ├─ variant_simplification    ; tab/S-tab 变体归一
+                      ├─ apply_wildcards(post 表)  ; 物理键 → 虚拟前缀
+                      └─ find_key_binding
+                          → Scheme (kbd-find-key-binding key)
+                              ├─ lazy-keyboard-force   ; 先按需加载 kbd 模块
+                              └─ ctx-resolve           ; 条件求值，取胜者
+```
+
+`get_keycomb` 返回三种 status：
+
+- **0**：未命中。`key_press` 回退路径：先打断序列重试单键
+  （`interrupt_shortcut` 后 `try_shortcut(key)`），再依次尝试
+  单字符插入、cork 实体 `<key>` 插入、字面插入。
+- **1**：命中命令闭包 → 执行 `cmd()`。
+- **2**：命中字符串（shorthand）→ `call("kbd-insert", shorth)` 插入文本。
+  多键序列的中间态也是 status 2（定义期 `kbd-sub-bindings` 补的
+  「原样回显」绑定）。
+
+status 2 的回显是**临时的**：`try_shortcut` 在插入前 `mark_start(sh_mark)`
+记标记；下一次击键若使序列继续命中，旧回显被标记区间覆盖替换；若
+`mark_cancel(sh_mark)` 失败（文档已改动），则中断序列
+（`edit_keyboard.cpp:126-133`）。
+
+## 延迟加载：lazy-keyboard
+
+kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开出的
+`kbd-binding` 调用是顶层副作用）。为避免启动时全部加载，提供
+`lazy-keyboard` 机制（`kbd-define.scm:22-78`）：
+
+- `(lazy-keyboard (module) pred)` 把 `(mode . module)` 记入
+  `lazy-keyboard-waiting`，不立即加载；250ms 后 `module-provide`。
+- 每次 `kbd-find-key-binding` 先调 `lazy-keyboard-force`：遍历等待队列，
+  若某模块的条件模式当前激活（`texmacs-in-mode?`）则立即
+  `module-provide` 加载之，保证查表前相关绑定已就位。
+- `lazy-keyboard-force #t` 强制全部加载（文档导出等场景使用，
+  见 `tmdoc-markup.scm`）。
+
+## 其他配套机制
+
+- **`kbd-commands` / `kbd-symbols`**：维护独立的 `kbd-command-table`
+  （反斜杠命令表，如 `\alpha`），由 `kbd-get-command` 查询，走
+  hybrid/补全通道而非 `kbd-map-table`。
+- **tab 前缀补全**：`kbd-find-prefix-tab`（`kbd-define.scm:242-282`）
+  扫描全表找出 `前缀 + " tab"` 结尾且当前可解析的绑定，按键长排序，
+  结果用 `s7-make-hash-table` 缓存；供数学模式的 tab 循环切换
+  （`math-tabcycle-menu-needed?` 等）。
+- **调试/编辑工具**（`kbd-define.scm:486-779`）：
+  `get-kbd-bindings`（按键查全部重载）、`get-bindings-by-command`、
+  `get-bindings-by-condition`、`kbd-conflict-query`（冲突检测）、
+  `kbd-execute-edit`（增/改/删绑定，支持四种状态组合）。
+  它们靠 `extract-code-str` 从闭包还原源码 S 表达式做结构化比对，
+  是快捷键编辑器（`source/shortcut-edit.scm`）的底层支撑。
+- **菜单显示快捷键**：菜单渲染时经 `kbd-find-inv-binding`（带模式）或
+  `kbd-find-rev-binding`（无模式）查反向表，再经 `kbd-system-rewrite`
+  本地化渲染（`menu-convert.scm:429`、`menu-widget.scm:139`）。
+
+## 本次改动
+
+### 1. 任务文档
+
+- What：新增 `devel/1177.md`，详解 `kbd-map` 的定义期注册、ctx 条件
+  重载、通配符改写、执行期派发与配套机制。
+- Why：分支 `da/1177/kbd-map` 的任务文档。
+- How：阅读 `kbd-define.scm`、`tm-define.scm`（ctx）、`tm-modes.scm`
+  （模式谓词）、`prefix-kbd.scm`（通配符实例）、`edit_keyboard.cpp` /
+  `tm_config.cpp`（C++ 派发与改写）后撰写。
+- 涉及文件：仅 `devel/1177.md`。
+
+### 2. `lazy-keyboard-force` 空队列短路
+
+- What：给 `lazy-keyboard-force` 入口加守卫
+  `(when (or (nnull? opt) (nnull? lazy-keyboard-waiting)) ...)`，
+  等待队列为空且非强制调用时直接返回。
+- Why：`kbd-find-key-binding` / `kbd-find-inv-binding` /
+  `kbd-find-rev-binding` / `kbd-get-command` 每次查询都调它，即每次按键、
+  菜单重建时每个菜单项的快捷键反查都会触发。原实现无条件拼调试字符串、
+  调 C++ `debug_message`（`tm_debug.cpp:268`，无开关，`cout` 打印 +
+  全局 `debug_messages` 无界追加）并回调 Scheme `notify-debug-message`，
+  而队列空时整趟不加载任何模块，纯属浪费。
+- How：守卫用一次 `nnull?` 判断替换掉上述全部工作。`lazy-force-all?`
+  只在 `opt` 非空时置真，且同一调用内队列清空即复位，不存在
+  「`lazy-force-all?` 为真而队列为空」的残留状态，故守卫不改变语义。
+- 涉及文件：`TeXmacs/progs/kernel/gui/kbd-define.scm`。
+- 验证：启动区段两次运行无差异（符合预期，启动时队列非空守卫放行，
+  math-kbd 稳定 ~340ms）；启动后按键，改进前每次按键打印
+  `lazy-keyboard-force called, opt=(), waiting=0`（开菜单时按菜单项成批
+  出现），改进后该类日志为 0 条，确认每次按键省掉「拼调试字符串 →
+  C++ `debug_message` 打印 → 全局 `debug_messages` 无界追加 → 回调
+  `notify-debug-message`」整趟空转。


### PR DESCRIPTION
## What

- 新增 `devel/1177.md`：kbd-map 工作原理详解（定义期注册、ctx 条件重载、通配符改写、执行期派发）。
- `lazy-keyboard-force` 入口加守卫：等待队列为空且非强制调用时直接返回。

## Why

`kbd-find-key-binding` / `kbd-find-inv-binding` 等每次查询都调 `lazy-keyboard-force`，即每次按键、菜单重建时每个菜单项的快捷键反查都会触发。原实现无条件拼调试字符串、调 C++ `debug_message`（`cout` 打印 + 全局 `debug_messages` 无界追加）并回调 Scheme `notify-debug-message`，而队列空时整趟不加载任何模块，纯属浪费。

## 验证

- 启动区段两次运行无差异（符合预期：启动时队列非空守卫放行，math-kbd 稳定 ~340ms）。
- 启动后按键：改进前每次按键打印 `lazy-keyboard-force called, opt=(), waiting=0`（开菜单时按菜单项成批出现），改进后该类日志为 0 条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)