### PR TITLE
[1185] update_menus 守卫收敛为 should_skip_update，跳过内嵌消息 buffer

### DIFF
--- a/devel/1185.md
+++ b/devel/1185.md
@@ -106,3 +106,39 @@ tab 与 dock 两种模式。全屏 tab 下这次重建不可见的问题，需�
 剩余热点：`activate session` 88 ms（chat-persist 读盘 + 排版）、
 `load chat modules` 47 ms（llm 插件 scheme 模块加载，可 idle 预加载）、
 sync→paint 残差 ~270 ms（Qt 布局/绘制 + kbd-map 懒注册 ~50 ms）。
+
+## p2：内嵌消息 buffer 纳入 update_menus 跳过守卫
+
+## What（p2）
+
+`update_menus` 的跳过条件收敛为 `should_skip_update = is_startup ||
+is_chat || is_chat_msg`，新增对只读消息展示 buffer
+（`tmfs://chat/<sid>/message`）的跳过；p1 遗留的无条件诊断
+`cout` 收进 `#ifdef LIII_DEBUG`。
+
+## Why（p2）
+
+p1 按 buffer 前缀跳过全部 `tmfs://chat/` 内嵌 buffer 的尝试已回退——
+dock 侧边栏模式下焦点切到**输入框**（`tmfs://chat/<sid>/input`）时模式
+工具栏可见，仍需随其重建。但**消息展示区**是只读的，任何模式下聚焦它
+都不需要重建菜单/工具栏，可按 buffer 名直接跳过，无需区分全屏 tab 与
+dock 模式。
+
+## How（p2）
+
+- `src/Texmacs/Data/new_view.{hpp,cpp}`：新增
+  `is_chat_message_buffer (url)`，匹配 `tmfs://chat/` 前缀且以
+  `/message` 结尾（buffer URL 构造见 `qt_chat_session.cpp`：
+  `tmfs://chat/<sid>/message` 与 `tmfs://chat/<sid>/input`）。
+- `src/Edit/Interface/edit_interface.cpp`（`update_menus`）：
+  - `MENU_MAIN` / `ICONS_MAIN` / `ICONS_MODE` / `ICONS_FOCUS` /
+    `ICONS_EXTRA` / `NOTIFICATION` 及提前返回统一改用
+    `!should_skip_update`；
+  - `TAB_PAGES` 守卫由 `!is_chat` 扩为 `!is_chat && !is_chat_msg`
+    （startup tab 仍需重建 tab 条，保持原语义）。
+
+## 涉及文件（p2）
+
+- `src/Texmacs/Data/new_view.hpp`
+- `src/Texmacs/Data/new_view.cpp`
+- `src/Edit/Interface/edit_interface.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -851,10 +851,15 @@ void
 edit_interface_rep::update_menus (int mask) {
   bool is_startup= is_startup_tab_buffer (buf->buf->name);
   bool is_chat   = is_chat_tab_buffer (buf->buf->name);
+  // 只读消息展示区任何模式下都不需要菜单/工具栏重建；输入框不并入——
+  // dock 侧边栏模式下焦点切到输入框时模式工具栏可见，仍需随其重建
+  bool is_chat_msg       = is_chat_message_buffer (buf->buf->name);
+  bool should_skip_update= is_startup || is_chat || is_chat_msg;
   bench_start ("update_menus");
-  // 临时诊断：记录触发重建的 buffer 与类别，定位 chat_init 期间两次全量重建
+#ifdef LIII_DEBUG
   cout << "[update_menus] buffer=" << as_string (buf->buf->name)
        << " mask=" << mask << LF;
+#endif
 
 #ifdef LIII_DEBUG
   cout << "update_menus [";
@@ -874,7 +879,7 @@ edit_interface_rep::update_menus (int mask) {
     return;
   }
 
-  if ((mask & MENU_MAIN) && !is_startup && !is_chat) {
+  if ((mask & MENU_MAIN) && !should_skip_update) {
     bench_start ("update_menus: menu_main");
     SERVER (menu_main ("(horizontal (link texmacs-menu))"));
     bench_end ("update_menus: menu_main");
@@ -883,38 +888,38 @@ edit_interface_rep::update_menus (int mask) {
   // WASM/React shell 只渲染主菜单（SLOT_MAIN_MENU → im_react_push_menu）；
   // icons/tabs 的 widget 建了也无前端消费，每次 update_menus 都为它们跑
   // scheme 求值是纯浪费（这是 WASM 下 update_menus 慢的主因）。native 保留。
-  if ((mask & ICONS_MAIN) && !is_startup && !is_chat) {
+  if ((mask & ICONS_MAIN) && !should_skip_update) {
     bench_start ("update_menus: icons0-main");
     SERVER (menu_icons (0, "(horizontal (link texmacs-main-icons))"));
     bench_end ("update_menus: icons0-main");
   }
-  if ((mask & ICONS_MODE) && !is_startup && !is_chat) {
+  if ((mask & ICONS_MODE) && !should_skip_update) {
     bench_start ("update_menus: icons1-mode");
     SERVER (menu_icons (1, "(horizontal (link texmacs-mode-icons))"));
     bench_end ("update_menus: icons1-mode");
   }
-  if ((mask & ICONS_FOCUS) && !is_startup && !is_chat) {
+  if ((mask & ICONS_FOCUS) && !should_skip_update) {
     bench_start ("update_menus: icons2-focus");
     SERVER (menu_icons (2, "(horizontal (link texmacs-focus-icons))"));
     bench_end ("update_menus: icons2-focus");
   }
-  if ((mask & ICONS_EXTRA) && !is_startup && !is_chat) {
+  if ((mask & ICONS_EXTRA) && !should_skip_update) {
     bench_start ("update_menus: icons3-extra");
     SERVER (menu_icons (3, "(horizontal (link texmacs-extra-icons))"));
     bench_end ("update_menus: icons3-extra");
   }
-  if ((mask & TAB_PAGES) && !is_chat) {
+  if ((mask & TAB_PAGES) && !is_chat && !is_chat_msg) {
     bench_start ("update_menus: icons4-tabs");
     SERVER (menu_icons (4, "(horizontal (link texmacs-tab-pages))"));
     bench_end ("update_menus: icons4-tabs");
   }
 #endif
-  if ((mask & NOTIFICATION) && !is_startup && !is_chat) {
+  if ((mask & NOTIFICATION) && !should_skip_update) {
     bench_start ("update_menus: notification");
     SERVER (notification_bar ("(horizontal (link texmacs-notification-bar))"));
     bench_end ("update_menus: notification");
   }
-  if (is_startup || is_chat) {
+  if (should_skip_update) {
     last_update= last_change;
     bench_end ("update_menus");
     return;

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -87,6 +87,19 @@ is_chat_tab_buffer (url name) {
   return starts (as_string (name), "tmfs://chat-tab");
 }
 
+/**
+ * @brief 判断 buffer 名称是否指向聊天会话的只读消息展示区。
+ * @param name 待检测的 buffer URL。
+ * @return 若名称形如 \c tmfs://chat/<sid>/message 则返回 true。
+ * @note 输入框（\c .../input）不在此列：dock 侧边栏模式下焦点切到输入框时
+ * 模式工具栏仍需随其重建。
+ */
+bool
+is_chat_message_buffer (url name) {
+  string s= as_string (name);
+  return starts (s, "tmfs://chat/") && ends (s, "/message");
+}
+
 bool
 is_startup_tab_buffer (url name) {
   return name == url ("tmfs://startup-tab");

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -52,6 +52,7 @@ void       make_cursor_visible (url u);
 url        get_most_recent_view ();
 void       invalidate_most_recent_view ();
 bool       is_chat_tab_buffer (url name);
+bool       is_chat_message_buffer (url name);
 bool       is_startup_tab_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);


### PR DESCRIPTION
## What

`update_menus` 的跳过条件收敛为 `should_skip_update = is_startup || is_chat || is_chat_msg`，新增对只读消息展示 buffer（`tmfs://chat/<sid>/message`）的跳过。

