### PR TITLE
[0878] 修复 strict_cork_to_utf8 返回空串时 decode_from_utf8 越界崩溃

### DIFF
--- a/devel/0878.md
+++ b/devel/0878.md
@@ -40,3 +40,9 @@ xmake r stem
 - **`symbol-font` 标签**：回退分支用 `tuple("symbol-font", "Stix Two Math")` 作 key，在 `initialize_font()` 加同名分支（与 `emoji-font` 同逻辑：`adjust_subfont(closest_font(...))`）。不复用 `emoji-font` 以保持语义独立。
 - **安全性**：回退只在 `advance()` 的 `cht` 表未命中时触发（`cht` 查的是符号名），已在 `.enc` 注册的符号（`<vartriangle>`/`<oblong>`/`<square>` 等）走 cht 命中各自字体，永不进入此回退，不受影响。
 - **符号绑定与语义**：`tmuniversaltounicode.scm` 绑定码点（复制/导出），`std-symbols.scm` 注册 `:type symbol` 排版语义（与同源的 `<square>`/`<vartriangle>` 一致）。
+
+## 7 紧急修复（2026-08-07）：空串导致 crash
+
+- **现象**：`resolve()` 在特定字符上崩溃，栈顶为 `decode_from_utf8`（`lolly/lolly/data/unicode.cpp:54`），调用方 `smart_font.cpp:1241`。
+- **原因**：`strict_cork_to_utf8 (c)` 对无法转换的 cork 字符返回空串 `""`，`decode_from_utf8` 第一行无边界检查读 `s[0]`，越界崩溃。且原判定 `pos == N (uc)` 在空串时（0==0）成立，会误用未初始化的 `code`。
+- **修复**（`src/Graphics/Fonts/smart_font.cpp` `resolve()`）：`N (uc) > 0` 时才调用 `decode_from_utf8`，`code` 初值 -1，判定追加 `code >= 0`；空串时 `geom_code` 保持 -1，跳过 Stix Two Math 回退，继续后续原有 fallback。

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -1238,8 +1238,9 @@ smart_font_rep::resolve (string c) {
   {
     string uc  = strict_cork_to_utf8 (c);
     int    pos = 0;
-    int    code= decode_from_utf8 (uc, pos);
-    if (pos == N (uc)) geom_code= code;
+    int    code= -1;
+    if (N (uc) > 0) code= decode_from_utf8 (uc, pos);
+    if (pos == N (uc) && code >= 0) geom_code= code;
   }
   if (geom_code >= 0x2500 && geom_code <= 0x25FF) {
     font cfn=


### PR DESCRIPTION
## What
`smart_font_rep::resolve()` 的 Geometric Shapes 回退分支中，`strict_cork_to_utf8 (c)` 对无法转换的 cork 字符返回空串，`decode_from_utf8`（`lolly/lolly/data/unicode.cpp:54`）无边界检查读 `s[0]` 导致越界崩溃。

崩溃栈：
```
decode_from_utf8            lolly/lolly/data/unicode.cpp:54
smart_font_rep::resolve     src/Graphics/Fonts/smart_font.cpp:1241
```

## How
- `N (uc) > 0` 时才调用 `decode_from_utf8`，`code` 初值 -1
- 判定追加 `code >= 0`（空串时 `pos == N(uc)` 即 0==0 成立，会误用未初始化的 `code`）
- 空串时 `geom_code` 保持 -1，跳过 Stix Two Math 回退，继续后续原有 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)