### PR TITLE
[1192] tmfs://aux/replace 缓冲区跳过 update_menus 重建

### DIFF
--- a/devel/1192.md
+++ b/devel/1192.md
@@ -24,3 +24,30 @@
 - `src/Texmacs/Data/new_view.hpp`
 - `src/Edit/Interface/edit_interface.cpp`
 - `tests/Edit/Interface/should_update_menu_test.cpp`
+
+## 追加：tmfs://aux/replace 同样跳过
+
+### What
+
+门控再放开一类：`tmfs://aux/replace` 开头的替换辅助缓冲区同样全部跳过。
+
+### Why
+
+替换输入框与搜索输入框同属搜索面板 widget（`search-widgets.scm` 中两者
+互相转换）。实测 `update_menus: tmfs://aux/replace/<md5>/1` 单次耗时 81ms，
+重建同样纯属浪费。
+
+### How
+
+- `new_view.cpp/hpp`：新增 `is_aux_replace_buffer` 谓词
+  （名称以 `tmfs://aux/replace` 开头）。
+- `edit_interface.cpp` `should_update_menu`：与 search 同一分支判
+  `allow= 0`。
+- `should_update_menu_test.cpp`：新增 `test_aux_replace` 用例。
+
+### 涉及文件
+
+- `src/Texmacs/Data/new_view.cpp`
+- `src/Texmacs/Data/new_view.hpp`
+- `src/Edit/Interface/edit_interface.cpp`
+- `tests/Edit/Interface/should_update_menu_test.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -865,8 +865,8 @@ edit_interface_rep::update_menus () {
  * - chat 只读消息区：全部跳过；
  * - chat 输入框：仅重建模式工具栏（ICONS_MODE）——dock 侧边栏模式下焦点
  *   切到输入框时模式工具栏可见，仍需随其重建。
- * - 搜索辅助缓冲区（tmfs://aux/search）：全部跳过——它嵌在搜索面板
- *   widget 里，各菜单段都与它无关。
+ * - 搜索/替换辅助缓冲区（tmfs://aux/search、tmfs://aux/replace）：全部
+ *   跳过——它们嵌在搜索面板 widget 里，各菜单段都与它无关。
  */
 bool
 should_update_menu (int mask, url name) {
@@ -877,7 +877,8 @@ should_update_menu (int mask, url name) {
   else if (is_chat_tab_buffer (name)) allow= TAB_PAGES;
   else if (is_chat_message_buffer (name)) allow= 0;
   else if (is_chat_input_buffer (name)) allow= ICONS_MODE;
-  else if (is_aux_search_buffer (name)) allow= 0;
+  else if (is_aux_search_buffer (name) || is_aux_replace_buffer (name))
+    allow= 0;
   return (mask & allow) == mask;
 }
 
@@ -966,7 +967,7 @@ edit_interface_rep::update_menus (int mask) {
     bench_end ("update_menus: side-tools");
   }
 #endif
-  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框/搜索辅助）
+  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框/搜索替换辅助）
   // 同样不需要 footer 与尾部簿记
   if (!should_update_menu (MENU_MAIN, name)) {
     last_update= last_change;

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -126,6 +126,16 @@ is_aux_search_buffer (url name) {
   return starts (as_string (name), "tmfs://aux/search");
 }
 
+/**
+ * @brief 判断 buffer 名称是否指向替换辅助缓冲区。
+ * @param name 待检测的 buffer URL。
+ * @return 若名称以 \c tmfs://aux/replace 开头则返回 true。
+ */
+bool
+is_aux_replace_buffer (url name) {
+  return starts (as_string (name), "tmfs://aux/replace");
+}
+
 url
 abstract_view (tm_view vw) {
   if (vw == NULL) return url_none ();

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -56,6 +56,7 @@ bool       is_chat_message_buffer (url name);
 bool       is_chat_input_buffer (url name);
 bool       is_startup_tab_buffer (url name);
 bool       is_aux_search_buffer (url name);
+bool       is_aux_replace_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);
 

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -30,6 +30,7 @@ private slots:
   void test_chat_input ();
   void test_unknown_chat_sub_buffer ();
   void test_aux_search ();
+  void test_aux_replace ();
 };
 
 // 普通 buffer：所有段都重建
@@ -98,6 +99,15 @@ TestShouldUpdateMenu::test_unknown_chat_sub_buffer () {
 void
 TestShouldUpdateMenu::test_aux_search () {
   url u= url ("tmfs://aux/search/0123456789abcdef0123456789abcdef/1");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  QVERIFY (!should_update_menu (MENU_ALL, u));
+}
+
+// 替换辅助缓冲区：全部不重建（与 search 同属搜索面板 widget）
+void
+TestShouldUpdateMenu::test_aux_replace () {
+  url u= url ("tmfs://aux/replace/0123456789abcdef0123456789abcdef/1");
   for (int i= 0; i < N_BITS; i++)
     QVERIFY (!should_update_menu (ALL_BITS[i], u));
   QVERIFY (!should_update_menu (MENU_ALL, u));


### PR DESCRIPTION
## What

`update_menus` 的 buffer 类别门控 `should_update_menu` 在 `tmfs://aux/search` 之外再放开一类：`tmfs://aux/replace` 开头的替换辅助缓冲区同样全部跳过，任何菜单段都不重建。

## Why

替换输入框与搜索输入框同属搜索面板 widget（`search-widgets.scm` 中两者互相转换）。实测 `update_menus: tmfs://aux/replace/<md5>/1` 单次耗时 81ms，主菜单、图标栏、tab 栏、通知栏、侧栏工具都与它无关，重建纯属浪费。

## How

- `new_view.cpp/hpp`：新增 `is_aux_replace_buffer` 谓词（名称以 `tmfs://aux/replace` 开头）。
- `edit_interface.cpp` `should_update_menu`：与 search 同一分支判 `allow= 0`；footer 簿记走既有的「MENU_MAIN 不重建则跳过」路径。
- `should_update_menu_test.cpp`：新增 `test_aux_replace` 用例钉死全部段不重建。

仅放开 `aux/replace` 这一类，`aux/edit-*`、`aux/macro-editor` 等其它 aux 缓冲区不受影响。

## 测试

`xmake b should_update_menu_test && xmake r should_update_menu_test` 10/10 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)