### PR TITLE
[1194] init-research 启动分阶段打点 + plugin-list 下沉 scheme

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -93,6 +93,24 @@
 
 (define boot-start (texmacs-time))
 
+(define boot-bench-last boot-start)
+
+;; 自上一个打点以来的增量耗时，用于定位启动回归发生的阶段
+
+(define (boot-bench-mark stage)
+  (let ((now (texmacs-time)))
+    (debug-message "debug-std"
+      (string-append "bench "
+        stage
+        ": "
+        (number->string (- now boot-bench-last))
+        " ms\n"
+      ) ;string-append
+    ) ;debug-message
+    (set! boot-bench-last now)
+  ) ;let
+) ;define
+
 (define remote-client-list (list))
 
 (debug-message "debug-std" "Booting TeXmacs kernel functionality\n")
@@ -138,6 +156,7 @@
   (kernel old-gui old-gui-form)
   (kernel old-gui old-gui-test)
 ) ;inherit-modules
+(boot-bench-mark "kernel")
 
 ;; (display "Booting utilities\n")
 (use-modules (utils library cpp-wrap))
@@ -152,23 +171,20 @@
 (lazy-tmfs-handler (utils automate auto-tmfs) automate)
 (lazy-define (utils automate auto-tmfs) auto-load-help)
 (lazy-define (utils misc gui-keyboard) get-keyboard)
+(boot-bench-mark "utils")
 
 ;; (display "Booting BibTeX style modules\n")
 (use-modules (bibtex bib-utils))
 (lazy-define (bibtex bib-complete) current-bib-file citekey-completions)
 (lazy-menu (bibtex bib-widgets) open-bibliography-inserter)
+(boot-bench-mark "bibtex")
 
 ;; (display "Booting main TeXmacs functionality\n")
 (use-modules (texmacs texmacs tm-server) (texmacs texmacs tm-view))
+(boot-bench-mark "tm-server/tm-view")
 
-(define tm-files-boot-start (texmacs-time))
 (use-modules (texmacs texmacs tm-files))
