### PR TITLE
[1192] tmfs://aux/page-* 页眉页脚缓冲区跳过 update_menus 重建

### DIFF
--- a/devel/1192.md
+++ b/devel/1192.md
@@ -51,3 +51,33 @@
 - `src/Texmacs/Data/new_view.hpp`
 - `src/Edit/Interface/edit_interface.cpp`
 - `tests/Edit/Interface/should_update_menu_test.cpp`
+
+## 追加：tmfs://aux/page-* 页眉页脚同样跳过
+
+### What
+
+门控再放开一类：`tmfs://aux/page-` 开头的页眉页脚辅助缓冲区
+（page-odd/even-header/footer 四个变体）同样全部跳过。
+
+### Why
+
+这四个 buffer 由 `document-widgets.scm` 的 `header-buffer` 创建，嵌在
+页眉页脚设置 widget 里。实测打开该 widget 时
+`update_menus: tmfs://aux/page-odd-header/1` 单次 187ms，四个 buffer
+的 `apply_changes` 合计约 1.8s，重建同样纯属浪费。
+
+### How
+
+- `new_view.cpp/hpp`：新增 `is_aux_page_buffer` 谓词
+  （名称以 `tmfs://aux/page-` 开头，一条规则覆盖四个变体）。
+- `edit_interface.cpp` `should_update_menu`：与 search/replace 同一
+  分支判 `allow= 0`。
+- `should_update_menu_test.cpp`：新增 `test_aux_page_header_footer`
+  用例，四个名称逐一钉死全部段不重建。
+
+### 涉及文件
+
+- `src/Texmacs/Data/new_view.cpp`
+- `src/Texmacs/Data/new_view.hpp`
+- `src/Edit/Interface/edit_interface.cpp`
+- `tests/Edit/Interface/should_update_menu_test.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -867,6 +867,8 @@ edit_interface_rep::update_menus () {
  *   切到输入框时模式工具栏可见，仍需随其重建。
  * - 搜索/替换辅助缓冲区（tmfs://aux/search、tmfs://aux/replace）：全部
  *   跳过——它们嵌在搜索面板 widget 里，各菜单段都与它无关。
+ * - 页眉页脚辅助缓冲区（tmfs://aux/page-odd/even-header/footer）：全部
+ *   跳过——它们嵌在页眉页脚设置 widget 里，各菜单段都与它无关。
  */
 bool
 should_update_menu (int mask, url name) {
@@ -877,7 +879,8 @@ should_update_menu (int mask, url name) {
   else if (is_chat_tab_buffer (name)) allow= TAB_PAGES;
   else if (is_chat_message_buffer (name)) allow= 0;
   else if (is_chat_input_buffer (name)) allow= ICONS_MODE;
-  else if (is_aux_search_buffer (name) || is_aux_replace_buffer (name))
+  else if (is_aux_search_buffer (name) || is_aux_replace_buffer (name) ||
+           is_aux_page_buffer (name))
     allow= 0;
   return (mask & allow) == mask;
 }
@@ -967,7 +970,8 @@ edit_interface_rep::update_menus (int mask) {
     bench_end ("update_menus: side-tools");
   }
 #endif
-  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框/搜索替换辅助）
+  // MENU_MAIN 不重建的 buffer（startup/chat 标签页/消息区/输入框/搜索替换
+  // 辅助/页眉页脚辅助）
   // 同样不需要 footer 与尾部簿记
   if (!should_update_menu (MENU_MAIN, name)) {
     last_update= last_change;

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -136,6 +136,17 @@ is_aux_replace_buffer (url name) {
   return starts (as_string (name), "tmfs://aux/replace");
 }
 
+/**
+ * @brief 判断 buffer 名称是否指向页眉页脚辅助缓冲区。
+ * @param name 待检测的 buffer URL。
+ * @return 若名称以 \c tmfs://aux/page- 开头则返回 true
+ *         （page-odd/even-header/footer 四个变体均命中）。
+ */
+bool
+is_aux_page_buffer (url name) {
+  return starts (as_string (name), "tmfs://aux/page-");
+}
+
 url
 abstract_view (tm_view vw) {
   if (vw == NULL) return url_none ();

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -57,6 +57,7 @@ bool       is_chat_input_buffer (url name);
 bool       is_startup_tab_buffer (url name);
 bool       is_aux_search_buffer (url name);
 bool       is_aux_replace_buffer (url name);
+bool       is_aux_page_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);
 

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -31,6 +31,7 @@ private slots:
   void test_unknown_chat_sub_buffer ();
   void test_aux_search ();
   void test_aux_replace ();
+  void test_aux_page_header_footer ();
 };
 
 // 普通 buffer：所有段都重建
@@ -111,6 +112,20 @@ TestShouldUpdateMenu::test_aux_replace () {
   for (int i= 0; i < N_BITS; i++)
     QVERIFY (!should_update_menu (ALL_BITS[i], u));
   QVERIFY (!should_update_menu (MENU_ALL, u));
+}
+
+// 页眉页脚辅助缓冲区：全部不重建（嵌在页眉页脚设置 widget 里）
+void
+TestShouldUpdateMenu::test_aux_page_header_footer () {
+  const char* names[]= {
+      "tmfs://aux/page-odd-header/1", "tmfs://aux/page-even-header/1",
+      "tmfs://aux/page-odd-footer/1", "tmfs://aux/page-even-footer/1"};
+  for (int n= 0; n < 4; n++) {
+    url u= url (names[n]);
+    for (int i= 0; i < N_BITS; i++)
+      QVERIFY (!should_update_menu (ALL_BITS[i], u));
+    QVERIFY (!should_update_menu (MENU_ALL, u));
+  }
 }
 
 QTEST_MAIN (TestShouldUpdateMenu)


### PR DESCRIPTION
## What

`update_menus` 的 buffer 类别门控 `should_update_menu` 新增一类：`tmfs://aux/page-` 开头的页眉页脚辅助缓冲区（page-odd/even-header/footer 四个变体）全部跳过，任何菜单段都不重建。

## Why

这四个 buffer 由 `document-widgets.scm` 的 `header-buffer` 创建，嵌在页眉页脚设置 widget 里，主菜单、图标栏、tab 栏、通知栏、侧栏工具都与它无关。实测打开该 widget 时 `update_menus: tmfs://aux/page-odd-header/1` 单次 187ms，重建纯属浪费。

## How

- `new_view.cpp/hpp`：新增 `is_aux_page_buffer` 谓词（名称以 `tmfs://aux/page-` 开头，一条规则覆盖四个变体）。
- `edit_interface.cpp` `should_update_menu`：与 search/replace 同一分支判 `allow= 0`；MENU_MAIN 不重建时 footer 簿记走既有跳过路径。
- `should_update_menu_test.cpp`：新增 `test_aux_page_header_footer` 用例，四个名称逐一钉死全部段不重建。

## 测试

`xmake r should_update_menu_test` 11/11 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)