### PR TITLE
[1193] account 插件模块改名 (liii account) -> (account liii)

### DIFF
--- a/TeXmacs/plugins/account/progs/account/liii.scm
+++ b/TeXmacs/plugins/account/progs/account/liii.scm
@@ -1,7 +1,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; MODULE      : account.scm
+;; MODULE      : liii.scm
 ;; DESCRIPTION : login
 ;; COPYRIGHT   : (C) 2025  Mogan STEM authors
 ;;
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (liii account))
+(texmacs-module (account liii))
 (import (liii os))
 
 ;; 获取当前时间戳（秒）

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1372,7 +1372,7 @@
 ;; 那么应该粘贴为LaTeX格式
 (tm-define (check-magic-paste)
   (when (not (defined? 'account-load-token))
-    (use-modules (liii account))
+    (use-modules (account liii))
   ) ;when
   (let* ((token (account-load-token))
          (base-url (current-stem-site))

--- a/devel/1193.md
+++ b/devel/1193.md
@@ -1,0 +1,20 @@
+# 1193 规范化 account 插件模块命名
+
+## What
+
+account 插件的模块从 `(liii account)` 改名为 `(account liii)`。
+
+## Why
+
+插件内模块命名规范：必须以插件名开头。`(liii account)` 占据 liii 命名空间，
+违反规范。
+
+## How
+
+- 模块文件迁移：`TeXmacs/plugins/account/progs/liii/account.scm`
+  → `TeXmacs/plugins/account/progs/account/liii.scm`
+- `texmacs-module` 声明改为 `(account liii)`
+- 更新全部引用：
+  - `TeXmacs/progs/generic/generic-edit.scm` 的 `(use-modules (liii account))`
+  - `src/Plugins/Qt/QTMOAuth.cpp`、`src/Plugins/Qt/qt_tm_widget.cpp`
+    中 `eval ("(use-modules (liii account))")` 各调用点

--- a/src/Plugins/Qt/QTMOAuth.cpp
+++ b/src/Plugins/Qt/QTMOAuth.cpp
@@ -35,7 +35,7 @@
 
 QTMOAuth::QTMOAuth (QObject* parent) {
   // 加载 OAuth2 配置
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
 
   c_string clientIdentifier (
       as_string (call ("account-oauth2-config", "client-identifier")));
@@ -201,7 +201,7 @@ QTMOAuth::handleAuthorizationCode (const QString& code) {
         oauth2.setToken (accessToken);
 
         // 保存token信息
-        eval ("(use-modules (liii account))");
+        eval ("(use-modules (account liii))");
         call ("account-save-token", from_qstring (accessToken));
 
         // 设置登录状态
@@ -288,7 +288,7 @@ QTMOAuth::refreshToken () {
         oauth2.setToken (newAccessToken);
 
         // 保存新的token信息
-        eval ("(use-modules (liii account))");
+        eval ("(use-modules (account liii))");
         call ("account-save-token", from_qstring (newAccessToken));
 
         if (!newRefreshToken.isEmpty ()) {
@@ -369,7 +369,7 @@ QTMOAuth::checkTokenStatus () {
 
 void
 QTMOAuth::loadExistingToken () {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
 
   // 加载access_token
   c_string tokenStr (as_string (call ("account-load-token")));
@@ -394,7 +394,7 @@ QTMOAuth::loadExistingToken () {
 
 void
 QTMOAuth::clearInvalidTokens () {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   call ("account-clear-tokens");
 
   // 清除内存中的token信息
@@ -441,7 +441,7 @@ QTMOAuth::generateCodeChallenge (const QString& verifier) {
 
 QUrl
 QTMOAuth::getAuthorizationUrl () {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   c_string authorizationUrl (
       as_string (call ("account-oauth2-config", "authorization-url")));
   return QUrl ((char*) authorizationUrl);
@@ -449,7 +449,7 @@ QTMOAuth::getAuthorizationUrl () {
 
 QUrl
 QTMOAuth::getAccessTokenUrl () {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   c_string accessTokenUrl (
       as_string (call ("account-oauth2-config", "access-token-url")));
   return QUrl ((char*) accessTokenUrl);
@@ -457,14 +457,14 @@ QTMOAuth::getAccessTokenUrl () {
 
 QString
 QTMOAuth::getGrowthUrl () {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   c_string growthUrl (as_string (call ("account-oauth2-config", "growth-url")));
   return QString::fromUtf8 ((const char*) growthUrl);
 }
 
 QByteArray
 QTMOAuth::getPreviewCookieHeader () {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   c_string previewCookie (
       as_string (call ("account-oauth2-config", "preview-cookie-header")));
   return QByteArray ((const char*) previewCookie);

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -3025,7 +3025,7 @@ qt_tm_widget_rep::refreshMembershipInfoInBackground () {
     return;
   }
 
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   QString token= to_qstring (as_string (call ("account-load-token")));
   if (token.isEmpty ()) {
     syncScmMembershipNotification (false);
@@ -3059,7 +3059,7 @@ qt_tm_widget_rep::checkLocalTokenAndLogin () {
   setLoginDialogUpdateSectionVisible (shouldShowLoginDialogUpdateSection ());
 
   // 使用scheme代码获取本地token缓存
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   string  token  = as_string (call ("account-load-token"));
   QString q_token= to_qstring (token);
   qDebug ("Cached token: %s", q_token.isEmpty () ? "empty" : "found");
@@ -3092,7 +3092,7 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
   // 创建请求
   QNetworkRequest request;
   // 从Scheme配置获取用户信息API URL
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   string userInfoUrl=
       as_string (call ("account-oauth2-config", "user-info-url"));
   request.setUrl (QUrl (to_qstring (userInfoUrl)));
@@ -3191,7 +3191,7 @@ qt_tm_widget_rep::triggerOAuth2 () {
     m_loginDialog->hide ();
   }
   // 直接调用scheme代码触发OAuth2登录流程
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   call ("login");
 }
 
@@ -3345,7 +3345,7 @@ qt_tm_widget_rep::logout () {
  */
 QString
 qt_tm_widget_rep::buildAuthUrl (const QString& baseUrl) {
-  eval ("(use-modules (liii account))");
+  eval ("(use-modules (account liii))");
   string  token  = as_string (call ("account-load-token"));
   QString q_token= to_qstring (token);
 


### PR DESCRIPTION
## What

account 插件的模块从 `(liii account)` 改名为 `(account liii)`。

## Why

插件内模块命名规范：必须以插件名开头。`(liii account)` 占据 liii 命名空间，违反规范。

## How

- 模块文件迁移：`TeXmacs/plugins/account/progs/liii/account.scm` → `TeXmacs/plugins/account/progs/account/liii.scm`
- `texmacs-module` 声明改为 `(account liii)`
- 更新全部 `use-modules` 引用：`generic-edit.scm`、`QTMOAuth.cpp`（9 处）、`qt_tm_widget.cpp`（5 处）

## 验证

- `xmake b stem` 构建通过
- `gf fmt --changed-since=main` 无额外改动
- 全仓库 grep 无 `liii account` 残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)