### PR TITLE
[1187] tree-search 累加器化：先补测试与基准，再改实现

### DIFF
--- a/TeXmacs/progs/kernel/library/tree-test.scm
+++ b/TeXmacs/progs/kernel/library/tree-test.scm
@@ -1,0 +1,124 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tree-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：kernel 树工具函数（tree-search 等）。
+;;               无 GUI，headless 可跑。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r tree-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/kernel/library/tree.scm")
+
+;; 复合树的 tree->string 为空串，取第一个子节点的字符串来区分匹配项。
+
+(define (first-arg-string t)
+  (tree->string (tree-ref t 0))
+) ;define
+
+(define (frac? t)
+  (tree-func? t 'frac)
+) ;define
+
+(define (make-doc)
+  (tm->tree '(document (frac "a" "b") "x" (frac "c" "d")))
+) ;define
+
+;; 基本匹配：按 label 搜索，命中所有匹配子树，跳过不匹配的中间节点。
+
+(define (test-tree-search-basic)
+  (with r
+    (tree-search (make-doc) frac?)
+    (check (length r) => 2)
+    (check (map tree-label r) => '(frac frac))
+    (check (map first-arg-string r) => '("a" "c"))
+  ) ;with
+) ;define
+
+;; 顺序契约：结果按文档顺序（先序遍历，子节点从左到右），含跨层嵌套。
+
+(define (test-tree-search-document-order)
+  (with t
+    (tm->tree '(document (section "s" (frac "1" "x")) (frac "2" "y")))
+    (check (map first-arg-string (tree-search t frac?)) => '("1" "2"))
+  ) ;with
+) ;define
+
+;; 嵌套匹配：外层和内层同时命中时两者都返回，外层在前。
+;; 外层 frac 的首子是复合树（tree->string 为空串），借此区分内外层。
+
+(define (test-tree-search-nested)
+  (with t
+    (tm->tree '(document (frac (frac "i" "x") "o")))
+    (check (map first-arg-string (tree-search t frac?)) => '("" "i"))
+  ) ;with
+) ;define
+
+;; 根匹配：根节点自身满足谓词时排在首位，且返回的就是原树对象本身。
+
+(define (test-tree-search-root-match)
+  (let* ((t (make-doc)) (r (tree-search t (lambda (x) (tree-func? x 'document)))))
+    (check (length r) => 1)
+    (check (eq? (car r) t) => #t)
+  ) ;let*
+  (let* ((t (tm->tree '(frac "a" "b"))) (r (tree-search t frac?)))
+    (check (length r) => 1)
+    (check (eq? (car r) t) => #t)
+  ) ;let*
+) ;define
+
+;; 无匹配返回空列表。
+
+(define (test-tree-search-no-match)
+  (check (tree-search (make-doc) (lambda (t) #f)) => '())
+  (check (tree-search (make-doc) (lambda (t) (tree-func? t 'table))) => '())
+) ;define
+
+;; 原子树输入：只检查根自身，匹配返回单元素列表，否则空列表。
+
+(define (test-tree-search-atomic)
+  (let* ((t (string->tree "hello")) (r (tree-search t tree-atomic?)))
+    (check (length r) => 1)
+    (check (eq? (car r) t) => #t)
+  ) ;let*
+  (check (tree-search (string->tree "hello") frac?) => '())
+) ;define
+
+;; 空复合树（无子节点）输入。
+
+(define (test-tree-search-empty-compound)
+  (with t
+    (tm->tree '(document))
+    (check (tree-search t frac?) => '())
+    (check (length (tree-search t (lambda (x) (tree-func? x 'document)))) => 1)
+  ) ;with
+) ;define
+
+;; 纯函数：不修改输入树；返回新列表，调用方 set-car! 不影响再次搜索的结果。
+
+(define (test-tree-search-pure)
+  (let* ((t (make-doc)) (r (tree-search t frac?)))
+    (set-car! r 'dummy)
+    (check (map first-arg-string (tree-search t frac?)) => '("a" "c"))
+    (check (first-arg-string (tree-ref t 0)) => "a")
+  ) ;let*
+) ;define
+
+(tm-define (regtest-tree)
+  (test-tree-search-basic)
+  (test-tree-search-document-order)
+  (test-tree-search-nested)
+  (test-tree-search-root-match)
+  (test-tree-search-no-match)
+  (test-tree-search-atomic)
+  (test-tree-search-empty-compound)
+  (test-tree-search-pure)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/library/tree-test.scm
+++ b/TeXmacs/progs/kernel/library/tree-test.scm
@@ -111,6 +111,46 @@
   ) ;let*
 ) ;define
 
+;; 性能基准：深链 + 宽文档两种树形，供优化前后对比耗时。
+;; 只打印耗时不断言上限，避免慢机器上误报；匹配数仍做 check 保证规模正确。
+
+(define (make-deep-tree n)
+  (if (<= n 0)
+    (string->tree "x")
+    (tm->tree (list 'emph (make-deep-tree (- n 1))))
+  ) ;if
+) ;define
+
+(define (make-wide-doc n)
+  (tm->tree (cons 'document (map (lambda (i) (list 'frac (number->string i) "y")) (.. 0 n)))
+  ) ;tm->tree
+) ;define
+
+(define (bench-tree-search)
+  (let ((deep (make-deep-tree 200)) (wide (make-wide-doc 500)) (start 0))
+    (check (length (tree-search deep (lambda (t) (tree-func? t 'emph)))) => 200)
+    (check (length (tree-search wide frac?)) => 500)
+    (set! start (texmacs-time))
+    (do ((i 0 (+ i 1)))
+      ((= i 50))
+      (tree-search deep (lambda (t) (tree-func? t 'emph)))
+    ) ;do
+    (display* "bench tree-search deep(200) x50: "
+      (- (texmacs-time) start)
+      " msec\n"
+    ) ;display*
+    (set! start (texmacs-time))
+    (do ((i 0 (+ i 1)))
+      ((= i 50))
+      (tree-search wide frac?)
+    ) ;do
+    (display* "bench tree-search wide(500) x50: "
+      (- (texmacs-time) start)
+      " msec\n"
+    ) ;display*
+  ) ;let
+) ;define
+
 (tm-define (regtest-tree)
   (test-tree-search-basic)
   (test-tree-search-document-order)
@@ -120,5 +160,6 @@
   (test-tree-search-atomic)
   (test-tree-search-empty-compound)
   (test-tree-search-pure)
+  (bench-tree-search)
   (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/kernel/library/tree.scm
+++ b/TeXmacs/progs/kernel/library/tree.scm
@@ -70,14 +70,23 @@
   ) ;with
 ) ;define-public
 
+;; 累加器收集 + 一次 reverse!：避免旧实现每层节点 append 复制子树结果（O(N*树深)）。
+;; 累加列表全部由本函数 cons 出来，reverse! 就地反转是安全的。
+
 (define-public (tree-search t pred?)
-  (with me
-    (if (pred? t) (list t) '())
-    (if (tree-atomic? t)
-      me
-      (append me (append-map (cut tree-search <> pred?) (tree-children t)))
-    ) ;if
-  ) ;with
+  (define (visit-sub t acc)
+    (with acc1
+      (if (pred? t) (cons t acc) acc)
+      (if (tree-atomic? t)
+        acc1
+        (let loop
+          ((cs (tree-children t)) (acc2 acc1))
+          (if (null? cs) acc2 (loop (cdr cs) (visit-sub (car cs) acc2)))
+        ) ;let
+      ) ;if
+    ) ;with
+  ) ;define
+  (reverse! (visit-sub t '()))
 ) ;define-public
 
 (define (prepend-index l i)

--- a/devel/1187.md
+++ b/devel/1187.md
@@ -63,3 +63,31 @@
 
 ### 涉及文件
 - `TeXmacs/progs/kernel/library/tree-test.scm`
+
+## 2026-08-08 tree-search 改为累加器实现
+
+### What
+`tree-search` 从「每层节点 `(append me (append-map ...))`」改为
+「先序遍历累加器 cons + 末尾一次 `reverse!`」。
+
+### Why
+旧实现叶子匹配项的 cons 链每经过一层祖先就被 `append` 复制一遍，
+复杂度 O(N × 树深)，且每层都走 `append-map` 的双重 `apply`。
+
+### How
+内部 `visit-sub` 递归携带累加器：节点命中即 `cons` 到累加器头部，
+子节点按从左到右顺序依次处理，最终 `reverse!` 一次得到文档顺序。
+累加列表全部细胞由本函数分配，`reverse!` 就地反转安全。
+子节点正序遍历即可（靠末尾 reverse! 归位），不需要先 reverse 子列表——
+初版曾误加，被 tree-test 的顺序用例当场抓住。
+
+### 性能（release 构建，本机，三次运行取范围）
+- deep(200) x50：346 → 225–246 msec（约 -30%）
+- wide(500) x50：1376 → 946–985 msec（约 -30%）
+
+### 验证
+- `xmake r tree-test`：20 correct / 0 failed（含顺序、根匹配身份、纯函数性）
+- 回归：`xmake r list-test` 64/64，`xmake r menu-test` 15/15
+
+### 涉及文件
+- `TeXmacs/progs/kernel/library/tree.scm`

--- a/devel/1187.md
+++ b/devel/1187.md
@@ -39,3 +39,27 @@
 
 ### 涉及文件
 - `TeXmacs/progs/kernel/library/tree-test.scm`（新增）
+
+## 2026-08-08 tree-test.scm 增加性能基准
+
+### What
+在 `regtest-tree` 末尾追加 `bench-tree-search`：两种典型树形各跑 50 轮
+`tree-search`，用 `texmacs-time` 打印耗时。
+
+### Why
+为后续累加器优化提供可对比的基线数字。
+
+### How
+- 深链树：200 层 `emph` 嵌套（匹配 200 个），模拟深层递归场景；
+- 宽文档：500 个 `frac` 子节点的 document（匹配 500 个），模拟大段落场景；
+- 只打印耗时、不断言上限，避免慢机器误报；匹配数量仍走 check 保证规模正确。
+
+### 基线（优化前，release 构建，本机）
+- `bench tree-search deep(200) x50`: 346 msec
+- `bench tree-search wide(500) x50`: 1376 msec
+
+### 验证
+`xmake r tree-test`：20 correct / 0 failed，基准正常打印。
+
+### 涉及文件
+- `TeXmacs/progs/kernel/library/tree-test.scm`

--- a/devel/1187.md
+++ b/devel/1187.md
@@ -1,0 +1,41 @@
+# 1187 tree-search 性能优化：先补单元测试
+
+## 背景
+
+`TeXmacs/progs/kernel/library/tree.scm` 的 `tree-search` 在编辑热路径上被大量调用
+（`ref-edit.scm` 标签/引用解析 7 处、`table-edit`、`math-edit`、`generic-edit` 等，
+全项目 tree-search 家族约 110 处出现）。当前实现每个内部节点都执行
+`(append me (append-map ...))`，叶子匹配项的 cons 链每经过一层祖先就被复制一遍，
+复杂度 O(N × 树深)；内部的 `append-map`（`list.scm:237`）还有中间列表 + 双重
+`apply` 的常数开销（源码自带 `WARNING: not portable for long lists`）。
+
+优化方向：累加器 + 末尾一次 `reverse`，降到 O(N)，契约（返回文档顺序的新列表）不变。
+
+## 2026-08-08 为 tree-search 补 Scheme 纯逻辑单元测试
+
+### What
+新增 `TeXmacs/progs/kernel/library/tree-test.scm`，在动实现之前先把
+`tree-search` 的现有行为契约固化成回归测试。
+
+### Why
+后续要把递归 append 实现改成累加器实现，需要测试保证语义（结果列表内容、
+文档顺序、纯函数性）不变。
+
+### How
+参照同目录 `list-test.scm` 的模式：`(load "./TeXmacs/progs/kernel/library/tree.scm")`，
+用 `(liii check)` 断言，`(regtest-tree)` 入口，headless 运行。
+覆盖用例：
+- 基本匹配：扁平 document 中按 label 搜索多个匹配；
+- 顺序：结果按文档顺序（先序遍历：先父后子、子节点从左到右）；
+- 根匹配：根本身满足谓词时排在结果首位；
+- 嵌套匹配：外层和内层同时匹配时两者都返回，外层在前；
+- 无匹配返回 `'()`；
+- 原子树输入：匹配/不匹配两种情形；
+- 空复合树（无子节点）输入；
+- 纯函数性：搜索后输入树内容不变，且返回列表可被调用方独占修改。
+
+### 验证
+`xmake b stem && xmake r tree-test` 全部 check 通过。
+
+### 涉及文件
+- `TeXmacs/progs/kernel/library/tree-test.scm`（新增）


### PR DESCRIPTION
## What
`kernel/library/tree.scm` 的 `tree-search` 从逐层 `(append me (append-map ...))` 改为「累加器 cons + 末尾一次 `reverse!`」，并配套补齐测试与性能基准。

## Why
旧实现中叶子匹配项的 cons 链每经过一层祖先就被 `append` 复制一遍（O(N × 树深)），且每层走 `append-map` 的双重 `apply`。`tree-search` 家族全项目约 110 处出现，位于 ref-edit 标签/引用解析、table/math/generic-edit 等编辑热路径。

## How（4 步小 commit）
1. `devel/1187.md` 任务文档
2. 新增 `kernel/library/tree-test.scm`：18 项 check 固化现有行为契约（文档顺序、嵌套匹配先外后内、根匹配 `eq?` 身份、纯函数性等）
3. 追加性能基准：deep(200)/wide(500) 两种树形各 50 轮，记录优化前基线
4. 实现改造：子节点正序遍历 + 命中 cons + 一次 `reverse!`（累加列表全为新分配细胞，就地反转安全）

## 性能（release，本机）
| 基准 | 优化前 | 优化后 |
|------|--------|--------|
| deep(200) x50 | 346 msec | 225–246 msec（约 -30%）|
| wide(500) x50 | 1376 msec | 946–985 msec（约 -30%）|

## 验证
- `xmake r tree-test`：20 correct / 0 failed
- 回归：`xmake r list-test` 64/64、`xmake r menu-test` 15/15
- 注：初版曾把子节点遍历方向写反，被第 2 步固化的顺序用例当场捕获

🤖 Generated with [Claude Code](https://claude.com/claude-code)