### PR TITLE
[1190] 升级内置 Goldfish 到 v18.11.22

### DIFF
--- a/TeXmacs/plugins/goldfish/goldfish/liii/string.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/liii/string.scm
@@ -47,12 +47,7 @@
     ;; ; 基于 SRFI-13 的 string-trim 实现
     (define string-trim-left string-trim)
 
-    (define (string-starts? str prefix)
-      (if (and (string? str) (string? prefix))
-        (string-prefix? prefix str)
-        (type-error "string-starts? parameter is not a string")
-      ) ;if
-    ) ;define
+    (define string-starts? g_string-starts?)
 
     (define string-contains?
       (typed-lambda ((str string?) (sub-str string?)) (string-contains str sub-str))
@@ -60,73 +55,9 @@
 
     (define string-split g_string-split)
 
-    (define (string-replace str old new . rest)
-      (when (> (length rest) 1)
-        (error 'wrong-number-of-args "string-replace: too many arguments")
-      ) ;when
-      (unless (string? str)
-        (type-error "string-replace: str must be a string")
-      ) ;unless
-      (unless (string? old)
-        (type-error "string-replace: old must be a string")
-      ) ;unless
-      (unless (string? new)
-        (type-error "string-replace: new must be a string")
-      ) ;unless
-      (let ((count (if (null? rest) -1 (car rest))))
-        (unless (integer? count)
-          (type-error "string-replace: count must be an integer")
-        ) ;unless
-        (let ((str-len (string-length str)) (old-len (string-length old)))
-          (cond ((zero? count) (string-copy str))
-                ((zero? old-len)
-                 (if (zero? str-len)
-                   new
-                   (let* ((max-inserts (+ str-len 1))
-                          (remaining (if (negative? count) max-inserts (min count max-inserts)))
-                         ) ;
-                     (let loop
-                       ((i 0) (acc '()) (r remaining))
-                       (cond ((and (= i str-len) (> r 0)) (apply string-append (reverse (cons new acc))))
-                             ((= i str-len) (apply string-append (reverse acc)))
-                             ((zero? r) (apply string-append (reverse (cons (substring str i str-len) acc))))
-                             (else (loop (+ i 1) (cons (substring str i (+ i 1)) (cons new acc)) (- r 1)))
-                       ) ;cond
-                     ) ;let
-                   ) ;let*
-                 ) ;if
-                ) ;
-                (else (let ((remaining (if (negative? count) -1 count)))
-                        (let loop
-                          ((search-start 0) (parts '()) (r remaining))
-                          (let ((next-pos (string-position old str search-start)))
-                            (if (and next-pos (not (zero? r)))
-                              (loop (+ next-pos old-len)
-                                (cons new (cons (substring str search-start next-pos) parts))
-                                (- r 1)
-                              ) ;loop
-                              (if (null? parts)
-                                (string-copy str)
-                                (apply string-append
-                                  (reverse (cons (substring str search-start str-len) parts))
-                                ) ;apply
-                              ) ;if
-                            ) ;if
-                          ) ;let
-                        ) ;let
-                      ) ;let
-                ) ;else
-          ) ;cond
-        ) ;let
-      ) ;let
-    ) ;define
+    (define string-replace g_string-replace)
 
-    (define (string-ends? str suffix)
-      (if (and (string? str) (string? suffix))
-        (string-suffix? suffix str)
-        (type-error "string-ends? parameter is not a string")
-      ) ;if
-    ) ;define
+    (define string-ends? g_string-ends?)
 
     (define string-remove-prefix
       (typed-lambda ((str string?) (prefix string?))

--- a/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-13.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-13.scm
@@ -61,55 +61,12 @@
       ) ;cond
     ) ;define
 
-    (define (string-join l . delim+grammer)
-      (define (extract-params params-l)
-        (cond ((null-list? params-l) (list "" 'infix))
-              ((and (= (length params-l) 1) (string? (car params-l)))
-               (list (car params-l) 'infix)
-              ) ;
-              ((and (= (length params-l) 2)
-                 (string? (first params-l))
-                 (symbol? (second params-l))
-               ) ;and
-               params-l
-              ) ;
-              ((> (length params-l) 2)
-               (error 'wrong-number-of-args "optional params in string-join")
-              ) ;
-              (else (error 'type-error "optional params in string-join"))
-        ) ;cond
-      ) ;define
-      ;; 一次性把元素和分隔符交错收集到列表，再交给 string-append 一次完成拼接
-      ;; 避免旧实现每层递归重复拼接后缀导致的 O(n^2) 开销
-      (define (string-join-sub l delim)
-        (cond ((null-list? l) "")
-              ((null? (cdr l)) (car l))
-              (else (let loop
-                      ((rest (cdr l)) (acc (list (car l))))
-                      (if (null? rest)
-                        (apply string-append (reverse acc))
-                        (loop (cdr rest) (cons (car rest) (cons delim acc)))
-                      ) ;if
-                    ) ;let
-              ) ;else
-        ) ;cond
-      ) ;define
-      (let* ((params (extract-params delim+grammer))
-             (delim (first params))
-             (grammer (second params))
-             (ret (string-join-sub l delim))
-            ) ;
-        (case grammer
-         ('infix ret)
-         ('strict-infix
-          (if (null-list? l) (error 'value-error "empty list not allowed") ret)
-         ) ;
-         ('suffix (if (null-list? l) "" (string-append ret delim)))
-         ('prefix (if (null-list? l) "" (string-append delim ret)))
-         (else (error 'value-error "invalid grammer"))
-        ) ;case
-      ) ;let*
-    ) ;define
+    ;; string-join 的 C 实现见 src/liii_string.cpp 的 g_string-join
+    ;; 错误契约与旧 Scheme 实现一致：
+    ;;   type-error "optional params in string-join"（分隔符非字符串或 grammar 非符号）
+    ;;   value-error "invalid grammer"（grammar 非四种之一）
+    ;;   value-error "empty list not allowed"（strict-infix 遇到空列表）
+    (define string-join g_string-join)
 
     (define (string-null? str)
       (if (not (string? str))
@@ -330,18 +287,21 @@
       ) ;let
     ) ;define
 
+    ;; string-prefix?/string-suffix? 复用 C 实现的 g_string-starts?/g_string-ends?
+    ;; （见 src/liii_string.cpp），避免旧实现的 substring 临时分配；
+    ;; 注意参数顺序相反，且错误契约为 wrong-type-arg（区别于 liii 的 type-error）
     (define (string-prefix? prefix str)
-      (let* ((prefix-len (string-length prefix)) (str-len (string-length str)))
-        (and (<= prefix-len str-len) (string=? prefix (substring str 0 prefix-len)))
-      ) ;let*
+      (if (and (string? prefix) (string? str))
+        (g_string-starts? str prefix)
+        (error 'wrong-type-arg "string-prefix?: expected string arguments")
+      ) ;if
     ) ;define
 
     (define (string-suffix? suffix str)
-      (let* ((suffix-len (string-length suffix)) (str-len (string-length str)))
-        (and (<= suffix-len str-len)
-          (string=? suffix (substring str (- str-len suffix-len) str-len))
-        ) ;and
-      ) ;let*
+      (if (and (string? suffix) (string? str))
+        (g_string-ends? str suffix)
+        (error 'wrong-type-arg "string-suffix?: expected string arguments")
+      ) ;if
     ) ;define
 
     (define (string-index str char/pred? . start+end)

--- a/TeXmacs/plugins/goldfish/src/goldfish.hpp
+++ b/TeXmacs/plugins/goldfish/src/goldfish.hpp
@@ -68,7 +68,7 @@
 #include <isocline.h>
 #endif
 
-#define GOLDFISH_VERSION "18.11.21"
+#define GOLDFISH_VERSION "18.11.22"
 
 #define GOLDFISH_PATH_MAXN TB_PATH_MAXN
 

--- a/TeXmacs/plugins/goldfish/src/liii_string.cpp
+++ b/TeXmacs/plugins/goldfish/src/liii_string.cpp
@@ -15,6 +15,8 @@
 //
 
 #include "s7.h"
+#include <cmath>
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -126,6 +128,246 @@ f_string_split (s7_scheme* sc, s7_pointer args) {
   return s7_cdr (head);
 }
 
+enum class string_join_grammar { infix, strict_infix, suffix, prefix };
+
+static s7_pointer
+f_string_join (s7_scheme* sc, s7_pointer args) {
+  s7_pointer l   = s7_car (args);
+  s7_pointer rest= s7_cdr (args);
+
+  std::string delim;
+  if (!s7_is_null (sc, rest)) {
+    s7_pointer delim_arg= s7_car (rest);
+    if (!s7_is_string (delim_arg)) {
+      return liii_string_type_error (sc, "optional params in string-join", delim_arg);
+    }
+    delim.assign (s7_string (delim_arg), (size_t) s7_string_length (delim_arg));
+    rest= s7_cdr (rest);
+  }
+
+  string_join_grammar grammar      = string_join_grammar::infix;
+  bool                grammar_valid= true;
+  if (!s7_is_null (sc, rest)) {
+    s7_pointer grammar_arg= s7_car (rest);
+    if (!s7_is_symbol (grammar_arg)) {
+      return liii_string_type_error (sc, "optional params in string-join", grammar_arg);
+    }
+    const char* name= s7_symbol_name (grammar_arg);
+    if (std::strcmp (name, "infix") == 0) grammar= string_join_grammar::infix;
+    else if (std::strcmp (name, "strict-infix") == 0) grammar= string_join_grammar::strict_infix;
+    else if (std::strcmp (name, "suffix") == 0) grammar= string_join_grammar::suffix;
+    else if (std::strcmp (name, "prefix") == 0) grammar= string_join_grammar::prefix;
+    else grammar_valid= false;
+  }
+
+  // 第一趟：校验元素均为字符串并累计总字节数，与旧实现一样在 grammar 分支之前报错
+  size_t     count    = 0;
+  size_t     total_len= 0;
+  s7_pointer p        = l;
+  while (s7_is_pair (p)) {
+    s7_pointer elem= s7_car (p);
+    if (!s7_is_string (elem)) {
+      return liii_string_type_error (sc, "string-join: elements must be strings", elem);
+    }
+    total_len+= (size_t) s7_string_length (elem);
+    count++;
+    p= s7_cdr (p);
+  }
+  if (!s7_is_null (sc, p)) {
+    return liii_string_type_error (sc, "string-join: first parameter must be a proper list", l);
+  }
+
+  if (!grammar_valid) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"), s7_list (sc, 1, s7_make_string (sc, "invalid grammer")));
+  }
+
+  if (grammar == string_join_grammar::strict_infix && count == 0) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "empty list not allowed")));
+  }
+
+  const size_t delim_len  = delim.size ();
+  size_t       delim_count= 0;
+  switch (grammar) {
+  case string_join_grammar::infix:
+  case string_join_grammar::strict_infix:
+    delim_count= (count > 0) ? count - 1 : 0;
+    break;
+  case string_join_grammar::suffix:
+  case string_join_grammar::prefix:
+    delim_count= count;
+    break;
+  }
+
+  std::string result;
+  result.reserve (total_len + delim_count * delim_len);
+  size_t i= 0;
+  for (p= l; s7_is_pair (p); p= s7_cdr (p), i++) {
+    if (grammar == string_join_grammar::prefix || (i > 0 && grammar != string_join_grammar::suffix)) {
+      result.append (delim);
+    }
+    s7_pointer elem= s7_car (p);
+    result.append (s7_string (elem), (size_t) s7_string_length (elem));
+    if (grammar == string_join_grammar::suffix) result.append (delim);
+  }
+
+  /* no Scheme callbacks here, so args (and the strings reachable from the
+   * input list) stay put; the result is built in a C++ buffer first and
+   * copied into the Scheme heap in a single allocation */
+  return s7_make_string_with_length (sc, result.data (), (s7_int) result.size ());
+}
+
+static s7_pointer
+f_string_replace (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str_arg= s7_car (args);
+  s7_pointer old_arg= s7_cadr (args);
+  s7_pointer new_arg= s7_caddr (args);
+  s7_pointer rest   = s7_cdddr (args);
+
+  if (!s7_is_string (str_arg)) {
+    return liii_string_type_error (sc, "string-replace: str must be a string", str_arg);
+  }
+  if (!s7_is_string (old_arg)) {
+    return liii_string_type_error (sc, "string-replace: old must be a string", old_arg);
+  }
+  if (!s7_is_string (new_arg)) {
+    return liii_string_type_error (sc, "string-replace: new must be a string", new_arg);
+  }
+
+  s7_int count= -1;
+  if (!s7_is_null (sc, rest)) {
+    s7_pointer count_arg= s7_car (rest);
+    // 与旧实现 (integer? count) 的契约一致：整数或整数值的浮点数均可
+    if (s7_is_integer (count_arg)) {
+      count= s7_integer (count_arg);
+    }
+    else if (s7_is_real (count_arg) && std::floor (s7_real (count_arg)) == s7_real (count_arg)) {
+      count= (s7_int) s7_real (count_arg);
+    }
+    else {
+      return liii_string_type_error (sc, "string-replace: count must be an integer", count_arg);
+    }
+  }
+
+  /* 先全部拷入 C++ 缓冲区，之后只在最后做一次 Scheme 堆分配，
+   * 因此无需额外的 GC anchor（且全程没有 Scheme 回调） */
+  const std::string_view str (s7_string (str_arg), (size_t) s7_string_length (str_arg));
+  const std::string_view old_v (s7_string (old_arg), (size_t) s7_string_length (old_arg));
+  const std::string_view new_v (s7_string (new_arg), (size_t) s7_string_length (new_arg));
+
+  if (count == 0) {
+    return s7_make_string_with_length (sc, str.data (), (s7_int) str.size ());
+  }
+
+  std::string result;
+  if (old_v.empty ()) {
+    // 空 pattern：在每个字节之间插入 new（Python 兼容行为）
+    if (str.empty ()) {
+      result.assign (new_v);
+    }
+    else {
+      const size_t max_insert= str.size () + 1;
+      size_t       remaining = (count < 0) ? max_insert : std::min ((size_t) count, max_insert);
+      result.reserve (str.size () + remaining * new_v.size ());
+      size_t i= 0;
+      while (i < str.size () && remaining > 0) {
+        result.append (new_v);
+        result.append (str, i, 1);
+        i++;
+        remaining--;
+      }
+      if (i == str.size ()) {
+        if (remaining > 0) result.append (new_v);
+      }
+      else {
+        result.append (str, i, str.size () - i);
+      }
+    }
+  }
+  else {
+    // 非空 pattern：从左到右、非重叠替换；UTF-8 字节级匹配是精确的
+    size_t remaining= (count < 0) ? std::string_view::npos : (size_t) count;
+    size_t start    = 0;
+    while (remaining > 0) {
+      size_t pos= str.find (old_v, start);
+      if (pos == std::string_view::npos) break;
+      result.append (str, start, pos - start);
+      result.append (new_v);
+      start= pos + old_v.size ();
+      remaining--;
+    }
+    if (start == 0) {
+      // 无匹配：返回原内容的副本
+      return s7_make_string_with_length (sc, str.data (), (s7_int) str.size ());
+    }
+    result.append (str, start, str.size () - start);
+  }
+
+  return s7_make_string_with_length (sc, result.data (), (s7_int) result.size ());
+}
+
+static s7_pointer
+f_string_starts_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str_arg   = s7_car (args);
+  s7_pointer prefix_arg= s7_cadr (args);
+
+  if (!s7_is_string (str_arg) || !s7_is_string (prefix_arg)) {
+    return s7_error (sc, s7_make_symbol (sc, "type-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "string-starts? parameter is not a string")));
+  }
+
+  // UTF-8 字节级前缀比较是精确的：前缀字节序列必然落在码点边界上
+  const size_t str_len   = (size_t) s7_string_length (str_arg);
+  const size_t prefix_len= (size_t) s7_string_length (prefix_arg);
+  if (prefix_len > str_len) return s7_f (sc);
+  return s7_make_boolean (sc, std::memcmp (s7_string (str_arg), s7_string (prefix_arg), prefix_len) == 0);
+}
+
+static s7_pointer
+f_string_ends_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str_arg   = s7_car (args);
+  s7_pointer suffix_arg= s7_cadr (args);
+
+  if (!s7_is_string (str_arg) || !s7_is_string (suffix_arg)) {
+    return s7_error (sc, s7_make_symbol (sc, "type-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "string-ends? parameter is not a string")));
+  }
+
+  const size_t str_len   = (size_t) s7_string_length (str_arg);
+  const size_t suffix_len= (size_t) s7_string_length (suffix_arg);
+  if (suffix_len > str_len) return s7_f (sc);
+  const char* tail= s7_string (str_arg) + (str_len - suffix_len);
+  return s7_make_boolean (sc, std::memcmp (tail, s7_string (suffix_arg), suffix_len) == 0);
+}
+
+static void
+glue_string_join (s7_scheme* sc) {
+  const char* name= "g_string-join";
+  const char* desc= "(g_string-join string-list . delim+grammar) => string";
+  s7_define_function (sc, name, f_string_join, 1, 2, false, desc);
+}
+
+static void
+glue_string_starts_p (s7_scheme* sc) {
+  const char* name= "g_string-starts?";
+  const char* desc= "(g_string-starts? str prefix) => boolean";
+  s7_define_function (sc, name, f_string_starts_p, 2, 0, false, desc);
+}
+
+static void
+glue_string_ends_p (s7_scheme* sc) {
+  const char* name= "g_string-ends?";
+  const char* desc= "(g_string-ends? str suffix) => boolean";
+  s7_define_function (sc, name, f_string_ends_p, 2, 0, false, desc);
+}
+
+static void
+glue_string_replace (s7_scheme* sc) {
+  const char* name= "g_string-replace";
+  const char* desc= "(g_string-replace str old new . count) => string";
+  s7_define_function (sc, name, f_string_replace, 3, 1, false, desc);
+}
+
 static void
 glue_string_split (s7_scheme* sc) {
   const char* name= "g_string-split";
@@ -135,6 +377,10 @@ glue_string_split (s7_scheme* sc) {
 
 void
 glue_liii_string (s7_scheme* sc) {
+  glue_string_join (sc);
+  glue_string_replace (sc);
+  glue_string_starts_p (sc);
+  glue_string_ends_p (sc);
   glue_string_split (sc);
 }
 

--- a/devel/1190.md
+++ b/devel/1190.md
@@ -1,0 +1,42 @@
+# 1190 升级内置 Goldfish 到 v18.11.22
+
+## 2026-08-09 升级内置 Goldfish 到 v18.11.22
+
+### What
+把 `TeXmacs/plugins/goldfish` 内置的 Goldfish 从 18.11.21 升级到 18.11.22，
+同步自本地 `~/git/goldfish`（tag v18.11.22，HEAD `e8281d3c`）。
+
+### Why
+跟进上游 18.11.22：srfi-13 / liii string 的 `string-join`、`string-replace`、
+`string-starts?`、`string-ends?`、`string-prefix?`、`string-suffix?` 获得
+C/C++ 原生实现（上游 devel/0102-0105），`string-join` 另有 O(n) 化（0098，
+18.11.21 已含）。mogan kernel 的 `string-join`（kernel/library/base.scm）
+走 srfi-13，透明受益，无需接线改动。
+
+### How
+上游 18.11.21 → 18.11.22 仅 4 个运行时文件变动，逐文件复制即可：
+- `src/goldfish.hpp`：`GOLDFISH_VERSION` 改为 `"18.11.22"`；
+- `src/liii_string.cpp`：新增 `g_string-join`、`g_string-starts?`、
+  `g_string-ends?`、`g_string-replace` 的 C++ 实现，注册自包含在该文件内；
+- `goldfish/srfi/srfi-13.scm`、`goldfish/liii/string.scm`：上述函数改为
+  `g_*` 直接别名，`string-prefix?`/`string-suffix?` 复用 starts/ends 的
+  C 实现。
+
+复制前逐文件核对 mogan 当前副本与上游 v18.11.21 完全一致（无本地补丁），
+升级后 4 个文件与上游 v18.11.22 字节一致。`gf fmt` 会把 `goldfish.hpp`
+按 mogan clang-format 风格重排（约 70KB 差异），为保持 vendored 副本与
+上游字节一致以便后续 diff 核对，未采纳 fmt 对该文件的格式化。
+
+验证：
+- `xmake b stem` 通过，`bin/goldfish --version` 输出 18.11.22；
+- 上游测试在内置 goldfish 下通过：string-join 37 correct、
+  string-replace 57 correct、string-starts? 31 correct、
+  string-ends? 120 correct、srfi-13 exit 0；
+- mogan 侧 `xmake r list-test` 64 correct、`xmake r print-widgets-test`
+  23 correct。
+
+### 涉及文件
+- `TeXmacs/plugins/goldfish/src/goldfish.hpp`
+- `TeXmacs/plugins/goldfish/src/liii_string.cpp`
+- `TeXmacs/plugins/goldfish/goldfish/srfi/srfi-13.scm`
+- `TeXmacs/plugins/goldfish/goldfish/liii/string.scm`


### PR DESCRIPTION
## What
把 `TeXmacs/plugins/goldfish` 内置的 Goldfish 从 18.11.21 升级到 18.11.22，同步自上游 tag v18.11.22（`e8281d3c`）。

## Why
跟进上游 18.11.22：srfi-13 / liii string 的 `string-join`、`string-replace`、`string-starts?`、`string-ends?`、`string-prefix?`、`string-suffix?` 获得 C/C++ 原生实现（上游 devel/0102-0105）。mogan kernel 的 `string-join` 走 srfi-13，透明受益，无需接线改动。

## How
上游 18.11.21 → 18.11.22 仅 4 个运行时文件变动，逐文件复制，升级后与上游 v18.11.22 字节一致：
- `src/goldfish.hpp`：版本号
- `src/liii_string.cpp`：新增 `g_string-join` / `g_string-starts?` / `g_string-ends?` / `g_string-replace` C++ 实现
- `goldfish/srfi/srfi-13.scm`、`goldfish/liii/string.scm`：改为 `g_*` 别名

详见 `devel/1190.md`。

## 验证
- `xmake b stem` 通过，`goldfish --version` 输出 18.11.22
- 上游测试：string-join 37 / string-replace 57 / string-starts? 31 / string-ends? 120 全 correct
- mogan 侧 `list-test` 64、`print-widgets-test` 23 全 correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)