### PR TITLE
[1143] telemetry 插件启动时直接初始化，不走 idle 延迟

### DIFF
--- a/TeXmacs/plugins/telemetry/progs/init-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/progs/init-telemetry.scm
@@ -46,9 +46,9 @@
   (:serializer ,telemetry-serialize)
 ) ;plugin-configure
 
-;; 启动初始化与周期 flush 调度由插件懒加载触发（插件在事件循环启动
-;; ~3s 后由 lazy-plugin-initialize 加载，因此 telemetry-clean-orphans、
-;; on-exit CLOSE 上报、周期 flush 均不在启动关键路径上）
+;; 启动初始化与周期 flush 调度：telemetry 与文档无关，lazy-plugin-initialize
+;; 对其直接初始化（不走 idle 延迟），故 telemetry-clean-orphans、on-exit
+;; CLOSE 上报、周期 flush 在启动时即注册
 (catch #t
   (lambda () (init-telemetry))
   (lambda args

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -28,7 +28,7 @@
 (varlet (rootlet) '*current-module* (curlet))
 
 ;; 启动期 telemetry pending 队列：telemetry 实现已迁至 (plugin telemetry-*)
-;; 插件，由事件循环 ~3s 后懒加载。插件加载前的 C++ 上报（OPEN/LOGIN 等）
+;; 插件，启动时由 lazy-plugin-initialize 直接加载。插件加载前的 C++ 上报（OPEN/LOGIN 等）
 ;; 由 telemetry-track-or-enqueue 入队，(plugin init-telemetry) 加载时
 ;; 通过 telemetry-drain-pending! 一次性补 track。这组符号注入 rootlet，
 ;; 不依赖任何模块，C++ 可直接 call。

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -704,7 +704,11 @@
 (define-public (lazy-plugin-initialize name)
   "Initialize the plug-in @name in a lazy way"
   (ahash-set! plugin-initialize-todo name #t)
-  (delayed (:idle 10) (plugin-initialize name))
+  ;; telemetry 与文档无关，直接初始化，不走 idle 延迟
+  (if (== name 'telemetry)
+    (plugin-initialize name)
+    (delayed (:idle 10) (plugin-initialize name))
+  ) ;if
 ) ;define-public
 
 (define-public (lazy-plugin-force-one name)

--- a/devel/1143.md
+++ b/devel/1143.md
@@ -252,6 +252,12 @@ MOGAN_TEST_GUI=1 xmake r <启动相关测试>
     初始化）改为 `:idle 10`（10ms 空闲即触发）：插件在界面空闲时按序
     逐个初始化，单个插件初始化耗时短、穿插在空闲间隙执行，不占用
     用户操作期间的主线程，不影响界面使用
+25. telemetry 插件改为启动时直接初始化：telemetry 与文档无关，
+    `lazy-plugin-initialize` 按插件名特判——`telemetry` 走
+    `plugin-initialize` 同步加载（不走 `:idle 10` 延迟），其余插件
+    保持 idle 延迟初始化不变；同步更新 `init-research.scm` 与
+    `plugins/telemetry/progs/init-telemetry.scm` 中「~3s 后懒加载」的
+    过期注释
 
 本次分段计时（临时 `boot-bench` 打点，测完即删，未入库）实测
 init-research.scm 全程 ~475ms，分布：01 kernel ~102ms、
@@ -266,7 +272,7 @@ tm-files 的模块加载内容。
 `src/Plugins/Qt/qt_tm_widget.{cpp,hpp}`（推迟 chrome 补装、LoginDialog 惰性创建、checkNetworkAvailable 与 membership 刷新延后）、
 `TeXmacs/progs/database/bib-kbd.scm`（删除）、
 `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`（插件加载日志、
-lazy-plugin-force-one）、
+lazy-plugin-force-one、telemetry 按名特判直接初始化）、
 `TeXmacs/plugins/emoji/progs/init-emoji.scm`（新增）、
 `TeXmacs/progs/text/text-kbd-utf8.scm`（移出 emoji 绑定）、
 `TeXmacs/progs/kernel/gui/kbd-define.scm`（lazy-keyboard-force 日志）、
@@ -276,7 +282,8 @@ lazy-plugin-force-one）、
 `TeXmacs/plugins/keyboard/progs/init-keyboard.scm`（新增）、
 `TeXmacs/plugins/math/progs/init-math.scm`（新增，接收 math lazy-keyboard 注册）、
 `TeXmacs/plugins/llm/progs/init-llm.scm`（接收 chat-loader 加载）、
-`TeXmacs/progs/texmacs/texmacs/tm-view.scm`（移除 delayed 强载及 fullscreen kbd-map）
+`TeXmacs/progs/texmacs/texmacs/tm-view.scm`（移除 delayed 强载及 fullscreen kbd-map）、
+`TeXmacs/plugins/telemetry/progs/init-telemetry.scm`（注释更新：直接初始化，不再 ~3s 懒加载）
 
 ## 7 Why
 OPEN → STARTUP 约 1.3~1.6s，是用户可感知的启动延迟。首屏（启动页）不依赖


### PR DESCRIPTION
## What
`lazy-plugin-initialize` 按插件名特判：telemetry 与文档无关，启动时直接 `plugin-initialize` 同步加载，不再走 `:idle 10` 延迟；其余插件保持 idle 延迟初始化不变。

同时更新 `init-research.scm` 与 `plugins/telemetry/progs/init-telemetry.scm` 中「~3s 后懒加载」的过期注释。

## Why
telemetry 插件初始化不依赖任何文档状态，延迟到 idle 再加载只会推迟启动期事件（OPEN/LOGIN 等）pending 队列的补 track 时机，无收益。

## How
- `tm-plugins.scm`：`lazy-plugin-initialize` 内 `(== name 'telemetry)` 特判直走 `plugin-initialize`
- 任务文档 `devel/1143.md` 追加第 25 条改动记录

## 测试
- `gf fmt --changed-since=main`：无需改动
- `xmake r 2013`（telemetry 集成测试，headless 冒烟启动路径）：9 项全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)