### PR TITLE
[1193] maxima/literate/ocr 插件模块命名空间规范化

### DIFF
--- a/TeXmacs/plugins/literate/packages/utilities/literate.stem
+++ b/TeXmacs/plugins/literate/packages/utilities/literate.stem
@@ -16,7 +16,7 @@
                                       ) ;document
                            ) ;src-title
                   ) ;active*
-          (use-module "(utils literate lp-menu)")
+          (use-module "(literate lp-menu)")
           (active* (document (src-comment (document "Presentation macros"))))
           (assign "wide-bothlined-named"
             (macro "top-border"

--- a/TeXmacs/plugins/literate/progs/literate/lp-build.scm
+++ b/TeXmacs/plugins/literate/progs/literate/lp-build.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (utils literate lp-build) (:use (utils literate lp-edit)))
+(texmacs-module (literate lp-build) (:use (literate lp-edit)))
 
 (import (liii hash-table) (liii base) (liii list))
 

--- a/TeXmacs/plugins/literate/progs/literate/lp-edit.scm
+++ b/TeXmacs/plugins/literate/progs/literate/lp-edit.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (utils literate lp-edit)
+(texmacs-module (literate lp-edit)
   (:use (utils library cursor) (generic document-edit) (dynamic dynamic-drd))
 ) ;texmacs-module
 

--- a/TeXmacs/plugins/literate/progs/literate/lp-menu.scm
+++ b/TeXmacs/plugins/literate/progs/literate/lp-menu.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (utils literate lp-menu) (:use (utils literate lp-build)))
+(texmacs-module (literate lp-menu) (:use (literate lp-build)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main literate programming menu

--- a/TeXmacs/plugins/maxima/packages/session/maxima.stem
+++ b/TeXmacs/plugins/maxima/packages/session/maxima.stem
@@ -16,8 +16,8 @@
                                       ) ;document
                            ) ;src-title
                   ) ;active*
-          (use-module "(plugin maxima-menu)")
-          (use-module "(plugin maxima-kbd)")
+          (use-module "(maxima maxima-menu)")
+          (use-module "(maxima maxima-kbd)")
           (assign "maxima-output"
             (macro "body" (document (padded (document (generic-output* (arg "body"))))))
           ) ;assign

