### PR TITLE
[1185] chat_init 540→415 ms:计时盲区探针定位 + message 嵌入编辑器懒创建

### DIFF
--- a/devel/1185.md
+++ b/devel/1185.md
@@ -358,3 +358,20 @@ QAction 命令不是 release 里同步触发,而是排队到下一次 `update()`
 - `src/Plugins/Qt/QTMTabPage.{hpp,cpp}`(release dispatch 探针)
 - `src/Plugins/Qt/qt_gui.cpp`(gui update + delayed/queued/repaint 子段)
 - `src/Plugins/Qt/qt_chat_tab_widget.cpp`(first paint 探针)
+
+### p5 二轮实测(GUI,2026-08-08,`chat_init` 512 ms)
+
+子段归因后结构清晰:`update/queued` 46 ms(切 view 全链路:resume →
+createView → sync_chat_tab_mode 都在这一条队列事件里)+ `update/repaint`
+398 ms。repaint 内除 icons1-mode 的 130 ms 外,仍有 ~200 ms 空档
+(19.276→19.367→19.491,三次 typeset 均 0 ms,排版不慢)。
+
+二轮补三个探针继续定位空档:
+
+- `chat_init: update/interpose` / `chat_init: update/repaint_all`:
+  拆开原 `update/repaint`(interpose handler = 逐 view `apply_changes`
+  + `windows_refresh`;repaint_all = 逐可见 canvas 重绘)。
+- `apply_changes: <buffer>`(`tm_server_rep::interpose_handler`,逐 view,
+  ≥10ms 打印):定位空档属于哪个 buffer 的 apply_changes。
+- `repaint_invalid_regions`(`repaint_all` 内逐 widget,≥10ms 打印):
+  定位是否为 canvas 实际绘制(首次字体缓存等)耗时。

--- a/devel/1185.md
+++ b/devel/1185.md
@@ -375,3 +375,27 @@ createView → sync_chat_tab_mode 都在这一条队列事件里)+ `update/repai
   ≥10ms 打印):定位空档属于哪个 buffer 的 apply_changes。
 - `repaint_invalid_regions`(`repaint_all` 内逐 widget,≥10ms 打印):
   定位是否为 canvas 实际绘制(首次字体缓存等)耗时。
+
+### p5 三轮:message 嵌入编辑器懒创建(消除不存在 buffer 的 104ms apply_changes)
+
+三轮实测确认 `apply_changes: tmfs://chat/<sid>/message` 每次都花
+~100ms,但首次点击 Chat 标签页只展示 welcome + 输入框,消息区
+`messageFrame_` 一直 hide——`ChatConversationPanel::setup_ui` 无条件
+`texmacs_input_widget` 创建 message 嵌入编辑器,为一个不可见、空会话
+下本不存在的 buffer 支付 editor/view/typeset/apply_changes 全链路成本。
+
+**改动**:message 编辑器懒创建——
+
+- `setup_ui` 只创建 `messageFrame_` 容器(保持 hide),不再创建嵌入编辑器;
+- 新增 `ChatConversationPanel::ensureMessageWidget()`(幂等),在
+  `enterConversationMode()` 开头调用;
+- 关键陷阱:`texmacs_input_widget` 对已存在 buffer 会
+  `set_buffer_tree` 整体覆盖(tm_window.cpp),而 scheme 侧
+  (chat-persist 恢复 / chat-tab-send 首轮)可能已写入内容——
+  `ensureMessageWidget` 先读 `get_buffer_body`,以现有内容初始化,
+  避免覆盖;
+- 安全性:`get_buffer_body`/`pretend_buffer_saved` 对不存在 buffer
+  均安全返回;`chat-persist-load-session-content` 在 message.tmu
+  不存在时不触碰 buffer。
+
+**涉及文件**:`src/Plugins/Qt/qt_chat_tab_widget.{hpp,cpp}`

