### PR TITLE
[1184] perf: load-input-styles 合并样式树重建

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
@@ -397,22 +397,20 @@
 
 (tm-define (chat-tab-add-default-style-packages! session-name)
   ;; 偏好驱动，参考 buffer-set-default-style（tm-files.scm:130-146）
-  (add-style-package "number-europe")
-  (add-style-package "preview-ref")
-  (with lan
-    (get-preference "language")
-    (when (!= lan "english")
-      (set-document-language lan)
+  ;; 一次性 set-style-list：逐包 add 会每包触发一次样式树重建，耗时成倍
+  (let ((packs (list "number-europe" "preview-ref")) (lan (get-preference "language")))
+    (when (and (!= lan "english") (in? lan supported-languages))
+      (set! packs (append packs (list lan)))
       ;; 中文等 CJK 语言自动加载对应样式包
       (when (== lan "chinese")
-        (add-style-package "chinese")
-        (add-style-package "table-captions-above")
+        (set! packs (append packs (list "table-captions-above")))
       ) ;when
     ) ;when
-  ) ;with
-  ;; 插件样式包：动态检测，参考 session-edit 的 make-session
-  (when (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append session-name ".ts"))
-        ) ;url-exists?
-    (add-style-package session-name)
-  ) ;when
+    ;; 插件样式包：动态检测，参考 session-edit 的 make-session
+    (when (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append session-name ".ts"))
+          ) ;url-exists?
+      (set! packs (append packs (list session-name)))
+    ) ;when
+    (set-style-list (append (get-style-list) packs))
+  ) ;let
 ) ;tm-define

