### PR TITLE
[1177] delayed-kbd-map:快捷键绑定分片延迟注册

### DIFF
--- a/TeXmacs/plugins/keyboard/progs/keyboard/emoji.scm
+++ b/TeXmacs/plugins/keyboard/progs/keyboard/emoji.scm
@@ -14,7 +14,7 @@
 
 (tm-define (enable-emoji-keyboard)
   (debug-message "keyboard" "(keyboard emoji): registering emoji kbd-map ...\n")
-  (kbd-map (": + 1 :" "<#1F44D>")
+  (delayed-kbd-map (": + 1 :" "<#1F44D>")
    (": - 1 :" "<#1F44E>")
    (": 1 0 0 :" "<#1F4AF>")
    (": 1 2 3 4 :" "<#1F522>")
@@ -810,6 +810,6 @@
    (": y u m :" "<#1F60B>")
    (": z a p :" "<#26A1>")
    (": z z z :" "<#1F4A4>")
-  ) ;kbd-map
+  ) ;delayed-kbd-map
   (debug-message "keyboard" "(keyboard emoji): emoji kbd-map registered\n")
 ) ;tm-define

--- a/TeXmacs/progs/kernel/gui/kbd-define-test.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define-test.scm
@@ -1,0 +1,76 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : kbd-define-test.scm
+;; DESCRIPTION : Test suite for delayed-kbd-map
+;; COPYRIGHT   : (C) 2026  Da Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (kernel gui kbd-define-test) (:use (kernel gui kbd-define)))
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;; kbd-find-key-binding 对 shorthand 返回 (插入串 help) 列表
+
+(define (test-enqueue-defers)
+  ;; 入队后未 flush:绑定留在队列里,尚未写表
+  (delayed-kbd-map ("T17a" "AAA"))
+  (check (kbd-pending-empty?) => #f)
+) ;define
+
+(define (test-flush-registers)
+  (kbd-flush-pending)
+  (check (kbd-pending-empty?) => #t)
+  (check (kbd-find-key-binding "T17a") => (list "AAA" ""))
+) ;define
+
+(define (test-getter-drains)
+  ;; 不经显式 flush,查询路径经 getter 自动 drain
+  (delayed-kbd-map ("T17b" "BBB"))
+  (check (kbd-find-key-binding "T17b") => (list "BBB" ""))
+  (check (kbd-pending-empty?) => #t)
+) ;define
+
+(define (test-override-after-delayed)
+  ;; delayed 先入队 old,同步 kbd-map 随后写 new:同步写先触发 drain,后定义胜出
+  (delayed-kbd-map ("T17c" "old"))
+  (kbd-map ("T17c" "new"))
+  (check (kbd-find-key-binding "T17c") => (list "new" ""))
+) ;define
+
+(define (test-override-before-delayed)
+  ;; 同步先写 old,delayed 后入队 new:flush 后后定义胜出
+  (kbd-map ("T17d" "old"))
+  (delayed-kbd-map ("T17d" "new"))
+  (kbd-flush-pending)
+  (check (kbd-find-key-binding "T17d") => (list "new" ""))
+) ;define
+
+(define (test-multi-key-sequence)
+  ;; 多键序列:完整序列命中 shorthand
+  (delayed-kbd-map ("T17e x y" "EEE"))
+  (kbd-flush-pending)
+  (check (kbd-find-key-binding "T17e x y") => (list "EEE" ""))
+) ;define
+
+(define (cleanup)
+  ;; kbd-unmap 的条目是裸按键字符串;"T17e"/"T17e x" 是多键序列的中间回显绑定
+  (kbd-unmap "T17a" "T17b" "T17c" "T17d" "T17e" "T17e x" "T17e x y")
+) ;define
+
+(tm-define (regtest-kbd-define)
+  (test-enqueue-defers)
+  (test-flush-registers)
+  (test-getter-drains)
+  (test-override-after-delayed)
+  (test-override-before-delayed)
+  (test-multi-key-sequence)
+  (cleanup)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/gui/kbd-define-test.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define-test.scm
@@ -31,17 +31,18 @@
 ) ;define
 
 (define (test-getter-drains)
-  ;; 不经显式 flush,查询路径经 getter 自动 drain
+  ;; 不经显式 flush,按键查询路径(kbd-find-key-binding)自动 drain
   (delayed-kbd-map ("T17b" "BBB"))
   (check (kbd-find-key-binding "T17b") => (list "BBB" ""))
   (check (kbd-pending-empty?) => #t)
 ) ;define
 
 (define (test-override-after-delayed)
-  ;; delayed 先入队 old,同步 kbd-map 随后写 new:同步写先触发 drain,后定义胜出
+  ;; 同步写不触发 drain:delayed 批次的 old 在查询 drain 时才执行,
+  ;; 按执行先后后执行的 old 覆盖先写入的 new
   (delayed-kbd-map ("T17c" "old"))
   (kbd-map ("T17c" "new"))
-  (check (kbd-find-key-binding "T17c") => (list "new" ""))
+  (check (kbd-find-key-binding "T17c") => (list "old" ""))
 ) ;define
 
 (define (test-override-before-delayed)

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -247,8 +247,12 @@
   ) ;when
 ) ;tm-define
 
+;; kbd-get-map 保持纯读，不隐式 drain：需要一致性的入口显式调
+;; kbd-flush-pending（kbd-find-key-binding / kbd-find-prefix-tab-inner /
+;; 快捷键编辑器工具）。注意同步写不再触发 drain，与在途 delayed 批次
+;; 绑定同键同条件时，批次 drain 时后执行会覆盖同步写
+
 (define (kbd-get-map key)
-  (kbd-flush-pending)
   (ahash-ref kbd-map-table key)
 ) ;define
 
@@ -310,6 +314,8 @@
   (:synopsis "Find the command associated to the keystroke @key")
   ;; (display* "Find binding '" key "'\n")
   (lazy-keyboard-force)
+  ;; 按键是正确性关键路径：查表前必须 drain 在途 delayed 批次
+  (kbd-flush-pending)
   (ctx-resolve (kbd-get-map key) #f)
 ) ;tm-define
 
@@ -664,6 +670,7 @@
 ;; 2. 返回结果中的条件部分始终是一个列表（如 `((cond1) (cond2))`），
 ;;   因为 Mogan 允许一个快捷键绑定同时依赖多个条件（逻辑与关系）。
 (tm-define (get-kbd-bindings key-str)
+  (kbd-flush-pending)
   (let ((raw-map (kbd-get-map key-str)))
     (if (not raw-map)
       (list 'not-bound)
@@ -815,6 +822,7 @@
 ;; - 如果存在冲突：返回冲突绑定的命令源码（通常是一个列表）。
 ;; - 如果无冲突：返回 #f。
 (tm-define (kbd-conflict-query conds new-key)
+  (kbd-flush-pending)
   (let ((raw-map (kbd-get-map new-key)))
     (if raw-map
       (let loop
@@ -873,6 +881,7 @@
 ;; - 删除: old-key="C-b",  new-key="" -> C-b 被解绑，且没有新绑定生成。
 ;; - 无效操作：都为空，直接返回。
 (tm-define (kbd-execute-edit conds cmd old-key new-key)
+  (kbd-flush-pending)
   ;; 1. 如果提供了旧按键，则尝试删除旧绑定
   (when (and (string? old-key) (> (string-length old-key) 0))
     (let ((raw-map (kbd-get-map old-key)))

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -163,12 +163,20 @@
 (define (kbd-pump)
   (set! kbd-pump-armed? #f)
   (set! kbd-pumping? #t)
-  (with start
-    (texmacs-time)
+  (with (start (texmacs-time) n 0)
     ;; 每片最多 5ms，片间让出事件循环使用户输入可插队
     (while (and (not (list-queue-empty? kbd-pending)) (< (- (texmacs-time) start) 5))
      ((list-queue-remove-front! kbd-pending))
+     (set! n (+ n 1))
     ) ;while
+    (debug-message "keyboard"
+      (string-append "kbd-pump: registered "
+        (number->string n)
+        " bindings in "
+        (number->string (- (texmacs-time) start))
+        " ms\n"
+      ) ;string-append
+    ) ;debug-message
   ) ;with
   (set! kbd-pumping? #f)
   (when (and (not (list-queue-empty? kbd-pending)) (not kbd-pump-armed?))

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -16,6 +16,16 @@
 (import (liii hash-table))
 (import (liii queue))
 
+(define (kbd-on-linux?)
+  ;; lolly glue 只有 os-win32?/os-mingw?/os-macos?/os-wasm?,反向推断
+  (not (or (os-win32?) (os-mingw?) (os-macos?) (os-wasm?)))
+) ;define
+
+;; (liii logging) 仅 Linux 加载，节省其他平台的加载时间
+(when (kbd-on-linux?)
+  (import (liii logging))
+) ;when
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy keyboard bindings
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -147,13 +157,39 @@
 
 (define kbd-pump-armed? #f)
 
+;; 分片日志仅 Linux 启用（/tmp 路径语义）；文件 handler 全局唯一，惰性初始化
+
+(define kbd-pump-log-inited? #f)
+
+(define (kbd-pump-log msg)
+  (when (kbd-on-linux?)
+    (when (not kbd-pump-log-inited?)
+      (log-set-file-handler! "/tmp/kbd-pump.log")
+      (set! kbd-pump-log-inited? #t)
+    ) ;when
+    (log-info msg)
+    ;; liii logging 只在 s7 exit-hook 里 flush,mogan 退出不走该钩子,逐条 flush
+    (log-flush!)
+  ) ;when
+) ;define
+
 (tm-define (kbd-flush-pending)
   ;; 同步跑完剩余全部注册，供读写三张表前兜底
   (when (and (not (list-queue-empty? kbd-pending)) (not kbd-pumping?))
     (set! kbd-pumping? #t)
-    (while (not (list-queue-empty? kbd-pending))
-     ((list-queue-remove-front! kbd-pending))
-    ) ;while
+    (let ((n 0) (start (texmacs-time)))
+      (while (not (list-queue-empty? kbd-pending))
+       ((list-queue-remove-front! kbd-pending))
+       (set! n (+ n 1))
+      ) ;while
+      (kbd-pump-log (string-append "kbd-flush: drained "
+                      (number->string n)
+                      " bindings in "
+                      (number->string (- (texmacs-time) start))
+                      " ms"
+                    ) ;string-append
+      ) ;kbd-pump-log
+    ) ;let
     (set! kbd-pumping? #f)
   ) ;when
 ) ;tm-define
@@ -182,16 +218,15 @@
         (set! kbd-pump-batch
           (if (> elapsed 0) (max 1 (quotient (* n kbd-pump-budget) elapsed)) (* n 2))
         ) ;set!
-        (debug-message "keyboard"
-          (string-append "kbd-pump: registered "
-            (number->string n)
-            " bindings in "
-            (number->string elapsed)
-            " ms (next batch "
-            (number->string kbd-pump-batch)
-            ")\n"
-          ) ;string-append
-        ) ;debug-message
+        (kbd-pump-log (string-append "kbd-pump: registered "
+                        (number->string n)
+                        " bindings in "
+                        (number->string elapsed)
+                        " ms (next batch "
+                        (number->string kbd-pump-batch)
+                        ")"
+                      ) ;string-append
+        ) ;kbd-pump-log
       ) ;when
     ) ;with
   ) ;let*

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -14,6 +14,7 @@
 (texmacs-module (kernel gui kbd-define) (:use (kernel texmacs tm-define)))
 
 (import (liii hash-table))
+(import (liii queue))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy keyboard bindings
@@ -134,14 +135,68 @@
   (ahash-set! kbd-rev-table key im)
 ) ;define
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delayed (chunked) registration of keyboard bindings
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define kbd-pending (make-list-queue '()))
+
+;; 泵/flush 执行期间为 #t，防止经 getter 重入 drain
+
+(define kbd-pumping? #f)
+
+(define kbd-pump-armed? #f)
+
+(tm-define (kbd-flush-pending)
+  ;; 同步跑完剩余全部注册，供读写三张表前兜底
+  (when (and (not (list-queue-empty? kbd-pending)) (not kbd-pumping?))
+    (set! kbd-pumping? #t)
+    (while (not (list-queue-empty? kbd-pending))
+     ((list-queue-remove-front! kbd-pending))
+    ) ;while
+    (set! kbd-pumping? #f)
+  ) ;when
+) ;tm-define
+
+(tm-define (kbd-pending-empty?) (list-queue-empty? kbd-pending))
+
+(define (kbd-pump)
+  (set! kbd-pump-armed? #f)
+  (set! kbd-pumping? #t)
+  (with start
+    (texmacs-time)
+    ;; 每片最多 5ms，片间让出事件循环使用户输入可插队
+    (while (and (not (list-queue-empty? kbd-pending)) (< (- (texmacs-time) start) 5))
+     ((list-queue-remove-front! kbd-pending))
+    ) ;while
+  ) ;with
+  (set! kbd-pumping? #f)
+  (when (and (not (list-queue-empty? kbd-pending)) (not kbd-pump-armed?))
+    (set! kbd-pump-armed? #t)
+    (exec-delayed kbd-pump)
+  ) ;when
+) ;define
+
+(tm-define (kbd-enqueue thunks)
+  ;; thunks 为 per-binding thunk 列表，整体按序入队
+  ;; tm-define:delayed-kbd-map 的展开式在调用方模块中求值，需导出
+  (for-each (lambda (t) (list-queue-add-back! kbd-pending t)) thunks)
+  (when (and (nnull? thunks) (not kbd-pump-armed?) (not kbd-pumping?))
+    (set! kbd-pump-armed? #t)
+    (exec-delayed kbd-pump)
+  ) ;when
+) ;tm-define
+
 (define (kbd-get-map key)
+  (kbd-flush-pending)
   (ahash-ref kbd-map-table key)
 ) ;define
 
 (define (kbd-get-inv key)
+  (kbd-flush-pending)
   (ahash-ref kbd-inv-table key)
 ) ;define
-(tm-define (kbd-get-rev key) (ahash-ref kbd-rev-table key))
+(tm-define (kbd-get-rev key) (kbd-flush-pending) (ahash-ref kbd-rev-table key))
 
 (define (kbd-remove-map! key)
   (ahash-remove! kbd-map-table key)
@@ -246,6 +301,8 @@
 ) ;tm-define
 
 (tm-define (kbd-find-prefix-tab-inner prefix)
+  ;; 直读 kbd-map-table 绕过 getter，需显式 drain
+  (kbd-flush-pending)
   (let* ((pairs (filter (lambda (pair)
                           (let* ((key (car pair)) (val (cdr pair)))
                             (and (string? key)
@@ -390,6 +447,11 @@
 (tm-define-macro (kbd-map . l)
   (:synopsis "Add entries in @l to the keyboard mapping")
   `(begin ,@(kbd-map-body '() l))
+) ;tm-define-macro
+
+(tm-define-macro (delayed-kbd-map . l)
+  (:synopsis "Like kbd-map, but register bindings in chunks via the event loop")
+  `(kbd-enqueue (list ,@(map (lambda (x) `(lambda ,() ,x)) (kbd-map-body '() l))))
 ) ;tm-define-macro
 
 (define (kbd-remove-one conds key)

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -160,24 +160,41 @@
 
 (tm-define (kbd-pending-empty?) (list-queue-empty? kbd-pending))
 
+(define kbd-pump-budget 5)
+
+;; 每片注册条数，初始 10，按上片实测耗时向 budget 等比自适应
+
+(define kbd-pump-batch 10)
+
 (define (kbd-pump)
   (set! kbd-pump-armed? #f)
   (set! kbd-pumping? #t)
-  (with (start (texmacs-time) n 0)
-    ;; 每片最多 5ms，片间让出事件循环使用户输入可插队
-    (while (and (not (list-queue-empty? kbd-pending)) (< (- (texmacs-time) start) 5))
+  (let* ((start (texmacs-time)) (n 0))
+    ;; 每片最多 kbd-pump-batch 条，片间让出事件循环使用户输入可插队
+    (while (and (not (list-queue-empty? kbd-pending)) (< n kbd-pump-batch))
      ((list-queue-remove-front! kbd-pending))
      (set! n (+ n 1))
     ) ;while
-    (debug-message "keyboard"
-      (string-append "kbd-pump: registered "
-        (number->string n)
-        " bindings in "
-        (number->string (- (texmacs-time) start))
-        " ms\n"
-      ) ;string-append
-    ) ;debug-message
-  ) ;with
+    (with elapsed
+      (- (texmacs-time) start)
+      (when (> n 0)
+        ;; 按实测耗时等比调整批量；不足 1ms 测不出时翻倍试探
+        (set! kbd-pump-batch
+          (if (> elapsed 0) (max 1 (quotient (* n kbd-pump-budget) elapsed)) (* n 2))
+        ) ;set!
+        (debug-message "keyboard"
+          (string-append "kbd-pump: registered "
+            (number->string n)
+            " bindings in "
+            (number->string elapsed)
+            " ms (next batch "
+            (number->string kbd-pump-batch)
+            ")\n"
+          ) ;string-append
+        ) ;debug-message
+      ) ;when
+    ) ;with
+  ) ;let*
   (set! kbd-pumping? #f)
   (when (and (not (list-queue-empty? kbd-pending)) (not kbd-pump-armed?))
     (set! kbd-pump-armed? #t)
@@ -200,11 +217,13 @@
   (ahash-ref kbd-map-table key)
 ) ;define
 
+;; inv/rev 是菜单反查显示路径，不 drain：避免菜单重建把队列同步抽干，
+;; 容忍短暂缺失（与 lazy-keyboard 未加载模块时菜单无快捷键同语义）
+
 (define (kbd-get-inv key)
-  (kbd-flush-pending)
   (ahash-ref kbd-inv-table key)
 ) ;define
-(tm-define (kbd-get-rev key) (kbd-flush-pending) (ahash-ref kbd-rev-table key))
+(tm-define (kbd-get-rev key) (ahash-ref kbd-rev-table key))
 
 (define (kbd-remove-map! key)
   (ahash-remove! kbd-map-table key)

--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -19,7 +19,7 @@
     (table table-edit)
   ) ;:use
 ) ;texmacs-module
-(debug-message "keyboard" "(math math-kbd): registering kbd-map ...\n")
+(debug-message "keyboard" "(math math-kbd): enqueueing delayed kbd-map ...\n")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Bypassing the pre-edit mechanism
@@ -73,7 +73,7 @@
 ;; Main keyboard shortcuts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(kbd-map (:mode in-math?)
+(delayed-kbd-map (:mode in-math?)
   ;; must come first in order not to screw the menus up
   ("accent:deadhat" (make-script #t #t))
   ("accent:deadhat var" "^")
@@ -1227,9 +1227,9 @@
   ("~ ~ /" "<napprox>")
   ("~ - /" "<nsimeq>")
   ("~ = /" "<ncong>")
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:mode in-math-or-hybrid?)
+(delayed-kbd-map (:mode in-math-or-hybrid?)
  ("/ \\" "<wedge>")
  ("/ \\ var " "<cap>")
  ("/ \\ var var" "<sqcap>")
@@ -1249,9 +1249,9 @@
  ("\\ / var var var var var var" "<curlyveeuparrow>")
  ("\\ / var var var var var var var" (begin (make-hybrid) (insert "/")))
  ("\\ / -" "<veebar>")
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:mode in-math?)
+(delayed-kbd-map (:mode in-math?)
  ("# var" "<sharp>")
  ("# var var" "<natural>")
  ("# var var var" "<flat>")
@@ -1510,9 +1510,9 @@
  ("math:misc | | var" "<shortparallel>")
  ("math:misc | | var /" "<nshortparallel>")
  ("math:misc | | var var /" "<nvarparallel>")
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:mode in-math-not-hybrid?)
+(delayed-kbd-map (:mode in-math-not-hybrid?)
  ("a var" "<alpha>")
  ("b var" "<beta>")
  ("b var var" "<flat>")
@@ -1672,9 +1672,9 @@
  ("i j k var" "ijk")
  ("x y z" (insert '(concat "x" " " "y" " " "z")))
  ("x y z var" "xyz")
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:mode in-math?)
+(delayed-kbd-map (:mode in-math?)
  ("math:bold 0" "<b-0>")
  ("math:bold 1" "<b-1>")
  ("math:bold 2" "<b-2>")
@@ -2092,9 +2092,9 @@
  ("math:frak X" "<frak-X>")
  ("math:frak Y" "<frak-Y>")
  ("math:frak Z" "<frak-Z>")
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:mode in-math-not-hybrid?)
+(delayed-kbd-map (:mode in-math-not-hybrid?)
  ("0 var" "<emptyset>")
  ("0 0 var" "<Bbb-0>")
  ("0 0 var var" "<b-0>")
@@ -2473,13 +2473,13 @@
  ("d w var" "<mathd><omega>")
  ("d w var var" "<mathd><mho>")
  ("d w var var var" "dw")
-) ;kbd-map
+) ;delayed-kbd-map
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Textual operators
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(kbd-map (:mode in-math-english?)
+(delayed-kbd-map (:mode in-math-english?)
   ;; ("a n d" (make 'infix-and))
   ;; ("a n d space" (make 'infix-and))
   ("space a" " a")
@@ -2509,21 +2509,21 @@
   ("f o r space" "for ")
   ("f o r space a l l" (make 'prefix-for-all))
   ("f o r space a l l space" (make 'prefix-for-all))
-) ;kbd-map
+) ;delayed-kbd-map
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Special toggles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(kbd-map (:require (inside? 'equation*))
+(delayed-kbd-map (:require (inside? 'equation*))
  ("C-&" (equation->eqnarray (tree-innermost 'equation*)))
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:require (inside? 'equation))
+(delayed-kbd-map (:require (inside? 'equation))
  ("C-&" (equation->eqnarray (tree-innermost 'equation)))
-) ;kbd-map
+) ;delayed-kbd-map
 
-(kbd-map (:require (inside? 'eqnarray*))
+(delayed-kbd-map (:require (inside? 'eqnarray*))
  ("C-&" (eqnarray->equation (tree-innermost 'eqnarray*)))
-) ;kbd-map
+) ;delayed-kbd-map
 (debug-message "keyboard" "(math math-kbd): kbd-map registered\n")

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -267,12 +267,15 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
        保证查表不见半成品状态。
 - 涉及文件：仅 `devel/1177.md`（分析结论，无代码改动）。
 
-### 5. delayed-kbd-map：分片延迟注册（emoji 试点）
+### 5. delayed-kbd-map：分片延迟注册（emoji + math-kbd 试点）
 
 - What：新增 `delayed-kbd-map` 宏（语法与 `kbd-map` 相同），把每条绑定包成
   thunk 进全局 FIFO 队列（`(liii queue)` 的 list-queue，头尾 O(1)），由
-  事件循环分片消费；`enable-emoji-keyboard`（796 条多键序列 shorthand）
-  作为首个试点从 `kbd-map` 切换为 `delayed-kbd-map`。
+  事件循环分片消费。两处试点从 `kbd-map` 切换为 `delayed-kbd-map`：
+  `enable-emoji-keyboard`（796 条多键序列 shorthand，preference 触发）与
+  `math-kbd.scm`（10 处顶层调用、约 2940 条带 `:mode`/`:require` 条件的
+  绑定，启动期经 `lazy-keyboard-force #t` 加载——加载本身只剩 thunk
+  构造，注册摊到事件循环分片）。
 - Why：单线程 Scheme 下 `kbd-map` 注册同步阻塞，绑定量大时卡顿。分片后
   片间让出事件循环，用户输入/菜单/重绘可插队。机制对比与选型分析见
   第 4 节（队列方案优于 call/cc）。
@@ -328,6 +331,9 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
     多键序列；`xmake r kbd-define-test` 全通过（8 correct, 0 failed）。
   - `TeXmacs/plugins/keyboard/progs/keyboard/emoji.scm`：`kbd-map` →
     `delayed-kbd-map`。
+  - `TeXmacs/progs/math/math-kbd.scm`：10 处顶层 `kbd-map` →
+    `delayed-kbd-map`（含 `;kbd-map` 收尾注释同步改名），启动日志改为
+    "enqueueing delayed kbd-map ..."。
 - 验证：单元测试见上；emoji 三表等价性 dump 对比与 GUI 手工验证另行
   手动进行。测试中发现 `kbd-unmap` 的条目是裸按键字符串（参照
   `shortcut-edit.scm:133` 的 `(eval \`(kbd-unmap ,sh))`），传

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -232,3 +232,77 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
     `lazy-keyboard-force #t` 全量加载后，导出三张表
     （`kbd-map-table`/`kbd-inv-table`/`kbd-rev-table`，条件与命令取
     `extract-code-str` 源码、按键排序）共 3074 行，`diff` 完全一致。
+
+### 4. call/cc 实现 kbd-map 的可行性分析（结论：不建议）
+
+- What：评估「用 call/cc 把 kbd-map 注册改成协程，使注册期间其他操作
+  可优先执行」的方案，并与「队列 + `delayed` 分片」对比。
+- Why：目标是在单线程 Scheme 下把 kbd 注册切片让出事件循环（把
+  `lazy-keyboard` 的粒度从模块级细化到模块内分片），call/cc 是候选
+  手段之一。
+- How（验证与推理）：
+  1. **s7 能力验证**（Goldfish 解释器实测）：`call/cc` 捕获的续延可
+     存入全局变量、事后多次调用，且可在续延内再次 `call/cc` 实现
+     yield——generator 协程测试（依次产出 1/2/3/done）通过，即 s7
+     提供**可重入的完整续延**，协程方案技术上可行。
+  2. **但 call/cc 不适合本场景**，理由：
+     - call/cc 的价值在「控制状态难以显式表示」的场景（深度递归挂起、
+       回溯搜索）；`kbd-map-body` 是平铺列表遍历，挂起点状态就是
+       「剩余列表」，一个 `cdr` 即可表示，用续延保存是大材小用。
+     - **查表一致性**：注册顺序敏感（`ctx-insert` 头插、后定义覆盖），
+       按键在模块注册到一半时到达会拿到半成品 ctx 列表，故
+       `kbd-find-key-binding` 前必须有 flush 屏障（强制跑完该模块剩余
+       注册）。队列方案 drain 自然；续延散落的控制状态难补齐。
+     - **动态上下文**：续延恢复时 module 环境 / dynamic-wind 上下文
+       可能已变，而注册代码依赖 `current-module` 与 tm 模块系统加载
+       上下文。
+     - **性能**：s7 的 `call/cc` 需复制栈，逐条绑定 yield（math-kbd
+       约 3000 条）开销大；分片（每 tick 固定条数）几乎零开销。
+  3. **推荐方案**（如后续要做模块内分片）：
+     - `kbd-map` 宏展开从「直接调 `kbd-binding`」改为「向全局
+       `kbd-pending` 队列 cons thunk」；
+     - 驱动器每 tick 注册固定条数（或按 bench 计时），队列非空则
+       `(delayed (:idle 0) ...)` 重新武装，让出事件循环；
+     - `kbd-find-key-binding` 查询前 drain 相关模块的待注册队列，
+       保证查表不见半成品状态。
+- 涉及文件：仅 `devel/1177.md`（分析结论，无代码改动）。
+
+### 5. delayed-kbd-map：分片延迟注册（emoji 试点）
+
+- What：新增 `delayed-kbd-map` 宏（语法与 `kbd-map` 相同），把每条绑定包成
+  thunk 进全局 FIFO 队列（`(liii queue)` 的 list-queue，头尾 O(1)），由
+  事件循环分片消费；`enable-emoji-keyboard`（796 条多键序列 shorthand）
+  作为首个试点从 `kbd-map` 切换为 `delayed-kbd-map`。
+- Why：单线程 Scheme 下 `kbd-map` 注册同步阻塞，绑定量大时卡顿。分片后
+  片间让出事件循环，用户输入/菜单/重绘可插队。机制对比与选型分析见
+  第 4 节（队列方案优于 call/cc）。
+- How：
+  1. **队列与泵**（`kbd-define.scm`）：`kbd-pending` 存 per-binding
+     thunk；`kbd-enqueue` 整体按序入队并以 `exec-delayed` 起泵（单例守卫
+     `kbd-pump-armed?`）；`kbd-pump` 每片按 5ms 时间预算（`texmacs-time`）
+     消费，队列未空则 re-arm。
+  2. **flush 屏障**（语义等价的核心）：`kbd-flush-pending` 同步跑完剩余
+     注册；三个 getter（`kbd-get-map`/`kbd-get-inv`/`kbd-get-rev`）入口
+     各加一行 drain——写路径 `kbd-insert-key-binding` 第一步必读
+     `kbd-get-map`（经 `kbd-delete-key-binding2`），故 drain 自动覆盖
+     全部读写路径，防止「同步 kbd-map 与在途 delayed 批次」的覆盖顺序
+     反转。`kbd-pumping?` 守卫防泵内经 getter 重入；泵内读表见前缀状态，
+     与原 begin 顺序执行语义一致。`kbd-find-prefix-tab-inner` 直读
+     `kbd-map-table` 绕过 getter，单独补 drain。
+  3. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
+     `(kbd-binding ...)` 包 thunk 交给 `kbd-enqueue`。展开式在调用方模块
+     求值，`kbd-enqueue`/`kbd-flush-pending`/`kbd-pending-empty?` 故为
+     `tm-define` 导出（`kbd-binding` 同理本来就是导出符号）。
+- 涉及文件：
+  - `TeXmacs/progs/kernel/gui/kbd-define.scm`：import (liii queue)、
+    队列/泵/flush/getter 守卫/`delayed-kbd-map` 宏、`kbd-find-prefix-tab-inner`
+    补 drain。
+  - `TeXmacs/progs/kernel/gui/kbd-define-test.scm`（新增）：8 项断言覆盖
+    入队未注册、flush 生效、getter 自动 drain、两种方向的覆盖顺序、
+    多键序列；`xmake r kbd-define-test` 全通过（8 correct, 0 failed）。
+  - `TeXmacs/plugins/keyboard/progs/keyboard/emoji.scm`：`kbd-map` →
+    `delayed-kbd-map`。
+- 验证：单元测试见上；emoji 三表等价性 dump 对比与 GUI 手工验证另行
+  手动进行。测试中发现 `kbd-unmap` 的条目是裸按键字符串（参照
+  `shortcut-edit.scm:133` 的 `(eval \`(kbd-unmap ,sh))`），传
+  `(key action)` 对会把列表当 key 查表。

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -281,19 +281,23 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
      thunk；`kbd-enqueue` 整体按序入队并以 `exec-delayed` 起泵（单例守卫
      `kbd-pump-armed?`）；`kbd-pump` 分片消费，队列未空则 re-arm。
   2. **flush 屏障**（语义等价的核心）：`kbd-flush-pending` 同步跑完剩余
-     注册；drain 只嵌在 `kbd-get-map`——写路径
-     `kbd-insert-key-binding`/`kbd-delete-key-binding2` 第一步必读
-     `kbd-get-map`，故全覆盖所有写路径，防止「同步 kbd-map 与在途
-     delayed 批次」的覆盖顺序反转；C++ 按键查询唯一入口
-     `kbd-find-key-binding` 也经它，查表永不见半成品。
-     **`kbd-get-inv`/`kbd-get-rev`（菜单反查显示路径）不 drain**：
-     实测发现三 getter 全加 flush 时，开启 emoji 后紧跟的菜单重建会把
-     队列同步抽干，泵永远捡不到活、分片名存实亡；显示路径容忍短暂
+     注册。**getter 保持纯读，flush 显式放在需要一致性的入口**：
+     `kbd-find-key-binding`（按键正确性关键路径，C++ 查表唯一入口）、
+     `kbd-find-prefix-tab-inner`（直读 `kbd-map-table` 绕过 getter）、
+     快捷键编辑器三工具（`get-kbd-bindings`/`kbd-conflict-query`/
+     `kbd-execute-edit`）。
+     迭代过程：最初 drain 嵌在 getter 里「一处覆盖全部读写路径」，
+     但 `/tmp/kbd-pump.log` 实测（一条 `kbd-flush: drained 796 bindings
+     in 363 ms`，泵日志为零）发现启动期 `init-keyboard.scm:51` 的
+     `(delayed (:idle 0) (kbd-map ...))` 同步写经 `kbd-get-map` 触发
+     drain，在泵的第一个 tick 后就把队列抽干，分片名存实亡；改为纯读
+     getter + 显式 flush 后同步写不再干扰分片。
+     `kbd-get-inv`/`kbd-get-rev`（菜单反查显示路径）不 drain，容忍短暂
      缺失（与 lazy-keyboard 未加载模块时菜单无快捷键同语义，drain 完
-     下次菜单重建自愈）。`kbd-pumping?` 守卫防泵内经 getter 重入；泵内
-     读表见前缀状态，与原 begin 顺序执行语义一致。
-     `kbd-find-prefix-tab-inner` 直读 `kbd-map-table` 绕过 getter，
-     单独补 drain。
+     下次菜单重建自愈）。**语义注意**：同步写不再触发 drain，与在途
+     delayed 批次绑定同键同条件时，批次 drain 时后执行会覆盖同步写
+     （按执行先后定胜负）。`kbd-pumping?` 守卫防泵内经 getter 重入；
+     泵内读表见前缀状态，与原 begin 顺序执行语义一致。
   3. **计数分片 + 自适应批量**：`kbd-pump` 每片消费 `kbd-pump-batch`
      条（初始 10），片末按实测耗时把批量向 5ms 预算等比调整
      （`batch = n * 5 / elapsed`，单条超预算时保底 1；不足 1ms 测不出
@@ -308,7 +312,7 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
      `kbd-pump-log` 每条日志后显式 `log-flush!`。改用独立日志文件替代
      `debug-message`，是为了把分片明细从系统日志噪声中分离，且 flush
      日志可直接判别「活是泵干的还是 flush 抢的」。
-  4. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
+  5. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
      `(kbd-binding ...)` 包 thunk 交给 `kbd-enqueue`。展开式在调用方模块
      求值，`kbd-enqueue`/`kbd-flush-pending`/`kbd-pending-empty?` 故为
      `tm-define` 导出（`kbd-binding` 同理本来就是导出符号）。

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -280,7 +280,8 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
   1. **队列与泵**（`kbd-define.scm`）：`kbd-pending` 存 per-binding
      thunk；`kbd-enqueue` 整体按序入队并以 `exec-delayed` 起泵（单例守卫
      `kbd-pump-armed?`）；`kbd-pump` 每片按 5ms 时间预算（`texmacs-time`）
-     消费，队列未空则 re-arm。
+     消费，队列未空则 re-arm。每片结束经 `debug-message`（`keyboard`
+     channel）打印本片注册条数与耗时，便于观察分片行为。
   2. **flush 屏障**（语义等价的核心）：`kbd-flush-pending` 同步跑完剩余
      注册；三个 getter（`kbd-get-map`/`kbd-get-inv`/`kbd-get-rev`）入口
      各加一行 drain——写路径 `kbd-insert-key-binding` 第一步必读

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -297,8 +297,17 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
   3. **计数分片 + 自适应批量**：`kbd-pump` 每片消费 `kbd-pump-batch`
      条（初始 10），片末按实测耗时把批量向 5ms 预算等比调整
      （`batch = n * 5 / elapsed`，单条超预算时保底 1；不足 1ms 测不出
-     时翻倍试探），片间让出事件循环。每片经 `debug-message`
-     （`keyboard` channel）打印本片条数、耗时与下片批量；空片不打印。
+     时翻倍试探），片间让出事件循环。空片不打印。
+  4. **分片日志**：`kbd-pump-log` 经 `(liii logging)` 写
+     `/tmp/kbd-pump.log`（泵每片条数/耗时/下片批量 + flush 抽干条数），
+     仅 Linux 启用——`(liii logging)` 也只在 Linux 下条件 import
+     （`(when (kbd-on-linux?) (import (liii logging)))`，
+     `kbd-on-linux?` 用 lolly glue 的 `os-win32?/os-mingw?/os-macos?/os-wasm?`
+     反向推断），节省其他平台加载时间。注意：liii logging 只在 s7
+     `*exit-hook*` 里 flush 文件端口，mogan 退出不走该钩子，故
+     `kbd-pump-log` 每条日志后显式 `log-flush!`。改用独立日志文件替代
+     `debug-message`，是为了把分片明细从系统日志噪声中分离，且 flush
+     日志可直接判别「活是泵干的还是 flush 抢的」。
   4. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
      `(kbd-binding ...)` 包 thunk 交给 `kbd-enqueue`。展开式在调用方模块
      求值，`kbd-enqueue`/`kbd-flush-pending`/`kbd-pending-empty?` 故为

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -279,18 +279,27 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
 - How：
   1. **队列与泵**（`kbd-define.scm`）：`kbd-pending` 存 per-binding
      thunk；`kbd-enqueue` 整体按序入队并以 `exec-delayed` 起泵（单例守卫
-     `kbd-pump-armed?`）；`kbd-pump` 每片按 5ms 时间预算（`texmacs-time`）
-     消费，队列未空则 re-arm。每片结束经 `debug-message`（`keyboard`
-     channel）打印本片注册条数与耗时，便于观察分片行为。
+     `kbd-pump-armed?`）；`kbd-pump` 分片消费，队列未空则 re-arm。
   2. **flush 屏障**（语义等价的核心）：`kbd-flush-pending` 同步跑完剩余
-     注册；三个 getter（`kbd-get-map`/`kbd-get-inv`/`kbd-get-rev`）入口
-     各加一行 drain——写路径 `kbd-insert-key-binding` 第一步必读
-     `kbd-get-map`（经 `kbd-delete-key-binding2`），故 drain 自动覆盖
-     全部读写路径，防止「同步 kbd-map 与在途 delayed 批次」的覆盖顺序
-     反转。`kbd-pumping?` 守卫防泵内经 getter 重入；泵内读表见前缀状态，
-     与原 begin 顺序执行语义一致。`kbd-find-prefix-tab-inner` 直读
-     `kbd-map-table` 绕过 getter，单独补 drain。
-  3. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
+     注册；drain 只嵌在 `kbd-get-map`——写路径
+     `kbd-insert-key-binding`/`kbd-delete-key-binding2` 第一步必读
+     `kbd-get-map`，故全覆盖所有写路径，防止「同步 kbd-map 与在途
+     delayed 批次」的覆盖顺序反转；C++ 按键查询唯一入口
+     `kbd-find-key-binding` 也经它，查表永不见半成品。
+     **`kbd-get-inv`/`kbd-get-rev`（菜单反查显示路径）不 drain**：
+     实测发现三 getter 全加 flush 时，开启 emoji 后紧跟的菜单重建会把
+     队列同步抽干，泵永远捡不到活、分片名存实亡；显示路径容忍短暂
+     缺失（与 lazy-keyboard 未加载模块时菜单无快捷键同语义，drain 完
+     下次菜单重建自愈）。`kbd-pumping?` 守卫防泵内经 getter 重入；泵内
+     读表见前缀状态，与原 begin 顺序执行语义一致。
+     `kbd-find-prefix-tab-inner` 直读 `kbd-map-table` 绕过 getter，
+     单独补 drain。
+  3. **计数分片 + 自适应批量**：`kbd-pump` 每片消费 `kbd-pump-batch`
+     条（初始 10），片末按实测耗时把批量向 5ms 预算等比调整
+     （`batch = n * 5 / elapsed`，单条超预算时保底 1；不足 1ms 测不出
+     时翻倍试探），片间让出事件循环。每片经 `debug-message`
+     （`keyboard` channel）打印本片条数、耗时与下片批量；空片不打印。
+  4. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
      `(kbd-binding ...)` 包 thunk 交给 `kbd-enqueue`。展开式在调用方模块
      求值，`kbd-enqueue`/`kbd-flush-pending`/`kbd-pending-empty?` 故为
      `tm-define` 导出（`kbd-binding` 同理本来就是导出符号）。

--- a/devel/1177.md
+++ b/devel/1177.md
@@ -310,8 +310,11 @@ kbd 模块（`*-kbd.scm`）随模块系统加载后即完成注册（宏展开�
      反向推断），节省其他平台加载时间。注意：liii logging 只在 s7
      `*exit-hook*` 里 flush 文件端口，mogan 退出不走该钩子，故
      `kbd-pump-log` 每条日志后显式 `log-flush!`。改用独立日志文件替代
-     `debug-message`，是为了把分片明细从系统日志噪声中分离，且 flush
-     日志可直接判别「活是泵干的还是 flush 抢的」。
+     `debug-message` 的原因：GUI 下 `debug-message` 输出实测不可见
+     （headless 正常进系统日志；双通道对照实验证明同一点位
+     liii logging 写文件可见而 `debug-message` 不可见），且独立文件
+     把分片明细从系统日志噪声中分离，flush 日志可直接判别「活是泵
+     干的还是 flush 抢的」。
   5. **宏**：`delayed-kbd-map` 复用 `kbd-map-body` 展开，每个
      `(kbd-binding ...)` 包 thunk 交给 `kbd-enqueue`。展开式在调用方模块
      求值，`kbd-enqueue`/`kbd-flush-pending`/`kbd-pending-empty?` 故为


### PR DESCRIPTION
## 概述

新增 `delayed-kbd-map` 宏（语法与 `kbd-map` 相同），把绑定注册从同步阻塞改为 per-binding thunk 队列 + 事件循环分片消费，消除大批量注册（math-kbd ~2940 条、emoji 796 条）造成的卡顿。

方案选型分析（为什么不用 call/cc）与完整机制说明见 `devel/1177.md`。

## 机制

- **队列与泵**：`kbd-pending`（`(liii queue)` list-queue，头尾 O(1)）存 per-binding thunk；`kbd-enqueue` 入队并以 `exec-delayed` 起泵；`kbd-pump` 计数分片消费，片间让出事件循环，用户输入可插队。
- **自适应批量**：每片消费 `kbd-pump-batch` 条（初始 10），片末按实测耗时向 5ms 预算等比调整，不足 1ms 翻倍试探，单条超预算保底 1。
- **flush 屏障**：`kbd-flush-pending` 同步跑完剩余注册。getter 保持纯读，flush 显式放在需要一致性的入口：`kbd-find-key-binding`（按键正确性）、`kbd-find-prefix-tab-inner`、快捷键编辑器三工具。菜单反查（inv/rev）不 drain，容忍短暂缺失。
- **语义注意**：同步写不触发 drain，与在途 delayed 批次同键同条件时，批次 drain 后执行覆盖同步写（按执行先后定胜负）。
- **分片日志**：`kbd-pump-log` 经 `(liii logging)` 写 `/tmp/kbd-pump.log`（仅 Linux，条件 import；GUI 下 `debug-message` 实测不可见）。

## 试点

- `emoji.scm`：`enable-emoji-keyboard` 796 条 shorthand 切换。
- `math-kbd.scm`：10 处顶层 `kbd-map`（~2940 条带条件绑定）切换；启动期 `lazy-keyboard-force #t` 加载只剩 thunk 构造。

## 测试

- 新增 `TeXmacs/progs/kernel/gui/kbd-define-test.scm`：8 项断言覆盖入队未注册、flush 生效、查询路径自动 drain、两种方向覆盖顺序、多键序列。`xmake r kbd-define-test` 全通过（8 correct, 0 failed）。
- emoji 三表等价性 dump 对比与 GUI 验证：手动进行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)