### PR TITLE
[1188] lolly replace 小修：整段拷贝 + 空模式守卫

### DIFF
--- a/devel/1188.md
+++ b/devel/1188.md
@@ -1,0 +1,34 @@
+# 1188 lolly replace 小修：整段拷贝 + 空模式守卫
+
+## 背景
+
+lolly 的 `replace`（`lolly/Kernel/Types/analyze.cpp:899`）经
+`src/Scheme/L2/glue_lolly.lua` 以 `string-replace` 暴露给 Scheme，
+mogan 全项目约 120 个调用点。现状两个问题：
+
+1. 未命中区段逐字符 `r << s[i]` 拷贝，命中之间的长区段没有批量拷贝；
+2. `what` 为空串时 `i += N (what)` 步进为 0，死循环（目前靠调用方自觉不传空串）。
+
+## 2026-08-08 实现
+
+### What
+
+- `replace` 空 `what` 时原样返回 `s`；
+- 未命中区段改为记录起点、命中时整段 `s(start, i)` 拷贝。
+
+### Why
+
+消除逐字符 append 的常数开销；堵死空模式死循环隐患。
+
+### How
+
+- 行为契约变化仅一处：`replace (s, "", by)` 由死循环变为返回 `s`
+  （与 `contains (s, "") == true` 的现状不冲突，替换语义选「空模式不匹配任何位置」）。
+- 先补 `lolly/tests/Kernel/Types/analyze_test.cpp` 的 `replace` 用例
+  （无命中、首尾命中、相邻命中、空替换串、空模式守卫），再改实现。
+- 注意：空模式用例在旧实现上会死循环，无法用于「改前红」验证，只能改后验证。
+
+### 涉及文件
+
+- `lolly/Kernel/Types/analyze.cpp`
+- `lolly/tests/Kernel/Types/analyze_test.cpp`

--- a/lolly/Kernel/Types/analyze.cpp
+++ b/lolly/Kernel/Types/analyze.cpp
@@ -897,17 +897,20 @@ overlapping (string s1, string s2) {
 
 string
 replace (string s, string what, string by) {
-  int    i, n= N (s);
+  int i, n= N (s), k= N (what);
+  // 空模式按「不匹配任何位置」处理，否则下方 i+= k 步进为 0 会死循环
+  if (k == 0) return s;
   string r;
+  int    start= 0;
   for (i= 0; i < n;)
     if (test (s, i, what)) {
+      r << s (start, i);
       r << by;
-      i+= N (what);
+      i+= k;
+      start= i;
     }
-    else {
-      r << s[i];
-      i++;
-    }
+    else i++;
+  r << s (start, n);
   return r;
 }
 

--- a/lolly/tests/Kernel/Types/analyze_test.cpp
+++ b/lolly/tests/Kernel/Types/analyze_test.cpp
@@ -163,6 +163,22 @@ TEST_CASE ("contains/occurs") {
 TEST_CASE ("replace") {
   CHECK_EQ (replace ("a-b", "-", "_") == "a_b", true);
   CHECK_EQ (replace ("a-b-c", "-", "_") == "a_b_c", true);
+  // 无命中：内容不变
+  CHECK_EQ (replace ("abc", "-", "_") == "abc", true);
+  CHECK_EQ (replace ("", "-", "_") == "", true);
+  // 首尾命中与相邻命中
+  CHECK_EQ (replace ("-a-", "-", "_") == "_a_", true);
+  CHECK_EQ (replace ("a--b", "-", "_") == "a__b", true);
+  // 替换串比模式长/短/为空
+  CHECK_EQ (replace ("a-b", "-", "<->") == "a<->b", true);
+  CHECK_EQ (replace ("a<->b", "<->", "-") == "a-b", true);
+  CHECK_EQ (replace ("a-b", "-", "") == "ab", true);
+  // 多字符模式不重叠匹配：从左到右，命中后跳过整个模式
+  CHECK_EQ (replace ("aaaa", "aa", "b") == "bb", true);
+  CHECK_EQ (replace ("aaa", "aa", "b") == "ba", true);
+  // 空模式守卫：原样返回，不死循环
+  CHECK_EQ (replace ("abc", "", "_") == "abc", true);
+  CHECK_EQ (replace ("", "", "_") == "", true);
 }
 
 TEST_CASE ("tokenize") {


### PR DESCRIPTION
## What

lolly `replace`（`lolly/Kernel/Types/analyze.cpp`）两个小修：

1. 未命中区段由逐字符 `r << s[i]` 改为记录起点、命中时整段 `s(start, i)` 拷贝；
2. 空 `what` 守卫：原样返回 `s`，堵死 `i += 0` 死循环隐患。

## Why

`replace` 经 glue 以 `string-replace` 暴露给 Scheme，mogan 全项目约 120 个调用点。逐字符 append 有常数开销；空模式死循环目前靠调用方自觉规避。

## 语义变化

`replace(s, "", by)` 由死循环变为返回 `s`（「空模式不匹配任何位置」）。其余行为不变，详见 `devel/1188.md`。

## 测试

- 测试先行：`analyze_test.cpp` 的 `replace` 用例从 2 个扩到 12 个（无命中、空串、首尾/相邻命中、替换串长/短/空、多字符模式不重叠匹配、空模式守卫）
- `xmake test "lolly_tests/*"` 全绿（34 个测试二进制）
- `gf fmt --changed-since=main` 无改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)