### PR TITLE
[1185] update_menus 按 buffer 跳过冗余重建:chat_init 866→650 ms(-216 ms)

### DIFF
--- a/devel/1185.md
+++ b/devel/1185.md
@@ -133,7 +133,7 @@ dock 模式。
 - `src/Edit/Interface/edit_interface.cpp`（`update_menus`）：
   - `MENU_MAIN` / `ICONS_MAIN` / `ICONS_MODE` / `ICONS_FOCUS` /
     `ICONS_EXTRA` / `NOTIFICATION` 及提前返回统一改用
-    `!should_update_menu`；
+    `!should_skip_update`；
   - `TAB_PAGES` 守卫由 `!is_chat` 扩为 `!is_chat && !is_chat_msg`
     （startup tab 仍需重建 tab 条，保持原语义）。
 
@@ -208,3 +208,32 @@ notification 7 / footer+tail 21），但 dock 模式下输入框只需要模式�
 - `src/Texmacs/Data/new_view.cpp`
 - `src/Edit/Interface/edit_interface.cpp`
 - `tests/Edit/Interface/should_update_menu_test.cpp`
+
+## p3 效果验证（GUI 实测,2026-08-08)
+
+`xmake b stem` 后 GUI 启动并聚焦 chat 输入框,bench 输出确认:
+
+- `update_menus: tmfs://chat-tab` → 0 ms(全部跳过);
+- `update_menus: tmfs://chat/<sid>/input` → 131 ms,子项只剩
+  `icons1-mode` 一条;紧跟的第二次调用 0 ms(请求掩码不含
+  ICONS_MODE,空掩码短路)。
+
+p1 → p3 累计耗时减少(p2 未单独计时,收益并入整体):
+
+| 指标 | p1 前 | p3 后 | 变化 |
+|---|---|---|---|
+| `chat_init` 总耗时 | 866 ms | 650 ms | -216 ms |
+| chat-tab buffer 的 `update_menus` | 118 ms | 0 ms | -118 ms |
+| input buffer 的 `update_menus` | 269 ms | 131 ms | -138 ms |
+
+最新 `chat_init` 总计 650 ms,构成:
+
+| 段 | 耗时 |
+|---|---|
+| `createView`(含 load chat modules 48 / widget 搭建 ~14 / activate session 93) | 152 ms |
+| `sync_chat_tab_mode`(含 kbd-map 懒注册 generic/text 等) | 153 ms |
+| `icons1-mode`(input buffer) | 131 ms |
+| 其余(typeset、收尾) | ~100 ms |
+
+后续候选热点:`icons1-mode` 的 scheme 求值(131 ms)、
+`sync_chat_tab_mode` 内的 kbd-map 懒注册、`activate session` 93 ms。

--- a/devel/1185.md
+++ b/devel/1185.md
@@ -133,7 +133,7 @@ dock 模式。
 - `src/Edit/Interface/edit_interface.cpp`（`update_menus`）：
   - `MENU_MAIN` / `ICONS_MAIN` / `ICONS_MODE` / `ICONS_FOCUS` /
     `ICONS_EXTRA` / `NOTIFICATION` 及提前返回统一改用
-    `!should_skip_update`；
+    `!should_update_menu`；
   - `TAB_PAGES` 守卫由 `!is_chat` 扩为 `!is_chat && !is_chat_msg`
     （startup tab 仍需重建 tab 条，保持原语义）。
 
@@ -142,3 +142,69 @@ dock 模式。
 - `src/Texmacs/Data/new_view.hpp`
 - `src/Texmacs/Data/new_view.cpp`
 - `src/Edit/Interface/edit_interface.cpp`
