### PR TITLE
[1191] 标签页与 tm-menu 解耦

### DIFF
--- a/TeXmacs/progs/kernel/gui/menu-widget.scm
+++ b/TeXmacs/progs/kernel/gui/menu-widget.scm
@@ -101,7 +101,6 @@
               ) ;:or
   ) ;:menu-item
   (:menu-item-list (:repeat :menu-item))
-  (:tab-page (tab-page :%4))
 ) ;define-regexp-grammar
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -687,22 +686,6 @@
   ) ;let
 ) ;define
 
-(define (make-tab-page entry-data style bar?)
-
-  (let* ((args (cdar entry-data))
-         (url (first args))
-         (title (second args))
-         (close-btn (third args))
-         (active? (fourth args))
-        ) ;
-    (widget-tab-page url
-      (car (make-menu-items title style bar?))
-      (car (make-menu-items close-btn style bar?))
-      active?
-    ) ;widget-tab-page
-  ) ;let*
-) ;define
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbol fields
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1119,7 +1102,7 @@
   (append-map (lambda (p) (make-menu-items p style bar?)) l)
 ) ;define
 
-(define (make-menu-items p style bar?)
+(define-public (make-menu-items p style bar?)
   "Make menu items @p. The items are on a bar if @bar? and of a given @style."
   ;; (display* "Make items " p ", " style "\n")
   (if (pair? p)
@@ -1152,7 +1135,6 @@
              (list (make-menu-entry p style bar?))
            ) ;if
           ) ;
-          ((match? (car p) ':tab-page) (list (make-tab-page p style bar?)))
           (else (make-menu-items-list p style bar?))
     ) ;cond
     (cond ((== p '---) (list (make-menu-hsep)))
@@ -1162,7 +1144,7 @@
           (else (list (make-menu-bad-format p style)))
     ) ;cond
   ) ;if
-) ;define
+) ;define-public
 
 (define-table make-menu-items-table
   (glue (:boolean? :boolean? :integer? :integer?)

--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -50,26 +50,38 @@
   ) ;let
 ) ;define
 
-(tm-menu (texmacs-tab-pages)
-  (for (view (tabpage-list #t))
-    (let* ((buf (view->buffer view))
-           (view-win (view->window-of-tabpage view))
-           (tab-title (tabpage-display-title buf))
-           (doc-path (tabpage-doc-path buf))
-          ) ;
-      (tab-page (eval view)
-       ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path)))
-        (window-set-view view-win view #t)
-       ) ;
-       ;; #t stansd for focus
-       ((balloon "" "Close") (safely-kill-tabpage-by-url view-win view buf))
-       ;; active 不进展开树（否则切 tab 让展开树变化、缓存失效、整条重建），
-       ;; 改由 Qt 端 updateActiveTab 维护。这里恒为 #f。
-       (eval #f)
-      ) ;tab-page
-    ) ;let*
-  ) ;for
-) ;tm-menu
+;; tab 栏不经 tm-menu：直接用 widget 原语构建整栏。
+;; title/close 子 widget 仍复用 kernel 的 make-menu-items（widget 构造器，
+;; 非 tm-menu），参数 style=0、bar?=#t 与旧 make-tab-page 一致，
+;; 保证 Qt 端拿到的 widget 树形状不变。
+;; active 恒为 #f：不进展开树（否则切 tab 让树变化、签名失效、整条重建），
+;; active 高亮由 Qt 端 updateActiveTab 维护。
+
+(define (tabpage->widget view)
+  (let* ((buf (view->buffer view))
+         (view-win (view->window-of-tabpage view))
+         (tab-title (tabpage-display-title buf))
+         (doc-path (tabpage-doc-path buf))
+         (title (list (list 'balloon (list 'verbatim tab-title) (list 'verbatim doc-path))
+                  (lambda () (window-set-view view-win view #t))
+                ) ;list
+         ) ;title
+         (close-btn (list (list 'balloon "" "Close")
+                      (lambda () (safely-kill-tabpage-by-url view-win view buf))
+                    ) ;list
+         ) ;close-btn
+        ) ;
+    (widget-tab-page view
+      (car (make-menu-items title 0 #t))
+      (car (make-menu-items close-btn 0 #t))
+      #f
+    ) ;widget-tab-page
+  ) ;let*
+) ;define
+
+(tm-define (texmacs-tab-pages)
+  (widget-hmenu (map tabpage->widget (tabpage-list #t)))
+) ;tm-define
 
 ;; tab 栏稳定签名：view-url + 显示标题序列（不含 lambda/command）。
 ;; get_menu_widget 对 which==4 用它判等——menu-expand 后的 xmenu 含每次新建的

--- a/TeXmacs/tests/1191.scm
+++ b/TeXmacs/tests/1191.scm
@@ -1,0 +1,165 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1191.scm
+;; DESCRIPTION : GUI 集成测试：tab 栏与 tm-menu 解耦后行为不变
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   [1191] tab 栏不再经 tm-menu（menu-expand / menu_cache），改由 scheme
+;;   直接用 widget 原语构建、C++ 经 tab_pages() 专用通道下发。本测试钉死
+;;   解耦后的外部行为契约（任一条回退都会红）：
+;;     1. (texmacs-tab-pages) 直接返回非空 widget（旧的是 tm-menu，只能被
+;;        menu-expand 消费，不能直接当 widget 用）。
+;;     2. (update-menus 'tab-pages) 走新通道重建不报错。
+;;     3. 签名（tabpage-menu-signature）语义不变：切 tab 签名不变（Qt 端
+;;        只做 active 高亮、不重建），增/删 tab 签名变。
+;;     4. 关闭路径 safely-kill-tabpage-by-url（tab 关闭按钮的命令）可用。
+;;
+;;   注意动作与断言分步：new-document / kill 的 tab 增删是异步落地的，
+;;   同步步里立即断言 tabpage-list 会拿到旧值，故每步只做一类事。
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 1191      # 真实 GUI，跑断言链
+;;
+;; 注意：断言在异步链里，必须 MOGAN_TEST_GUI=1 才执行——headless 模式
+;; （xmake r 1191）启动即 (quit-TeXmacs)，异步链来不及调度，断言不跑
+;; （仅冒烟进程不崩）。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY whatsoever. For details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+;; 重新 load 被测模块，保证本测试拿到的是工作区版本而非启动期缓存。
+(load "./TeXmacs/progs/texmacs/menus/tabpage-menu.scm")
+
+(check-set-mode! 'report-failed)
+
+;; 步骤间隔：给 Qt 事件循环 + tab 异步增删 + 菜单重建足够时间。
+
+(define step-delay-ms 4000)
+
+;; 串异步链：每步在 exec-delayed-at 触发，步间隔 step-delay-ms。
+;; 每个元素是 (label . action-thunk)。
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1191-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+;; 关指定 buffer 的 tab：走 tab 关闭按钮同款命令。buffer 已去脏，不弹确认框。
+
+(define (find-view-of buf)
+  (let loop ((l (tabpage-list #t)))
+    (cond ((null? l) #f)
+          ((== (view->buffer (car l)) buf) (car l))
+          (else (loop (cdr l))))
+  ) ;let
+) ;define
+
+(define (kill-tab-of buf)
+  (let ((v (find-view-of buf)))
+    (when v
+      (safely-kill-tabpage-by-url (view->window-of-tabpage v) v buf)
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1191)
+  (let ((n0 0) (s0 "") (s1 "") (s2 "") (buf1 #f) (buf2 #f))
+    (run-chain (list
+      (cons "baseline"
+        (lambda ()
+          (set! n0 (length (tabpage-list #t)))
+          (set! s0 (tabpage-menu-signature))
+          (check-true (>= n0 1))
+        ) ;lambda
+      ) ;cons
+      (cons "texmacs-tab-pages builds a widget directly (no tm-menu)"
+        (lambda ()
+          ;; 旧实现是 tm-menu，直接调用返回的不是 widget；新实现必须给出
+          ;; 非空 widget 对象（widget-hmenu 包一串 widget-tab-page）。
+          (check-true (not (null? (texmacs-tab-pages))))
+        ) ;lambda
+      ) ;cons
+      (cons "update-menus 'tab-pages rebuilds via new channel"
+        (lambda () (update-menus 'tab-pages))
+      ) ;cons
+      (cons "new-document #1"
+        (lambda () (new-document))
+      ) ;cons
+      (cons "check tab #1 + new-document #2"
+        (lambda ()
+          (set! buf1 (current-buffer))
+          (buffer-pretend-saved buf1)
+          (set! s1 (tabpage-menu-signature))
+          (check (length (tabpage-list #t)) => (+ n0 1))
+          (check-true (not (== s1 s0)))
+          (new-document)
+        ) ;lambda
+      ) ;cons
+      (cons "check tab #2"
+        (lambda ()
+          (set! buf2 (current-buffer))
+          (buffer-pretend-saved buf2)
+          (set! s2 (tabpage-menu-signature))
+          (check (length (tabpage-list #t)) => (+ n0 2))
+          (check-true (not (== s2 s1)))
+        ) ;lambda
+      ) ;cons
+      (cons "switch to view 1"
+        (lambda () (switch-to-view-index 1))
+      ) ;cons
+      (cons "signature unchanged by switch + switch to view 2"
+        (lambda ()
+          (check (tabpage-menu-signature) => s2)
+          (switch-to-view-index 2)
+        ) ;lambda
+      ) ;cons
+      (cons "signature still unchanged; rebuild works after switches"
+        (lambda ()
+          (check (tabpage-menu-signature) => s2)
+          (update-menus 'tab-pages)
+          (check-true (not (null? (texmacs-tab-pages))))
+        ) ;lambda
+      ) ;cons
+      (cons "close tab of buf2 via close-button command"
+        (lambda () (kill-tab-of buf2))
+      ) ;cons
+      (cons "check count -1 and signature changed; close tab of buf1"
+        (lambda ()
+          (check (length (tabpage-list #t)) => (+ n0 1))
+          (check-true (not (== (tabpage-menu-signature) s2)))
+          (kill-tab-of buf1)
+        ) ;lambda
+      ) ;cons
+      (cons "check back to baseline count"
+        (lambda ()
+          (check (length (tabpage-list #t)) => n0)
+        ) ;lambda
+      ) ;cons
+      (cons "report + quit"
+        (lambda ()
+          (check-report)
+          (quit-TeXmacs)
+        ) ;lambda
+      ) ;cons
+    )) ;run-chain
+  ) ;let
+) ;tm-define

--- a/devel/1191.md
+++ b/devel/1191.md
@@ -1,0 +1,43 @@
+# 1191 标签页与 tm-menu 解耦
+
+## 2026-08-09 标签页与 tm-menu 解耦
+
+### What
+tab 栏不再经过 tm-menu 抽象（`(tm-menu (texmacs-tab-pages))` 定义、
+`menu-expand` 展开、`get_menu_widget` 的 menu_cache/menu_current 机制），
+改为 scheme 直接用 widget 原语构建、C++ 经新增的 `tab_pages()` 专用通道
+下发。行为与现状完全一致。
+
+### Why
+tab 栏不是菜单：它不走菜单缓存、不需要 menu-expand 的 `(link ...)` 间接
+寻址，却被迫套在 tm-menu 抽象里——每次重建都要跑一遍菜单展开，xmenu 里
+含每次新建的 lambda 导致 equal 判等失效，只得在 `get_menu_widget` 里为
+which==4 加签名特判。解耦后 tab 栏的数据流独立、直白，菜单机制不再背负
+tab 特例。
+
+### How
+旧链路：
+`update_menus(TAB_PAGES)` → `SERVER(menu_icons(4, "(horizontal (link texmacs-tab-pages))"))`
+→ `get_menu_widget(4,...)`（menu-expand + 签名特判 + make_menu_widget）
+→ `set_tab_pages` → `SLOT_TAB_PAGES` → Qt `replaceTabPages`。
+
+新链路：
+`update_menus(TAB_PAGES)` → `SERVER(tab_pages())` →
+`tm_window_rep::tab_pages()`：先算 `tabpage-menu-signature` 判等（不变则
+跳过，行为同旧签名特判），变则 `call("texmacs-tab-pages")` 直接拿到
+scheme 构建好的 widget（`widget-hmenu` 包一串 `widget-tab-page`），
+`set_tab_pages` 下发。Qt 侧零改动。
+
+scheme 侧 `(tm-define (texmacs-tab-pages))` 逐 tab 构建的 title/close
+子 widget 仍复用 `make-menu-items`（kernel 的 widget 构造器，非 tm-menu），
+入口参数（style=0、bar?=#t）与旧 `make-tab-page` 一致，保证 Qt 拿到的
+widget 树形状不变。menu-widget.scm 的 `:tab-page` 语法、`make-tab-page`
+随之删除（无其他使用者）。
+
+### 涉及文件
+- `src/Edit/Interface/edit_interface.cpp`（TAB_PAGES 分支改调 tab_pages()）
+- `src/Texmacs/server.hpp`、`src/Texmacs/tm_frame.hpp/.cpp`、
+  `src/Texmacs/tm_window.hpp/.cpp`（新增 tab_pages()；移除 which==4 特判）
+- `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`（tm-menu → tm-define 直构）
+- `TeXmacs/progs/kernel/gui/menu-widget.scm`（删 :tab-page / make-tab-page）
+- `TeXmacs/tests/1191.scm`（新增 GUI 集成测试）

--- a/devel/1191.md
+++ b/devel/1191.md
@@ -31,8 +31,21 @@ scheme 构建好的 widget（`widget-hmenu` 包一串 `widget-tab-page`），
 scheme 侧 `(tm-define (texmacs-tab-pages))` 逐 tab 构建的 title/close
 子 widget 仍复用 `make-menu-items`（kernel 的 widget 构造器，非 tm-menu），
 入口参数（style=0、bar?=#t）与旧 `make-tab-page` 一致，保证 Qt 拿到的
-widget 树形状不变。menu-widget.scm 的 `:tab-page` 语法、`make-tab-page`
+widget 树形状不变。`make-menu-items` 原为 kernel 模块私有，本次改为
+`define-public` 导出。menu-widget.scm 的 `:tab-page` 语法、`make-tab-page`
 随之删除（无其他使用者）。
+
+验证：
+- `TeXmacs/tests/1191.scm` GUI 集成测试 12 correct / 0 failed：钉死
+  (texmacs-tab-pages) 直接返回非空 widget、(update-menus 'tab-pages) 走
+  新通道、切 tab 签名不变（不重建）、增/删 tab 签名变、关闭按钮命令可用；
+- 回归：`2014.scm` GUI（切/增/删/排序 tab 全链路）正常走完；
+  `should_update_menu_test` 8 passed、`qt_tabpage_rebuild_test`、
+  `qt_tab_page_test`、`qt_tm_widget_add_tab_test`、`startup_tab_widget_test`
+  全过；`menu-test` 15 correct、`print-widgets-test` 23 correct、
+  `kbd-define-test` 8 correct。
+- 注意：server.hpp 加了虚函数，增量构建曾因陈旧对象（vtable 错位）
+  启动段错误，`xmake clean -a` 全量重建后正常——判定时先排除构建污染。
 
 ### 涉及文件
 - `src/Edit/Interface/edit_interface.cpp`（TAB_PAGES 分支改调 tab_pages()）

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -932,7 +932,7 @@ edit_interface_rep::update_menus (int mask) {
   }
   if (should_update_menu (mask & TAB_PAGES, name)) {
     bench_start ("update_menus: icons4-tabs");
-    SERVER (menu_icons (4, "(horizontal (link texmacs-tab-pages))"));
+    SERVER (tab_pages ());
     bench_end ("update_menus: icons4-tabs");
   }
 #endif

--- a/src/Texmacs/Window/tm_frame.cpp
+++ b/src/Texmacs/Window/tm_frame.cpp
@@ -136,6 +136,12 @@ tm_frame_rep::menu_icons (int which, string menu) {
 }
 
 void
+tm_frame_rep::tab_pages () {
+  if (!has_current_view ()) return;
+  concrete_window ()->tab_pages ();
+}
+
+void
 tm_frame_rep::notification_bar (string menu) {
   if (!has_current_view ()) return;
   concrete_window ()->notification_bar (menu);

--- a/src/Texmacs/Window/tm_window.cpp
+++ b/src/Texmacs/Window/tm_window.cpp
@@ -14,6 +14,7 @@
 #include "iterator.hpp"
 #include "merge_sort.hpp"
 #include "message.hpp"
+#include "object_l5.hpp"
 #include "preferences.hpp"
 #include "tm_data.hpp"
 #include "tm_url.hpp"
@@ -408,13 +409,6 @@ tm_window_rep::get_menu_widget (int which, string menu, widget& w) {
   }
   object xmenu= call ("menu-expand", eval ("'" * menu));
   the_drd     = old_drd;
-  // tab 栏（which==4）：xmenu 含每次新建的 lambda，无法用 equal 比较，故用
-  // 稳定签名判等。签名不变（如切 tab）=> 跳过重建，保持上次 widget。
-  if (which == 4) {
-    string sig= as_string (call ("tabpage-menu-signature"));
-    if (sig == tab_menu_signature) return false;
-    tab_menu_signature= sig;
-  }
   if (menu_cache->contains (xmenu)) {
     if (menu_current[which] == xmenu) return false;
     if (which < 10) {
@@ -455,8 +449,34 @@ tm_window_rep::menu_icons (int which, string menu) {
     else if (which == 1) set_mode_icons (wid, w);
     else if (which == 2) set_focus_icons (wid, w);
     else if (which == 3) set_user_icons (wid, w);
-    else if (which == 4) set_tab_pages (wid, w);
   }
+}
+
+/**
+ * @brief 重建 tab 栏。
+ *
+ * tab 栏不经 tm-menu：scheme 的 texmacs-tab-pages 直接用 widget 原语构建
+ * 整栏 widget。这里仅做签名判等（签名由 tabpage-menu-signature 给出，
+ * 不含每次新建的 lambda，故可稳定比较）：签名不变（如切 tab）则跳过重建，
+ * 保持上次下发的 widget，active 高亮由 Qt 端 updateActiveTab 维护。
+ */
+void
+tm_window_rep::tab_pages () {
+  eval ("(lazy-initialize-force)");
+  drd_info old_drd= the_drd;
+  if (!is_none (window_to_view (id))) {
+    tm_view vw= concrete_view (window_to_view (id));
+    if (vw != NULL) the_drd= vw->ed->drd;
+  }
+  string sig= as_string (call ("tabpage-menu-signature"));
+  if (sig == tab_menu_signature) {
+    the_drd= old_drd;
+    return;
+  }
+  tab_menu_signature= sig;
+  widget w          = as_widget (call ("texmacs-tab-pages"));
+  the_drd           = old_drd;
+  if (!is_nil (w)) set_tab_pages (wid, w);
 }
 
 void

--- a/src/Texmacs/server.hpp
+++ b/src/Texmacs/server.hpp
@@ -70,6 +70,7 @@ public:
   virtual void menu_widget (string menu, widget& w)    = 0;
   virtual void menu_main (string menu)                 = 0;
   virtual void menu_icons (int which, string menu)     = 0;
+  virtual void tab_pages ()                            = 0;
   virtual void notification_bar (string menu)          = 0;
   virtual void side_tools (int which, string menu)     = 0;
   virtual void auxiliary_widget (widget w, string name)= 0;

--- a/src/Texmacs/tm_frame.hpp
+++ b/src/Texmacs/tm_frame.hpp
@@ -53,6 +53,7 @@ public:
   void menu_widget (string menu, widget& w);
   void menu_main (string menu);
   void menu_icons (int which, string menu);
+  void tab_pages ();
   void notification_bar (string menu);
   void side_tools (int which, string menu);
   void set_auxiliary_widget_title (string title);

--- a/src/Texmacs/tm_window.hpp
+++ b/src/Texmacs/tm_window.hpp
@@ -53,6 +53,7 @@ public:
   bool get_menu_widget (int which, string menu, widget& w);
   void menu_main (string menu);
   void menu_icons (int which, string menu);
+  void tab_pages ();
   void notification_bar (string menu);
   void side_tools (int which, string tools);
   void auxiliary_widget (widget w, string name);


### PR DESCRIPTION
## What
tab 栏不再经过 tm-menu 抽象（tm-menu 定义、menu-expand、menu_cache），改为 scheme 直接用 widget 原语构建、C++ 经新增的 `tab_pages()` 专用通道下发。行为与现状完全一致。

## Why
tab 栏不是菜单：它不走菜单缓存、不需要 menu-expand 的 (link ...) 间接寻址，却被迫套在 tm-menu 抽象里——每次重建都要跑一遍菜单展开，xmenu 含每次新建的 lambda 导致 equal 判等失效，只得在 get_menu_widget 里为 which==4 加签名特判。解耦后 tab 栏数据流独立直白，菜单机制不再背负 tab 特例。

## How
- 旧链路：`update_menus(TAB_PAGES)` → `menu_icons(4, "(horizontal (link texmacs-tab-pages))")` → menu-expand + 签名特判 + make_menu_widget → set_tab_pages
- 新链路：`update_menus(TAB_PAGES)` → `SERVER(tab_pages())` → `tm_window_rep::tab_pages()`：tabpage-menu-signature 判等（不变则跳过，同旧行为），变则 `call("texmacs-tab-pages")` 直接拿到 scheme 构建好的 widget（widget-hmenu 包 widget-tab-page），set_tab_pages 下发。Qt 侧零改动。
- scheme 侧 title/close 子 widget 复用 kernel `make-menu-items`（本次改为 define-public 导出），参数 style=0、bar?=#t 与旧 make-tab-page 一致，widget 树形状不变。
- 删除 menu-widget.scm 的 `:tab-page` 语法与 `make-tab-page`（无其他使用者）。

## 测试
- 新增 `TeXmacs/tests/1191.scm` GUI 集成测试（`MOGAN_TEST_GUI=1 xmake r 1191`）：**12 correct / 0 failed**。钉死：直构返回非空 widget、新通道重建、切 tab 签名不变（不重建）、增/删 tab 签名变、关闭按钮命令可用。
- 回归：`2014.scm` GUI（切/增/删/排序 tab 全链路）正常；`should_update_menu_test` 8 passed、`qt_tabpage_rebuild_test` / `qt_tab_page_test` / `qt_tm_widget_add_tab_test` / `startup_tab_widget_test` 全过；`menu-test` 15 correct、`print-widgets-test` 23 correct、`kbd-define-test` 8 correct。

🤖 Generated with [Claude Code](https://claude.com/claude-code)