### PR TITLE
[1195] 移除 os-mingw?：scheme 调用 + glue 绑定 + C++ 函数及死代码

### DIFF
--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -33,7 +33,7 @@
 
 (define (julia-launcher)
   (let* ((boot (string-quote (julia-entry))) (cmd (url->system (find-binary-julia))))
-    (if (or (os-windows?) (os-mingw?))
+    (if (os-windows?)
       (string-append cmd " " boot)
       (string-append "env -u LD_LIBRARY_PATH -u QT_PLUGIN_PATH " cmd " " boot)
     ) ;if

--- a/TeXmacs/progs/doc/docgrep.scm
+++ b/TeXmacs/progs/doc/docgrep.scm
@@ -126,7 +126,7 @@
 
 (define url-collect-cache (make-ahash-table))
 
-(define path-separator (if (or (os-mingw?) (os-windows?)) #\; #\:))
+(define path-separator (if (os-windows?) #\; #\:))
 
 (define (url-collect path pattern)
   (or (ahash-ref url-collect-cache (string-append path pattern))

--- a/TeXmacs/progs/kernel/library/base.scm
+++ b/TeXmacs/progs/kernel/library/base.scm
@@ -382,11 +382,7 @@
   (with base
     (buffer-get-master (current-buffer))
     ;; Handle Windows drive letter issues - if different drives, return #f
-    (cond ((and (or (os-mingw?) (os-windows?))
-             (!= (url-drive-letter u) (url-drive-letter base))
-           ) ;and
-           #f
-          ) ;
+    (cond ((and (os-windows?) (!= (url-drive-letter u) (url-drive-letter base))) #f)
           ((and (url-rooted? u) (not (url-none? base))) (url->unix (url-delta base u)))
           (else (url->unix u))
     ) ;cond

--- a/TeXmacs/progs/kernel/texmacs/tm-convert.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-convert.scm
@@ -174,10 +174,7 @@
 (define (converter-shell-cmd l from to)
   (with x
     (car l)
-    (string-append (if (or (os-windows?) (os-mingw?))
-                     (escape-shell (url-concretize (url-resolve-in-path x)))
-                     x
-                   ) ;if
+    (string-append (if (os-windows?) (escape-shell (url-concretize (url-resolve-in-path x))) x)
       " "
       (converter-shell-cmd-args (cdr l) from to)
     ) ;string-append

--- a/TeXmacs/progs/kernel/texmacs/tm-file-system.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-file-system.scm
@@ -880,12 +880,7 @@
     ) ;with
     (let* ((protocol (url-root u)) (file (url->unix (url-unroot u))))
       (cond ((== protocol "") (string-append "here/" file))
-            ((== protocol "default")
-             (if (os-mingw?)
-               (string-append "file/" (strip-colon file))
-               (string-append "file/" file)
-             ) ;if
-            ) ;
+            ((== protocol "default") (string-append "file/" file))
             (else (string-append protocol "/" file))
       ) ;cond
     ) ;let*
@@ -919,12 +914,7 @@
     (let* ((protocol (tmfs-car s)) (file (unix->url (tmfs-cdr s))))
       (cond ((== protocol "tm") (url-append (get-texmacs-path) file))
             ((== protocol "here") file)
-            ((== protocol "file")
-             (if (os-mingw?)
-               (string->url (string-append "/" (tmfs-cdr s)))
-               (url-append (root->url "default") file)
-             ) ;if
-            ) ;
+            ((== protocol "file") (url-append (root->url "default") file))
             ((in? protocol '("http" "https" "ftp" "tmfs"))
              (url-append (root->url protocol) file)
             ) ;

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -575,7 +575,7 @@
 ) ;define
 
 (define-public (plugin-add-windows-path rad rel after?)
-  (when (or (os-windows?) (os-mingw?))
+  (when (os-windows?)
     (add-windows-program-path (url-append rad rel) after?)
   ) ;when
 ) ;define-public
@@ -645,7 +645,7 @@
          (connection-insert-handler name (second cmd) (symbol->string (third cmd)))
         ) ;
         ((func? cmd :winpath 2)
-         (when (or (os-windows?) (os-mingw?))
+         (when (os-windows?)
            (add-windows-program-path (url-append (second cmd) (third cmd)) #t)
          ) ;when
         ) ;

--- a/TeXmacs/progs/kernel/texmacs/tm-preferences.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-preferences.scm
@@ -211,7 +211,7 @@
 
 (define (default-look-and-feel)
   (cond ((os-macos?) "macos")
-        ((or (os-windows?) (os-mingw?)) "windows")
+        ((os-windows?) "windows")
         ((== (xdg-dekstop-session) "kde") "kde")
         ((== (xdg-dekstop-session) "deepin") "kde")
         ((== (xdg-dekstop-session) "gnome") "gnome")

--- a/TeXmacs/progs/prog/glue-symbols.scm
+++ b/TeXmacs/progs/prog/glue-symbols.scm
@@ -33,7 +33,6 @@
     "updater-set-interval"
     "get-original-path"
     "os-win32?"
-    "os-mingw?"
     "os-macos?"
     "has-printing-cmd?"
     "x-gui?"

--- a/TeXmacs/tests/11_4.scm
+++ b/TeXmacs/tests/11_4.scm
@@ -20,7 +20,6 @@
 
 (define (test-default-chinese-font)
   (cond ((os-macos?) (check (default-chinese-font) => "Singti SC"))
-        ((os-mingw?) (check (default-chinese-font) => "simsun"))
         (else (check (default-chinese-font) => "Noto CJK SC"))
   ) ;cond
 ) ;define

--- a/devel/1195.md
+++ b/devel/1195.md
@@ -210,3 +210,4 @@ Linux 为前提。
 - `src/Plugins/Freetype/tt_file.cpp`
 - `src/Plugins/Qt/qt_tm_widget.cpp`
 - `tests/System/Misc/tm_memory_test.cpp`
+- `TeXmacs/tests/11_4.scm`

--- a/devel/1195.md
+++ b/devel/1195.md
@@ -169,3 +169,44 @@ Linux 为前提。
 ### 涉及文件
 
 - `TeXmacs/progs/kernel/gui/kbd-define.scm`
+
+## 任务 8：移除 os-mingw?（scheme + glue + C++ 函数）
+
+### What
+
+- `TeXmacs/progs/`（8 处）和 `TeXmacs/plugins/`（1 处）中所有 `os-mingw?`
+  调用移除：
+  - `(or (os-mingw?) (os-windows?))` → `(os-windows?)`（7 处）
+  - 独立 `(os-mingw?)` → `if` 坍缩为 else 分支（2 处，tm-file-system.scm）
+- `TeXmacs/progs/prog/glue-symbols.scm` 删除 `"os-mingw?"` 条目
+- `src/Scheme/L2/glue_lolly.lua` 删除 `os-mingw?` → `os_mingw` glue 条目
+- `lolly/System/Misc/sys_utils.hpp` 删除 `bool os_mingw ();` 声明
+- `lolly/System/Misc/sys_utils.cpp` 删除 `os_mingw()` 函数定义
+- C++ 调用处清理：`os_mingw ()` 全部移除（3 处 src + 2 处 lolly + 1 处 tests）
+- `lolly/System/Classes/url.cpp` 连带删除 `heuristic_is_mingw_default`、
+  `url_mingw_default` 两个仅被该死代码引用的函数
+
+### Why
+
+`os-mingw?` 在 progs 中始终返回 `#f`（项目不支持 MinGW 构建），
+对应的代码路径全为死代码。清理后消除误导性的平台分支。
+
+### 涉及文件
+
+- `TeXmacs/progs/doc/docgrep.scm`
+- `TeXmacs/progs/kernel/texmacs/tm-plugins.scm`
+- `TeXmacs/progs/kernel/library/base.scm`
+- `TeXmacs/progs/kernel/texmacs/tm-convert.scm`
+- `TeXmacs/progs/kernel/texmacs/tm-preferences.scm`
+- `TeXmacs/progs/kernel/texmacs/tm-file-system.scm`
+- `TeXmacs/progs/prog/glue-symbols.scm`
+- `TeXmacs/plugins/julia/progs/init-julia.scm`
+- `src/Scheme/L2/glue_lolly.lua`
+- `lolly/System/Misc/sys_utils.hpp`
+- `lolly/System/Misc/sys_utils.cpp`
+- `lolly/System/Classes/url.cpp`
+- `lolly/System/Files/file.cpp`
+- `src/System/Misc/tm_sys_utils.cpp`
+- `src/Plugins/Freetype/tt_file.cpp`
+- `src/Plugins/Qt/qt_tm_widget.cpp`
+- `tests/System/Misc/tm_memory_test.cpp`

--- a/lolly/System/Classes/url.cpp
+++ b/lolly/System/Classes/url.cpp
@@ -194,18 +194,6 @@ heuristic_is_ftp (string name) {
   return starts (name, "ftp.");
 }
 
-static bool
-heuristic_is_mingw_default (string name, int type) {
-#ifdef WINPATHS
-  return type != URL_SYSTEM && N (name) >= 2 && name[0] == '/' &&
-         is_alpha (name[1]) && (N (name) == 2 || name[2] == '/');
-#else
-  (void) name;
-  (void) type;
-  return false;
-#endif
-}
-
 static url
 url_get_atom (string s, int type) {
   if (type < URL_STANDARD) {
@@ -288,12 +276,6 @@ url_path (string s, int type) {
 }
 
 static url
-url_mingw_default (string name, int type) {
-  string s= name (0, 2) * ":" * name (2, N (name));
-  return url_root ("default") * url_get_name (s, type);
-}
-
-static url
 url_default (string name, int type= URL_SYSTEM) {
   url u= url_get_name (name, type);
 #ifdef WINPATHS
@@ -331,8 +313,6 @@ url_general (string name, int type= URL_SYSTEM) {
     return url_path (name, type);
   }
   if (heuristic_is_default (name, type)) return url_default (name, type);
-  if (os_mingw () && heuristic_is_mingw_default (name, type))
-    return url_mingw_default (name, type);
   if (type != URL_CLEAN_UNIX) {
     if (heuristic_is_http (name)) return http_url (name);
     if (heuristic_is_ftp (name)) return ftp_url (name);

--- a/lolly/System/Files/file.cpp
+++ b/lolly/System/Files/file.cpp
@@ -111,7 +111,7 @@ is_of_type (url name, string filter) {
   int i, n= N (filter);
 
   // Normal files
-  if (os_win () || os_mingw ()) {
+  if (os_win ()) {
     string suf;
     if (filter == "x") {
       suf= suffix (name);

--- a/lolly/System/Misc/sys_utils.cpp
+++ b/lolly/System/Misc/sys_utils.cpp
@@ -100,15 +100,6 @@ os_win () {
 }
 
 bool
-os_mingw () {
-#ifdef OS_MINGW
-  return true;
-#else
-  return false;
-#endif
-}
-
-bool
 os_macos () {
 #if defined(OS_MACOS)
   return true;

--- a/lolly/System/Misc/sys_utils.hpp
+++ b/lolly/System/Misc/sys_utils.hpp
@@ -30,7 +30,6 @@ string get_user_login ();
 string get_user_name ();
 
 bool os_win ();
-bool os_mingw ();
 bool os_macos ();
 bool os_wasm ();
 

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -92,7 +92,7 @@ tt_font_search_path () {
   if (!is_empty (xtt)) {
     ret= ret | url (xtt);
   }
-  if (os_win () || os_mingw ()) {
+  if (os_win ()) {
     ret= ret | url_system ("$windir/Fonts");
   }
   else if (os_macos ()) {

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -626,7 +626,7 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
   double status_scale=
       (((double) retina_icons) > retina_scale ? 1.5 : retina_scale);
   if (status_scale > 1.0) {
-    int std_h= (os_mingw () ? 28 : 20);
+    int std_h= 20;
     int min_h= (int) floor (std_h * status_scale);
     bar->setMinimumHeight (min_h);
   }

--- a/src/Scheme/L2/glue_lolly.lua
+++ b/src/Scheme/L2/glue_lolly.lua
@@ -310,11 +310,6 @@ function main()
                 ret_type = "string"
             },
             {
-                scm_name = "os-mingw?",
-                cpp_name = "os_mingw",
-                ret_type = "bool"
-            },
-            {
                 scm_name = "os-wasm?",
                 cpp_name = "os_wasm",
                 ret_type = "bool"

--- a/src/System/Misc/tm_sys_utils.cpp
+++ b/src/System/Misc/tm_sys_utils.cpp
@@ -117,7 +117,7 @@ void
 init_texmacs_home_path () {
   if (!is_empty (get_env ("TEXMACS_HOME_PATH"))) return;
 
-  if (os_mingw () || os_win ()) {
+  if (os_win ()) {
     set_env ("TEXMACS_HOME_PATH", get_env ("APPDATA") * "/" * PREFIX_DIR);
   }
   else if (os_macos ()) {

--- a/tests/System/Misc/tm_memory_test.cpp
+++ b/tests/System/Misc/tm_memory_test.cpp
@@ -16,7 +16,7 @@
 
 inline bool
 os_gnu_linux () {
-  return !os_win () && !os_mingw () && !os_macos ();
+  return !os_win () && !os_macos ();
 }
 
 #include <QtTest/QtTest>


### PR DESCRIPTION
## 改动

移除 `os-mingw?` 及其 C++ 对应函数 `os_mingw()`——项目不支持 MinGW 构建，该谓词在所有代码路径中始终返回 `#f`，相关分支均为死代码。

### Scheme 层（progs + plugins）
- 9 处 `os-mingw?` 调用全部移除：`(or (os-mingw?) (os-windows?))` → `(os-windows?)`（7 处），独立 `(os-mingw?)` 的 `if` 坍缩为 else 分支（2 处）
- `glue-symbols.scm` 删除 `"os-mingw?"` 条目

### Glue 层
- `glue_lolly.lua` 删除 `os-mingw?` → `os_mingw` 绑定

### C++ 层
- `sys_utils.hpp/.cpp` 删除 `os_mingw()` 声明与定义
- 6 处调用点清理：`os_mingw ()` 全部移除
- `url.cpp` 连带删除 `heuristic_is_mingw_default`、`url_mingw_default` 死代码

### 不改动
- `OS_MINGW` 预处理器宏保留——它是编译期条件，与运行时谓词无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)