### PR TITLE
[1193] code 插件模块命名空间规范化： (prog prog-*) → (code prog-*)

### DIFF
--- a/TeXmacs/plugins/code/progs/code/prog-drd.scm
+++ b/TeXmacs/plugins/code/progs/code/prog-drd.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (prog prog-drd))
+(texmacs-module (code prog-drd))
 
 ;; Code fragments
 

--- a/TeXmacs/plugins/code/progs/code/prog-kbd.scm
+++ b/TeXmacs/plugins/code/progs/code/prog-kbd.scm
@@ -11,16 +11,16 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (prog prog-kbd)
+(texmacs-module (code prog-kbd)
   (:use (kernel gui kbd-define)
     (utils edit selections)
     (prog scheme-tools)
-    (prog prog-mode)
+    (code prog-mode)
     (code scheme-edit)
     (cpp cpp-edit)
   ) ;:use
 ) ;texmacs-module
-(debug-message "keyboard" "(prog prog-kbd): registering kbd-map ...\n")
+(debug-message "keyboard" "(code prog-kbd): registering kbd-map ...\n")
 
 (kbd-map (:mode in-prog?)
  ("cmd i" (program-indent #f))
@@ -46,4 +46,4 @@
  ("- -" "--")
  ("- - -" "---")
 ) ;kbd-map
-(debug-message "keyboard" "(prog prog-kbd): kbd-map registered\n")
+(debug-message "keyboard" "(code prog-kbd): kbd-map registered\n")

--- a/TeXmacs/plugins/code/progs/code/prog-mode.scm
+++ b/TeXmacs/plugins/code/progs/code/prog-mode.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (prog prog-mode)
+(texmacs-module (code prog-mode)
   (:use (kernel texmacs tm-modes)))
 
 (texmacs-modes

--- a/TeXmacs/plugins/code/progs/init-code.scm
+++ b/TeXmacs/plugins/code/progs/init-code.scm
@@ -12,4 +12,4 @@
 
 (texmacs-module (code))
 
-(lazy-keyboard (prog prog-kbd) in-prog?)
+(lazy-keyboard (code prog-kbd) in-prog?)

--- a/TeXmacs/progs/text/text-drd.scm
+++ b/TeXmacs/progs/text/text-drd.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (text text-drd) (:use (utils edit variants) (prog prog-drd)))
+(texmacs-module (text text-drd) (:use (utils edit variants) (code prog-drd)))
 
 ;; General groups
 

--- a/devel/1193.md
+++ b/devel/1193.md
@@ -153,3 +153,42 @@ account 插件的模块从 `(liii account)` 改名为 `(account liii)`。
   - `TeXmacs/progs/generic/generic-edit.scm` 的 `(use-modules (liii account))`
   - `src/Plugins/Qt/QTMOAuth.cpp`、`src/Plugins/Qt/qt_tm_widget.cpp`
     中 `eval ("(use-modules (liii account))")` 各调用点
+
+## 任务 6：code 插件
+
+### What
+
+code 插件 `progs/prog/` 下的 3 个模块从共享命名空间 `prog` 改为插件专属 `code`：
+
+| 旧模块名 | 新模块名 |
+|---------|---------|
+| `(prog prog-drd)` | `(code prog-drd)` |
+| `(prog prog-kbd)` | `(code prog-kbd)` |
+| `(prog prog-mode)` | `(code prog-mode)` |
+
+### Why
+
+插件内模块命名规范：必须以插件名开头。`(prog prog-*)` 占据 prog 命名空间，
+且与 `TeXmacs/progs/prog/` 核心模块容易混淆。
+
+### How
+
+- 模块文件迁移：`progs/prog/prog-*.scm` → `progs/code/prog-*.scm`
+- `texmacs-module` 声明改为 `(code prog-*)`
+- `prog-kbd.scm` 内部 `:use (prog prog-mode)` 同步更新
+- 外部引用更新：
+  - `init-code.scm` 的 `lazy-keyboard` 引用
+  - `TeXmacs/progs/text/text-drd.scm` 的 `:use` 引用
+
+### 涉及文件
+
+- `TeXmacs/plugins/code/progs/code/prog-drd.scm`（新）
+- `TeXmacs/plugins/code/progs/code/prog-kbd.scm`（新）
+- `TeXmacs/plugins/code/progs/code/prog-mode.scm`（新）
+- `TeXmacs/plugins/code/progs/prog/`（删）
+- `TeXmacs/plugins/code/progs/init-code.scm`
+- `TeXmacs/progs/text/text-drd.scm`
+
+### 如何测试
+
+`xmake b stem && xmake r scheme-tools-test`（7 项测试通过）。


### PR DESCRIPTION
## What

code 插件 `progs/prog/` 下的 3 个模块从共享命名空间 `prog` 改为插件专属 `code`：

| 旧模块名 | 新模块名 |
|---------|---------|
| `(prog prog-drd)` | `(code prog-drd)` |
| `(prog prog-kbd)` | `(code prog-kbd)` |
| `(prog prog-mode)` | `(code prog-mode)` |

## Why

插件内模块命名规范：必须以插件名开头。`(prog prog-*)` 占据 `prog` 命名空间，且与 `TeXmacs/progs/prog/` 核心模块容易混淆。

## Verifications

- `xmake b stem` 构建通过
- `xmake r scheme-tools-test` 7 项测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)