### PR TITLE
[1192] tmfs://aux/search 缓冲区跳过 update_menus 重建

### DIFF
--- a/devel/1192.md
+++ b/devel/1192.md
@@ -1,0 +1,26 @@
+# 1192 tmfs://aux/search 缓冲区跳过 update_menus
+
+## What
+
+`update_menus` 的 buffer 类别门控 `should_update_menu` 新增一类：
+`tmfs://aux/search` 开头的搜索辅助缓冲区全部跳过，任何菜单段都不重建。
+
+## Why
+
+搜索辅助缓冲区是嵌入在搜索面板 widget 里的 buffer，触发/切换它时
+主菜单、图标栏、tab 栏、通知栏、侧栏工具都与它无关，重建纯属浪费。
+
+## How
+
+- `new_view.cpp/hpp`：新增 `is_aux_search_buffer` 谓词
+  （名称以 `tmfs://aux/search` 开头）。
+- `edit_interface.cpp` `should_update_menu`：该类 buffer `allow= 0`，
+  与 chat 只读消息区同级；footer 簿记走既有的「MENU_MAIN 不重建则跳过」路径。
+- `should_update_menu_test.cpp`：新增用例钉死「aux/search 全部段不重建」。
+
+## 涉及文件
+
+- `src/Texmacs/Data/new_view.cpp`
+- `src/Texmacs/Data/new_view.hpp`
+- `src/Edit/Interface/edit_interface.cpp`
+- `tests/Edit/Interface/should_update_menu_test.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -865,6 +865,8 @@ edit_interface_rep::update_menus () {
  * - chat 只读消息区：全部跳过；
  * - chat 输入框：仅重建模式工具栏（ICONS_MODE）——dock 侧边栏模式下焦点
  *   切到输入框时模式工具栏可见，仍需随其重建。
+ * - 搜索辅助缓冲区（tmfs://aux/search）：全部跳过——它嵌在搜索面板
+ *   widget 里，各菜单段都与它无关。
  */
 bool
 should_update_menu (int mask, url name) {
@@ -875,6 +877,7 @@ should_update_menu (int mask, url name) {
   else if (is_chat_tab_buffer (name)) allow= TAB_PAGES;
   else if (is_chat_message_buffer (name)) allow= 0;
   else if (is_chat_input_buffer (name)) allow= ICONS_MODE;
+  else if (is_aux_search_buffer (name)) allow= 0;
   return (mask & allow) == mask;
 }
 
@@ -963,7 +966,7 @@ edit_interface_rep::update_menus (int mask) {
     bench_end ("update_menus: side-tools");
   }
 #endif
-  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框）
+  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框/搜索辅助）
   // 同样不需要 footer 与尾部簿记
   if (!should_update_menu (MENU_MAIN, name)) {
     last_update= last_change;

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -116,6 +116,16 @@ is_startup_tab_buffer (url name) {
   return name == url ("tmfs://startup-tab");
 }
 
+/**
+ * @brief 判断 buffer 名称是否指向搜索辅助缓冲区。
+ * @param name 待检测的 buffer URL。
+ * @return 若名称以 \c tmfs://aux/search 开头则返回 true。
+ */
+bool
+is_aux_search_buffer (url name) {
+  return starts (as_string (name), "tmfs://aux/search");
+}
+
 url
 abstract_view (tm_view vw) {
   if (vw == NULL) return url_none ();

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -55,6 +55,7 @@ bool       is_chat_tab_buffer (url name);
 bool       is_chat_message_buffer (url name);
 bool       is_chat_input_buffer (url name);
 bool       is_startup_tab_buffer (url name);
+bool       is_aux_search_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);
 

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -29,6 +29,7 @@ private slots:
   void test_chat_message ();
   void test_chat_input ();
   void test_unknown_chat_sub_buffer ();
+  void test_aux_search ();
 };
 
 // 普通 buffer：所有段都重建
@@ -91,6 +92,15 @@ TestShouldUpdateMenu::test_unknown_chat_sub_buffer () {
   url u= url ("tmfs://chat/B86AD167-589F-4820-88A0-388A12AAAF30/draft");
   for (int i= 0; i < N_BITS; i++)
     QVERIFY (should_update_menu (ALL_BITS[i], u));
+}
+
+// 搜索辅助缓冲区：全部不重建（嵌在搜索面板 widget 里，各菜单段与它无关）
+void
+TestShouldUpdateMenu::test_aux_search () {
+  url u= url ("tmfs://aux/search/0123456789abcdef0123456789abcdef/1");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  QVERIFY (!should_update_menu (MENU_ALL, u));
 }
 
 QTEST_MAIN (TestShouldUpdateMenu)


### PR DESCRIPTION
## What

`update_menus` 的 buffer 类别门控 `should_update_menu` 新增一类：`tmfs://aux/search` 开头的搜索辅助缓冲区全部跳过，任何菜单段都不重建。

## Why

搜索辅助缓冲区嵌在搜索面板 widget 里，触发/切换它时主菜单、图标栏、tab 栏、通知栏、侧栏工具都与它无关，重建纯属浪费。

## How

- `new_view.cpp/hpp`：新增 `is_aux_search_buffer` 谓词（名称以 `tmfs://aux/search` 开头）
- `edit_interface.cpp` `should_update_menu`：该类 buffer `allow= 0`，与 chat 只读消息区同级；footer 簿记走既有「MENU_MAIN 不重建则跳过」路径
- `should_update_menu_test.cpp`：新增 `test_aux_search` 钉死规则（9/9 通过）

任务文档：`devel/1192.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)