### PR TITLE
[1170] 大纲侧边栏默认关闭

### DIFF
--- a/devel/1170.md
+++ b/devel/1170.md
@@ -54,3 +54,15 @@ xmake b qt_pdf_reader_widget_test && xmake r qt_pdf_reader_widget_test
 - PDF 大纲：PDFReaderWidget 新增 extractOutline()（仿 extractPageLinks 的「重开 doc → fz_resolve_link」模式），loadFromFile 成功后 emit outlineLoaded 信号；OutlineWidget 接收 QVector<PdfOutlineItem> 建树
 - 文档大纲：新增 text-outline.scm 模块，document-outline 函数通过 tree-search-sections 获取章节列表并返回 (title path-str) 对；OutlineWidget::loadDocumentOutline 通过 eval_scheme 获取数据并建树
 - 可见性：update_visibility 在 PDF 模式按 hasContent() 显示 dock，编辑器模式同理；离开 PDF 模式时只 hide 不清空树内容，避免重复打开同一 PDF 时丢失大纲
+
+## 2026/08/07 默认关闭大纲侧边栏
+
+### What
+大纲侧边栏功能改为默认关闭，通过偏好设置 `outline sidebar` 控制（默认 `off`）。
+
+### Why
+该功能仍在探索阶段，默认开启会影响所有用户的界面布局，先默认关闭，需要时通过 `(set-preference "outline sidebar" "on")` 开启。
+
+### How
+- `qt_pdf_outline_widget.cpp`：新增 `outline_sidebar_enabled()` 读取偏好；两个 `setOutline` 重载和 `loadDocumentOutline` 在开关关闭时直接清空并隐藏 dock，跳过 scheme 求值
+- `qt_tm_widget.cpp`：`update_visibility` 两处 dock 可见性计算增加开关判断，运行时关闭偏好后已显示的 dock 也会被隐藏

--- a/src/Plugins/Qt/qt_pdf_outline_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_outline_widget.cpp
@@ -10,11 +10,21 @@
 #include <QTreeWidgetItem>
 
 #include "converter.hpp" // cork_to_utf8
+#include "preferences.hpp"
 #include "qt_dpi_utils.hpp"
 #include "qt_pdf_reader_widget.hpp"
 #include "qt_utilities.hpp" // utf8_to_qstring
 #include "s7_tm.hpp"
 #include "sys_utils.hpp" // get_env
+
+namespace {
+/** @brief 大纲侧边栏功能开关，默认关闭（探索性功能），
+ *  可通过 (set-preference "outline sidebar" "on") 开启。 */
+static bool
+outline_sidebar_enabled () {
+  return get_preference ("outline sidebar", "off") == "on";
+}
+} // namespace
 
 OutlineWidget::OutlineWidget (const QString& title, QWidget* parent)
     : QDockWidget (title, parent), tree_ (new QTreeWidget (this)) {
@@ -82,7 +92,7 @@ OutlineWidget::buildTree (const QVector<OutlineItem>& items,
 void
 OutlineWidget::setOutline (const QVector<PdfOutlineItem>& outline) {
   tree_->clear ();
-  if (outline.isEmpty ()) {
+  if (!outline_sidebar_enabled () || outline.isEmpty ()) {
     setVisible (false);
     return;
   }
@@ -94,7 +104,7 @@ OutlineWidget::setOutline (const QVector<PdfOutlineItem>& outline) {
 void
 OutlineWidget::setOutline (const QVector<OutlineItem>& outline) {
   tree_->clear ();
-  if (outline.isEmpty ()) {
+  if (!outline_sidebar_enabled () || outline.isEmpty ()) {
     setVisible (false);
     return;
   }
@@ -131,6 +141,10 @@ parseOutlinePair (tmscm pair) {
 bool
 OutlineWidget::loadDocumentOutline () {
   tree_->clear ();
+  if (!outline_sidebar_enabled ()) {
+    setVisible (false);
+    return false;
+  }
   // 确保模块已加载（init-research.scm 中的 use-modules 可能未生效时兜底）
   if (!eval_scheme ("(defined? 'document-outline)")) {
     string texmacs_path= get_env ("TEXMACS_PATH");

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1466,8 +1466,10 @@ qt_tm_widget_rep::update_visibility () {
   bool new_titleVisibility     = visibility[0];
   bool new_pdfToolBarVisibility= false;
   bool new_pdfOutlineVisibility= false;
+  bool outlineEnabled= get_preference ("outline sidebar", "off") == "on";
   // 编辑器模式：根据文档大纲内容决定是否显示 dock
-  if (!startupTabMode && !pdfTabMode && !chatTabMode && pdfOutlineDock) {
+  if (!startupTabMode && !pdfTabMode && !chatTabMode && pdfOutlineDock &&
+      outlineEnabled) {
     new_pdfOutlineVisibility= pdfOutlineDock->hasContent ();
   }
 
@@ -1518,7 +1520,8 @@ qt_tm_widget_rep::update_visibility () {
     new_tabVisibility       = true;
     new_titleVisibility     = true;
     new_pdfToolBarVisibility= true;
-    new_pdfOutlineVisibility= (pdfOutlineDock && pdfOutlineDock->hasContent ());
+    new_pdfOutlineVisibility=
+        outlineEnabled && pdfOutlineDock && pdfOutlineDock->hasContent ();
   }
   if (XOR (old_mainVisibility, new_mainVisibility)) {
     mainToolBar->setVisible (new_mainVisibility);


### PR DESCRIPTION
## What
PDF 阅读器与文档编辑器的树形目录侧边栏改为默认关闭，新增偏好设置 `outline sidebar`（默认 `off`）控制。

## Why
该功能仍在探索阶段，默认开启会影响所有用户的界面布局。先默认关闭，需要时通过 `(set-preference "outline sidebar" "on")` 开启。

## How
- `qt_pdf_outline_widget.cpp`：新增 `outline_sidebar_enabled()` 读取偏好；两个 `setOutline` 重载和 `loadDocumentOutline` 在开关关闭时直接清空并隐藏 dock，跳过 scheme 求值
- `qt_tm_widget.cpp`：`update_visibility` 两处 dock 可见性计算增加开关判断，运行时关闭偏好后已显示的 dock 也会被隐藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)