### PR TITLE
[1179] gnuplot 插件清理：移除 define-library 包装对齐 python/julia 风格

### DIFF
--- a/TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm
+++ b/TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm
@@ -2,7 +2,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : init-gnuplot.scm
-;; DESCRIPTION : Initialize Goldfish plugin
+;; DESCRIPTION : Initialize gnuplot plugin
 ;; COPYRIGHT   : (C) 2024   Darcy Shen
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -11,64 +11,54 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-library (session gnuplot)
-  (import (scheme base) (liii list))
-  (export init-gnuplot)
-  (begin
-    (use-modules (binary gnuplot) (binary goldfish) (binary gs))
+(use-modules (binary gnuplot) (binary goldfish) (binary gs))
 
-    (lazy-format (data gnuplot) gnuplot)
+(lazy-format (data gnuplot) gnuplot)
 
-    (define (gnuplot-serialize lan t)
-      (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
-        (string-append s "\n<EOF>\n")
-      ) ;let*
-    ) ;define
+(define (gnuplot-serialize lan t)
+  (with u
+    (pre-serialize lan t)
+    (with s (texmacs->utf8raw (stree->tree u)) (string-append s "\n<EOF>\n"))
+  ) ;with
+) ;define
 
-    (define (gen-launcher image-format)
-      (string-append (string-quote (url->system (find-binary-goldfish)))
-        " "
-        "load"
-        " "
-        (string-quote (string-append (url->system (get-texmacs-path))
-                        "/plugins/gnuplot/goldfish/tm-gnuplot.scm"
-                      ) ;string-append
-        ) ;string-quote
-        " "
-        (string-quote (url->system (find-binary-gnuplot)))
-        " "
-        image-format
-      ) ;string-append
-    ) ;define
+(define (gen-launcher image-format)
+  (string-append (string-quote (url->system (find-binary-goldfish)))
+    " "
+    "load"
+    " "
+    (string-quote (string-append (url->system (get-texmacs-path))
+                    "/plugins/gnuplot/goldfish/tm-gnuplot.scm"
+                  ) ;string-append
+    ) ;string-quote
+    " "
+    (string-quote (url->system (find-binary-gnuplot)))
+    " "
+    image-format
+  ) ;string-append
+) ;define
 
-    (define (gnuplot-launchers)
-      (let ((l (list (list :launch "pdf" (gen-launcher "pdf"))
-                 (list :launch "svg" (gen-launcher "svg"))
-                 (list :launch "png" (gen-launcher "png"))
-               ) ;list
-            ) ;l
-           ) ;
-        (if (has-binary-gs?)
-          (append l (list (list :launch "eps" (gen-launcher "eps"))))
-          l
-        ) ;if
-      ) ;let
-    ) ;define
+(define (gnuplot-launchers)
+  (let ((l (list (list :launch "pdf" (gen-launcher "pdf"))
+             (list :launch "svg" (gen-launcher "svg"))
+             (list :launch "png" (gen-launcher "png"))
+           ) ;list
+        ) ;l
+       ) ;
+    (if (has-binary-gs?)
+      (append l (list (list :launch "eps" (gen-launcher "eps"))))
+      l
+    ) ;if
+  ) ;let
+) ;define
 
-    (define (all-gnuplot-launchers)
-      (cons (list :launch (gen-launcher "pdf")) (gnuplot-launchers))
-    ) ;define
+(define (all-gnuplot-launchers)
+  (cons (list :launch (gen-launcher "pdf")) (gnuplot-launchers))
+) ;define
 
-    (define (init-gnuplot)
-      (plugin-configure gnuplot
-        (:require (and (has-binary-goldfish?) (has-binary-gnuplot?)))
-        ,(#_apply-values (all-gnuplot-launchers))
-        (:serializer ,gnuplot-serialize)
-        (:session "Gnuplot")
-      ) ;plugin-configure
-    ) ;define
-  ) ;begin
-) ;define-library
-
-(import (session gnuplot))
-(init-gnuplot)
+(plugin-configure gnuplot
+  (:require (and (has-binary-goldfish?) (has-binary-gnuplot?)))
+  ,(#_apply-values (all-gnuplot-launchers))
+  (:serializer ,gnuplot-serialize)
+  (:session "Gnuplot")
+) ;plugin-configure

--- a/devel/1179.md
+++ b/devel/1179.md
@@ -1,0 +1,26 @@
+# 1179 gnuplot 插件初始化优化
+
+## 2026-08-07 精简 init-gnuplot.scm，对齐 python/maxima/julia 风格
+
+### What
+- 移除 `(define-library (session gnuplot) ...)` 包装及末尾的
+  `(import (session gnuplot)) (init-gnuplot)` 自引用，改为顶层直接
+  `use-modules` + `plugin-configure`
+- 移除未用到的 `(liii list)` 导入（文件内只用 `list`/`cons`/`append`，
+  均为 scheme base 内置）
+- 删除只被调用一次的 `init-gnuplot` 包装函数，`plugin-configure` 顶层直接调用
+- 修正文件头 DESCRIPTION（原来误写为 "Initialize Goldfish plugin"）
+
+### Why
+`define-library` 包装是多余间接层：没有任何其他文件 import
+`(session gnuplot)`，init 文件本来就是被插件机制直接 load 的。
+python（2e2342450, [1176]）、julia（8510286c3, [1178]）、maxima 的
+init 均为顶层 `use-modules` 风格，本次对齐，减少初始化开销并保持
+插件间结构一致。
+
+### How
+按 8510286c3（julia）的模式重写；`gf fmt` 校验通过；headless 启动
+冒烟测试无 gnuplot 相关报错。
+
+### 涉及文件
+- `TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm`


### PR DESCRIPTION
## What
- 移除 `init-gnuplot.scm` 的 `(define-library (session gnuplot) ...)` 包装及末尾自引用，改为顶层 `use-modules` + `plugin-configure`
- 移除未用到的 `(liii list)` 导入
- 删除只调用一次的 `init-gnuplot` 包装函数
- 修正文件头 DESCRIPTION（原误写为 Goldfish plugin）

## Why
对齐 python（[1176]）、julia（[1178]）、maxima 插件 init 的顶层 `use-modules` 风格；`(session gnuplot)` 无任何外部引用，define-library 是多余间接层。

## 验证
- `gf fmt` 通过
- headless 启动冒烟测试无 gnuplot 报错

任务文档：`devel/1179.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)