+
+## p3：update_menus bench 任务名带上 buffer URL
+
+## What（p3）
+
+外层 `update_menus` 的 bench 任务名由固定字符串 `"update_menus"` 改为
+`"update_menus: " * as_string (buf->buf->name)`，bench 输出可区分是哪个
+buffer 触发的菜单重建；`menu_main` / `icons*` 等子项任务名保持不变。
+
+## Why（p3）
+
+之前的输出 `Task 'update_menus' took 0 ms` 无法定位到具体 buffer，
+排查 chat 标签页场景下哪个 buffer 在拖慢菜单重建时需要 URL 信息。
+
+## How（p3）
+
+`src/Edit/Interface/edit_interface.cpp`（`update_menus (int mask)`）：
+新增局部 `bench_task`，三处 `bench_start/bench_end`（含全屏与
+`should_skip_update` 两条提前返回路径）统一改用它。
+
+## 涉及文件（p3）
+
+- `src/Edit/Interface/edit_interface.cpp`
+
+## p4：should_update_menu(mask, url) 收敛跳过规则，chat 输入框仅重建 mode 工具栏
+
+## What（p4）
+
+`update_menus` 各重建段的重建判断收敛为纯函数
+`should_update_menu (int mask, url name)`（`edit_interface.cpp` 自由函数），
+规则由新增 C++ 单元测试钉死；新增规则：chat 输入框 buffer
+（`tmfs://chat/<sid>/input`）仅重建模式工具栏（ICONS_MODE），其余段全部
+跳过。
+
+## Why（p4）
+
+插桩显示输入框聚焦时整套 update_menus 花 269 ms（menu_main 22 /
+icons0-main 42 / icons1-mode 133 / icons2-focus 30 / icons4-tabs 11 /
+notification 7 / footer+tail 21），但 dock 模式下输入框只需要模式工具栏
+可见性随其重建，其余段都是纯浪费。收敛为 mask+url 的纯函数后规则可读、
+可测。
+
+## How（p4）
+
+- `src/Texmacs/Data/new_view.{hpp,cpp}`：新增 `is_chat_input_buffer (url)`，
+  匹配 `tmfs://chat/` 前缀且以 `/input` 结尾。
+- `src/Edit/Interface/edit_interface.cpp`：
+  - 新增 `should_update_menu (mask, name)`：按 buffer 类别算 allow 掩码
+    （普通=MENU_ALL，startup=TAB_PAGES，chat 标签页/消息区=0，
+    输入框=ICONS_MODE），`(mask & allow) == 0` 即跳过；空掩码视为跳过，
+    调用处传 `mask & BIT` 一并完成「未请求」与「按规则跳过」判断。
+  - `update_menus`：删除局部 is_startup/is_chat/is_chat_msg 布尔，各段
+    守卫统一为 `!should_update_menu (mask & BIT, name)`；SIDE_TOOLS 段
+    自带守卫后移到提前返回之前；footer+tail 的提前返回条件改为
+    `should_update_menu (MENU_MAIN, name)`（MENU_MAIN 被跳过的 buffer
+    同样不需要 footer 与尾部簿记），保留 `last_update= last_change`。
+- 测试 `tests/Edit/Interface/should_update_menu_test.cpp`：普通 buffer /
+  startup tab / chat 标签页 / 消息区 / 输入框 / 未识别 chat 子 buffer
+  （按普通处理）六类 × 8 个掩码位。
+
+## 涉及文件（p4）
+
+- `src/Texmacs/Data/new_view.hpp`
+- `src/Texmacs/Data/new_view.cpp`
+- `src/Edit/Interface/edit_interface.cpp`
+- `tests/Edit/Interface/should_update_menu_test.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -847,18 +847,40 @@ edit_interface_rep::update_menus () {
   update_menus (MENU_ALL);
 }
 
+/**
+ * @brief 判断指定 buffer 在 update_menus 中是否应重建某些段。
+ * @param mask 待检测的段（MENU_MAIN / ICONS_* / TAB_PAGES / NOTIFICATION /
+ * SIDE_TOOLS，可多位或）。
+ * @param name buffer URL。
+ * @return 若 mask 中所有位对该 buffer 都允许重建则返回 true；空掩码视为不
+ * 重建，故调用处直接传 \c{mask & BIT} 即可同时完成「已请求」与「按规则
+ * 允许」两种判断。
+ * @par 规则（由 should_update_menu_test 钉死）
+ * - 普通 buffer：全部重建；
+ * - startup tab：仅重建 tab 栏（TAB_PAGES）；
+ * - chat 标签页 / 只读消息区：全部跳过；
+ * - chat 输入框：仅重建模式工具栏（ICONS_MODE）——dock 侧边栏模式下焦点
+ *   切到输入框时模式工具栏可见，仍需随其重建。
+ */
+bool
+should_update_menu (int mask, url name) {
+  // 未请求的段直接判不重建，避免无谓的 buffer 类别判定（字符串比较）
+  if (mask == 0) return false;
+  int allow= MENU_ALL;
+  if (is_startup_tab_buffer (name)) allow= TAB_PAGES;
+  else if (is_chat_tab_buffer (name) || is_chat_message_buffer (name)) allow= 0;
+  else if (is_chat_input_buffer (name)) allow= ICONS_MODE;
+  return (mask & allow) == mask;
+}
+
 void
 edit_interface_rep::update_menus (int mask) {
-  bool is_startup= is_startup_tab_buffer (buf->buf->name);
-  bool is_chat   = is_chat_tab_buffer (buf->buf->name);
-  // 只读消息展示区任何模式下都不需要菜单/工具栏重建；输入框不并入——
-  // dock 侧边栏模式下焦点切到输入框时模式工具栏可见，仍需随其重建
-  bool is_chat_msg       = is_chat_message_buffer (buf->buf->name);
-  bool should_skip_update= is_startup || is_chat || is_chat_msg;
-  bench_start ("update_menus");
+  url    name      = buf->buf->name;
+  string bench_task= "update_menus: " * as_string (name);
+  bench_start (bench_task);
 #ifdef LIII_DEBUG
-  cout << "[update_menus] buffer=" << as_string (buf->buf->name)
-       << " mask=" << mask << LF;
+  cout << "[update_menus] buffer=" << as_string (name) << " mask=" << mask
+       << LF;
 #endif
 
 #ifdef LIII_DEBUG
@@ -875,11 +897,11 @@ edit_interface_rep::update_menus (int mask) {
 #endif
 
   if (get_server ()->in_full_screen_mode ()) {
-    bench_end ("update_menus");
+    bench_end (bench_task);
     return;
   }
 
-  if ((mask & MENU_MAIN) && !should_skip_update) {
+  if (should_update_menu (mask & MENU_MAIN, name)) {
     bench_start ("update_menus: menu_main");
     SERVER (menu_main ("(horizontal (link texmacs-menu))"));
     bench_end ("update_menus: menu_main");
@@ -888,47 +910,42 @@ edit_interface_rep::update_menus (int mask) {
   // WASM/React shell 只渲染主菜单（SLOT_MAIN_MENU → im_react_push_menu）；
   // icons/tabs 的 widget 建了也无前端消费，每次 update_menus 都为它们跑
   // scheme 求值是纯浪费（这是 WASM 下 update_menus 慢的主因）。native 保留。
-  if ((mask & ICONS_MAIN) && !should_skip_update) {
+  if (should_update_menu (mask & ICONS_MAIN, name)) {
     bench_start ("update_menus: icons0-main");
     SERVER (menu_icons (0, "(horizontal (link texmacs-main-icons))"));
     bench_end ("update_menus: icons0-main");
   }
-  if ((mask & ICONS_MODE) && !should_skip_update) {
+  if (should_update_menu (mask & ICONS_MODE, name)) {
     bench_start ("update_menus: icons1-mode");
     SERVER (menu_icons (1, "(horizontal (link texmacs-mode-icons))"));
     bench_end ("update_menus: icons1-mode");
   }
-  if ((mask & ICONS_FOCUS) && !should_skip_update) {
+  if (should_update_menu (mask & ICONS_FOCUS, name)) {
     bench_start ("update_menus: icons2-focus");
     SERVER (menu_icons (2, "(horizontal (link texmacs-focus-icons))"));
     bench_end ("update_menus: icons2-focus");
   }
-  if ((mask & ICONS_EXTRA) && !should_skip_update) {
+  if (should_update_menu (mask & ICONS_EXTRA, name)) {
     bench_start ("update_menus: icons3-extra");
     SERVER (menu_icons (3, "(horizontal (link texmacs-extra-icons))"));
     bench_end ("update_menus: icons3-extra");
   }
-  if ((mask & TAB_PAGES) && !is_chat && !is_chat_msg) {
+  if (should_update_menu (mask & TAB_PAGES, name)) {
     bench_start ("update_menus: icons4-tabs");
     SERVER (menu_icons (4, "(horizontal (link texmacs-tab-pages))"));
     bench_end ("update_menus: icons4-tabs");
   }
 #endif
-  if ((mask & NOTIFICATION) && !should_skip_update) {
+  if (should_update_menu (mask & NOTIFICATION, name)) {
     bench_start ("update_menus: notification");
     SERVER (notification_bar ("(horizontal (link texmacs-notification-bar))"));
     bench_end ("update_menus: notification");
   }
-  if (should_skip_update) {
-    last_update= last_change;
-    bench_end ("update_menus");
-    return;
-  }
 #ifndef OS_WASM
   // 同 icons：WASM/React 无 side-tools 前端，跳过其 scheme 求值。
-  if (mask & SIDE_TOOLS) {
+  if (should_update_menu (mask & SIDE_TOOLS, name)) {
     bench_start ("update_menus: side-tools");
-    array<url> a= buffer_to_windows (buf->buf->name);
+    array<url> a= buffer_to_windows (name);
     if (N (a) > 0) {
       string win = "(string->url \"" * as_string (a[0]) * "\")";
       string ldyn= "(dynamic (texmacs-left-tools " * win * "))";
@@ -941,6 +958,13 @@ edit_interface_rep::update_menus (int mask) {
     bench_end ("update_menus: side-tools");
   }
 #endif
+  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框）
+  // 同样不需要 footer 与尾部簿记
+  if (!should_update_menu (MENU_MAIN, name)) {
+    last_update= last_change;
+    bench_end (bench_task);
+    return;
+  }
   bench_start ("update_menus: footer+tail");
   set_footer ();
   if (mask == MENU_ALL) {
@@ -962,7 +986,7 @@ edit_interface_rep::update_menus (int mask) {
     menu_focus_path= focus_get ();
   if (mask & TAB_PAGES) menu_need_save= need_save ();
   bench_end ("update_menus: footer+tail");
-  bench_end ("update_menus");
+  bench_end (bench_task);
 }
 
 int

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -100,6 +100,17 @@ is_chat_message_buffer (url name) {
   return starts (s, "tmfs://chat/") && ends (s, "/message");
 }
 
+/**
+ * @brief 判断 buffer 名称是否指向聊天会话的输入框。
+ * @param name 待检测的 buffer URL。
+ * @return 若名称形如 \c tmfs://chat/<sid>/input 则返回 true。
+ */
+bool
+is_chat_input_buffer (url name) {
+  string s= as_string (name);
+  return starts (s, "tmfs://chat/") && ends (s, "/input");
+}
+
 bool
 is_startup_tab_buffer (url name) {
   return name == url ("tmfs://startup-tab");

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -53,6 +53,7 @@ url        get_most_recent_view ();
 void       invalidate_most_recent_view ();
 bool       is_chat_tab_buffer (url name);
 bool       is_chat_message_buffer (url name);
+bool       is_chat_input_buffer (url name);
 bool       is_startup_tab_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -13,8 +13,8 @@
 // 被测函数定义于 edit_interface.cpp
 extern bool should_update_menu (int mask, url name);
 
-static const int ALL_BITS[]= {MENU_MAIN,   ICONS_MAIN, ICONS_MODE,
-                              ICONS_FOCUS, ICONS_EXTRA, TAB_PAGES,
+static const int ALL_BITS[]= {MENU_MAIN,    ICONS_MAIN,  ICONS_MODE,
+                              ICONS_FOCUS,  ICONS_EXTRA, TAB_PAGES,
                               NOTIFICATION, SIDE_TOOLS};
 static const int N_BITS    = sizeof (ALL_BITS) / sizeof (ALL_BITS[0]);
 

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -1,0 +1,94 @@
+
+/******************************************************************************
+ * MODULE     : should_update_menu_test.cpp
+ * DESCRIPTION: 钉死 update_menus 按 buffer 类别重建各段的规则
+ * COPYRIGHT  : (C) 2026
+ ******************************************************************************/
+
+#include "base.hpp"
+#include "editor.hpp"
+#include "url.hpp"
+#include <QtTest/QtTest>
+
+// 被测函数定义于 edit_interface.cpp
+extern bool should_update_menu (int mask, url name);
+
+static const int ALL_BITS[]= {MENU_MAIN,   ICONS_MAIN, ICONS_MODE,
+                              ICONS_FOCUS, ICONS_EXTRA, TAB_PAGES,
+                              NOTIFICATION, SIDE_TOOLS};
+static const int N_BITS    = sizeof (ALL_BITS) / sizeof (ALL_BITS[0]);
+
+class TestShouldUpdateMenu : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+  void test_normal_buffer ();
+  void test_startup_tab ();
+  void test_chat_tab ();
+  void test_chat_message ();
+  void test_chat_input ();
+  void test_unknown_chat_sub_buffer ();
+};
+
+// 普通 buffer：所有段都重建
+void
+TestShouldUpdateMenu::test_normal_buffer () {
+  url u= url ("/tmp/should_update_menu_test.tm");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (should_update_menu (ALL_BITS[i], u));
+  QVERIFY (should_update_menu (MENU_ALL, u));
+  // 空掩码（未请求任何段）一律不重建
+  QVERIFY (!should_update_menu (0, u));
+}
+
+// startup tab：仅重建 tab 栏
+void
+TestShouldUpdateMenu::test_startup_tab () {
+  url u= url ("tmfs://startup-tab");
+  for (int i= 0; i < N_BITS; i++) {
+    if (ALL_BITS[i] == TAB_PAGES) QVERIFY (should_update_menu (TAB_PAGES, u));
+    else QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  }
+  // TAB_PAGES 在 MENU_ALL 中，整掩码不全允许时判不重建
+  QVERIFY (!should_update_menu (MENU_ALL, u));
+}
+
+// chat 标签页：全部不重建
+void
+TestShouldUpdateMenu::test_chat_tab () {
+  url u= url ("tmfs://chat-tab/B86AD167-589F-4820-88A0-388A12AAAF30");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  QVERIFY (!should_update_menu (MENU_ALL, u));
+}
+
+// chat 只读消息区：全部不重建
+void
+TestShouldUpdateMenu::test_chat_message () {
+  url u= url ("tmfs://chat/B86AD167-589F-4820-88A0-388A12AAAF30/message");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  QVERIFY (!should_update_menu (MENU_ALL, u));
+}
+
+// chat 输入框：仅重建模式工具栏
+void
+TestShouldUpdateMenu::test_chat_input () {
+  url u= url ("tmfs://chat/B86AD167-589F-4820-88A0-388A12AAAF30/input");
+  for (int i= 0; i < N_BITS; i++) {
+    if (ALL_BITS[i] == ICONS_MODE) QVERIFY (should_update_menu (ICONS_MODE, u));
+    else QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  }
+}
+
+// 未识别的 chat 子 buffer：按普通 buffer 处理
+void
+TestShouldUpdateMenu::test_unknown_chat_sub_buffer () {
+  url u= url ("tmfs://chat/B86AD167-589F-4820-88A0-388A12AAAF30/draft");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (should_update_menu (ALL_BITS[i], u));
+}
+
+QTEST_MAIN (TestShouldUpdateMenu)
+#include "should_update_menu_test.moc"


### PR DESCRIPTION
## What

- update_menus 外层 bench 任务名带上 buffer URL,可定位是哪个 buffer 触发的重建
- 各重建段守卫收敛为纯函数 `should_update_menu (mask, url)`,规则由 C++ 单元测试钉死
- 新增 `is_chat_input_buffer`;chat 输入框(`tmfs://chat/<sid>/input`)仅重建模式工具栏(ICONS_MODE),其余段全部跳过

## Why

插桩显示 chat 输入框聚焦时整套 update_menus 花 269 ms(menu_main 22 / icons0-main 42 / icons1-mode 133 / icons2-focus 30 / icons4-tabs 11 / notification 7 / footer+tail 21),但 dock 模式下输入框只有模式工具栏需要随其重建。本 PR 后预期降到 ~133 ms。

## 规则矩阵(单测覆盖)

| buffer | 允许重建 |
|---|---|
| 普通 / 未识别 chat 子 buffer | 全部 |
| tmfs://startup-tab | 仅 TAB_PAGES |
| tmfs://chat-tab... / .../message | 无 |
| tmfs://chat/<sid>/input | 仅 ICONS_MODE |

## Test plan

- [x] `xmake r should_update_menu_test` 8/8 通过
- [x] `xmake b stem` 通过,headless 2044 冒烟正常
- [ ] GUI 验证:聚焦 chat 输入框,bench 输出仅剩 icons1-mode,mode 工具栏正常刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)