### PR TITLE
[1182] chat_tab 初始化新增 bench_start/bench_end 计时

### DIFF
--- a/devel/1182.md
+++ b/devel/1182.md
@@ -1,0 +1,29 @@
+# 1182 Chat 标签页初始化性能计时
+
+## What
+
+为 chat_tab 的初始化新增 `bench_start ("chat_init")` / `bench_end ("chat_init")` 计时。
+
+## Why
+
+测量从点击 Chat 标签页到页面渲染完成的耗时，定位 Chat 标签页初始化性能瓶颈。
+
+## How
+
+- `bench_start`：点击 Chat 标签页时开始计时。位置在
+  `QTMTabPage::mousePressEvent`——确认不是重复点击当前标签页后、且目标是
+  chat tab 时调用 `QTChatTabWidget::beginInitBench ()`（静态方法，内部置
+  `initBenchPending_` 标记并调用 `bench_start`）。
+- `bench_end`：chat_tab 渲染完成时结束计时。位置在
+  `QTChatTabWidget::paintEvent`——首次绘制即视为渲染完成，若
+  `initBenchPending_` 为 true 则清除标记并调用 `bench_end ("chat_init")`。
+  用标记位保证 bench_start 未触发时 bench_end 不会误打印。
+
+## 涉及文件
+
+- `src/Plugins/Qt/QTMTabPage.cpp`：mousePressEvent 中 chat tab 点击处调用
+  `QTChatTabWidget::beginInitBench ()`
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`：新增 `beginInitBench ()` 静态方法、
+  `paintEvent` override、`initBenchPending_` 静态成员
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`：实现 `beginInitBench ()` 与
+  `paintEvent`（bench_end）

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -12,6 +12,7 @@
 
 #include "QTMTabPage.hpp"
 #include "new_view.hpp"
+#include "qt_chat_tab_widget.hpp"
 #include "qt_utilities.hpp"
 #include "string.hpp"
 #include "tm_window.hpp"
@@ -358,6 +359,7 @@ QTMTabPage::mousePressEvent (QMouseEvent* e) {
     if (!is_none (currentView) && currentView == m_viewUrl) {
       return;
     }
+    if (is_chat_tab_view (m_viewUrl)) QTChatTabWidget::beginInitBench ();
     return QToolButton::mousePressEvent (e);
   }
   if (e->button () == Qt::LeftButton) {

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -21,6 +21,7 @@
 #include "qt_utilities.hpp"
 #include "qt_widget.hpp"
 #include "s7_tm.hpp"
+#include "tm_debug.hpp"
 #include "tm_window.hpp"
 
 #include <moebius/tree_label.hpp>
@@ -50,6 +51,13 @@
 using namespace moebius;
 
 bool QTChatTabWidget::globalSidebarCollapsed_= false;
+bool QTChatTabWidget::initBenchPending_      = false;
+
+void
+QTChatTabWidget::beginInitBench () {
+  initBenchPending_= true;
+  bench_start ("chat_init");
+}
 
 namespace {
 
@@ -1671,6 +1679,16 @@ QTChatTabWidget::setGlobalSidebarCollapsed (bool collapsed) {
 /******************************************************************************
  * QTChatTabWidget 事件处理
  ******************************************************************************/
+
+void
+QTChatTabWidget::paintEvent (QPaintEvent* event) {
+  QWidget::paintEvent (event);
+  // 点击 Chat 标签页后的首次绘制视为渲染完成，结束 chat_init 计时
+  if (initBenchPending_) {
+    initBenchPending_= false;
+    bench_end ("chat_init");
+  }
+}
 
 void
 QTChatTabWidget::keyPressEvent (QKeyEvent* event) {

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -32,6 +32,7 @@ class QTimer;
 class QToolButton;
 class QVBoxLayout;
 class QEvent;
+class QPaintEvent;
 class QTMWidget;
 class QTMStateToolButton;
 class qt_tm_widget_rep;
@@ -398,6 +399,12 @@ public:
   // ---- 供外部组件访问 ----
   QWidget* contentWidget () const { return contentWidget_; }
 
+  /**
+   * @brief 点击 Chat 标签页时开始 chat_init 计时，
+   * 在控件首次绘制完成（paintEvent）时结束。
+   */
+  static void beginInitBench ();
+
 signals:
   void cancelRequested (const string& sessionId);
   void newChatRequested ();
@@ -409,6 +416,8 @@ protected:
   void keyReleaseEvent (QKeyEvent* event) override;
   /// 事件过滤器
   bool eventFilter (QObject* watched, QEvent* event) override;
+  /// 首次绘制时结束 chat_init 计时
+  void paintEvent (QPaintEvent* event) override;
 
 private:
   /// 构建左侧侧边栏布局
@@ -441,6 +450,7 @@ private:
   qt_tm_widget_rep*      parentTmWidget_= nullptr; ///< 关联的 TeXmacs widget
 
   static bool globalSidebarCollapsed_; ///< 全局记忆的侧边栏折叠状态
+  static bool initBenchPending_;       ///< chat_init 计时待结束标记
 };
 
 #endif // QT_CHAT_TAB_WIDGET_HPP


### PR DESCRIPTION
## What

为 chat_tab 的初始化新增 `bench_start ("chat_init")` / `bench_end ("chat_init")` 性能计时。

## Why

测量从点击 Chat 标签页到页面渲染完成的耗时，用于定位 Chat 标签页初始化性能瓶颈。

## How

- **bench_start**：`QTMTabPage::mousePressEvent` 中，点击 Chat 标签页（排除重复点击当前页）时调用 `QTChatTabWidget::beginInitBench ()`，置 `initBenchPending_` 标记并开始计时。
- **bench_end**：`QTChatTabWidget::paintEvent` 首次绘制（渲染完成）时清除标记并结束计时。标记位保证未点击时 paint 不会误触发 bench_end。

## 涉及文件

- `src/Plugins/Qt/QTMTabPage.cpp`
- `src/Plugins/Qt/qt_chat_tab_widget.hpp`
- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
- `devel/1182.md`（任务文档）

🤖 Generated with [Claude Code](https://claude.com/claude-code)