### PR TITLE
[1191] 修复关闭当前 tab 跳转 chat 后已关 tab 残留

### DIFF
--- a/devel/1191.md
+++ b/devel/1191.md
@@ -54,3 +54,37 @@ widget 树形状不变。`make-menu-items` 原为 kernel 模块私有，本次�
 - `TeXmacs/progs/texmacs/menus/tabpage-menu.scm`（tm-menu → tm-define 直构）
 - `TeXmacs/progs/kernel/gui/menu-widget.scm`（删 :tab-page / make-tab-page）
 - `TeXmacs/tests/1191.scm`（新增 GUI 集成测试）
+
+## 2026-08-09 修复：关闭当前 tab 跳转到 chat 后已关 tab 残留
+
+### What
+打开软件、新建文档、关闭该文档 tab：视图跳转到 chat 标签页，但 tab 栏上
+被关闭的 tab 没有被移除。
+
+### Why
+关闭当前 tab 的链路：`safely-kill-tabpage-by-url` → `kill_tabpage` →
+`window_set_view` 切到 chat 视图 → 菜单动作收尾 `after_menu_action` 对
+新的当前编辑器（chat）`notify_change(THE_MENUS)` → `update_menus(MENU_ALL)`。
+但 `should_update_menu` 对 chat 标签页 buffer 一律 `allow=0`，TAB_PAGES
+段被跳过，tab 栏永不重建，残留已关 tab。
+该门槛来自 f1a09d932（[0170]）：当时 tab 栏每重建一次都要跑一遍昂贵的
+tm-menu expand，故 chat 全部跳过。解耦后 `tab_pages()` 自带签名判等——
+tab 集不变时仅一次签名比较，代价可忽略——门槛可以安全放开。
+（落到 startup tab 时本就会重建：startup 的 allow 恰是 TAB_PAGES，所以
+只有落在 chat 上才暴露此 bug。）
+
+### How
+`should_update_menu` 规则调整：仅 chat 标签页 `allow=0` → `TAB_PAGES`；
+chat 只读消息区（`allow=0`）与输入框（`ICONS_MODE`）维持不变。
+Qt 侧 `SLOT_TAB_PAGES` 本就无 chatTabMode 门槛，下发即生效，无需改动。
+
+验证：
+- `should_update_menu_test` 8 passed（chat 标签页规则按新契约更新，
+  消息区/输入框断言不变）；
+- 回归：`qt_tabpage_rebuild_test`、`qt_tab_page_test`、
+  `qt_tm_widget_add_tab_test`、`startup_tab_widget_test` 全过；
+  `TeXmacs/tests/1191.scm` GUI 12 correct / 0 failed。
+
+### 涉及文件
+- `src/Edit/Interface/edit_interface.cpp`（should_update_menu 规则 + 文档注释）
+- `tests/Edit/Interface/should_update_menu_test.cpp`（按新规则更新）

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -858,7 +858,11 @@ edit_interface_rep::update_menus () {
  * @par 规则（由 should_update_menu_test 钉死）
  * - 普通 buffer：全部重建；
  * - startup tab：仅重建 tab 栏（TAB_PAGES）；
- * - chat 标签页 / 只读消息区：全部跳过；
+ * - chat 标签页：仅重建 tab 栏（TAB_PAGES）——关闭当前 tab 后视图中转到
+ *   chat 时，tab 栏必须随这次 update_menus 重建才能移除已关 tab；解耦后
+ *   tab_pages() 有签名判等，tab 集不变时仅一次签名比较，代价远低于旧
+ *   menu-expand 全量重建（f1a09d932 全部跳过的初衷）；
+ * - chat 只读消息区：全部跳过；
  * - chat 输入框：仅重建模式工具栏（ICONS_MODE）——dock 侧边栏模式下焦点
  *   切到输入框时模式工具栏可见，仍需随其重建。
  */
@@ -868,7 +872,8 @@ should_update_menu (int mask, url name) {
   if (mask == 0) return false;
   int allow= MENU_ALL;
   if (is_startup_tab_buffer (name)) allow= TAB_PAGES;
-  else if (is_chat_tab_buffer (name) || is_chat_message_buffer (name)) allow= 0;
+  else if (is_chat_tab_buffer (name)) allow= TAB_PAGES;
+  else if (is_chat_message_buffer (name)) allow= 0;
   else if (is_chat_input_buffer (name)) allow= ICONS_MODE;
   return (mask & allow) == mask;
 }

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -54,12 +54,15 @@ TestShouldUpdateMenu::test_startup_tab () {
   QVERIFY (!should_update_menu (MENU_ALL, u));
 }
 
-// chat 标签页：全部不重建
+// chat 标签页：仅重建 tab 栏（关闭当前 tab 跳转到 chat 时，tab 栏须能移除
+// 已关 tab；解耦后 tab_pages() 签名判等，不变时仅一次签名比较）
 void
 TestShouldUpdateMenu::test_chat_tab () {
   url u= url ("tmfs://chat-tab/B86AD167-589F-4820-88A0-388A12AAAF30");
-  for (int i= 0; i < N_BITS; i++)
-    QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  for (int i= 0; i < N_BITS; i++) {
+    if (ALL_BITS[i] == TAB_PAGES) QVERIFY (should_update_menu (TAB_PAGES, u));
+    else QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  }
   QVERIFY (!should_update_menu (MENU_ALL, u));
 }
 


### PR DESCRIPTION
## 问题
打开软件，新建一个文档（新标签页），关闭这个标签页：视图跳转到 chat 标签页，但 tab 栏上被关闭的 tab 没有被移除。

## 根因
关闭当前 tab 后 `kill_tabpage` 将视图切到 chat 标签页，随后的 `update_menus(MENU_ALL)` 跑在 chat buffer 上；`should_update_menu` 对 chat 标签页 `allow=0` 跳过 TAB_PAGES 段（f1a09d932 的性能门槛，当时 tab 栏重建需跑昂贵的 tm-menu expand），tab 栏永不重建，已关 tab 残留。

#4263 解耦后 `tab_pages()` 自带签名判等，tab 集不变时仅一次签名比较，代价可忽略，门槛可以安全放开。

## 改动
- `should_update_menu`：仅 chat 标签页 `allow=0` → `TAB_PAGES`；chat 只读消息区（`allow=0`）与输入框（`ICONS_MODE`）维持不变
- `should_update_menu_test` 按新契约更新
- Qt 侧 `SLOT_TAB_PAGES` 本无 chatTabMode 门槛，无需改动

## 验证
- `should_update_menu_test` 8 passed
- `qt_tabpage_rebuild_test` / `qt_tab_page_test` / `qt_tm_widget_add_tab_test` / `startup_tab_widget_test` 全过
- `TeXmacs/tests/1191.scm` GUI 集成测试 12 correct / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)