### PR TITLE
[1190] kernel string-starts?/string-ends? 转调 goldfish C 实现

### DIFF
--- a/TeXmacs/progs/kernel/library/base.scm
+++ b/TeXmacs/progs/kernel/library/base.scm
@@ -79,18 +79,15 @@
   (!= (string-index s c) #f)
 ) ;define-public
 
+;; C 实现见 goldfish src/liii_string.cpp 的 g_string-starts?/g_string-ends?
 (define-public (string-starts? s what)
   "Test whether @s starts with @what."
-  (let ((n (string-length s)) (k (string-length what)))
-    (and (>= n k) (== (substring s 0 k) what))
-  ) ;let
+  (g_string-starts? s what)
 ) ;define-public
 
 (define-public (string-ends? s what)
   "Test whether @s ends with @what."
-  (let ((n (string-length s)) (k (string-length what)))
-    (and (>= n k) (== (substring s (- n k) n) what))
-  ) ;let
+  (g_string-ends? s what)
 ) ;define-public
 
 (define-public (string-contains? s what)

--- a/devel/1190.md
+++ b/devel/1190.md
@@ -40,3 +40,25 @@ C/C++ 原生实现（上游 devel/0102-0105），`string-join` 另有 O(n) 化�
 - `TeXmacs/plugins/goldfish/src/liii_string.cpp`
 - `TeXmacs/plugins/goldfish/goldfish/srfi/srfi-13.scm`
 - `TeXmacs/plugins/goldfish/goldfish/liii/string.scm`
+
+## 2026-08-09 kernel string-starts?/string-ends? 接线 C 实现
+
+### What
+`TeXmacs/progs/kernel/library/base.scm` 的 `string-starts?`/`string-ends?`
+从 substring + `==` 的 Scheme 实现改为转调 goldfish 原生
+`g_string-starts?`/`g_string-ends?`。
+
+### Why
+18.11.22 已把这两个函数下沉为 C 实现（`src/liii_string.cpp`，
+`std::memcmp` 字节级比较，无 Scheme 堆分配）；kernel 旧实现每次调用都要
+截取子串并分配新 string。两者语义一致（非 string 参数报 type-error、
+prefix/suffix 更长返回 `#f`），可透明替换。
+
+### How
+沿用 list.scm 的接线惯例：保留 `define-public` 包装与 docstring（apidoc
+不丢），函数体直接调 `g_string-starts?`/`g_string-ends?`。`g_*` 由
+goldfish.hpp 在解释器初始化时注册（`glue_liii_string`），kernel .scm
+加载时即可解析，无需额外 import。
+
+### 涉及文件
+- `TeXmacs/progs/kernel/library/base.scm`


### PR DESCRIPTION
## What
`TeXmacs/progs/kernel/library/base.scm` 的 `string-starts?`/`string-ends?` 从 substring + `==` 的 Scheme 实现改为转调 goldfish 原生 `g_string-starts?`/`g_string-ends?`(18.11.22 已随 #4261 vendored)。

## Why
C 实现用 `std::memcmp` 字节级比较,无 Scheme 堆分配;旧实现每次调用都要截取子串并分配新 string。两者语义一致(非 string 参数报 type-error、prefix/suffix 更长返回 `#f`),透明替换。

## How
沿用 list.scm 的接线惯例:保留 `define-public` 包装与 docstring,函数体直接调 `g_string-starts?`/`g_string-ends?`。上游实现见 goldfish devel/0104。

🤖 Generated with [Claude Code](https://claude.com/claude-code)