### PR TITLE
[1185] 修复「开启新会话」后消息区误显示

### DIFF
--- a/devel/1185.md
+++ b/devel/1185.md
@@ -412,3 +412,35 @@ createView → sync_chat_tab_mode 都在这一条队列事件里)+ `update/repai
 
 剩余热点:input buffer apply_changes 的前置段(~130 ms,typeset 前)
 与 icons1-mode 首次构建(135 ms)。
+
+## p5_2:修复「开启新会话」后消息区误显示
+
+### What(p5_2)
+
+复用空白会话时,新会话面板应保持 welcome 状态(只有居中的 input
+buffer),但实际消息区也被显示出来。根因是
+`ChatConversationPanel::is_empty_document_body` 对原子空串误判:
+
+- `get_buffer_body` 对不存在的 buffer 返回原子空串 `""`
+  (`new_buffer.cpp`);
+- `is_empty_document_body` 只认 `DOCUMENT` 结构,原子串一律返回
+  `false`(即"非空");
+- 「开启新会话」复用空白会话时走 `activateSession` →
+  `loadSessionContent`,空白会话的 message buffer 不存在 → 误判为非空
+  → `enterConversationMode()` 懒创建空消息编辑器并 show;
+- `conversationMode_` 不可逆,之后每次复用该会话消息区都在。
+
+### How(p5_2)
+
+`is_empty_document_body` 开头增加原子串分支:原子串仅当内容为空时
+视为空文档。一处修改覆盖两个调用点(`loadSessionContent` 的消息判空、
+`onSendRequested` 的输入判空)。
+
+### 涉及文件(p5_2)
+
+- `src/Plugins/Qt/qt_chat_tab_widget.{hpp,cpp}`(修复 + 注释)
+- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp`(回归用例:
+  原子空串视为空、原子非空串不视为空)
+
+**验证**:`xmake r qt_chat_tab_widget_test` 113 全过;GUI 表现待实测。
+

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -441,6 +441,8 @@ ChatConversationPanel::readInputMessage () const {
 
 bool
 ChatConversationPanel::is_empty_document_body (tree body) {
+  // get_buffer_body 对不存在的 buffer 返回原子空串，同样视为空文档
+  if (is_atomic (body)) return body->label == "";
   if (!is_func (body, DOCUMENT)) return false;
   if (N (body) == 0) return true;
   return N (body) == 1 && is_atomic (body[0]) && body[0]->label == "";

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -100,6 +100,8 @@ public:
 
   /**
    * @brief 判断文档体是否为空（仅含一个空字符串的 DOCUMENT 节点）。
+   *
+   * get_buffer_body 对不存在的 buffer 返回原子空串，也视为空。
    * @param body 文档体 tree
    * @return 为空时返回 true
    */

--- a/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_tab_widget_test.cpp
@@ -98,6 +98,18 @@ private slots:
     QVERIFY (!ChatConversationPanel::is_empty_document_body (doc));
   }
 
+  void test_is_empty_document_body_missing_buffer () {
+    // get_buffer_body 对不存在的 buffer 返回原子空串，必须视为空文档，
+    // 否则复用空白会话会被误判有消息而进入对话模式（消息区误显示）
+    tree missing= tree ("");
+    QVERIFY (ChatConversationPanel::is_empty_document_body (missing));
+  }
+
+  void test_is_empty_document_body_atomic_non_empty () {
+    tree atom= tree ("hello");
+    QVERIFY (!ChatConversationPanel::is_empty_document_body (atom));
+  }
+
   // === setSidebarCollapsed / isSidebarCollapsed ===
   void test_setSidebarCollapsed_expand () {
     QList<SessionDisplayInfo> sessions;


### PR DESCRIPTION
## What

修复 LLM 标签页点击「开启新会话」后,消息区被误显示的问题——新会话应保持 welcome 状态,只有居中的 input buffer。

## Why(根因)

- `get_buffer_body` 对不存在的 buffer 返回原子空串 `""`;
- `ChatConversationPanel::is_empty_document_body` 只认 `DOCUMENT` 结构,原子串一律判为"非空";
- 「开启新会话」复用启动时创建的空白会话,走 `activateSession` → `loadSessionContent`,空白会话的 message buffer 不存在 → 误判为有消息 → `enterConversationMode()` 懒创建空消息编辑器并 show;且 `conversationMode_` 不可逆,之后每次复用都在。

## How

`is_empty_document_body` 增加原子串分支:空原子串视为空文档。一处修复覆盖两个调用点(`loadSessionContent` 消息判空、`onSendRequested` 输入判空)。

## 测试

- `tests/Plugins/Qt/qt_chat_tab_widget_test.cpp` 新增 2 个回归用例(原子空串视为空、原子非空串不视为空)
- `xmake r qt_chat_tab_widget_test` 113 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)