### PR TITLE
[1172] Dutch 数学快捷键迁移到 lang 插件

### DIFF
--- a/TeXmacs/packages/customize/language/dutch.ts
+++ b/TeXmacs/packages/customize/language/dutch.ts
@@ -21,6 +21,8 @@
   </src-title>>
 
   <assign|language|dutch>
+
+  <use-module|(lang dutch-kbd)>
 </body>
 
 <\initial>

--- a/TeXmacs/plugins/lang/progs/lang/dutch-kbd.scm
+++ b/TeXmacs/plugins/lang/progs/lang/dutch-kbd.scm
@@ -1,0 +1,48 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : dutch-kbd.scm
+;; DESCRIPTION : keystrokes for the Dutch language
+;; COPYRIGHT   : (C) 2026  Da Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (lang dutch-kbd) (:use (math math-kbd)))
+
+(kbd-map (:mode in-math-dutch?)
+  ;; ("e n" (make 'infix-and))
+  ;; ("e n space" (make 'infix-and))
+  ("space e" " e")
+  ("space e var" (begin (kbd-space) (insert "<varepsilon>")))
+  ("space e var var" (begin (kbd-space) (insert "<mathe>")))
+  ("space e var var var" (begin (kbd-space) (insert "<epsilon>")))
+  ("space e var var var var" (begin (kbd-space) (insert "<backepsilon>")))
+  ("space e n" (make 'infix-and))
+  ("space e n space" (make 'infix-and))
+  ;; ("e n var" "en")
+  ;; ("o f" (make 'infix-or))
+  ;; ("o f space" (make 'infix-or))
+  ("space o" " o")
+  ("space o var" (begin (kbd-space) (insert "<omicron>")))
+  ("space o f" (make 'infix-or))
+  ("space o f space" (make 'infix-or))
+  ;; ("o f var" "of")
+  ;; ("d e s d a" (make 'infix-iff))
+  ;; ("d e s d a space" (make 'infix-iff))
+  ("space d" " d")
+  ("space d var" (begin (kbd-space) (insert "<delta>")))
+  ("space d var var" (begin (kbd-space) (insert "<mathd>")))
+  ("space d var var var" (begin (kbd-space) (insert "<partial>")))
+  ("space d e" " de")
+  ("space d e s" " des")
+  ("space d e s d" " desd")
+  ("space d e s d a" (make 'infix-iff))
+  ("space d e s d a space" (make 'infix-iff))
+  ;; ("d e s d a var" "desda")
+  ("v o o r space" "voor ")
+  ("v o o r space a l l e" (make 'prefix-for-all))
+  ("v o o r space a l l e space" (make 'prefix-for-all))
+) ;kbd-map

--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -2511,41 +2511,6 @@
   ("f o r space a l l space" (make 'prefix-for-all))
 ) ;kbd-map
 
-(kbd-map (:mode in-math-dutch?)
-  ;; ("e n" (make 'infix-and))
-  ;; ("e n space" (make 'infix-and))
-  ("space e" " e")
-  ("space e var" (begin (kbd-space) (insert "<varepsilon>")))
-  ("space e var var" (begin (kbd-space) (insert "<mathe>")))
-  ("space e var var var" (begin (kbd-space) (insert "<epsilon>")))
-  ("space e var var var var" (begin (kbd-space) (insert "<backepsilon>")))
-  ("space e n" (make 'infix-and))
-  ("space e n space" (make 'infix-and))
-  ;; ("e n var" "en")
-  ;; ("o f" (make 'infix-or))
-  ;; ("o f space" (make 'infix-or))
-  ("space o" " o")
-  ("space o var" (begin (kbd-space) (insert "<omicron>")))
-  ("space o f" (make 'infix-or))
-  ("space o f space" (make 'infix-or))
-  ;; ("o f var" "of")
-  ;; ("d e s d a" (make 'infix-iff))
-  ;; ("d e s d a space" (make 'infix-iff))
-  ("space d" " d")
-  ("space d var" (begin (kbd-space) (insert "<delta>")))
-  ("space d var var" (begin (kbd-space) (insert "<mathd>")))
-  ("space d var var var" (begin (kbd-space) (insert "<partial>")))
-  ("space d e" " de")
-  ("space d e s" " des")
-  ("space d e s d" " desd")
-  ("space d e s d a" (make 'infix-iff))
-  ("space d e s d a space" (make 'infix-iff))
-  ;; ("d e s d a var" "desda")
-  ("v o o r space" "voor ")
-  ("v o o r space a l l e" (make 'prefix-for-all))
-  ("v o o r space a l l e space" (make 'prefix-for-all))
-) ;kbd-map
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special toggles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/devel/1172.md
+++ b/devel/1172.md
@@ -110,3 +110,60 @@ chinese-kbd 的结构保持一致（见 1156、1157）。
 - `TeXmacs/plugins/lang/progs/lang/german-kbd.scm`（新增）
 - `TeXmacs/progs/math/math-kbd.scm`（删除 in-math-german? kbd-map）
 - `TeXmacs/packages/customize/language/german.ts`（加载模块）
+
+---
+
+# 1172 Dutch 数学快捷键迁移到 lang 插件
+
+## What
+
+将 `TeXmacs/progs/math/math-kbd.scm` 中 `in-math-dutch?` 的 kbd-map 迁移
+到 lang 插件 `TeXmacs/plugins/lang/progs/lang/dutch-kbd.scm`，并在
+`TeXmacs/packages/customize/language/dutch.ts` 中
+`<use-module|(lang dutch-kbd)>` 加载。
+
+迁移 23 条有效绑定（外加原块中注释掉的历史绑定一并搬移），内容逐行
+不变。绑定全部为纯 ASCII，无 cork 编码问题。
+
+## Why
+
+同 French/German 迁移：语言相关快捷键收敛到 lang 插件统一管理
+（见上文及 1156、1157）。
+
+## How
+
+- 新增 `plugins/lang/progs/lang/dutch-kbd.scm`：
+  `(texmacs-module (lang dutch-kbd) (:use (math math-kbd)))`，
+  内含原 `in-math-dutch?` kbd-map 全部 23 条绑定。
+- `math-kbd.scm` 删除整个 `in-math-dutch?` kbd-map 块。
+- `dutch.ts` 增加 `<use-module|(lang dutch-kbd)>`，文档切换为
+  Dutch 语言时加载快捷键。
+
+主要绑定（荷兰语数学模式，`var` 即 `Tab` 键）：
+
+| 按键序列 | 效果 |
+|----------|------|
+| `空格 e n` | 插入 `∧`（infix-and，"en"） |
+| `空格 o f` | 插入 `∨`（infix-or，"of"） |
+| `空格 d e s d a` | 插入 `⇔`（infix-iff，"desda"） |
+| `v o o r 空格 a l l e` | 插入 `∀`（prefix-for-all，"voor alle"） |
+| `空格 e var…` | ε 系列变体（varepsilon / mathe / epsilon / backepsilon） |
+| `空格 o var` | ο（omicron） |
+| `空格 d var[ var[ var]]` | δ / d / ∂（delta / mathd / partial） |
+
+## 如何测试
+
+迁移后行为应与迁移前完全一致。
+
+前置：启动 Mogan，新建文档，通过菜单「文档 → 语言 → Dutch」将文档语言
+切换为荷兰语，进入数学模式（`$`），输入 `v o o r space a l l e` 验证
+快捷键生效。
+
+回归：把文档语言切回 English，重复该序列，确认不再触发（快捷键已从
+全局 math-kbd 移除，仅随 Dutch 语言包加载）。
+
+## 涉及文件
+
+- `TeXmacs/plugins/lang/progs/lang/dutch-kbd.scm`（新增）
+- `TeXmacs/progs/math/math-kbd.scm`（删除 in-math-dutch? kbd-map）
+- `TeXmacs/packages/customize/language/dutch.ts`（加载模块）


### PR DESCRIPTION
## What

将 `TeXmacs/progs/math/math-kbd.scm` 中 `in-math-dutch?` 的 kbd-map 迁移到 lang 插件 `TeXmacs/plugins/lang/progs/lang/dutch-kbd.scm`，并在 `TeXmacs/packages/customize/language/dutch.ts` 中 `<use-module|(lang dutch-kbd)>` 加载。

迁移 23 条有效绑定（外加原块中注释掉的历史绑定一并搬移），内容逐行不变。绑定全部为纯 ASCII，无 cork 编码问题。

## Why

语言相关快捷键收敛到 lang 插件统一管理，与 French/German 迁移保持一致（#4207、#4208，另见 1156、1157）。

## How

- 新增 `plugins/lang/progs/lang/dutch-kbd.scm`：`(texmacs-module (lang dutch-kbd) (:use (math math-kbd)))`，内含原 `in-math-dutch?` kbd-map 全部 23 条绑定。
- `math-kbd.scm` 删除整个 `in-math-dutch?` kbd-map 块。
- `dutch.ts` 增加 `<use-module|(lang dutch-kbd)>`，文档切换为 Dutch 语言时加载快捷键。

## 如何测试

前置：启动 Mogan，新建文档，通过菜单「文档 → 语言 → Dutch」将文档语言切换为荷兰语，进入数学模式（`$`），输入 `v o o r space a l l e` 验证快捷键生效（插入 ∀）。

回归：把文档语言切回 English，重复该序列，确认不再触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)