### PR TITLE
[1193] telemetry/physics 插件模块命名空间规范化

### DIFF
--- a/TeXmacs/plugins/physics/packages/contrib/physics.stem
+++ b/TeXmacs/plugins/physics/packages/contrib/physics.stem
@@ -16,7 +16,7 @@
                                       ) ;document
                            ) ;src-title
                   ) ;active*
-          (use-module "(contrib physics physics-drd)")
+          (use-module "(physics physics-drd)")
           (active* (src-comment (document "Braket operators")))
           (assign "bra" (macro "x" (around* "<langle>" (arg "x") "|")))
           (assign "bra*" (macro "x" (concat "<langle>" (arg "x") "|")))

--- a/TeXmacs/plugins/physics/progs/physics/physics-drd.scm
+++ b/TeXmacs/plugins/physics/progs/physics/physics-drd.scm
@@ -1,4 +1,4 @@
-(texmacs-module (contrib physics physics-drd) (:use (utils edit variants)))
+(texmacs-module (physics physics-drd) (:use (utils edit variants)))
 
 (define-group variant-tag (physics-dirac-tag))
 

--- a/TeXmacs/plugins/telemetry/progs/init-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/progs/init-telemetry.scm
@@ -12,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (use-modules (binary goldfish))
-(use-modules (plugin telemetry))
+(use-modules (telemetry telemetry))
 (import (liii path))
 
 (define (telemetry-serialize lan t)

--- a/TeXmacs/plugins/telemetry/progs/telemetry/init-telemetry.scm
+++ b/TeXmacs/plugins/telemetry/progs/telemetry/init-telemetry.scm
@@ -11,8 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin init-telemetry)
-  (:use (plugin telemetry-track) (plugin telemetry-utils))
+(texmacs-module (telemetry init-telemetry)
+  (:use (telemetry telemetry-track) (telemetry telemetry-utils))
 ) ;texmacs-module
 
 (import (scheme base))

--- a/TeXmacs/plugins/telemetry/progs/telemetry/telemetry-track.scm
+++ b/TeXmacs/plugins/telemetry/progs/telemetry/telemetry-track.scm
@@ -11,8 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin telemetry-track)
-  (:use (plugin telemetry-utils) (utils plugins plugin-eval))
+(texmacs-module (telemetry telemetry-track)
+  (:use (telemetry telemetry-utils) (utils plugins plugin-eval))
 ) ;texmacs-module
 
 (import (scheme base) (liii base) (liii path) (liii string) (liii list))

