### PR TITLE
[1143] 插件初始化从延后 3s 改为 10ms 空闲依次初始化；math 快捷键拆为独立插件

### DIFF
--- a/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
+++ b/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
@@ -18,8 +18,6 @@
 (lazy-keyboard (generic search-kbd))
 (lazy-keyboard (text text-kbd) in-text?)
 (lazy-keyboard (keyboard text-kbd-utf8) in-text?)
-(lazy-keyboard (math math-kbd) in-math?)
-(lazy-keyboard (math math-sem-edit) in-sem-math?)
 (lazy-keyboard (prog prog-kbd) in-prog?)
 (lazy-keyboard (source source-kbd) always?)
 (lazy-keyboard (table table-kbd) in-table?)

--- a/TeXmacs/plugins/math/progs/init-math.scm
+++ b/TeXmacs/plugins/math/progs/init-math.scm
@@ -1,0 +1,17 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-math.scm
+;; DESCRIPTION : Initialize the math plugin
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (math))
+
+;; math-kbd 的绑定经 delayed-kbd-map 分片注册，无需在插件初始化时强载
+(lazy-keyboard (math math-kbd) in-math?)
+(lazy-keyboard (math math-sem-edit) in-sem-math?)

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -704,7 +704,7 @@
 (define-public (lazy-plugin-initialize name)
   "Initialize the plug-in @name in a lazy way"
   (ahash-set! plugin-initialize-todo name #t)
-  (delayed (:pause 3000) (plugin-initialize name))
+  (delayed (:idle 10) (plugin-initialize name))
 ) ;define-public
 
 (define-public (lazy-plugin-force-one name)

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -242,6 +242,16 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     原先只含 `TeXmacs/tests/*.scm`，纯 `TeXmacs/progs/**` 或
     `TeXmacs/plugins/**` 改动（如 #4021）不触发 CI，scheme 测试回归
     未被拦截；现补入 `TeXmacs/progs/**` 与 `TeXmacs/plugins/**`
+23. 新增 math 插件：`math-kbd`/`math-sem-edit` 两条 lazy-keyboard 注册从
+    keyboard 插件拆出至 `plugins/math/progs/init-math.scm`，单个插件的
+    初始化更小更快。math-kbd 的绑定经 `delayed-kbd-map` 分片注册
+    （见 #4240），无需在插件初始化阶段强载；拆出后 keyboard 插件末尾的
+    强载扫不到它（plugin_list 按字母序，keyboard 先于 math 初始化），
+    两条注册保持惰性，首次进入数学模式由按键守卫触发加载
+24. `lazy-plugin-initialize` 的延迟由 `:pause 3000`（固定 3s 后集中
+    初始化）改为 `:idle 10`（10ms 空闲即触发）：插件在界面空闲时按序
+    逐个初始化，单个插件初始化耗时短、穿插在空闲间隙执行，不占用
+    用户操作期间的主线程，不影响界面使用
 
 本次分段计时（临时 `boot-bench` 打点，测完即删，未入库）实测
 init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、
@@ -264,6 +274,7 @@ lazy-plugin-force-one）、
 `src/Plugins/Qt/QTMStartupTabWidget.{cpp,hpp}`（移除 showEvent 触发）、
 `src/System/Boot/init_texmacs.cpp`（事件循环起跑后触发 STARTUP）、
 `TeXmacs/plugins/keyboard/progs/init-keyboard.scm`（新增）、
+`TeXmacs/plugins/math/progs/init-math.scm`（新增，接收 math lazy-keyboard 注册）、
 `TeXmacs/plugins/llm/progs/init-llm.scm`（接收 chat-loader 加载）、
 `TeXmacs/progs/texmacs/texmacs/tm-view.scm`（移除 delayed 强载及 fullscreen kbd-map）
 


### PR DESCRIPTION
## What
1. **插件初始化时机**：`lazy-plugin-initialize` 由 `:pause 3000`（固定延后 3s 集中初始化）改为 `:idle 10`——界面空闲 10ms 即触发，插件按序逐个初始化。单个插件初始化耗时短、穿插在空闲间隙执行，不占用用户操作期间的主线程，不影响界面使用。
2. **拆出 math 插件**：新增 `plugins/math/progs/init-math.scm`，将 `math-kbd`/`math-sem-edit` 两条 lazy-keyboard 注册从 keyboard 插件独立出来，得到更小的单个插件初始化。

## Why
`math-kbd` 的绑定经 `delayed-kbd-map` 分片注册（#4240），无需在插件初始化阶段强载。拆出后 keyboard 插件末尾的强载扫不到它（`plugin_list` 按字母序，keyboard 先于 math 初始化），两条注册保持惰性，首次进入数学模式时由按键守卫触发加载。

任务文档：devel/1143.md（条目 23、24）

🤖 Generated with [Claude Code](https://claude.com/claude-code)