--- a/TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm
+++ b/TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin maxima-input) (:use (utils plugins plugin-convert)))
+(texmacs-module (maxima maxima-input) (:use (utils plugins plugin-convert)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specific conversion routines

--- a/TeXmacs/plugins/maxima/progs/maxima/maxima-kbd.scm
+++ b/TeXmacs/plugins/maxima/progs/maxima/maxima-kbd.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin maxima-kbd)
+(texmacs-module (maxima maxima-kbd)
   (:use (dynamic scripts-kbd)
     (utils plugins plugin-cmd)
     (utils plugins plugin-convert)
@@ -25,6 +25,6 @@
 (kbd-map (:mode in-maxima?) (:mode in-math?) ("$" "$"))
 
 (when (supports-maxima?)
-  (lazy-input-converter (plugin maxima-input) maxima)
+  (lazy-input-converter (maxima maxima-input) maxima)
   (plugin-approx-command-set! "maxima" "float")
 ) ;when

--- a/TeXmacs/plugins/maxima/progs/maxima/maxima-menu.scm
+++ b/TeXmacs/plugins/maxima/progs/maxima/maxima-menu.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin maxima-menu)
+(texmacs-module (maxima maxima-menu)
   (:use (utils plugins plugin-cmd)
     (doc help-funcs)
     (dynamic scripts-edit)

--- a/TeXmacs/plugins/ocr/progs/ocr/liii-ocr.scm
+++ b/TeXmacs/plugins/ocr/progs/ocr/liii-ocr.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (liii ocr))
+(texmacs-module (ocr liii-ocr))
 (import (liii base64))
 (import (liii time))
 (import (only (srfi srfi-19) current-time time-second))

--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1245,7 +1245,7 @@
 
 (tm-define (ocr-paste source-format)
   (when (not (defined? 'ocr-to-latex-by-cursor))
-    (use-modules (liii ocr))
+    (use-modules (ocr liii-ocr))
   ) ;when
   (with data
     (if (string=? source-format "texmacs-snippet")
@@ -1271,7 +1271,7 @@
       (kbd-paste)
       (kbd-return)
       (when (not (defined? 'ocr-to-latex-by-cursor))
-        (use-modules (liii ocr))
+        (use-modules (ocr liii-ocr))
       ) ;when
       (ocr-to-latex-by-cursor data)
     ) ;when
@@ -1318,7 +1318,7 @@
 
 (tm-define (paste-as-texmacs)
   (when (not (defined? 'ocr-to-latex-by-cursor))
-    (use-modules (liii ocr))
+    (use-modules (ocr liii-ocr))
   ) ;when
   (with img-tree
     (tree-ref (clipboard-get "primary") 0)

--- a/devel/1193.md
+++ b/devel/1193.md
@@ -391,3 +391,111 @@ converter 的 `(:require (url-exists-in-path? "xmgrace"))` 守卫确保 xmgrace
 ### 如何测试
 
 `xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。
+
+## 任务 11：maxima 插件 session 子模块命名空间规范化
+
+### What
+
+maxima 插件中 3 个 session 子模块从共享命名空间 `plugin` 改为插件专属 `maxima`：
+
+| 旧模块名 | 新模块名 |
+|---------|---------|
+| `(plugin maxima-input)` | `(maxima maxima-input)` |
+| `(plugin maxima-kbd)` | `(maxima maxima-kbd)` |
+| `(plugin maxima-menu)` | `(maxima maxima-menu)` |
+
+文件从 `progs/plugin/` 迁移至 `progs/maxima/`，删除空目录 `progs/plugin/`。
+
+### Why
+
+插件内模块命名规范：一级命名空间必须以插件名开头。`(plugin ...)` 占据 plugin
+命名空间，违反规范。
+
+### How
+
+- 3 个文件 `texmacs-module` 声明 + 文件迁移至 `progs/maxima/`
+- `maxima-kbd.scm` 中 `lazy-input-converter` 引用同步更新
+- `packages/session/maxima.stem` 中 `use-module` 路径更新
+- 删除空目录 `progs/plugin/`
+
+### 涉及文件
+
+- `TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/maxima/progs/maxima/maxima-kbd.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/maxima/progs/maxima/maxima-menu.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/maxima/packages/session/maxima.stem`
+- `TeXmacs/plugins/maxima/progs/plugin/`（删除）
+
+### 如何测试
+
+`xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。
+
+## 任务 12：literate 插件子模块命名空间规范化
+
+### What
+
+literate 插件中 3 个子模块从 `(utils literate lp-*)` 改为 `(literate lp-*)`：
+
+| 旧模块名 | 新模块名 |
+|---------|---------|
+| `(utils literate lp-build)` | `(literate lp-build)` |
+| `(utils literate lp-edit)` | `(literate lp-edit)` |
+| `(utils literate lp-menu)` | `(literate lp-menu)` |
+
+文件从 `progs/utils/literate/` 迁移至 `progs/literate/`，删除空目录 `progs/utils/`。
+
+### Why
+
+插件内模块命名规范：一级命名空间必须以插件名开头。`(utils literate lp-*)`
+占据 utils 命名空间，违反规范。
+
+### How
+
+- 3 个文件 `texmacs-module` 声明及模块间 `:use` 同步更新
+- 文件从 `progs/utils/literate/` 迁移至 `progs/literate/`
+- `packages/utilities/literate.stem` 中 `use-module` 路径更新
+- 删除空目录 `progs/utils/`
+
+### 涉及文件
+
+- `TeXmacs/plugins/literate/progs/literate/lp-build.scm`（从 `progs/utils/literate/` 移入）
+- `TeXmacs/plugins/literate/progs/literate/lp-edit.scm`（从 `progs/utils/literate/` 移入）
+- `TeXmacs/plugins/literate/progs/literate/lp-menu.scm`（从 `progs/utils/literate/` 移入）
+- `TeXmacs/plugins/literate/packages/utilities/literate.stem`
+- `TeXmacs/plugins/literate/progs/utils/`（删除）
+
+### 如何测试
+
+`xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。
+
+## 任务 13：ocr 插件子模块命名空间规范化
+
+### What
+
+ocr 插件模块从 `(liii ocr)` 改为 `(ocr liii-ocr)`。
+文件从 `progs/liii/ocr.scm` 迁移至 `progs/ocr/liii-ocr.scm`，删除空目录 `progs/liii/`。
+
+### Why
+
+插件内模块命名规范：一级命名空间必须以插件名开头。`(liii ocr)` 占据 liii
+命名空间，违反规范。与任务 1（account 插件 `(account liii)`）模式一致。
+
+### How
+
+- 模块文件从 `progs/liii/ocr.scm` 迁移至 `progs/ocr/liii-ocr.scm`
+- `texmacs-module` 声明从 `(liii ocr)` 改为 `(ocr liii-ocr)`
+- 外部引用更新：
+  - `TeXmacs/progs/generic/generic-edit.scm` 中 3 处 `use-modules`
+  - `src/Plugins/Qt/QTMImagePopup.cpp` 中 1 处 `eval`
+- 删除空目录 `progs/liii/`
+
+### 涉及文件
+
+- `TeXmacs/plugins/ocr/progs/ocr/liii-ocr.scm`（从 `progs/liii/ocr.scm` 移入）
+- `TeXmacs/progs/generic/generic-edit.scm`
+- `src/Plugins/Qt/QTMImagePopup.cpp`
+- `TeXmacs/plugins/ocr/progs/liii/`（删除）
+
+### 如何测试
+
+`xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。

--- a/src/Plugins/Qt/QTMImagePopup.cpp
+++ b/src/Plugins/Qt/QTMImagePopup.cpp
@@ -63,7 +63,7 @@ QTMImagePopup::QTMImagePopup (QWidget* parent, qt_simple_widget_rep* owner)
   alignGroup->addButton (rightBtn);
   alignGroup->addButton (ocrBtn);
   alignGroup->setExclusive (true);
-  eval ("(use-modules (liii ocr))");
+  eval ("(use-modules (ocr liii-ocr))");
   connect (alignGroup,
            QOverload<QAbstractButton*>::of (&QButtonGroup::buttonClicked), this,
            [=] (QAbstractButton* button) {


### PR DESCRIPTION
## Summary

3 个插件的子模块命名空间规范化，遵循"插件模块一级命名空间必须以插件名开头"的规范。

### maxima
- `(plugin maxima-input|kbd|menu)` → `(maxima maxima-input|kbd|menu)`
- 文件从 `progs/plugin/` 迁移到 `progs/maxima/`

### literate
- `(utils literate lp-build|edit|menu)` → `(literate lp-build|edit|menu)`
- 文件从 `progs/utils/literate/` 迁移到 `progs/literate/`

### ocr
- `(liii ocr)` → `(ocr liii-ocr)`
- 文件从 `progs/liii/ocr.scm` 迁移到 `progs/ocr/liii-ocr.scm`

### 外部引用更新
- `TeXmacs/progs/generic/generic-edit.scm`: 3 处 ocr use-modules
- `src/Plugins/Qt/QTMImagePopup.cpp`: 1 处 ocr use-modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)