--- a/devel/1185.md
+++ b/devel/1185.md
@@ -399,3 +399,16 @@ createView → sync_chat_tab_mode 都在这一条队列事件里)+ `update/repai
   不存在时不触碰 buffer。
 
 **涉及文件**:`src/Plugins/Qt/qt_chat_tab_widget.{hpp,cpp}`
+
+**效果验证(GUI 实测,2026-08-08)**:`chat_init` 518→415 ms(-103 ms),
+`apply_changes: .../message` 行从日志消失,符合预期。当前构成:
+
+| 段 | 耗时 |
+|---|---|
+| `update/queued`(切 view 全链路) | 30 ms |
+| `apply_changes: .../input` | 271 ms(icons1-mode 135 + 前置段 ~130) |
+| `update/repaint_all`(canvas 首绘) | ~50 ms |
+| 其余 | ~60 ms |
+
+剩余热点:input buffer apply_changes 的前置段(~130 ms,typeset 前)
+与 icons1-mode 首次构建(135 ms)。

--- a/devel/1185.md
+++ b/devel/1185.md
@@ -294,3 +294,67 @@ p1 → p3 累计耗时减少(p2 未单独计时,收益并入整体):
 剩余最大单项是 `icons1-mode` 的首次构建(menu-expand + widget/图标),
 为一次性成本,聚焦普通文本 buffer 时同样要付;后续可考虑细分
 menu-expand 与 make_menu_widget 的占比再决定优化方向。
+
+## p5:chat_init 计时盲区补探针 + 日志降噪(<10ms 不打印)
+
+## What(p5)
+
+1. **移除三个稳定 <10ms 的子段探针**:`chat_init: load/use-modules`、
+   `chat_init: load/persist-load-all`、`chat_init: new QTChatTabWidget`
+   (外层 `load chat modules` / `createView` 仍覆盖这些区间)。
+2. **新增探针闭合计时盲区**(均由 `isInitBenchPending` 守卫,仅在
+   chat_init 窗口内输出):
+   - `chat_init: release dispatch`(`QTMTabPage::mouseReleaseEvent`,
+     新增 override):覆盖 release 派发内的 QAction 触发。
+   - `chat_init: gui update`(`qt_gui_rep::update` 整体)及三个子段
+     `update/delayed`(delayed 命令)、`update/queued`(每条队列事件
+     单独计时)、`update/repaint`(interpose + `repaint_all`)。
+   - `chat_init: first paint`(`QTChatTabWidget::paintEvent`)。
+3. **日志降噪**:chat_init 相关探针统一 `bench_end (..., 10)`——
+   实际耗时 <10ms 不打印;`gui update` 每个 chat_init 窗口内首次必打
+   (静态标志在窗口结束后复位),后续同样 <10ms 不打印。
+
+## Why(p5)
+
+p4 后 `chat_init` 约 499 ms,但已埋点子段合计仅 ~210 ms,约 290 ms
+盲区;且 0~6 ms 的小段日志刷屏,干扰阅读。
+
+## p5 首轮实测发现(GUI,2026-08-08)
+
+首轮探针日志的关键事实:**release dispatch 仅 1 ms,整个 chat_init
+几乎都发生在随后一次 `gui update` 调用内(525 ms)**——tab 的
+QAction 命令不是 release 里同步触发,而是排队到下一次 `update()`
+的队列事件处理中执行。此前的"盲区"全部在这次 update 内部:
+
+| 时刻 | 事件 |
+|---|---|
+| 02.537 | `gui update` 开始(525 ms) |
+| 02.540 | resume(2 ms) |
+| 02.551 | load chat modules(11 ms) |
+| 02.572 | activate session(13)/ createView(32) |
+| 02.588 | sync_chat_tab_mode(48) |
+| 02.591 | typeset 0 / update_menus chat-tab 0 |
+| 02.591→02.707 | **空档 116 ms**,typeset 1 ms |
+| 02.707→02.858 | **空档 151 ms**,typeset 0 |
+| 02.858→03.002 | update_menus input(icons1-mode,144 ms) |
+| 03.004→03.048 | **空档 44 ms**,first paint |
+| 03.049 | chat_init 结束(605 ms) |
+| 03.062 | gui update 结束 |
+
+三段空档(116+151+44 ≈ 311 ms)都在 update 的队列事件/重绘处理内、
+既有探针之外——故补 `update/delayed`、`update/queued`、`update/repaint`
+三个子段继续定位。
+
+## How(p5)
+
+- 新探针统一 `chat_init: ` 前缀 + `QTChatTabWidget::isInitBenchPending ()`
+  守卫,与既有子段风格一致;`bench_end` 阈值 10 ms 抑制小段输出。
+- `gui update` 的 bench_end 放在 `repaint_all` 之后、函数尾部提前
+  return 之前,避免计时栈泄漏;`update/queued` 按事件逐条计时。
+
+## 涉及文件(p5)
+
+- `src/Plugins/Qt/qt_chat_controller.cpp`(删 3 个小探针)
+- `src/Plugins/Qt/QTMTabPage.{hpp,cpp}`(release dispatch 探针)
+- `src/Plugins/Qt/qt_gui.cpp`(gui update + delayed/queued/repaint 子段)
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`(first paint 探针)

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -373,6 +373,17 @@ QTMTabPage::mousePressEvent (QMouseEvent* e) {
 }
 
 void