## Why

- p1（#4249）按 buffer 前缀跳过全部 `tmfs://chat/` 内嵌 buffer 的尝试已回退——dock 侧边栏模式下焦点切到**输入框**（`tmfs://chat/<sid>/input`）时模式工具栏可见，仍需随其重建。
- 但**消息展示区**是只读的，任何模式下聚焦它都不需要重建菜单/工具栏，可按 buffer 名直接跳过，无需区分全屏 tab 与 dock 模式。

## How

- `src/Texmacs/Data/new_view.{hpp,cpp}`：新增 `is_chat_message_buffer (url)`，匹配 `tmfs://chat/` 前缀且以 `/message` 结尾。
- `src/Edit/Interface/edit_interface.cpp`（`update_menus`）：
  - `MENU_MAIN` / `ICONS_MAIN` / `ICONS_MODE` / `ICONS_FOCUS` / `ICONS_EXTRA` / `NOTIFICATION` 及提前返回统一改用 `!should_skip_update`；
  - `TAB_PAGES` 守卫由 `!is_chat` 扩为 `!is_chat && !is_chat_msg`（startup tab 保持原语义）；
  - p1 遗留的无条件诊断 `cout` 收进 `#ifdef LIII_DEBUG`。

详见 `devel/1185.md` p2 小节。

🤖 Generated with [Claude Code](https://claude.com/claude-code)