### PR TITLE
[1190] kernel string-join 转调 goldfish C 实现

### DIFF
--- a/TeXmacs/progs/kernel/library/base-test.scm
+++ b/TeXmacs/progs/kernel/library/base-test.scm
@@ -1,0 +1,78 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : base-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：kernel 字符串工具函数
+;;               （string-join、string-starts?、string-ends?）。
+;;               无 GUI，headless 可跑。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r base-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/kernel/library/base.scm")
+
+;; string-join：缺省分隔符是 " "（kernel 契约，区别于 g_string-join 的 ""）。
+
+(define (test-string-join-default-delimiter)
+  (check (string-join '("a" "b" "c")) => "a b c")
+  (check (string-join '("solo")) => "solo")
+  (check (string-join '()) => "")
+) ;define
+
+(define (test-string-join-explicit-delimiter)
+  (check (string-join '("a" "b" "c") ":") => "a:b:c")
+  (check (string-join '("a") ":") => "a")
+  (check (string-join '() ":") => "")
+  (check (string-join '("a" "b") "") => "ab")
+  (check (string-join '("" "") "-") => "-")
+  (check (string-join '("a" "b") "--") => "a--b")
+) ;define
+
+;; 分隔符只插入元素之间（infix），首尾不添加。
+
+(define (test-string-join-infix)
+  (check (string-join '("a" "b" "c") "x") => "axbxc")
+) ;define
+
+;; 错误契约：元素非 string、分隔符非 string、首参非 proper list 均抛 type-error。
+
+(define (test-string-join-errors)
+  (check-catch 'type-error (string-join '("a" 1) ":"))
+  (check-catch 'type-error (string-join '("a" "b") 1))
+  (check-catch 'type-error (string-join '("a" . "b") ":"))
+) ;define
+
+;; string-starts?/string-ends?：转调 g_string-starts?/g_string-ends? 的 C 实现。
+
+(define (test-string-starts-basic)
+  (check (string-starts? "hello" "he") => #t)
+  (check (string-starts? "hello" "hello") => #t)
+  (check (string-starts? "hello" "") => #t)
+  (check (string-starts? "hello" "lo") => #f)
+  (check (string-starts? "he" "hello") => #f)
+) ;define
+
+(define (test-string-ends-basic)
+  (check (string-ends? "hello" "lo") => #t)
+  (check (string-ends? "hello" "hello") => #t)
+  (check (string-ends? "hello" "") => #t)
+  (check (string-ends? "hello" "he") => #f)
+  (check (string-ends? "lo" "hello") => #f)
+) ;define
+
+(tm-define (regtest-base)
+  (test-string-join-default-delimiter)
+  (test-string-join-explicit-delimiter)
+  (test-string-join-infix)
+  (test-string-join-errors)
+  (test-string-starts-basic)
+  (test-string-ends-basic)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/library/base.scm
+++ b/TeXmacs/progs/kernel/library/base.scm
@@ -106,12 +106,11 @@
   (list->string (reverse cs))
 ) ;provide-public
 
+;; C 实现见 goldfish src/liii_string.cpp 的 g_string-join；
+;; 注意 g_string-join 缺省分隔符是 ""，kernel 契约是 " "，需显式传入
 (provide-public (string-join ss . opt)
   "Concatenate elements of @ss inserting separators."
-  (if (null? opt)
-    (string-join ss " ")
-    (string-concatenate (list-intersperse ss (car opt)))
-  ) ;if
+  (if (null? opt) (g_string-join ss " ") (g_string-join ss (car opt)))
 ) ;provide-public
 
 (provide-public (string-drop-right s n)

--- a/devel/1190.md
+++ b/devel/1190.md
@@ -88,5 +88,11 @@ docstring。注意 `g_string-join` 缺省分隔符是 `""`，而 kernel 契约�
 单元素、空串元素）全部通过；`xmake r list-test` 64 correct、
 `xmake r print-widgets-test` 23 correct。
 
+补纯逻辑测试 `kernel/library/base-test.scm`（`xmake r base-test`，
+23 correct）：覆盖 string-join 缺省/显式分隔符、infix 语义、空列表、
+空串元素、type-error 错误契约，以及 string-starts?/string-ends? 基本
+用例。
+
 ### 涉及文件
 - `TeXmacs/progs/kernel/library/base.scm`
+- `TeXmacs/progs/kernel/library/base-test.scm`（新增）

--- a/devel/1190.md
+++ b/devel/1190.md
@@ -62,3 +62,31 @@ goldfish.hpp 在解释器初始化时注册（`glue_liii_string`），kernel .sc
 
 ### 涉及文件
 - `TeXmacs/progs/kernel/library/base.scm`
+
+## 2026-08-09 kernel string-join 转调 g_string-join
+
+### What
+`TeXmacs/progs/kernel/library/base.scm` 的 `string-join` 从
+`string-concatenate + list-intersperse` 的 Scheme 实现改为转调 goldfish
+原生 `g_string-join`。
+
+### Why
+18.11.22 已把 srfi-13 `string-join` 下沉为 C 实现（`src/liii_string.cpp`，
+两趟扫描、单次分配 O(n)）；旧实现每次调用都要先 intersperse 出一个中间
+列表再 concatenate。全仓库调用点（shortcut-edit、apidoc-funcs、
+debug-widgets、scheme-tools、text-outline）均只传分隔符字符串、不传
+grammar 符号，可透明替换。
+
+### How
+沿用 string-starts?/string-ends? 的接线惯例：保留 `provide-public` 包装与
+docstring。注意 `g_string-join` 缺省分隔符是 `""`，而 kernel 契约是
+`" "`，故缺省分支显式传 `" "`；多出的第三个参数旧实现静默忽略、新实现
+按 grammar 解析，但无调用点这么做。错误路径均为报错（非 string 元素/
+分隔符由 C 侧抛 type-error），行为兼容。
+
+验证：headless 加载诊断脚本 6 项语义断言（缺省/指定分隔符、空列表、
+单元素、空串元素）全部通过；`xmake r list-test` 64 correct、
+`xmake r print-widgets-test` 23 correct。
+
+### 涉及文件
+- `TeXmacs/progs/kernel/library/base.scm`


### PR DESCRIPTION
## What
- kernel `string-join`（`kernel/library/base.scm`）从 `string-concatenate + list-intersperse` 的 Scheme 实现改为转调 goldfish 原生 `g_string-join`
- 新增纯逻辑测试 `kernel/library/base-test.scm`（覆盖 string-join 及此前接线的 string-starts?/string-ends?）

## Why
内置 Goldfish 18.11.22 已把 srfi-13 `string-join` 下沉为 C 实现（`src/liii_string.cpp`，两趟扫描、单次分配 O(n)）；旧实现每次调用先 intersperse 出中间列表再 concatenate。

## 兼容性
- 全仓库调用点（shortcut-edit、apidoc-funcs、debug-widgets、scheme-tools、text-outline）均只传分隔符字符串，不传 srfi-13 grammar 符号
- `g_string-join` 缺省分隔符为 `""`，kernel 契约为 `" "`，包装层缺省分支显式传 `" "`
- 错误路径均为报错（type-error），行为兼容

## 测试
- `xmake r base-test`：23 correct（新增）
- `xmake r list-test`：64 correct
- `xmake r print-widgets-test`：23 correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)