--- a/TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm
+++ b/TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm
@@ -11,7 +11,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin telemetry-utils))
+(texmacs-module (telemetry telemetry-utils))
 
 (import (scheme base)
   (liii base)

--- a/TeXmacs/plugins/telemetry/progs/telemetry/telemetry.scm
+++ b/TeXmacs/plugins/telemetry/progs/telemetry/telemetry.scm
@@ -2,7 +2,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : telemetry.scm
-;; DESCRIPTION : Entry point of the (plugin telemetry) module
+;; DESCRIPTION : Entry point of the (telemetry telemetry) module
 ;;
 ;; This module serves as the entry point loaded by init-telemetry.scm.
 ;; It MUST NOT contain (import ...) statements.
@@ -21,6 +21,6 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (plugin telemetry)
-  (:use (plugin telemetry-utils) (plugin telemetry-track) (plugin init-telemetry))
+(texmacs-module (telemetry telemetry)
+  (:use (telemetry telemetry-utils) (telemetry telemetry-track) (telemetry init-telemetry))
 ) ;texmacs-module

--- a/TeXmacs/plugins/telemetry/progs/telemetry/telemetry.scm
+++ b/TeXmacs/plugins/telemetry/progs/telemetry/telemetry.scm
@@ -22,5 +22,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (telemetry telemetry)
-  (:use (telemetry telemetry-utils) (telemetry telemetry-track) (telemetry init-telemetry))
+  (:use (telemetry telemetry-utils)
+    (telemetry telemetry-track)
+    (telemetry init-telemetry)
+  ) ;:use
 ) ;texmacs-module

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -27,9 +27,9 @@
 
 (varlet (rootlet) '*current-module* (curlet))
 
-;; 启动期 telemetry pending 队列：telemetry 实现已迁至 (plugin telemetry-*)
+;; 启动期 telemetry pending 队列：telemetry 实现已迁至 (telemetry telemetry-*)
 ;; 插件，启动时由 lazy-plugin-initialize 直接加载。插件加载前的 C++ 上报（OPEN/LOGIN 等）
-;; 由 telemetry-track-or-enqueue 入队，(plugin init-telemetry) 加载时
+;; 由 telemetry-track-or-enqueue 入队，(telemetry init-telemetry) 加载时
 ;; 通过 telemetry-drain-pending! 一次性补 track。这组符号注入 rootlet，
 ;; 不依赖任何模块，C++ 可直接 call。
 (let ((rl (rootlet)))

--- a/TeXmacs/tests/200_64.scm
+++ b/TeXmacs/tests/200_64.scm
@@ -17,8 +17,8 @@
 
 (check-set-mode! 'report-failed)
 
-(use-modules (plugin telemetry-utils))
-(use-modules (plugin telemetry-track))
+(use-modules (telemetry telemetry-utils))
+(use-modules (telemetry telemetry-track))
 
 (define (string-contains-digit? s)
   (let loop

--- a/TeXmacs/tests/2013.scm
+++ b/TeXmacs/tests/2013.scm
@@ -18,7 +18,7 @@
   (only (liii path) path-exists? path-with-suffix path->string)
 ) ;import
 
-(use-modules (plugin telemetry-utils))
+(use-modules (telemetry telemetry-utils))
 
 (check-set-mode! 'report-failed)
 

--- a/devel/1193.md
+++ b/devel/1193.md
@@ -499,3 +499,81 @@ ocr 插件模块从 `(liii ocr)` 改为 `(ocr liii-ocr)`。
 ### 如何测试
 
 `xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。
+
+## 任务 14：telemetry 插件子模块命名空间规范化
+
+### What
+
+telemetry 插件中 4 个子模块从共享命名空间 `plugin` 改为插件专属 `telemetry`：
+
+| 旧模块名 | 新模块名 |
+|---------|---------|
+| `(plugin telemetry)` | `(telemetry telemetry)` |
+| `(plugin telemetry-track)` | `(telemetry telemetry-track)` |
+| `(plugin telemetry-utils)` | `(telemetry telemetry-utils)` |
+| `(plugin init-telemetry)` | `(telemetry init-telemetry)` |
+
+文件从 `progs/plugin/` 迁移至 `progs/telemetry/`，删除空目录 `progs/plugin/`。
+
+### Why
+
+插件内模块命名规范：一级命名空间必须以插件名开头。`(plugin ...)` 占据 plugin
+命名空间，违反规范。
+
+### How
+
+- 4 个文件 `texmacs-module` 声明及模块间 `:use` 同步更新
+- 文件从 `progs/plugin/` 迁移至 `progs/telemetry/`
+- 外部引用更新：
+  - `TeXmacs/plugins/telemetry/progs/init-telemetry.scm` 中 `use-modules`
+  - `TeXmacs/tests/200_64.scm` 中 2 处 `use-modules`
+  - `TeXmacs/tests/2013.scm` 中 1 处 `use-modules`
+  - `src/Mogan/Telemetry/telemetry.hpp` 中注释引用
+  - `TeXmacs/progs/init-research.scm` 中 2 处注释引用
+- 删除空目录 `progs/plugin/`
+
+### 涉及文件
+
+- `TeXmacs/plugins/telemetry/progs/telemetry/telemetry.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-track.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/telemetry/progs/telemetry/init-telemetry.scm`（从 `progs/plugin/` 移入）
+- `TeXmacs/plugins/telemetry/progs/init-telemetry.scm`
+- `TeXmacs/tests/200_64.scm`
+- `TeXmacs/tests/2013.scm`
+- `src/Mogan/Telemetry/telemetry.hpp`
+- `TeXmacs/progs/init-research.scm`
+- `TeXmacs/plugins/telemetry/progs/plugin/`（删除）
+
+### 如何测试
+
+`xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。
+
+## 任务 15：physics 插件子模块命名空间规范化
+
+### What
+
+physics 插件模块从 `(contrib physics physics-drd)` 改为 `(physics physics-drd)`。
+文件从 `progs/contrib/physics/` 迁移至 `progs/physics/`，删除空目录 `progs/contrib/`。
+
+### Why
+
+插件内模块命名规范：一级命名空间必须以插件名开头。`(contrib physics ...)`
+占据 contrib 命名空间，违反规范。
+
+### How
+
+- 模块文件从 `progs/contrib/physics/physics-drd.scm` 迁移至 `progs/physics/physics-drd.scm`
+- `texmacs-module` 声明从 `(contrib physics physics-drd)` 改为 `(physics physics-drd)`
+- `packages/contrib/physics.stem` 中 `use-module` 路径更新
+- 删除空目录 `progs/contrib/`
+
+### 涉及文件
+
+- `TeXmacs/plugins/physics/progs/physics/physics-drd.scm`（从 `progs/contrib/physics/` 移入）
+- `TeXmacs/plugins/physics/packages/contrib/physics.stem`
+- `TeXmacs/plugins/physics/progs/contrib/`（删除）
+
+### 如何测试
+
+`xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新，导出符号不变）。

--- a/src/Mogan/Telemetry/telemetry.hpp
+++ b/src/Mogan/Telemetry/telemetry.hpp
@@ -13,7 +13,7 @@
 
 #if !IS_COMMUNITY
 
-// telemetry 相关 scheme 代码已迁移至 (plugin telemetry-*) 模块，由
+// telemetry 相关 scheme 代码已迁移至 (telemetry telemetry-*) 模块，由
 // telemetry 插件在事件循环启动 ~3s 后懒加载。C++ 调用由 init-research.scm
 // 注入 rootlet 的 telemetry-track-or-enqueue 兜底：插件加载前事件入
 // *telemetry-pending* 队列，加载后 (init-telemetry) 通过


### PR DESCRIPTION
## 改动

telemetry 和 physics 插件模块命名空间规范化，一级命名空间改为以插件名开头。

### telemetry 插件

| 旧模块名 | 新模块名 |
|---------|---------|
| `(plugin telemetry)` | `(telemetry telemetry)` |
| `(plugin telemetry-track)` | `(telemetry telemetry-track)` |
| `(plugin telemetry-utils)` | `(telemetry telemetry-utils)` |
| `(plugin init-telemetry)` | `(telemetry init-telemetry)` |

文件从 `progs/plugin/` 迁移至 `progs/telemetry/`。

### physics 插件

| 旧模块名 | 新模块名 |
|---------|---------|
| `(contrib physics physics-drd)` | `(physics physics-drd)` |

文件从 `progs/contrib/physics/` 迁移至 `progs/physics/`。

### 测试

`xmake b stem` 构建通过即可（纯文件迁移 + 模块引用更新）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)