### PR TITLE
[1183] prog-kbd 的 lazy-keyboard 注册移入 code 插件

### DIFF
--- a/TeXmacs/plugins/code/progs/init-code.scm
+++ b/TeXmacs/plugins/code/progs/init-code.scm
@@ -1,0 +1,15 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-code.scm
+;; DESCRIPTION : Initialize the code plugin
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (code))
+
+(lazy-keyboard (prog prog-kbd) in-prog?)

--- a/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
+++ b/TeXmacs/plugins/keyboard/progs/init-keyboard.scm
@@ -18,7 +18,6 @@
 (lazy-keyboard (generic search-kbd))
 (lazy-keyboard (text text-kbd) in-text?)
 (lazy-keyboard (keyboard text-kbd-utf8) in-text?)
-(lazy-keyboard (prog prog-kbd) in-prog?)
 (lazy-keyboard (source source-kbd) always?)
 (lazy-keyboard (table table-kbd) in-table?)
 (lazy-keyboard (graphics graphics-kbd) in-active-graphics?)

--- a/devel/1183.md
+++ b/devel/1183.md
@@ -1,0 +1,41 @@
+# [1183] prog-kbd 键盘注册移入 code 插件
+
+## 1 相关文档
+- [1143.md](1143.md) - 启动性能优化，keyboard/math 插件拆分的前置工作
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/keyboard/progs/init-keyboard.scm` — keyboard 插件初始化，
+  集中注册 lazy-keyboard 并在末尾 `(lazy-keyboard-force #t)` 强载
+- `TeXmacs/plugins/code/progs/prog/prog-kbd.scm` — prog 模式快捷键定义
+  （模块 `(prog prog-kbd)`）
+- `TeXmacs/plugins/code/progs/init-code.scm` — code 插件初始化（本次新增）
+- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm` — 插件初始化机制
+  （`plugin-initialize` 加载 `plugins/<name>/progs/init-<name>.scm`）
+
+## 3 What
+将 `(lazy-keyboard (prog prog-kbd) in-prog?)` 注册从 keyboard 插件的
+`init-keyboard.scm` 移入新增的 code 插件初始化文件
+`plugins/code/progs/init-code.scm`，prog 模式快捷键由所属插件自行注册。
+
+## 4 Why
+延续 #1143 的插件化拆分方向（keyboard → math 插件已拆分）：键盘注册
+按功能归属到各自插件，keyboard 插件不再代管 prog 的注册，单个插件的
+初始化职责更清晰。
+
+## 5 How
+`plugin-list`（C++ `plugin_list()`，init_texmacs.cpp）扫描 `plugins/`
+目录得到插件名，`lazy-plugin-initialize` 对每个插件在 idle 时加载
+`plugins/<name>/progs/init-<name>.scm`。新增 `plugins/code/progs/init-code.scm`
+即被自动加载，无需登记。
+
+注意插件初始化按目录名字母序（code < keyboard），init-code.scm 先于
+init-keyboard.scm 执行，prog-kbd 的注册会进入 keyboard 插件末尾
+`(lazy-keyboard-force #t)` 的强载范围（与拆分前行为一致，该注册本来
+就在强载列表中）。
+
+## 6 如何测试
+```bash
+xmake b stem
+# 启动后进入 prog 模式（如打开 .scm/.cpp 会话或代码块），
+# 验证 cmd i 缩进等 prog 快捷键生效
+```


### PR DESCRIPTION
## What
- 新增 `TeXmacs/plugins/code/progs/init-code.scm`，接收 `(lazy-keyboard (prog prog-kbd) in-prog?)` 注册
- 从 `plugins/keyboard/progs/init-keyboard.scm` 移除该注册

## Why
延续 #1143 的插件化拆分方向：键盘注册按功能归属到各自插件，keyboard 插件不再代管 prog 的注册。

## How
`plugin-list` 扫描 `plugins/` 目录，`lazy-plugin-initialize` 在 idle 时加载 `plugins/<name>/progs/init-<name>.scm`，新增 init-code.scm 自动被加载，无需登记。插件初始化按目录名字母序（code < keyboard），prog-kbd 仍会被 keyboard 插件末尾的 `(lazy-keyboard-force #t)` 强载，行为与拆分前一致。

## 测试
- `gf fmt --changed-since=main` 无改动
- `xmake b stem` 构建通过
- headless 集成测试 `xmake r 2044` 启动/退出正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)