### PR TITLE
[1131] fix: exec_use_package/load_style_tree 解析 .stem 文件走 generic_to_tree

### DIFF
--- a/TeXmacs/progs/generic/tests/style-package-load-test.scm
+++ b/TeXmacs/progs/generic/tests/style-package-load-test.scm
@@ -1,0 +1,39 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : style-package-load-test.scm
+;; DESCRIPTION : Verify .stem packages can be loaded via add-style-package
+;; COPYRIGHT   : (C) 2026  Da Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(check-set-mode! 'report-failed)
+
+;; Test 1: stem package file should exist
+(define (test-stem-package-exists)
+  (check
+    (url-exists? (url-append "$TEXMACS_STYLE_PATH" "python.stem"))
+    =>
+    #t
+  )
+) ;define
+
+;; Test 2: ts package should NOT exist (was deleted in 1131)
+(define (test-ts-package-absent)
+  (check
+    (url-exists? (url-append "$TEXMACS_STYLE_PATH" "python.ts"))
+    =>
+    #f
+  )
+) ;define
+
+(tm-define (regtest-style-package-load)
+  (display "=== Running style-package-load tests ===\n")
+  (test-stem-package-exists)
+  (test-ts-package-absent)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/generic/tests/style-package-load-test.scm
+++ b/TeXmacs/progs/generic/tests/style-package-load-test.scm
@@ -14,21 +14,15 @@
 (check-set-mode! 'report-failed)
 
 ;; Test 1: stem package file should exist
+
 (define (test-stem-package-exists)
-  (check
-    (url-exists? (url-append "$TEXMACS_STYLE_PATH" "python.stem"))
-    =>
-    #t
-  )
+  (check (url-exists? (url-append "$TEXMACS_STYLE_PATH" "python.stem")) => #t)
 ) ;define
 
 ;; Test 2: ts package should NOT exist (was deleted in 1131)
+
 (define (test-ts-package-absent)
-  (check
-    (url-exists? (url-append "$TEXMACS_STYLE_PATH" "python.ts"))
-    =>
-    #f
-  )
+  (check (url-exists? (url-append "$TEXMACS_STYLE_PATH" "python.ts")) => #f)
 ) ;define
 
 (tm-define (regtest-style-package-load)

--- a/devel/1131.md
+++ b/devel/1131.md
@@ -162,3 +162,27 @@ S-expression 解析器 `moebius/moebius/data/scheme_der.cpp` 中的 `string_to_s
 - `TeXmacs/progs/generic/document-style.scm`
 - `TeXmacs/progs/source/macro-edit.scm`
 - `devel/1131.md`
+
+## 2026/08/11 修复 exec_use_package / load_style_tree 解析 .stem 文件失败
+
+### 现象
+`插入 -> 程序 -> 代码块 -> Python` 失效。点击后代码块被插入但不加载 Python 样式包（`style-has? "python-package"` 始终为 `#f`），无语法高亮。
+
+### 根因
+`exec_use_package` 和 `load_style_tree` 的**查找**逻辑已适配 `.stem`（优先 `.stem`、回退 `.ts`），但**解析**逻辑未适配：两处都将 `.stem` 文件的 S-expression 内容直接传给 `texmacs_document_to_tree`，该函数只识别二进制 TeXmacs 格式和 `<TeXmacs|>` 格式，不识别 `(document ...)`，返回 `(error "bad format or data")`。
+
+### 修复
+对 `.stem` 后缀的文件使用 `generic_to_tree(doc_s, "stem-document")`（走 `stem->texmacs` 格式转换器），`.ts` 文件仍走 `texmacs_document_to_tree`：
+
+```cpp
+if (ends (as_string (name), ".stem")) {
+  doc= generic_to_tree (doc_s, "stem-document");
+} else {
+  doc= texmacs_document_to_tree (doc_s);
+}
+```
+
+### 涉及文件
+- `src/Typeset/Env/env_exec.cpp`
+- `src/Texmacs/Data/new_buffer.cpp`
+- `TeXmacs/progs/generic/tests/style-package-load-test.scm`（新增 headless 测试）

--- a/src/Texmacs/Data/new_buffer.cpp
+++ b/src/Texmacs/Data/new_buffer.cpp
@@ -545,7 +545,13 @@ load_style_tree (string package) {
   name= resolve (name);
   string doc_s;
   if (!load_string (name, doc_s, false)) {
-    tree doc= texmacs_document_to_tree (doc_s);
+    tree doc;
+    if (ends (as_string (name), ".stem")) {
+      doc= generic_to_tree (doc_s, "stem-document");
+    }
+    else {
+      doc= texmacs_document_to_tree (doc_s);
+    }
     if (is_compound (doc)) doc= extract (doc, "body");
     style_tree_cache (package)= doc;
     return doc;

--- a/src/Typeset/Env/env_exec.cpp
+++ b/src/Typeset/Env/env_exec.cpp
@@ -1227,7 +1227,13 @@ edit_env_rep::exec_use_package (tree t) {
     // cout << as_string (t[i]) << " -> " << name << "\n";
     string doc_s;
     if (!load_string (name, doc_s, false)) {
-      tree doc= texmacs_document_to_tree (doc_s);
+      tree doc;
+      if (ends (as_string (name), ".stem")) {
+        doc= generic_to_tree (doc_s, "stem-document");
+      }
+      else {
+        doc= texmacs_document_to_tree (doc_s);
+      }
       if (is_compound (doc)) exec (filter_style (extract (doc, "body")));
     }
   }


### PR DESCRIPTION
## Summary

修复 1131 引入的回归：`插入->程序->代码块->Python` 失效。

## Root Cause

1131 将 `python.ts` 替换为 S-expression 格式的 `python.stem`，`exec_use_package` 和 `load_style_tree` 的**查找**逻辑已适配（优先 `.stem`），但**解析**未适配——`texmacs_document_to_tree` 不识别 `(document ...)` S-expression 格式，导致 `python` 样式包加载失败。

## Fix

对 `.stem` 后缀的文件走 `generic_to_tree(doc_s, "stem-document")`（即 `stem->texmacs` 格式转换器），`.ts` 文件仍走 `texmacs_document_to_tree`。

## Changes

- `src/Typeset/Env/env_exec.cpp` — `exec_use_package`
- `src/Texmacs/Data/new_buffer.cpp` — `load_style_tree`
- `TeXmacs/progs/generic/tests/style-package-load-test.scm` — 新增 headless 测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)