--- a/TeXmacs/tests/1184.scm
+++ b/TeXmacs/tests/1184.scm
@@ -1,0 +1,93 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1184.scm
+;; DESCRIPTION : chat-tab-add-default-style-packages! 优化后的等价性与耗时验证
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report)
+
+;;; 旧实现（逐包 add-style-package），作为等价性基准
+(define (ref-add-default-style-packages! session-name)
+  (add-style-package "number-europe")
+  (add-style-package "preview-ref")
+  (with lan
+    (get-preference "language")
+    (when (!= lan "english")
+      (set-document-language lan)
+      (when (== lan "chinese")
+        (add-style-package "chinese")
+        (add-style-package "table-captions-above")
+      ) ;when
+    ) ;when
+  ) ;with
+  (when (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append session-name ".ts"))
+        ) ;url-exists?
+    (add-style-package session-name)
+  ) ;when
+) ;define
+
+(define (with-bench-buffer tag thunk)
+  ;; buffer-new 无参返回新 buffer，rename 到 tmfs 测试 url；
+  ;; 测试加载环境无 with-buffer 宏，用 buffer-focus 显式切换
+  (let ((buf (buffer-new))
+        (u   (string->url (string-append "tmfs://bench-1184-" tag))
+        )) ;
+    (buffer-rename buf u)
+    (let ((old (current-buffer)) (res #f))
+      (buffer-focus u #f)
+      (set! res (thunk))
+      (buffer-focus old #f)
+      (buffer-close u)
+      res
+    ) ;let
+  ) ;let
+) ;define
+
+(define (bench-style-impl f n)
+  (let ((start (texmacs-time)))
+    (do ((i 0 (+ i 1))) ((= i n))
+      (with-bench-buffer (number->string i) (lambda () (f "llm")))
+    ) ;do
+    (- (texmacs-time) start)
+  ) ;let
+) ;define
+
+(tm-define (test_1184)
+  (use-modules (llm chat-loader))
+
+  ;; 等价性：同一初始条件下，新旧实现最终 style list 必须一致
+  (let ((old-list '()) (new-list '()))
+    (with-bench-buffer "equiv-old"
+      (lambda ()
+        (ref-add-default-style-packages! "llm")
+        (set! old-list (get-style-list))
+      ) ;lambda
+    ) ;with-bench-buffer
+    (with-bench-buffer "equiv-new"
+      (lambda ()
+        (chat-tab-add-default-style-packages! "llm")
+        (set! new-list (get-style-list))
+      ) ;lambda
+    ) ;with-bench-buffer
+    (check new-list => old-list)
+  ) ;let
+
+  ;; 耗时对比（输出到日志，肉眼确认优化幅度）
+  (let ((t-old (bench-style-impl ref-add-default-style-packages! 10))
+        (t-new (bench-style-impl chat-tab-add-default-style-packages! 10))
+       ) ;
+    (display* "[1184] ref(old) x10: " t-old " ms\n")
+    (display* "[1184] new      x10: " t-new " ms\n")
+  ) ;let
+
+  (check-report)
+  (quit-TeXmacs)
+) ;tm-define

--- a/devel/1184.md
+++ b/devel/1184.md
@@ -1,0 +1,40 @@
+# [1184] LLM Chat 标签页 load-input-styles 性能优化
+
+## 1 任务相关的代码文件
+- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — `chat-tab-add-default-style-packages!`
+- `TeXmacs/progs/generic/document-style.scm` — `add-style-package` / `set-style-list` / `set-style-tree`
+- `TeXmacs/progs/generic/document-edit.scm` — `set-document-language`
+- `TeXmacs/tests/1184.scm` — 等价性 + 耗时对比测试
+- [1182](1182.md) — 前置任务：全链路耗时打点，实测 `load-input-styles` ~86ms
+
+## 2 改动记录
+
+### 2.1 合并多次样式树重建为一次（2026-08-08）
+
+**What**：`chat-tab-add-default-style-packages!` 由逐包 `add-style-package`
+（4~5 次）改为先算好完整样式包列表、最后一次 `set-style-list`。
+
+**Why**：每次 `add-style-package` 都走 `set-style-list` → `set-style-tree`
+重建样式树；新建会话输入区时要加 number-europe / preview-ref / 语言包 /
+table-captions-above / llm 插件包共 4~5 个，重建 4~5 次。[1182](1182.md)
+打点实测该函数耗时 ~86ms。
+
+**How**：
+- 用 `let` 累积 packs 列表：number-europe、preview-ref 固定；语言非
+  english 且在 `supported-languages` 内则加语言包；chinese 追加
+  table-captions-above；`$TEXMACS_STYLE_PATH/<session-name>.ts` 存在则追加
+  插件包；最后 `(set-style-list (append (get-style-list) packs))` 一次生效
+- 语义对齐原实现：`set-document-language` 内部同样是「去掉语言包后 append
+  lan，chinese 再加 table-captions-above」，新 buffer 的 style list 原本无
+  语言包，故最终列表一致（测试断言新旧实现 `get-style-list` 完全相等）
+
+**验证**（`TeXmacs/tests/1184.scm`，headless）：
+- 等价性：新旧实现最终 style list 均为
+  `("number-europe" "preview-ref" "chinese" "table-captions-above" "llm")`，
+  断言通过
+- 耗时：x10 次调用 96ms → 79ms（headless 无排版渲染，buffer 生命周期
+  开销占主导；GUI 下 set-style-tree 触发的排版失效成本更高，收益更大）
+
+**涉及文件**：
+- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm`
+- `TeXmacs/tests/1184.scm`（新增）


### PR DESCRIPTION
## What
`chat-tab-add-default-style-packages!` 由逐包 `add-style-package`（4~5 次，每次触发 `set-style-tree` 重建样式树）改为一次 `set-style-list`。

## Why
#4246 打点实测新建 Chat 会话时 `load-input-styles` 耗时 ~86ms，主要成本是每加一个样式包就重建一次样式树。

## 验证
新增 `TeXmacs/tests/1184.scm`（headless）：
- 等价性：新旧实现最终 style list 完全相等（`("number-europe" "preview-ref" "chinese" "table-captions-above" "llm")`）
- 耗时：x10 次 96ms → 79ms（headless 无排版开销；GUI 下 set-style-tree 触发排版失效成本更高，收益更大）

任务文档：devel/1184.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)