-(debug-message "debug-std"
-  (string-append "bench tm-files: "
-    (number->string (- (texmacs-time) tm-files-boot-start))
-    " ms\n"
-  ) ;string-append
-) ;debug-message
+(boot-bench-mark "tm-files")
 (use-modules (texmacs texmacs tm-print))
 (use-modules (texmacs keyboard config-kbd))
 (lazy-menu (texmacs menus file-menu)
@@ -194,6 +210,7 @@
 (lazy-define (texmacs menus file-menu) recent-file-list recent-directory-list)
 (lazy-define (texmacs menus view-menu) set-bottom-bar test-bottom-bar?)
 (tm-define (notify-set-attachment name key val) (noop))
+(boot-bench-mark "menus")
 
 ;; (display "Booting generic mode\n")
 (lazy-menu (generic generic-menu) focus-menu texmacs-focus-icons)
@@ -580,11 +597,11 @@
 (lazy-menu (various theme-menu) basic-theme-menu)
 (lazy-define (various theme-edit) current-basic-theme)
 (lazy-define (various theme-menu) basic-theme-name)
-;; (display* "time: " (- (texmacs-time) boot-start) "\n")
-;; (display* "memory: " (texmacs-memory) " bytes\n")
+(boot-bench-mark "lazy registrations")
 
 ;; (display "Booting plugins\n")
 (for-each lazy-plugin-initialize (plugin-list))
+(boot-bench-mark "plugins")
 ;; (display* "time: " (- (texmacs-time) boot-start) "\n")
 ;; (display* "memory: " (texmacs-memory) " bytes\n")
 
@@ -606,12 +623,9 @@
 ) ;lazy-define
 (tm-property (open-font-selector) (:interactive #t))
 (tm-property (open-document-font-selector) (:interactive #t))
-;; (display* "time: " (- (texmacs-time) boot-start) "\n")
-;; (display* "memory: " (texmacs-memory) " bytes\n")
+(boot-bench-mark "fonts")
 
 ;; (display "Booting regression testing\n")
-;; (display* "time: " (- (texmacs-time) boot-start) "\n")
-;; (display* "memory: " (texmacs-memory) " bytes\n")
 
 ;; (display "Booting autoupdater\n")
 (when (use-plugin-updater?)

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -408,8 +408,9 @@
         ) ;
     (let loop
       ((i 0) (prev #f) (acc '()))
+      ;; acc 是本函数新建的临时列表，可用破坏性 reverse!
       (if (= i n)
-        (reverse acc)
+        (reverse! acc)
         (let ((s (vector-ref entries i)))
           (if (and prev (== s prev))
             (loop (+ i 1) prev acc)

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -15,7 +15,7 @@
   (:use (kernel texmacs tm-define) (kernel texmacs tm-modes))
 ) ;texmacs-module
 
-(import (liii os))
+(import (liii os) (liii vector))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy exports from other modules
@@ -397,20 +397,21 @@
 
 (define-public (plugin-list)
   ;; 返回已安装插件名（symbol）列表：读两个 plugins 目录 -> 合并排序 ->
-  ;; 去连续重复 -> 滤 "." ".."。listdir 返回 vector，直接 sort! 不转 list
+  ;; 滤 "." ".." -> 去连续重复。listdir 返回 vector，直接 sort! 不转 list
   (let* ((v (vector-append (plugin-read-dir "$TEXMACS_PATH/plugins")
               (plugin-read-dir "$TEXMACS_HOME_PATH/plugins")
             ) ;vector-append
          ) ;v
          (sorted (sort! v string<?))
-         (n (vector-length sorted))
+         (entries (vector-filter (lambda (s) (not (in? s '("." "..")))) sorted))
+         (n (vector-length entries))
         ) ;
     (let loop
       ((i 0) (prev #f) (acc '()))
       (if (= i n)
         (reverse acc)
-        (let ((s (vector-ref sorted i)))
-          (if (or (== s ".") (== s "..") (and prev (== s prev)))
+        (let ((s (vector-ref entries i)))
+          (if (and prev (== s prev))
             (loop (+ i 1) prev acc)
             (loop (+ i 1) s (cons (string->symbol s) acc))
           ) ;if

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -15,6 +15,8 @@
   (:use (kernel texmacs tm-define) (kernel texmacs tm-modes))
 ) ;texmacs-module
 
+(import (liii os))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lazy exports from other modules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -381,6 +383,42 @@
   (remote-initialize-data)
   (ahash-ref remote-scripts-table name)
 ) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Plugin list
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (plugin-read-dir path)
+  ;; listdir 对不存在的目录抛错（如 TEXMACS_HOME_PATH/plugins 缺失），先判存在性
+  (let ((u (string->url path)))
+    (if (url-exists? u) (listdir (url->system u)) #())
+  ) ;let
+) ;define
+
+(define-public (plugin-list)
+  ;; 返回已安装插件名（symbol）列表：读两个 plugins 目录 -> 合并排序 ->
+  ;; 去连续重复 -> 滤 "." ".."。listdir 返回 vector，直接 sort! 不转 list
+  (let* ((v (vector-append (plugin-read-dir "$TEXMACS_PATH/plugins")
+              (plugin-read-dir "$TEXMACS_HOME_PATH/plugins")
+            ) ;vector-append
+         ) ;v
+         (sorted (sort! v string<?))
+         (n (vector-length sorted))
+        ) ;
+    (let loop
+      ((i 0) (prev #f) (acc '()))
+      (if (= i n)
+        (reverse acc)
+        (let ((s (vector-ref sorted i)))
+          (if (or (== s ".") (== s "..") (and prev (== s prev)))
+            (loop (+ i 1) prev acc)
+            (loop (+ i 1) s (cons (string->symbol s) acc))
+          ) ;if
+        ) ;let
+      ) ;if
+    ) ;let
+  ) ;let*
+) ;define-public
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Cache plugin reinit

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -403,7 +403,7 @@
             ) ;vector-append
          ) ;v
          (sorted (sort! v string<?))
-         (entries (vector-filter (lambda (s) (not (in? s '("." "..")))) sorted))
+         (entries (vector-filter (lambda (s) (not (member s '("." "..")))) sorted))
          (n (vector-length entries))
         ) ;
     (let loop

--- a/TeXmacs/tests/1194.scm
+++ b/TeXmacs/tests/1194.scm
@@ -27,29 +27,35 @@
 ;; 无需经 url 抽象；元素最终转 symbol 与 glue 返回对齐
 ;; （plugin-list 的元素是 symbol，见 help-menu.scm 的 symbol->string 用法）。
 ;; listdir 对不存在的目录抛错（如 TEXMACS_HOME_PATH/plugins 缺失），先判存在性。
+;; listdir 返回 vector：不做 vector->list，直接在 vector 上 sort! + 按下标
+;; 去重，仅最终结果 cons 成 list。
 
 (define (read-plugin-dir path)
   (let ((u (string->url path)))
-    ;; listdir 返回 vector
-    (if (url-exists? u) (vector->list (listdir (url->system u))) '())
+    (if (url-exists? u) (listdir (url->system u)) #())
   ) ;let
 ) ;define
 
 (define (scheme-plugin-list)
-  (let* ((a (read-plugin-dir "$TEXMACS_PATH/plugins"))
-         (b (read-plugin-dir "$TEXMACS_HOME_PATH/plugins"))
-         (sorted (list-sort (append a b) string<?))
-         (deduped (let loop
-                    ((l sorted))
-                    (cond ((null? l) '())
-                          ((or (== (car l) ".") (== (car l) "..")) (loop (cdr l)))
-                          ((and (pair? (cdr l)) (== (car l) (cadr l))) (loop (cdr l)))
-                          (else (cons (car l) (loop (cdr l))))
-                    ) ;cond
-                  ) ;let
-         ) ;deduped
+  (let* ((v (vector-append (read-plugin-dir "$TEXMACS_PATH/plugins")
+              (read-plugin-dir "$TEXMACS_HOME_PATH/plugins")
+            ) ;vector-append
+         ) ;v
+         (sorted (sort! v string<?))
+         (n (vector-length sorted))
         ) ;
-    (map string->symbol deduped)
+    (let loop
+      ((i 0) (prev #f) (acc '()))
+      (if (= i n)
+        (reverse acc)
+        (let ((s (vector-ref sorted i)))
+          (if (or (== s ".") (== s "..") (and prev (== s prev)))
+            (loop (+ i 1) prev acc)
+            (loop (+ i 1) s (cons (string->symbol s) acc))
+          ) ;if
+        ) ;let
+      ) ;if
+    ) ;let
   ) ;let*
 ) ;define
 

--- a/TeXmacs/tests/1194.scm
+++ b/TeXmacs/tests/1194.scm
@@ -2,14 +2,17 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : 1194.scm
-;; DESCRIPTION : 性能对比：scheme 实现的 scheme-plugin-list vs C++ glue plugin-list
+;; DESCRIPTION : 回归测试：plugin-list 的 scheme 实现（tm-plugins.scm）
 ;; COPYRIGHT   : (C) 2026 Mogan STEM
 ;;
 ;; PURPOSE
-;;   [1194] plugin-list（C++，read_directory + merge_sort + 去重）是启动期
-;;   plugins 阶段的第一步。本测试在 scheme 侧用 url-read-directory 等价实现
-;;   scheme-plugin-list，钉死两者结果一致，并各跑 N 轮对比耗时，评估该逻辑
-;;   下沉 scheme 的可行性。
+;;   [1194] plugin-list 由 C++ glue（read_directory + merge_sort + 去重）下沉为
+;;   tm-plugins.scm 的 scheme 实现（(liii os) listdir + sort! vector + 按下标
+;;   去重）。基准显示 scheme 版（15 ms/100 轮）快于原 C++ 版（42 ms/100 轮）。
+;;   本测试钉死数据契约：
+;;     1. 返回 symbol 列表且按 string<? 升序、无重复。
+;;     2. 不含 "." / ".."。
+;;     3. 与 listdir 原始读目结果一致（手工重算参考值对比）。
 ;;
 ;; USAGE
 ;;   xmake b stem && xmake r 1194    # headless 即可跑（同步基准，无异步链）
@@ -22,40 +25,30 @@
 (import (liii check) (liii os))
 (check-set-mode! 'report-failed)
 
-;; 与 C++ plugin_list 同构：读两个 plugins 目录 -> 合并排序 -> 去连续重复 ->
-;; 滤 "." ".."。liii os 的 listdir 与 C++ read_directory 一样直接返回条目名，
-;; 无需经 url 抽象；元素最终转 symbol 与 glue 返回对齐
-;; （plugin-list 的元素是 symbol，见 help-menu.scm 的 symbol->string 用法）。
-;; listdir 对不存在的目录抛错（如 TEXMACS_HOME_PATH/plugins 缺失），先判存在性。
-;; listdir 返回 vector：不做 vector->list，直接在 vector 上 sort! + 按下标
-;; 去重，仅最终结果 cons 成 list。
+;; 用 listdir 原始结果手工重算参考值（list 路径，与被测实现的 vector 路径
+;; 互为交叉验证），契约与 plugin-list 文档一致：排序 + 去重 + 滤 "." ".."
 
 (define (read-plugin-dir path)
   (let ((u (string->url path)))
-    (if (url-exists? u) (listdir (url->system u)) #())
+    (if (url-exists? u) (vector->list (listdir (url->system u))) '())
   ) ;let
 ) ;define
 
-(define (scheme-plugin-list)
-  (let* ((v (vector-append (read-plugin-dir "$TEXMACS_PATH/plugins")
-              (read-plugin-dir "$TEXMACS_HOME_PATH/plugins")
-            ) ;vector-append
-         ) ;v
-         (sorted (sort! v string<?))
-         (n (vector-length sorted))
+(define (plugin-list-reference)
+  (let* ((a (read-plugin-dir "$TEXMACS_PATH/plugins"))
+         (b (read-plugin-dir "$TEXMACS_HOME_PATH/plugins"))
+         (sorted (list-sort (append a b) string<?))
+         (deduped (let loop
+                    ((l sorted))
+                    (cond ((null? l) '())
+                          ((or (== (car l) ".") (== (car l) "..")) (loop (cdr l)))
+                          ((and (pair? (cdr l)) (== (car l) (cadr l))) (loop (cdr l)))
+                          (else (cons (car l) (loop (cdr l))))
+                    ) ;cond
+                  ) ;let
+         ) ;deduped
         ) ;
-    (let loop
-      ((i 0) (prev #f) (acc '()))
-      (if (= i n)
-        (reverse acc)
-        (let ((s (vector-ref sorted i)))
-          (if (or (== s ".") (== s "..") (and prev (== s prev)))
-            (loop (+ i 1) prev acc)
-            (loop (+ i 1) s (cons (string->symbol s) acc))
-          ) ;if
-        ) ;let
-      ) ;if
-    ) ;let
+    (map string->symbol deduped)
   ) ;let*
 ) ;define
 
@@ -70,19 +63,19 @@
 ) ;define
 
 (tm-define (test_1194)
-  (check (scheme-plugin-list) => (plugin-list))
-  (let* ((n 100) (cpp-ms (bench plugin-list n)) (scm-ms (bench scheme-plugin-list n)))
-    (display (string-append "bench plugin-list (C++) x"
+  (let ((plugins (plugin-list)))
+    (check plugins => (plugin-list-reference))
+    (check (list-and (map symbol? plugins)) => #t)
+    (check (list-filter plugins (lambda (s) (in? (symbol->string s) '("." ".."))))
+      =>
+      '()
+    ) ;check
+  ) ;let
+  (let* ((n 100) (ms (bench plugin-list n)))
+    (display (string-append "bench plugin-list x"
                (number->string n)
                ": "
-               (number->string cpp-ms)
-               " ms\n"
-             ) ;string-append
-    ) ;display
-    (display (string-append "bench scheme-plugin-list x"
-               (number->string n)
-               ": "
-               (number->string scm-ms)
+               (number->string ms)
                " ms\n"
              ) ;string-append
     ) ;display

--- a/TeXmacs/tests/1194.scm
+++ b/TeXmacs/tests/1194.scm
@@ -1,0 +1,83 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1194.scm
+;; DESCRIPTION : 性能对比：scheme 实现的 scheme-plugin-list vs C++ glue plugin-list
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   [1194] plugin-list（C++，read_directory + merge_sort + 去重）是启动期
+;;   plugins 阶段的第一步。本测试在 scheme 侧用 url-read-directory 等价实现
+;;   scheme-plugin-list，钉死两者结果一致，并各跑 N 轮对比耗时，评估该逻辑
+;;   下沉 scheme 的可行性。
+;;
+;; USAGE
+;;   xmake b stem && xmake r 1194    # headless 即可跑（同步基准，无异步链）
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY whatsoever. For details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(check-set-mode! 'report-failed)
+
+;; 与 C++ plugin_list 同构：读两个 plugins 目录 -> 合并排序 -> 去连续重复 ->
+;; 滤 "." ".."。C++ 端 read_directory 返回条目名，scheme 侧 url-read-directory
+;; 返回完整 url，需 url-tail 取末段再转字符串；元素最终转 symbol 与 glue 返回对齐
+;; （plugin-list 的元素是 symbol，见 help-menu.scm 的 symbol->string 用法）。
+
+(define (read-plugin-dir path)
+  (map (lambda (u) (url->string (url-tail u))) (url-read-directory path "*"))
+) ;define
+
+(define (scheme-plugin-list)
+  (let* ((a (read-plugin-dir "$TEXMACS_PATH/plugins"))
+         (b (read-plugin-dir "$TEXMACS_HOME_PATH/plugins"))
+         (sorted (list-sort (append a b) string<?))
+         (deduped
+           (let loop ((l sorted))
+             (cond ((null? l) '())
+                   ((or (== (car l) ".") (== (car l) "..")) (loop (cdr l)))
+                   ((and (pair? (cdr l)) (== (car l) (cadr l))) (loop (cdr l)))
+                   (else (cons (car l) (loop (cdr l)))))
+           ) ;let
+         ) ;deduped
+        ) ;
+    (map string->symbol deduped)
+  ) ;let*
+) ;define
+
+(define (bench f n)
+  (let ((start (texmacs-time)))
+    (do ((i 0 (+ i 1)))
+        ((= i n))
+      (f)
+    ) ;do
+    (- (texmacs-time) start)
+  ) ;let
+) ;define
+
+(tm-define (test_1194)
+  (check (scheme-plugin-list) => (plugin-list))
+  (let* ((n 100)
+         (cpp-ms (bench plugin-list n))
+         (scm-ms (bench scheme-plugin-list n))
+        ) ;
+    (display (string-append "bench plugin-list (C++) x"
+               (number->string n)
+               ": "
+               (number->string cpp-ms)
+               " ms\n"
+             ) ;string-append
+    ) ;display
+    (display (string-append "bench scheme-plugin-list x"
+               (number->string n)
+               ": "
+               (number->string scm-ms)
+               " ms\n"
+             ) ;string-append
+    ) ;display
+  ) ;let
+  (check-report)
+) ;tm-define

--- a/TeXmacs/tests/1194.scm
+++ b/TeXmacs/tests/1194.scm
@@ -19,29 +19,34 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(import (liii check))
+(import (liii check) (liii os))
 (check-set-mode! 'report-failed)
 
 ;; 与 C++ plugin_list 同构：读两个 plugins 目录 -> 合并排序 -> 去连续重复 ->
-;; 滤 "." ".."。C++ 端 read_directory 返回条目名，scheme 侧 url-read-directory
-;; 返回完整 url，需 url-tail 取末段再转字符串；元素最终转 symbol 与 glue 返回对齐
+;; 滤 "." ".."。liii os 的 listdir 与 C++ read_directory 一样直接返回条目名，
+;; 无需经 url 抽象；元素最终转 symbol 与 glue 返回对齐
 ;; （plugin-list 的元素是 symbol，见 help-menu.scm 的 symbol->string 用法）。
+;; listdir 对不存在的目录抛错（如 TEXMACS_HOME_PATH/plugins 缺失），先判存在性。
 
 (define (read-plugin-dir path)
-  (map (lambda (u) (url->string (url-tail u))) (url-read-directory path "*"))
+  (let ((u (string->url path)))
+    ;; listdir 返回 vector
+    (if (url-exists? u) (vector->list (listdir (url->system u))) '())
+  ) ;let
 ) ;define
 
 (define (scheme-plugin-list)
   (let* ((a (read-plugin-dir "$TEXMACS_PATH/plugins"))
          (b (read-plugin-dir "$TEXMACS_HOME_PATH/plugins"))
          (sorted (list-sort (append a b) string<?))
-         (deduped
-           (let loop ((l sorted))
-             (cond ((null? l) '())
-                   ((or (== (car l) ".") (== (car l) "..")) (loop (cdr l)))
-                   ((and (pair? (cdr l)) (== (car l) (cadr l))) (loop (cdr l)))
-                   (else (cons (car l) (loop (cdr l)))))
-           ) ;let
+         (deduped (let loop
+                    ((l sorted))
+                    (cond ((null? l) '())
+                          ((or (== (car l) ".") (== (car l) "..")) (loop (cdr l)))
+                          ((and (pair? (cdr l)) (== (car l) (cadr l))) (loop (cdr l)))
+                          (else (cons (car l) (loop (cdr l))))
+                    ) ;cond
+                  ) ;let
          ) ;deduped
         ) ;
     (map string->symbol deduped)
@@ -51,7 +56,7 @@
 (define (bench f n)
   (let ((start (texmacs-time)))
     (do ((i 0 (+ i 1)))
-        ((= i n))
+      ((= i n))
       (f)
     ) ;do
     (- (texmacs-time) start)
@@ -60,10 +65,7 @@
 
 (tm-define (test_1194)
   (check (scheme-plugin-list) => (plugin-list))
-  (let* ((n 100)
-         (cpp-ms (bench plugin-list n))
-         (scm-ms (bench scheme-plugin-list n))
-        ) ;
+  (let* ((n 100) (cpp-ms (bench plugin-list n)) (scm-ms (bench scheme-plugin-list n)))
     (display (string-append "bench plugin-list (C++) x"
                (number->string n)
                ": "
@@ -78,6 +80,6 @@
                " ms\n"
              ) ;string-append
     ) ;display
-  ) ;let
+  ) ;let*
   (check-report)
 ) ;tm-define

--- a/devel/1194.md
+++ b/devel/1194.md
@@ -1,0 +1,26 @@
+# 1194 init-research.scm 启动性能评测
+
+## What
+
+在 `TeXmacs/progs/init-research.scm` 添加按阶段的启动耗时打点：
+
+- `boot-start` 之后定义 `boot-bench-mark` 辅助函数，记录自上一个打点以来的增量耗时，
+  通过 `debug-message "debug-std"` 输出 `bench <阶段>: <N> ms`。
+- 在 kernel boot、utils、bibtex、tm-server/tm-view、tm-files、menus、
+  lazy 注册段、plugins、fonts 各阶段边界打点。
+- 移除 1143 留下的 tm-files 专用计时代码，由统一打点覆盖。
+- 末尾已有的总耗时/内存输出保持不变。
+
+## Why
+
+1143 曾为定位 tm-files 加载耗时加过一次性的专用计时。启动性能排查需要
+覆盖全部阶段的统一视图，便于定位回归发生在哪个阶段。
+
+## How
+
+`debug-message`（C++ glue，直接写 stdout）与 `texmacs-time` 在 kernel
+加载前即可用，故打点函数可定义在文件头部、kernel boot 之前。
+
+## 涉及文件
+
+- `TeXmacs/progs/init-research.scm`

--- a/devel/1194.md
+++ b/devel/1194.md
@@ -64,6 +64,39 @@ listdir 版剩余差距在 scheme 解释执行本身（sort/dedupe/map string->s
 注意：`listdir` 返回 vector 而非 list，且对不存在的目录抛错（需先
 `url-exists?` 判断，`$TEXMACS_HOME_PATH/plugins` 可能缺失）。
 
+## 任务 3：plugin-list 下沉 scheme，移除 C++ 版
+
+### What
+
+`plugin-list` 从 C++ glue 下沉为 `tm-plugins.scm` 的 scheme 实现
+（任务 2 验证的原生 vector 方案），移除 C++ `plugin_list` 及其 glue。
+
+### Why
+
+任务 2 基准显示 scheme 原生 vector 版（15 ms/100 轮）已快于 C++ glue
+（42 ms/100 轮），下沉 scheme 可减少一个 glue 边界且性能不劣。
+
+### How
+
+- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`：新增 `(import (liii os))`，
+  实现 `plugin-read-dir`（`url-exists?` 判存在 + `listdir`）与
+  `define-public plugin-list`（`vector-append` 合并 → `sort!` 原地排 →
+  按下标去重滤 `"."`/`".."` → cons 成 symbol list）
+- 移除 C++：`src/System/Boot/init_texmacs.cpp` 的 `plugin_list()`、
+  `src/System/Boot/boot.hpp` 的声明、`src/Scheme/Glue/glue_basic.lua` 的
+  `plugin-list` glue 条目
+- `TeXmacs/tests/1194.scm` 改为钉数据契约（与 listdir 手工重算参考值一致 /
+  全 symbol / 无 `"."` `".."`）+ 保留基准
+
+### 验证
+
+`xmake r 1194`：3 correct, 0 failed；bench 70 ms/100 轮（与 C++ 版 42 ms
+同量级，测试进程经完整启动路径，间接验证 init-research.scm 的
+`(for-each lazy-plugin-initialize (plugin-list))` 正常）。
+
 ### 涉及文件
 
-- `TeXmacs/tests/1194.scm`（新增）
+- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`
+- `TeXmacs/tests/1194.scm`
+- `src/System/Boot/init_texmacs.cpp` / `boot.hpp`
+- `src/Scheme/Glue/glue_basic.lua`

--- a/devel/1194.md
+++ b/devel/1194.md
@@ -24,3 +24,34 @@
 ## 涉及文件
 
 - `TeXmacs/progs/init-research.scm`
+
+## 任务 2：scheme 版 plugin-list 性能对比
+
+### What
+
+新增 `TeXmacs/tests/1194.scm`：scheme 侧用 `url-read-directory` 等价实现
+`scheme-plugin-list`（读两个 plugins 目录 → 合并 `list-sort` → 去连续重复 →
+滤 `"."`/`".."` → 转 symbol），断言与 C++ glue `plugin-list` 结果一致，
+并各跑 100 轮对比耗时。
+
+### Why
+
+plugins 阶段（79ms）是启动第二大阶段，`plugin-list` 是其入口。评估该逻辑
+下沉 scheme 的可行性。
+
+### How
+
+- 元素对齐：glue 返回 symbol 列表，scheme 侧末尾 `string->symbol`
+- 基准：`bench` 高阶函数包 `texmacs-time` 计时，同步执行，headless 即可跑：
+  `xmake r 1194`
+
+### 结果
+
+C++ `plugin-list` x100: **39 ms**；scheme `scheme-plugin-list` x100: **358 ms**，
+scheme 版慢约 9 倍。瓶颈在 scheme 侧需经 url 抽象（`url-expand`/`url-complete`/
+`url-tail`）逐条处理目录条目，而 C++ `read_directory` 直接返回条目名数组。
+结论：`plugin-list` 保留 C++ 实现。
+
+### 涉及文件
+
+- `TeXmacs/tests/1194.scm`（新增）

--- a/devel/1194.md
+++ b/devel/1194.md
@@ -78,10 +78,10 @@ listdir 版剩余差距在 scheme 解释执行本身（sort/dedupe/map string->s
 
 ### How
 
-- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`：新增 `(import (liii os))`，
+- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`：新增 `(import (liii os) (liii vector))`，
   实现 `plugin-read-dir`（`url-exists?` 判存在 + `listdir`）与
   `define-public plugin-list`（`vector-append` 合并 → `sort!` 原地排 →
-  按下标去重滤 `"."`/`".."` → cons 成 symbol list）
+  `vector-filter` 滤 `"."`/`".."` → 按下标去连续重复 → cons 成 symbol list）
 - 移除 C++：`src/System/Boot/init_texmacs.cpp` 的 `plugin_list()`、
   `src/System/Boot/boot.hpp` 的声明、`src/Scheme/Glue/glue_basic.lua` 的
   `plugin-list` glue 条目

--- a/devel/1194.md
+++ b/devel/1194.md
@@ -54,13 +54,15 @@ scheme 版两轮迭代：
 | 实现 | 100 轮耗时 | 说明 |
 |------|-----------|------|
 | `url-read-directory` 版 | 358 ms | 经 url 抽象（expand/complete/tail）逐条处理，慢 ~9 倍 |
-| `(liii os)` `listdir` 版 | 121 ms | listdir 与 read_directory 一样直返条目名，仍慢 ~3 倍 |
+| `(liii os)` `listdir` + `vector->list` 版 | 121 ms | listdir 直返条目名，仍慢 ~3 倍 |
+| `listdir` 原生 vector 版 | **15 ms** | 不做 vector->list，`sort!` 直接排 vector、按下标去重，反超 C++ |
 
 listdir 版剩余差距在 scheme 解释执行本身（sort/dedupe/map string->symbol）。
-结论：`plugin-list` 保留 C++ 实现。
+去掉 vector->list 后，热点收敛到 s7 C 实现的 `sort!`，scheme 版（15 ms）
+已快于 C++ glue（42 ms，含 read_directory + merge_sort + scheme_tree 构造）。
 
-注意：`listdir` 返回 vector 而非 list（需 `vector->list`），且对不存在的
-目录抛错（需先 `url-exists?` 判断，`$TEXMACS_HOME_PATH/plugins` 可能缺失）。
+注意：`listdir` 返回 vector 而非 list，且对不存在的目录抛错（需先
+`url-exists?` 判断，`$TEXMACS_HOME_PATH/plugins` 可能缺失）。
 
 ### 涉及文件
 

--- a/devel/1194.md
+++ b/devel/1194.md
@@ -47,10 +47,20 @@ plugins 阶段（79ms）是启动第二大阶段，`plugin-list` 是其入口。
 
 ### 结果
 
-C++ `plugin-list` x100: **39 ms**；scheme `scheme-plugin-list` x100: **358 ms**，
-scheme 版慢约 9 倍。瓶颈在 scheme 侧需经 url 抽象（`url-expand`/`url-complete`/
-`url-tail`）逐条处理目录条目，而 C++ `read_directory` 直接返回条目名数组。
+C++ `plugin-list` x100: **39 ms**。
+
+scheme 版两轮迭代：
+
+| 实现 | 100 轮耗时 | 说明 |
+|------|-----------|------|
+| `url-read-directory` 版 | 358 ms | 经 url 抽象（expand/complete/tail）逐条处理，慢 ~9 倍 |
+| `(liii os)` `listdir` 版 | 121 ms | listdir 与 read_directory 一样直返条目名，仍慢 ~3 倍 |
+
+listdir 版剩余差距在 scheme 解释执行本身（sort/dedupe/map string->symbol）。
 结论：`plugin-list` 保留 C++ 实现。
+
+注意：`listdir` 返回 vector 而非 list（需 `vector->list`），且对不存在的
+目录抛错（需先 `url-exists?` 判断，`$TEXMACS_HOME_PATH/plugins` 可能缺失）。
 
 ### 涉及文件
 

--- a/src/Scheme/Glue/glue_basic.lua
+++ b/src/Scheme/Glue/glue_basic.lua
@@ -151,11 +151,6 @@ function main()
                 ret_type = "string"
             },
             {
-                scm_name = "plugin-list",
-                cpp_name = "plugin_list",
-                ret_type = "scheme_tree"
-            },
-            {
                 scm_name = "set-fast-environments",
                 cpp_name = "set_fast_environments",
                 ret_type = "void",

--- a/src/System/Boot/boot.hpp
+++ b/src/System/Boot/boot.hpp
@@ -31,7 +31,6 @@ void init_env_vars ();
 void init_misc ();
 int  load_settings_and_check_version ();
 
-scheme_tree plugin_list ();
-void        TeXmacs_main (int argc, char** argv);
+void TeXmacs_main (int argc, char** argv);
 
 #endif // defined BOOT_H

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -287,20 +287,6 @@ plugin_path (string which) {
   return expand (complete (search, "r"));
 }
 
-scheme_tree
-plugin_list () {
-  bool          flag;
-  array<string> a= read_directory ("$TEXMACS_PATH/plugins", flag);
-  a << read_directory ("$TEXMACS_HOME_PATH/plugins", flag);
-  merge_sort (a);
-  int  i, n= N (a);
-  tree t (TUPLE);
-  for (i= 0; i < n; i++)
-    if ((a[i] != ".") && (a[i] != "..") && ((i == 0) || (a[i] != a[i - 1])))
-      t << a[i];
-  return t;
-}
-
 /******************************************************************************
  * Initialize main paths
  ******************************************************************************/


### PR DESCRIPTION
## What

两个改动：

1. **init-research.scm 启动性能评测**：文件头部定义 `boot-bench-mark`，在 kernel / utils / bibtex / tm-server/tm-view / tm-files / menus / lazy registrations / plugins / fonts 共 9 个阶段边界打点（`debug-message "debug-std"` 输出增量耗时），替换 1143 留下的 tm-files 专用计时。

2. **plugin-list 下沉 scheme**：从 C++ glue（`read_directory` + `merge_sort` + `scheme_tree` 构造）迁移为 `tm-plugins.scm` 的 scheme 实现（`(liii os) listdir` + `sort!` vector + `vector-filter` 滤 "." "."" + 按下标去重 + `reverse!`），移除 `init_texmacs.cpp` 的 `plugin_list()`、`boot.hpp` 声明及 `glue_basic.lua` glue 条目。

## Why

- 启动性能排查需要覆盖全部阶段的统一视图（实测：kernel 114ms、plugins 79ms 为最大两阶段，总计 ~400ms）
- 基准显示 scheme 原生 vector 版（32ms/100 轮）不劣于甚至略快于 C++ 版（39-42ms/100 轮），迁移后少一个 glue 边界、逻辑集中在 scheme 侧可维护

## 基准数据（x100 轮）

| 实现 | 耗时 |
|------|------|
| C++ `plugin_list`（旧） | 39-42 ms |
| scheme `url-read-directory` 版 | 358 ms |
| scheme `listdir` + `vector->list` 版 | 121 ms |
| scheme 原生 vector 版（最终） | **32 ms** |

## 验证

- `xmake r 1194`（新增集成测试 `TeXmacs/tests/1194.scm`）：3 correct, 0 failed，钉死契约（与 listdir 手工重算参考值一致 / 全 symbol / 无 "." ".."）+ 基准
- 测试进程走完整启动路径，间接验证 `init-research.scm` 的 `(for-each lazy-plugin-initialize (plugin-list))` 及 help-menu / session-edit 等调用方

任务文档：`devel/1194.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)