### PR TITLE
[1179] 升级内置 Goldfish 到 v18.11.20

### DIFF
--- a/TeXmacs/plugins/goldfish/goldfish/liii/base.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/liii/base.scm
@@ -30,26 +30,6 @@
     call-with-output-string
     reverse!
     format
-    let?
-    openlet?
-    funclet?
-    curlet
-    outlet
-    rootlet
-    owlet
-    funclet
-    inlet
-    sublet
-    varlet
-    cutlet
-    openlet
-    coverlet
-    unlet
-    let-ref
-    let-set!
-    let->list
-    symbol->value
-    symbol->dynamic-value
   ) ;export
   (begin
 

--- a/TeXmacs/plugins/goldfish/goldfish/scheme/let.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/scheme/let.scm
@@ -1,0 +1,47 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+(define-library (scheme let)
+  (export
+    ;; 谓词
+    let?
+    openlet?
+    funclet?
+    ;; 环境获取
+    curlet
+    outlet
+    rootlet
+    owlet
+    funclet
+    ;; 环境构造与操作
+    inlet
+    sublet
+    varlet
+    cutlet
+    openlet
+    coverlet
+    unlet
+    ;; 绑定访问
+    let-ref
+    let-set!
+    let->list
+    ;; 符号查找
+    symbol->value
+    symbol->dynamic-value
+  ) ;export
+  (begin
+  ) ;begin
+) ;define-library

--- a/TeXmacs/plugins/goldfish/src/goldfish.hpp
+++ b/TeXmacs/plugins/goldfish/src/goldfish.hpp
@@ -68,7 +68,7 @@
 #include <isocline.h>
 #endif
 
-#define GOLDFISH_VERSION "18.11.19"
+#define GOLDFISH_VERSION "18.11.20"
 
 #define GOLDFISH_PATH_MAXN TB_PATH_MAXN
 

--- a/devel/1179.md
+++ b/devel/1179.md
@@ -26,3 +26,34 @@ based on S7 Scheme 11.5 (22-Sep-2025)
 
 ### 涉及文件
 - `gf_fmt.json`
+
+## 2026-08-07 升级内置 Goldfish 到 v18.11.20
+
+### What
+把 `TeXmacs/plugins/goldfish` 内置的 Goldfish 从 18.11.19 升级到 18.11.20，
+同步自本地 `~/git/goldfish`（tag v18.11.20，HEAD `ff0e286e`）。
+
+### Why
+跟进上游 18.11.20：let 相关函数从 `(liii base)` 迁移到 `(scheme let)`，
+另含若干 `gf fmt` 修复（fmt 工具不内嵌在 mogan，不受影响）。
+
+### How
+上游 18.11.19 → 18.11.20 的 C/C++ 源码无变化，仅版本号与 scheme 库变动：
+- `src/goldfish.hpp`：`GOLDFISH_VERSION` 改为 `"18.11.20"`；
+- 新增 `goldfish/scheme/let.scm`（`(scheme let)` 库，导出 20 个 let 操作函数）；
+- `goldfish/liii/base.scm`：移除上述 20 个 let 符号的导出。
+
+兼容性：全仓 grep 确认没有 mogan 代码经 `(liii base)` 使用这些 let 符号
+（`TeXmacs/progs` 中用到 `curlet`/`sublet` 的 init-research.scm、boot-s7.scm
+走的是 s7 rootlet 内建，不经 `(liii base)` 导入），迁移不影响 mogan。
+
+验证：
+- `xmake b stem` 通过，`bin/goldfish --version` 输出 18.11.20；
+- `(import (scheme let))` 及 `let?`/`let->list`/`inlet` 调用正常；
+- 上游 `tests/scheme/let-test.scm` 在内置 goldfish 下通过（exit 0）；
+- mogan headless 启动冒烟通过；`xmake r print-widgets-test` 23 correct。
+
+### 涉及文件
+- `TeXmacs/plugins/goldfish/src/goldfish.hpp`
+- `TeXmacs/plugins/goldfish/goldfish/scheme/let.scm`（新增）
+- `TeXmacs/plugins/goldfish/goldfish/liii/base.scm`


### PR DESCRIPTION
## What
把 `TeXmacs/plugins/goldfish` 内置的 Goldfish 从 18.11.19 升级到 18.11.20，同步自上游 tag v18.11.20（`ff0e286e`）。

## How
上游 18.11.19 → 18.11.20 的 C/C++ 源码无变化，仅版本号与 scheme 库变动：
- `src/goldfish.hpp`：`GOLDFISH_VERSION` → `"18.11.20"`
- 新增 `goldfish/scheme/let.scm`（`(scheme let)` 库，导出 20 个 let 操作函数）
- `goldfish/liii/base.scm`：移除上述 let 符号导出（迁移至 `(scheme let)`）

兼容性：全仓 grep 确认没有 mogan 代码经 `(liii base)` 使用这些 let 符号，迁移不影响 mogan。

## 验证
- `xmake b stem` 通过，`bin/goldfish --version` 输出 18.11.20
- `(import (scheme let))` 及 let 操作函数调用正常
- 上游 `tests/scheme/let-test.scm` 通过
- mogan headless 冒烟通过；`xmake r print-widgets-test` 23 correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)