+QTMTabPage::mouseReleaseEvent (QMouseEvent* e) {
+  // chat tab 的 release 派发内含 QAction 触发与同步切 view 全链路；
+  // beginInitBench 到此处起点之间即按下→抬起的间隔，不计入任何子段
+  bool benching=
+      is_chat_tab_view (m_viewUrl) && QTChatTabWidget::isInitBenchPending ();
+  if (benching) bench_start ("chat_init: release dispatch");
+  QToolButton::mouseReleaseEvent (e);
+  if (benching) bench_end ("chat_init: release dispatch", 10);
+}
+
+void
 QTMTabPage::mouseMoveEvent (QMouseEvent* e) {
   m_hoverOnCloseArea= isPointerOnCloseArea (e->pos ());
   updateCloseButtonVisibility ();

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -69,6 +69,7 @@ protected:
   virtual bool eventFilter (QObject* watched, QEvent* event) override;
   virtual void resizeEvent (QResizeEvent* e) override;
   virtual void mousePressEvent (QMouseEvent* e) override;
+  virtual void mouseReleaseEvent (QMouseEvent* e) override;
   virtual void mouseMoveEvent (QMouseEvent* e) override;
   virtual void enterEvent (QEnterEvent* e) override;
   virtual void leaveEvent (QEvent* e) override;

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -59,12 +59,8 @@ ChatController::createView (QWidget* parent, qt_tm_widget_rep* tm) {
   // llm 插件按 idle 延迟初始化，新建 Chat 标签页时其 scheme 模块可能尚未加载
   bool benching= QTChatTabWidget::isInitBenchPending ();
   if (benching) bench_start ("chat_init: load chat modules");
-  if (benching) bench_start ("chat_init: load/use-modules");
   eval ("(use-modules (llm chat-list))");
-  if (benching) bench_end ("chat_init: load/use-modules");
-  if (benching) bench_start ("chat_init: load/persist-load-all");
   call ("chat-persist-load-all");
-  if (benching) bench_end ("chat_init: load/persist-load-all");
   if (benching) bench_end ("chat_init: load chat modules");
   cout << "[chat-persist] ChatController: restored "
        << sessionManager_.sessionCount () << " session metadatas" << LF;
@@ -82,9 +78,7 @@ ChatController::createView (QWidget* parent, qt_tm_widget_rep* tm) {
   }
 
   // 3. 创建 View，Sidebar 构造时就有数据
-  if (benching) bench_start ("chat_init: new QTChatTabWidget");
   view_= new QTChatTabWidget (infos, initialId, parent);
-  if (benching) bench_end ("chat_init: new QTChatTabWidget");
   view_->setParentTmWidget (tm);
 
   // 连接 Sidebar 信号

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -1682,10 +1682,13 @@ QTChatTabWidget::setGlobalSidebarCollapsed (bool collapsed) {
 
 void
 QTChatTabWidget::paintEvent (QPaintEvent* event) {
-  QWidget::paintEvent (event);
   // 点击 Chat 标签页后的首次绘制视为渲染完成，结束 chat_init 计时
-  if (initBenchPending_) {
+  bool benching= initBenchPending_;
+  if (benching) bench_start ("chat_init: first paint");
+  QWidget::paintEvent (event);
+  if (benching) {
     initBenchPending_= false;
+    bench_end ("chat_init: first paint", 10);
     bench_end ("chat_init");
   }
 }

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -199,16 +199,8 @@ ChatConversationPanel::setup_ui () {
   topLayout->addWidget (sessionTitle_, 0, Qt::AlignHCenter);
   topLayout->addSpacing (DpiUtils::scaled (kTitleToMessageSpacing));
 
-  // Message area
-  qreal chatZoom= DpiUtils::scaled (100) / 100.0;
-  messageWidget_= texmacs_input_widget (
-      tree (WITH, "font", "sys-chinese", "zoom-factor", as_string (chatZoom),
-            tree (DOCUMENT, "")),
-      compound (kChatEmbeddedStyle, tuple ("generic")), msgBufferUrl_);
-  set_zoom_factor (messageWidget_, chatZoom);
-
-  QWidget* messageQWidget= concrete (messageWidget_)->as_qwidget ();
-  messageFrame_          = new QWidget (topPanel);
+  // Message area（容器先行、嵌入编辑器懒创建，见 ensureMessageWidget）
+  messageFrame_= new QWidget (topPanel);
   messageFrame_->setObjectName ("chat-tab-message-frame");
   messageFrame_->setStyleSheet (
       QString ("border: none; border-radius: %1px;")
@@ -216,30 +208,11 @@ ChatConversationPanel::setup_ui () {
   QVBoxLayout* messageFrameLayout= new QVBoxLayout (messageFrame_);
   messageFrameLayout->setContentsMargins (0, 0, 0, 0);
   messageFrameLayout->setSpacing (0);
-  messageQWidget->setParent (messageFrame_);
-  messageQWidget->setMinimumHeight (DpiUtils::scaled (kMessageMinHeight));
-  // Ignored: 忽略 TeXmacs widget 返回的屏幕尺寸 sizeHint，
-  // 避免在 dock 模式下窗口被向下拉伸。
-  messageQWidget->setSizePolicy (QSizePolicy::Preferred, QSizePolicy::Ignored);
-  {
-    QAbstractScrollArea* msgArea=
-        messageQWidget->findChild<QAbstractScrollArea*> ();
-    if (msgArea) {
-      msgArea->setHorizontalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
-      msgArea->setVerticalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
-      msgArea->viewport ()->setBackgroundRole (QPalette::Base);
-    }
-    QTMWidget* msgEditor= messageQWidget->findChild<QTMWidget*> ();
-    if (msgEditor) {
-      msgEditor->setProperty ("chat_message_readonly", true);
-      msgEditor->installEventFilter (this);
-    }
-  }
-  messageFrameLayout->addWidget (messageQWidget);
   messageFrame_->hide ();
   topLayout->addWidget (messageFrame_, 1);
 
   // Input area
+  qreal    chatZoom = DpiUtils::scaled (100) / 100.0;
   QWidget* inputArea= new QWidget (topPanel);
   inputArea->setObjectName ("chat-tab-input-area-wrap");
   inputArea->setSizePolicy (QSizePolicy::Expanding, QSizePolicy::Preferred);
@@ -346,9 +319,47 @@ ChatConversationPanel::setup_ui () {
 }
 
 void
+ChatConversationPanel::ensureMessageWidget () {
+  if (!is_nil (messageWidget_) || !messageFrame_) return;
+  // message buffer 可能已被 scheme 侧写入内容（恢复的消息 / 首个问答轮）；
+  // texmacs_input_widget 对已存在 buffer 会 set_buffer_tree 整体覆盖，
+  // 故必须以现有 body 初始化
+  tree body= tree (DOCUMENT, "");
+  if (contains (msgBufferUrl_, get_all_buffers ()))
+    body= get_buffer_body (msgBufferUrl_);
+  qreal chatZoom= DpiUtils::scaled (100) / 100.0;
+  messageWidget_= texmacs_input_widget (
+      tree (WITH, "font", "sys-chinese", "zoom-factor", as_string (chatZoom),
+            body),
+      compound (kChatEmbeddedStyle, tuple ("generic")), msgBufferUrl_);
+  set_zoom_factor (messageWidget_, chatZoom);
+
+  QWidget* messageQWidget= concrete (messageWidget_)->as_qwidget ();
+  messageQWidget->setParent (messageFrame_);
+  messageQWidget->setMinimumHeight (DpiUtils::scaled (kMessageMinHeight));
+  // Ignored: 忽略 TeXmacs widget 返回的屏幕尺寸 sizeHint，
+  // 避免在 dock 模式下窗口被向下拉伸。
+  messageQWidget->setSizePolicy (QSizePolicy::Preferred, QSizePolicy::Ignored);
+  QAbstractScrollArea* msgArea=
+      messageQWidget->findChild<QAbstractScrollArea*> ();
+  if (msgArea) {
+    msgArea->setHorizontalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
+    msgArea->setVerticalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
+    msgArea->viewport ()->setBackgroundRole (QPalette::Base);
+  }
+  QTMWidget* msgEditor= messageQWidget->findChild<QTMWidget*> ();
+  if (msgEditor) {
+    msgEditor->setProperty ("chat_message_readonly", true);
+    msgEditor->installEventFilter (this);
+  }
+  messageFrame_->layout ()->addWidget (messageQWidget);
+}
+
+void
 ChatConversationPanel::enterConversationMode () {
   if (conversationMode_) return;
 
+  ensureMessageWidget ();
   conversationMode_  = true;
   const int endOffset= DpiUtils::scaled (kConversationTopOffsetY);
 

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -72,6 +72,15 @@ public:
   void enterConversationMode ();
 
   /**
+   * @brief 按需创建消息区嵌入编辑器（幂等）。
+   *
+   * welcome 阶段只展示输入框，message 嵌入编辑器推迟到进入对话模式时
+   * 才创建，避免空会话为不可见编辑器支付 buffer/view/typeset 成本。
+   * buffer 中可能已有 scheme 侧写入的内容，创建时以现有 body 初始化。
+   */
+  void ensureMessageWidget ();
+
+  /**
    * @brief 聚焦到输入区域。
    */
   void focusInput ();

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -977,8 +977,9 @@ qt_gui_rep::update () {
   timeout_time= texmacs_time () + time_credit;
 
   if (!postpone_treatment) {
-    if (bench_chat_init) bench_start ("chat_init: update/repaint");
+    if (bench_chat_init) bench_start ("chat_init: update/interpose");
     if (the_interpose_handler) the_interpose_handler ();
+    if (bench_chat_init) bench_end ("chat_init: update/interpose", 10);
 #ifdef LORO_ENABLED
     static time_t last_loro_poll_time= 0;
     if (now - last_loro_poll_time >= 1000 / 6) {
@@ -987,8 +988,9 @@ qt_gui_rep::update () {
       last_loro_poll_time= now;
     }
 #endif
+    if (bench_chat_init) bench_start ("chat_init: update/repaint_all");
     qt_simple_widget_rep::repaint_all ();
-    if (bench_chat_init) bench_end ("chat_init: update/repaint", 10);
+    if (bench_chat_init) bench_end ("chat_init: update/repaint_all", 10);
   }
   if (bench_chat_init) {
     bench_end ("chat_init: gui update", gui_update_logged ? 10 : 0);

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -31,6 +31,7 @@
 #include "loro_collab.hpp"
 #endif
 
+#include "qt_chat_tab_widget.hpp" // for QTChatTabWidget::isInitBenchPending
 #include "qt_gui.hpp"
 #include "qt_renderer.hpp" // for the_qt_renderer
 #include "qt_simple_widget.hpp"
@@ -908,6 +909,13 @@ qt_gui_rep::update () {
   updatetimer->stop ();
   updating= true;
 
+  // chat_init 窗口内的 update 计时：窗口内首次必打，后续 <10ms 不打印。
+  // delayed 命令 + 队列事件 + 重绘全在里面，再细分子段定位
+  bool        bench_chat_init  = QTChatTabWidget::isInitBenchPending ();
+  static bool gui_update_logged= false;
+  if (!bench_chat_init) gui_update_logged= false;
+  if (bench_chat_init) bench_start ("chat_init: gui update");
+
   static int count_events   = 0;
   static int max_proc_events= 40;
 
@@ -936,7 +944,11 @@ qt_gui_rep::update () {
   // 2.
   // Manage delayed commands
 
-  if (delayed_commands.must_wait (now)) process_delayed_commands ();
+  if (delayed_commands.must_wait (now)) {
+    if (bench_chat_init) bench_start ("chat_init: update/delayed");
+    process_delayed_commands ();
+    if (bench_chat_init) bench_end ("chat_init: update/delayed", 10);
+  }
 
   // 3.
   // If there are pending events in the private queue process them until the
@@ -949,7 +961,9 @@ qt_gui_rep::update () {
   }
   else
     while (waiting_events.size () > 0 && count_events < max_proc_events) {
+      if (bench_chat_init) bench_start ("chat_init: update/queued");
       process_queued_events (1);
+      if (bench_chat_init) bench_end ("chat_init: update/queued", 10);
       count_events++;
       // if (the_interpose_handler) the_interpose_handler();
     }
@@ -963,6 +977,7 @@ qt_gui_rep::update () {
   timeout_time= texmacs_time () + time_credit;
 
   if (!postpone_treatment) {
+    if (bench_chat_init) bench_start ("chat_init: update/repaint");
     if (the_interpose_handler) the_interpose_handler ();
 #ifdef LORO_ENABLED
     static time_t last_loro_poll_time= 0;
@@ -973,6 +988,11 @@ qt_gui_rep::update () {
     }
 #endif
     qt_simple_widget_rep::repaint_all ();
+    if (bench_chat_init) bench_end ("chat_init: update/repaint", 10);
+  }
+  if (bench_chat_init) {
+    bench_end ("chat_init: gui update", gui_update_logged ? 10 : 0);
+    gui_update_logged= true;
   }
 
   if (waiting_events.size () > 0) needing_update= true;

--- a/src/Plugins/Qt/qt_simple_widget.cpp
+++ b/src/Plugins/Qt/qt_simple_widget.cpp
@@ -635,8 +635,11 @@ qt_simple_widget_rep::repaint_all () {
   iterator<pointer> i= iterate (qt_simple_widget_rep::all_widgets);
   while (i->busy ()) {
     qt_simple_widget_rep* w= static_cast<qt_simple_widget_rep*> (i->next ());
-    if (w->canvas () && w->canvas ()->isVisible ())
+    if (w->canvas () && w->canvas ()->isVisible ()) {
+      bench_start ("repaint_invalid_regions");
       w->repaint_invalid_regions ();
+      bench_end ("repaint_invalid_regions", 10);
+    }
   }
 }
 

--- a/src/Texmacs/Server/tm_server.cpp
+++ b/src/Texmacs/Server/tm_server.cpp
@@ -26,6 +26,7 @@
 #include "socket_notifier.hpp"
 #include "sys_utils.hpp"
 #include "tm_configure.hpp"
+#include "tm_debug.hpp"
 #include "tm_link.hpp"
 #include "tm_sys_utils.hpp"
 #include "tmfs_url.hpp"
@@ -222,7 +223,12 @@ tm_server_rep::interpose_handler () {
 
       for (j= 0; j < N (buf->vws); j++) {
         tm_view vw= (tm_view) buf->vws[j];
-        if (vw->win != NULL) vw->ed->apply_changes ();
+        if (vw->win != NULL) {
+          string btask= "apply_changes: " * as_string (vw->buf->buf->name);
+          bench_start (btask);
+          vw->ed->apply_changes ();
+          bench_end (btask, 10);
+        }
         vw->ed->set_user_active (false);
       }
 


### PR DESCRIPTION
## What

1. **chat_init 计时盲区探针**:`release dispatch` / `gui update`(及 `update/queued`、`update/interpose`、`update/repaint_all` 子段) / `first paint`,均由 `isInitBenchPending` 守卫;新增 `apply_changes: <buffer>`、`repaint_invalid_regions` 通用探针。
2. **日志降噪**:chat_init 相关探针 `bench_end(..., 10)`,实测 <10ms 不打印;移除三个稳定 <10ms 的旧子段;`typeset` 探针加 10ms 阈值。
3. **message 嵌入编辑器懒创建**:探针定位出 `apply_changes: tmfs://chat/<sid>/message` 每次 ~100ms,但首开 Chat 标签页只展示 welcome + 输入框——`setup_ui` 无条件创建不可见的 message 编辑器。改为 `enterConversationMode` 时按需创建(幂等),并以 buffer 现有内容初始化,规避 `texmacs_input_widget` 的 `set_buffer_tree` 覆盖陷阱。

## 效果(GUI 实测)

`chat_init` 540→**415 ms**;本分支探针定位链路:499ms 总耗时 → 单次 `gui update` 525ms → `update/interpose` 374ms → message/input 两个 buffer 的 `apply_changes`。

剩余热点:input buffer apply_changes 前置段(~130 ms)与 icons1-mode 首次构建(135 ms),后续分支跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)