### PR TITLE
[1198] 修复 GUI 导出 PDF 报 no window attached to view

### DIFF
--- a/TeXmacs/tests/1198.scm
+++ b/TeXmacs/tests/1198.scm
@@ -1,0 +1,72 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1198.scm
+;; DESCRIPTION : 回归测试：GUI 下导出 PDF 抛 "no window attached to view"
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   在真实 GUI 进程中复现 File -> Export -> Pdf 的完整链路
+;;   （wrapped-print-to-file：复制当前 buffer 到临时 buffer、切过去排版打印、
+;;   切回、关闭临时 buffer），断言 PDF 真正落盘。
+;;   修复前：链路中某处取到未挂窗口的 current view，concrete_window () 断言
+;;   "no window attached to view" 被抛出，导出中断、PDF 不生成。
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 1198      # 真实 GUI，跑断言链
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+;; wrapped-print-to-file 里调 screens-buffer?（定义在 dynamic/fold-edit.scm，
+;; 生产环境经菜单惰性加载）；测试在启动早期就跑，需显式加载避免 unbound。
+(load "./TeXmacs/progs/dynamic/fold-edit.scm")
+
+(check-set-mode! 'report-failed)
+
+(define in-path "/tmp/1198_in.tm")
+(define out-path "/tmp/1198_out.pdf")
+
+(define step-delay-ms 1000)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1198-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1198)
+  (run-chain (list
+    (cons "prepare doc" (lambda ()
+      (string-save "<\\document>\n  Hello PDF export test.\n</document>\n" in-path)
+      (load-buffer in-path)
+    ))
+    (cons "wrapped-print-to-file" (lambda ()
+      (wrapped-print-to-file out-path)
+    ))
+    (cons "check pdf exists" (lambda ()
+      (check (url-exists? (system->url out-path)) => #t)
+    ))
+    (cons "report + quit" (lambda ()
+      (check-report)
+      (quit-TeXmacs)
+    ))
+  ))
+) ;tm-define

--- a/devel/1198.md
+++ b/devel/1198.md
@@ -1,0 +1,62 @@
+# 1198 修复 GUI 导出 PDF 报 "Throwing no window attached to view"
+
+## 现象
+
+界面上 File -> Export -> Pdf（以及另两个内嵌 tmu/tm 的 PDF 导出），导出中断，
+终端打印 `Throwing no window attached to view`，PDF 不生成。
+
+## 根因
+
+e0359ebdf（[0853] update_menus 分类重建）在 `edit_modify_rep::notify_save`
+里新增「保存清脏后刷新 tab 栏与侧栏」：
+
+```cpp
+if (has_current_window ()) update_menus (TAB_PAGES | SIDE_TOOLS);
+```
+
+`has_current_window ()` 检查的是**全局** current view，而不是发起保存的
+editor 自己的视图。导出 PDF 的链路：
+
+1. `wrapped-print-to-file`（tm-print.scm）`buffer-new` 建临时 buffer
+   （只有一个 passive view，`win == NULL`），`buffer-copy` 复制内容；
+2. `buffer-copy` → C++ `set_buffer_body` → `pretend_buffer_saved` →
+   对临时 buffer 每个视图的 editor 调 `notify_save ()`；
+3. 此时全局 current view 仍是挂在窗口上的原文档视图，守卫通过，
+   于是对**临时 buffer 的 editor** 调 `update_menus`；
+4. `update_menus` 里 `SERVER (tab_pages ())` 宏（src/Edit/editor.hpp）
+   先 `focus_on_this_editor ()` 把 current view 切到本 editor 的
+   passive view（无窗口），再执行 `tab_pages ()`；
+5. `tm_frame_rep::tab_pages` → `concrete_window ()` 断言
+   `vw->win != NULL` 失败，抛 "no window attached to view"。
+
+gdb 定位过程：复现用 `MOGAN_TEST_GUI=1 QT_QPA_PLATFORM=offscreen` +
+`MOGAN_TEST_CHOOSE_FILE` 钩子驱动导出，`break tm_throw` 拿栈，
+`watch 'new_view.cpp'::the_view` 抓到 current view 在
+`update_menus`（edit_interface.cpp:949）内被 `focus_on_editor` 换成
+无窗口视图。
+
+## 修复
+
+`notify_save` 的守卫从「全局有窗口」改为「本 editor 的视图挂在窗口上」：
+遍历本 buffer 的视图，找到本 editor 的视图且 `view_to_window` 非 none
+才刷新菜单。未上屏的 editor（导出临时 buffer、后台 passive view）不再
+触发菜单重建——本来也无可视内容可刷新。
+
+正常保存路径（当前上屏 editor）行为不变；`pretend_buffer_saved` 对上屏
+buffer 的刷新也不变。
+
+## 涉及文件
+
+- `src/Edit/Modify/edit_modify.cpp` — `notify_save` 守卫改为按本 editor
+  视图的窗口挂载状态判断；新增 `new_view.hpp` include。
+- `TeXmacs/tests/1198.scm` — GUI 集成回归测试：真实 GUI 下跑
+  `wrapped-print-to-file` 全链路，断言 PDF 落盘。
+
+## 测试
+
+```bash
+xmake b stem
+MOGAN_TEST_GUI=1 xmake r 1198   # 1 correct, 0 failed（修复前抛断言、PDF 不生成）
+xmake r 1198                    # headless 冒烟
+xmake r should_update_menu_test # 0853 既有单元测试 12 passed
+```

