### PR TITLE
[1180] 新建 Chat 标签页前显式加载 llm chat-loader，修复 unbound variable chat-persist-load-all

### DIFF
--- a/TeXmacs/tests/0205.scm
+++ b/TeXmacs/tests/0205.scm
@@ -633,6 +633,8 @@
 ;;; ========== 测试入口 ==========
 
 (tm-define (test_0205)
+  ;; llm 插件按 idle 延迟初始化，headless 下测试先于插件加载执行
+  (use-modules (llm chat-loader))
   (test-chat-persist-home-path)
   (test-chat-persist-base-dir)
   (test-chat-persist-manifest-path)

--- a/devel/1180.md
+++ b/devel/1180.md
@@ -1,0 +1,33 @@
+# [1180] LLM Chat 标签页
+
+## 1 任务相关的代码文件
+- `src/Plugins/Qt/qt_chat_controller.cpp` — ChatController，Chat Tab 的核心管理类（逻辑 + Scheme 交互）
+- `TeXmacs/plugins/llm/progs/init-llm.scm` — llm 插件入口，`(use-modules (llm chat-loader))`
+- `TeXmacs/plugins/llm/progs/llm/chat-loader.scm` — chat 模块加载入口，`(:use (llm chat-protocol) (llm chat-persist))`
+- `TeXmacs/plugins/llm/progs/llm/chat-persist.scm` — 会话持久化（`chat-persist-load-all` 等）
+- `TeXmacs/tests/0205.scm` — chat 会话持久化集成测试
+
+## 2 改动记录
+
+### 2.1 修复新建 Chat 标签页报 `unbound variable chat-persist-load-all`（2026-08-07）
+
+**What**：`ChatController::createView` 调 `chat-persist-load-all` 前，先
+`eval ("(use-modules (llm chat-loader))")` 加载 llm 插件的 scheme 模块；
+集成测试 `test_0205` 入口同样补 `(use-modules (llm chat-loader))`。
+
+**Why**：插件 init 文件由 `lazy-plugin-initialize` 以 10ms idle 延迟依次初始化
+（见 [1143](1143.md)），新建 Chat 标签页可能发生在 llm 插件 init 之前，此时
+`chat-persist-load-all` 尚未定义，scheme 报 `unbound variable` 且会话元数据无法恢复。
+`use-modules` 幂等（已加载则直接返回），在调用点直接加载最可靠；实测
+`lazy-plugin-force-one` 路径不能解决该问题。
+
+**How**：
+- `src/Plugins/Qt/qt_chat_controller.cpp`：`createView` 顶部 `call ("chat-persist-load-all")`
+  之前插入 `eval ("(use-modules (llm chat-loader))")`
+- `TeXmacs/tests/0205.scm`：`test_0205` 入口补 `(use-modules (llm chat-loader))`，
+  修复 headless 下测试先于插件 init 执行导致的 unbound variable
+
+**已知遗留**（本分支既有问题，与本次改动无关）：
+- `TeXmacs/tests/0205.scm:240-246` 调用的 `chat-tab-get-state` 在全仓库无定义，
+  headless 跑到该处报 unbound variable
+- `test-chat-persist-update-manifest-updateAt-changes` 一处 `updateAt` 断言失败

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -55,6 +55,8 @@ ChatController::destroyView () {
 QWidget*
 ChatController::createView (QWidget* parent, qt_tm_widget_rep* tm) {
   // 1. Load session metadata
+  // llm 插件按 idle 延迟初始化，新建 Chat 标签页时其 scheme 模块可能尚未加载
+  eval ("(use-modules (llm chat-loader))");
   call ("chat-persist-load-all");
   cout << "[chat-persist] ChatController: restored "
        << sessionManager_.sessionCount () << " session metadatas" << LF;


### PR DESCRIPTION
## 问题
新建 LLM Chat 标签页时报 `;unbound variable chat-persist-load-all`，会话元数据无法恢复。

## 原因
插件 init 文件由 `lazy-plugin-initialize` 以 10ms idle 延迟依次初始化（#1143），新建 Chat 标签页可能早于 llm 插件 init，此时 `chat-persist-load-all` 尚未定义。

## 修复
- `ChatController::createView` 调 `chat-persist-load-all` 前先 `eval ("(use-modules (llm chat-loader))")`（幂等，已加载则直接返回）
- 集成测试 `test_0205` 入口同样补 `(use-modules (llm chat-loader))`，修复 headless 下测试先于插件 init 执行的问题

## 已知遗留（本分支既有问题，与本次无关）
- `TeXmacs/tests/0205.scm:240-246` 调用的 `chat-tab-get-state` 全仓库无定义
- `test-chat-persist-update-manifest-updateAt-changes` 一处 updateAt 断言失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)