### PR TITLE
[1177] kbd-map 初始化性能优化（math-kbd 加载 -40%）

### DIFF
--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -152,7 +152,10 @@
 ) ;define
 
 (define (simple-insert l x)
-  (if (nlist? l) (list x) (list-union (list x) l))
+  (cond ((nlist? l) (list x))
+        ((member x l) l)
+        (else (cons x l))
+  ) ;cond
 ) ;define
 
 (define (simple-remove l x)
@@ -318,13 +321,14 @@
 ) ;define
 
 (define (kbd-sub-bindings-sub conds s prev-end end)
-  (cond ((== end (string-length s)) (noop))
-        ((== (string-ref s end) #\space)
-         (kbd-sub-binding conds s prev-end end)
-         (kbd-sub-bindings-sub conds s end (+ end 1))
-        ) ;
-        (else (kbd-sub-bindings-sub conds s prev-end (+ end 1)))
-  ) ;cond
+  ;; 用 C 级 char-position 直接跳到下一个空格，替代逐字符递归扫描
+  (with pos
+    (char-position #\space s end)
+    (when pos
+      (kbd-sub-binding conds s prev-end pos)
+      (kbd-sub-bindings-sub conds s pos (+ pos 1))
+    ) ;when
+  ) ;with
 ) ;define
 
 (define (kbd-sub-bindings conds s)

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -205,3 +205,30 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
   出现），改进后该类日志为 0 条，确认每次按键省掉「拼调试字符串 →
   C++ `debug_message` 打印 → 全局 `debug_messages` 无界追加 → 回调
   `notify-debug-message`」整趟空转。
+
+### 3. kbd-map 定义期（初始化）性能优化
+
+- What：优化 `kbd-sub-bindings-sub` 与 `simple-insert` 两处定义期热点。
+- Why：以加载 `(math math-kbd)`（2940 条绑定）为基准插桩，`kbd-binding`
+  总耗 267ms 中 `kbd-sub-bindings` 占 209ms、`kbd-insert-key-binding`
+  占 54ms（其中 rev 表 `simple-insert` 占 36ms），`kbd-pre-rewrite`
+  仅 2ms。两个热点：
+  1. `kbd-sub-bindings-sub` 对每条绑定**逐字符递归**扫描找空格
+     （`string-ref` + 每步 `string-length`），math-kbd 中 1108/1146 条是
+     多键序列，累计约 5 万次 s7 解释层递归调用（~170ms）；
+  2. `simple-insert` 用通用集合并 `list-union` 实现「没有就 cons」，
+     每条绑定白走一遍通用算法（~36ms）。
+- How：
+  1. 改用 s7 C 级原语 `char-position` 直接跳到下一个空格，消除逐字符
+     递归；空格位置驱动的 `prev-end`/`end` 语义与原实现完全一致
+     （含连续空格、尾部空格等边界）。
+  2. `simple-insert` 改为 `member` 判重 + `cons`。
+- 涉及文件：`TeXmacs/progs/kernel/gui/kbd-define.scm`。
+- 验证：
+  - 性能：math-kbd 加载 ~430ms → ~250ms（-40%，三次运行
+    244/260/245ms）；`lazy-keyboard-force #t` 全量 19 个 kbd 模块
+    ~475ms，其中 math-kbd 203ms，其余模块注册均已降至 1–18ms。
+  - 等价性：旧/新实现分别加载 math-kbd + text-kbd + generic-kbd 并
+    `lazy-keyboard-force #t` 全量加载后，导出三张表
+    （`kbd-map-table`/`kbd-inv-table`/`kbd-rev-table`，条件与命令取
+    `extract-code-str` 源码、按键排序）共 3074 行，`diff` 完全一致。


### PR DESCRIPTION
## What

优化 `kbd-map` 定义期（初始化）两处热点：

1. **`kbd-sub-bindings-sub`**：逐字符递归扫描找空格 → s7 C 级原语 `char-position` 直接跳扫
2. **`simple-insert`**：通用 `list-union` 判重插入 → `member` + `cons`

## Why

以加载 `(math math-kbd)`（2940 条绑定）插桩定位：

| 阶段 | 优化前耗时 | 占比 |
|---|---|---|
| `kbd-sub-bindings`（逐字符扫描 ~5 万次递归） | 209ms | 78% |
| `kbd-insert-key-binding`（其中 rev 表 `simple-insert` 36ms） | 54ms | 20% |
| `kbd-pre-rewrite` | 2ms | 可忽略 |

## 效果

- math-kbd 加载：**~430ms → ~250ms（-40%）**
- `lazy-keyboard-force #t` 全量 19 个 kbd 模块 ~475ms，其余模块注册均降至 1–18ms

## 验证

等价性：旧/新实现分别全量加载 kbd 模块后导出三张表（`kbd-map-table`/`kbd-inv-table`/`kbd-rev-table`，条件与命令取源码、按键排序，共 3074 行），`diff` 完全一致。

详见 `devel/1177.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)