### PR TITLE
[1181] 社区版隐藏文档区域右上角的新建对话浮动按钮

### DIFF
--- a/devel/1181.md
+++ b/devel/1181.md
@@ -1,0 +1,18 @@
+# 1181 社区版隐藏文档区域右侧的新建对话按钮
+
+## 需求
+
+对于社区版（community stem），文档区域右上角浮动的「新建对话」按钮
+（`chatSidebarToggleBtn`，`:llm-chat/addchat.svg`）需要隐藏。
+
+## 背景
+
+- 社区版已不创建 `chatSideDock`（`qt_tm_widget.cpp` 中 `is_community_stem()`
+  守卫），但右上角浮动按钮仍无条件创建，且 `update_visibility()` 只按
+  `!chatTabMode && !chatSidebarMode && !startupTabMode` 判定显示，
+  导致社区版文档区域右上角仍出现该按钮，点击后无响应（dock 为 nullptr）。
+
+## 方案
+
+在 `update_visibility()` 的 `shouldShow` 条件中加 `!is_community_stem()`，
+与 `chatSideDock` 的处理方式保持一致（保持按钮创建逻辑不动，仅控制可见性）。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1563,9 +1563,10 @@ qt_tm_widget_rep::update_visibility () {
     pdfOutlineDock->setVisible (new_pdfOutlineVisibility);
   }
 
-  // AI 聊天侧边栏浮动按钮可见性
+  // AI 聊天侧边栏浮动按钮可见性（community 版无 AI Chat，始终隐藏）
   if (chatSidebarToggleBtn) {
-    bool shouldShow= !chatTabMode && !chatSidebarMode && !startupTabMode;
+    bool shouldShow= !is_community_stem () && !chatTabMode &&
+                     !chatSidebarMode && !startupTabMode;
     chatSidebarToggleBtn->setVisible (shouldShow);
     if (shouldShow) {
       chatSidebarToggleBtn->raise ();


### PR DESCRIPTION
## What

社区版（community stem）下，文档区域右上角浮动的「新建对话」按钮（`chatSidebarToggleBtn`）仍然显示，但社区版并不创建 `chatSideDock`，点击无响应。

## Why

`update_visibility()` 的显示条件只判断了 `chatTabMode` / `chatSidebarMode` / `startupTabMode`，缺少 community 守卫。

## How

`shouldShow` 条件加 `!is_community_stem ()`，与 `chatSideDock` 的 community 守卫保持一致；按钮创建逻辑不动，仅控制可见性。

## 涉及文件

- `devel/1181.md`（任务文档）
- `src/Plugins/Qt/qt_tm_widget.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)