--- a/src/Edit/Modify/edit_modify.cpp
+++ b/src/Edit/Modify/edit_modify.cpp
@@ -11,6 +11,7 @@
 
 #include "edit_modify.hpp"
 #include "modification.hpp"
+#include "new_view.hpp"
 #include "new_window.hpp"
 #include "observers.hpp"
 #include "tm_window.hpp"
@@ -456,8 +457,19 @@ edit_modify_rep::notify_save (bool real_save) {
   arch->notify_autosave ();
   if (real_save) {
     arch->notify_save ();
-    // 保存清脏后刷新 tab 栏与侧栏文档列表
-    if (has_current_window ()) update_menus (TAB_PAGES | SIDE_TOOLS);
+    // 保存清脏后刷新 tab 栏与侧栏文档列表；本 editor 的视图未挂窗口时跳过：
+    // update_menus 的 SERVER 宏会 focus_on_this_editor 把 current view 切到
+    // 本 editor 的视图，无窗口（如导出 PDF 临时 buffer 的 passive view）时
+    // concrete_window () 断言 "no window attached to view"
+    bool attached= false;
+    if (!is_nil (buf)) {
+      array<url> vs= buffer_to_views (buf->buf->name);
+      for (int i= 0; i < N (vs); i++)
+        if (view_to_editor (vs[i]) == editor (this) &&
+            !is_none (view_to_window (vs[i])))
+          attached= true;
+    }
+    if (attached) update_menus (TAB_PAGES | SIDE_TOOLS);
   }
 }
 


### PR DESCRIPTION
## 现象

界面上 File -> Export -> Pdf（及内嵌 tmu/tm 的两个 PDF 导出），导出中断，终端打印 `Throwing no window attached to view`，PDF 不生成。

## 根因

e0359ebdf（[0853] update_menus 分类重建）在 `edit_modify_rep::notify_save` 新增「保存清脏后刷新 tab 栏与侧栏」：`if (has_current_window ()) update_menus (TAB_PAGES | SIDE_TOOLS);`。

`has_current_window ()` 检查的是**全局** current view，而非发起保存的 editor 自己。导出 PDF 链路中 `wrapped-print-to-file` 建临时 buffer（仅一个无窗口 passive view）并 `buffer-copy` → `set_buffer_body` → `pretend_buffer_saved` → 对临时 buffer 的 editor 调 `notify_save`。全局守卫通过后，`update_menus` 里 `SERVER` 宏（src/Edit/editor.hpp）先 `focus_on_this_editor ()` 把 current view 切到本 editor 的无窗口视图，`tab_pages ()` → `concrete_window ()` 断言失败抛出。

## 修复

`notify_save` 守卫改为判断**本 editor 的视图是否挂在窗口上**（`buffer_to_views` + `view_to_editor == editor(this)` + `view_to_window` 非 none）。未上屏的 editor 不再触发菜单重建；正常保存路径行为不变。三个 `wrapped-print-to-*` 共用该路径，一并覆盖。

## 测试

- 新增 `TeXmacs/tests/1198.scm` GUI 集成回归测试：`MOGAN_TEST_GUI=1 xmake r 1198` 修复前复现 throw、PDF 不生成；修复后 1 correct, 0 failed
- `xmake r 1198` headless 冒烟通过
- `xmake r should_update_menu_test`（0853 既有单测）12 passed

详见 devel/1198.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)