### PR TITLE
[1192] tmfs://aux/edit-comment 缓冲区跳过 update_menus 重建

### DIFF
--- a/devel/1192.md
+++ b/devel/1192.md
@@ -81,3 +81,32 @@
 - `src/Texmacs/Data/new_view.hpp`
 - `src/Edit/Interface/edit_interface.cpp`
 - `tests/Edit/Interface/should_update_menu_test.cpp`
+
+## 追加：tmfs://aux/edit-comment 评论编辑同样跳过
+
+### What
+
+门控再放开一类：`tmfs://aux/edit-comment` 开头的评论编辑辅助缓冲区
+同样全部跳过。
+
+### Why
+
+该 buffer 由 comment 插件的 `comment-widgets.scm`
+（`open-comment-editor-aux`）创建，嵌在评论编辑辅助 widget 里。
+实测 `update_menus: tmfs://aux/edit-comment/1` 单次 161ms，重建同样
+纯属浪费。
+
+### How
+
+- `new_view.cpp/hpp`：新增 `is_aux_comment_buffer` 谓词
+  （名称以 `tmfs://aux/edit-comment` 开头）。
+- `edit_interface.cpp` `should_update_menu`：与 search/replace/page
+  同一分支判 `allow= 0`。
+- `should_update_menu_test.cpp`：新增 `test_aux_comment` 用例。
+
+### 涉及文件
+
+- `src/Texmacs/Data/new_view.cpp`
+- `src/Texmacs/Data/new_view.hpp`
+- `src/Edit/Interface/edit_interface.cpp`
+- `tests/Edit/Interface/should_update_menu_test.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -869,6 +869,8 @@ edit_interface_rep::update_menus () {
  *   跳过——它们嵌在搜索面板 widget 里，各菜单段都与它无关。
  * - 页眉页脚辅助缓冲区（tmfs://aux/page-odd/even-header/footer）：全部
  *   跳过——它们嵌在页眉页脚设置 widget 里，各菜单段都与它无关。
+ * - 评论编辑辅助缓冲区（tmfs://aux/edit-comment）：全部跳过——它嵌在
+ *   comment 插件的辅助 widget 里，各菜单段都与它无关。
  */
 bool
 should_update_menu (int mask, url name) {
@@ -880,7 +882,7 @@ should_update_menu (int mask, url name) {
   else if (is_chat_message_buffer (name)) allow= 0;
   else if (is_chat_input_buffer (name)) allow= ICONS_MODE;
   else if (is_aux_search_buffer (name) || is_aux_replace_buffer (name) ||
-           is_aux_page_buffer (name))
+           is_aux_page_buffer (name) || is_aux_comment_buffer (name))
     allow= 0;
   return (mask & allow) == mask;
 }

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -147,6 +147,16 @@ is_aux_page_buffer (url name) {
   return starts (as_string (name), "tmfs://aux/page-");
 }
 
+/**
+ * @brief 判断 buffer 名称是否指向评论编辑辅助缓冲区。
+ * @param name 待检测的 buffer URL。
+ * @return 若名称以 \c tmfs://aux/edit-comment 开头则返回 true。
+ */
+bool
+is_aux_comment_buffer (url name) {
+  return starts (as_string (name), "tmfs://aux/edit-comment");
+}
+
 url
 abstract_view (tm_view vw) {
   if (vw == NULL) return url_none ();

--- a/src/Texmacs/Data/new_view.hpp
+++ b/src/Texmacs/Data/new_view.hpp
@@ -58,6 +58,7 @@ bool       is_startup_tab_buffer (url name);
 bool       is_aux_search_buffer (url name);
 bool       is_aux_replace_buffer (url name);
 bool       is_aux_page_buffer (url name);
+bool       is_aux_comment_buffer (url name);
 bool       is_tmfs_view_type (string s, string type);
 bool       is_tmfs_view_type (url s, string type);
 

--- a/tests/Edit/Interface/should_update_menu_test.cpp
+++ b/tests/Edit/Interface/should_update_menu_test.cpp
@@ -32,6 +32,7 @@ private slots:
   void test_aux_search ();
   void test_aux_replace ();
   void test_aux_page_header_footer ();
+  void test_aux_comment ();
 };
 
 // 普通 buffer：所有段都重建
@@ -126,6 +127,15 @@ TestShouldUpdateMenu::test_aux_page_header_footer () {
       QVERIFY (!should_update_menu (ALL_BITS[i], u));
     QVERIFY (!should_update_menu (MENU_ALL, u));
   }
+}
+
+// 评论编辑辅助缓冲区：全部不重建（嵌在 comment 插件的辅助 widget 里）
+void
+TestShouldUpdateMenu::test_aux_comment () {
+  url u= url ("tmfs://aux/edit-comment/1");
+  for (int i= 0; i < N_BITS; i++)
+    QVERIFY (!should_update_menu (ALL_BITS[i], u));
+  QVERIFY (!should_update_menu (MENU_ALL, u));
 }
 
 QTEST_MAIN (TestShouldUpdateMenu)


### PR DESCRIPTION
## What

`should_update_menu` 门控再放开一类：`tmfs://aux/edit-comment` 开头的评论编辑辅助缓冲区全部跳过菜单重建。

## Why

该 buffer 由 comment 插件的 `comment-widgets.scm`（`open-comment-editor-aux`）创建，嵌在评论编辑辅助 widget 里，各菜单段都与它无关。实测 `update_menus: tmfs://aux/edit-comment/1` 单次 161ms，重建纯属浪费。

## How

- `new_view.cpp/hpp`：新增 `is_aux_comment_buffer` 谓词
- `edit_interface.cpp` `should_update_menu`：与 search/replace/page 同一分支判 `allow= 0`
- `should_update_menu_test.cpp`：新增 `test_aux_comment` 用例（12/12 通过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)