### PR TITLE
[1199] kbd-map 支持 ￥、、 等非 ASCII 键

### DIFF
--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -50,8 +50,16 @@
  ("\\" (if (or (inside? 'hybrid) (in-prog?)) (insert "\\") (make-hybrid)))
  ("\\ var" "\\")
  ("\\ var var" "<setminus>")
+ ;; 中文输入法 \ 键提交的 、（U+3001）：默认同 \（进 hybrid），
+ ;; Tab 变体插入 、 字符本身（shorthand 用 cork，见 kbd-insert）
+ ("、" (if (or (inside? 'hybrid) (in-prog?)) (insert "<#3001>") (make-hybrid)))
+ ("、 var" "<#3001>")
  ("$" (make 'math))
  ("$ var" "$")
+ ;; 中文输入法 Shift+4 提交的全角 ￥（U+FFE5）：默认进数学模式（同 $），
+ ;; 按 Tab 变体插入 ￥ 字符本身（shorthand 用 cork，见 kbd-insert）
+ ("￥" (make 'math))
+ ("￥ var" "<#FFE5>")
 
  ("-" "-")
  ("space" (kbd-space))

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -458,8 +458,11 @@
 (tm-define (kbd-binding conds key2 cmd help)
   (:synopsis "Helper routine for kbd-map macro")
   ;; (display* conds ", " key2 ", " cmd ", " help "\n")
+  ;; 键名字面量按 UTF-8 归一为运行时查找用的 cork，kbd-map 因此可直接
+  ;; 书写非 ASCII 键（如 "￥"，见 devel/1199.md）；查找路径不转换——
+  ;; 运行时键本就是 cork，可能含单字节高位 cork 字符，再转会被破坏
   (with key
-    (kbd-pre-rewrite key2)
+    (kbd-pre-rewrite (string-convert key2 "UTF-8" "Cork"))
     (kbd-sub-bindings conds key)
     (kbd-insert-key-binding conds key (list cmd help))
   ) ;with

--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -109,6 +109,8 @@
   ("altcmd F7" (make 'math-tt))
   ("altcmd F8" (make 'math-ss))
   ("$" (math-make-math))
+  ;; 中文输入法 Shift+4 提交的全角 ￥，与 $ 一致：跳出数学模式
+  ("￥" (math-make-math))
   ("math $" (make 'text))
   ("`" (make-lprime "`"))
   ("'" (make-rprime "'"))

--- a/TeXmacs/tests/1199.scm
+++ b/TeXmacs/tests/1199.scm
@@ -1,0 +1,92 @@
+;; MODULE      : 1199.scm
+;; DESCRIPTION : 回归测试：kbd-map 支持 UTF-8 键名（kbd-binding 注册时
+;;             : UTF-8→cork 归一），中文输入法 Shift+4 提交的全角 ￥
+;;             : （cork <#FFE5>）由此可在 kbd-map 生效。
+;;
+;;   断言（keyboard-press 直调，驱动真实 key_press 路径）：
+;;     1. 编码契约：(string-convert "￥" "UTF-8" "Cork") => "<#FFE5>"。
+;;     2. 注册契约：(kbd-find-key-binding "<#FFE5>") 有绑定
+;;        （scheme 侧 ("￥" ...) 键名经归一后被 cork 查找命中）。
+;;     3. 文本模式 keyboard-press "<#FFE5>" → (get-env "mode") 变 "math"。
+;;     4. 数学模式再次 keyboard-press "<#FFE5>" → mode 回到 "text"。
+;;     5. 变体：文本模式 ￥ 后按 tab → 撤销数学模式、插入 ￥ 字符本身。
+;;     6. 文本模式 keyboard-press "<#3001>"（、）→ 进入 hybrid（同 \）。
+;;     7. 、 后按 tab → 撤销 hybrid、插入 、 字符本身。
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 1199      # 真实 GUI，跑断言链
+;;
+;; 注意：断言在异步链里，必须 MOGAN_TEST_GUI=1 才执行——headless 模式
+;; （xmake r 1199）启动即 (quit-TeXmacs)，异步链来不及调度，断言不跑
+;; （仅冒烟进程不崩）。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY whatsoever. For details see LICENSE.
+
+(texmacs-module (texmacs tests 1199))
+
+(import (liii check))
+(check-set-mode! 'report-failed)
+
+(define step-delay-ms 500)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1199-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1199)
+  (run-chain (list (cons "encoding contract: ￥ -> cork <#FFE5>"
+                     (lambda () (check (string-convert "￥" "UTF-8" "Cork") => "<#FFE5>"))
+                   ) ;cons
+               (cons "new document in text mode"
+                 (lambda () (new-document) (check (get-env "mode") => "text"))
+               ) ;cons
+               (cons "registration: utf8 key ￥ reachable via cork lookup"
+                 (lambda () (check-true (pair? (kbd-find-key-binding "<#FFE5>"))))
+               ) ;cons
+               (cons "<#FFE5> enters math mode"
+                 (lambda () (keyboard-press "<#FFE5>" 0) (check (get-env "mode") => "math"))
+               ) ;cons
+               (cons "<#FFE5> again leaves math mode"
+                 (lambda () (keyboard-press "<#FFE5>" 0) (check (get-env "mode") => "text"))
+               ) ;cons
+               (cons "variant: ￥ then tab inserts ￥ itself"
+                 (lambda ()
+                   (keyboard-press "<#FFE5>" 0)
+                   (check (get-env "mode") => "math")
+                   (keyboard-press "tab" 0)
+                   (check (get-env "mode") => "text")
+                   (check-true (string-contains? (tree->string (buffer-tree)) "￥"))
+                 ) ;lambda
+               ) ;cons
+               (cons "、 behaves like backslash (hybrid) in text mode"
+                 (lambda () (keyboard-press "<#3001>" 0) (check-true (inside? 'hybrid)))
+               ) ;cons
+               (cons "、 then tab inserts 、 itself"
+                 (lambda ()
+                   (keyboard-press "tab" 0)
+                   (check-false (inside? 'hybrid))
+                   (check-true (string-contains? (tree->string (buffer-tree)) "、"))
+                 ) ;lambda
+               ) ;cons
+               (cons "report + quit" (lambda () (check-report) (quit-TeXmacs)))
+             ) ;list
+  ) ;run-chain
+  (noop)
+) ;tm-define

--- a/devel/1199.md
+++ b/devel/1199.md
@@ -1,0 +1,107 @@
+# [1199] kbd-map 支持 UTF-8 键名：中文输入法 Shift+4 的全角 ￥ 进数学模式
+
+## 问题
+
+文本模式下按 Shift+4，中文输入法激活时提交的是全角人民币符号 ￥
+（U+FFE5），而不是 $——于是既不触发 `$` 的 kbd-map 绑定
+（`(make 'math)`，进入数学模式），还把 ￥ 原样插进了文档。
+
+输入法提交链路：Qt `inputMethodEvent` commit 字符串 → `process_keypress`
+→ `handle_keypress`（`utf8_to_cork`）→ `keyboard-press` → `key_press`
+→ `try_shortcut` → scheme `kbd-find-key-binding`。
+
+编码事实（用 `(string-convert s "UTF-8" "Cork")` 实测）：
+
+- 全角 ￥（U+FFE5）→ cork `<#FFE5>`（中文输入法 Shift+4 的提交）
+- 半角 ¥（U+00A5）→ cork `<yen>`（日文的 ¥ 键等场景，本任务不处理）
+
+**核心矛盾**：kbd-map 的查找键是 cork 形式（`<#FFE5>`），而 scheme 源码里
+自然的写法是 UTF-8 字面量（`"￥"`）——两者不匹配，导致 kbd-map 无法绑定
+非 ASCII 键。
+
+## 方案（How）
+
+### 1. kbd-binding 注册时把键名 UTF-8→cork 归一
+
+`TeXmacs/progs/kernel/gui/kbd-define.scm` 的 `kbd-binding`：
+`(kbd-pre-rewrite key2)` 改为 `(kbd-pre-rewrite (string-convert key2 "UTF-8" "Cork"))`。
+
+- 注册侧键名永远是 scheme 源码字面量（合法 UTF-8），转换安全；
+  纯 ASCII 键（含 `<#FFE5>` 这类实体写法）经转换是恒等，无回归。
+- **查找路径（kbd-find-key-binding）刻意不转换**：运行时键本就是 cork，
+  可能含单字节高位 cork 字符（如 £ → 单字节 0x9E），再按 UTF-8 转换会被
+  破坏。
+- 影响面排查：现有全部 kbd 文件中仅 generic-kbd.scm 一条非 ASCII 键
+  （`("symbol <U+FFFD>" ...)`，历史编码损坏残留），本就永不命中，转换后
+  反而变为可命中的 cork 形式。
+- 用户提过备选 `utf8-kbd-map` 宏；因 kbd-map 本体即可安全支持，未新增宏。
+
+### 2. ￥ 与 、 的绑定镜像 $ 与 \
+
+`TeXmacs/progs/generic/generic-kbd.scm`（无条件块，紧跟 $ 之后）：
+
+```scheme
+ ("￥" (make 'math))
+ ("￥ var" "<#FFE5>")
+```
+
+- 默认行为同 $：文本模式进数学模式（`(make 'math)`）。
+- `var` 变体（按 Tab）：走既有 variant 机制——`"￥ var"` 经 pre-wildcard
+  `var→tab` 注册为 `"<#FFE5> tab"`；按 Tab 时 `try_shortcut` 命中后
+  `mark_cancel` 撤销上一步的 `(make 'math)`，再 `kbd-insert` shorthand
+  插入 ￥ 字符本身。**shorthand 必须是 cork**（`kbd-insert` = `insert`，
+  按 cork 解释；先例见 jcuken-kbd.scm 的 `("q" "<#439>")`）。
+
+同一文件中，镜像 `\`（中文输入法 \ 键提交 、，U+3001）：
+
+```scheme
+ ("、" (if (or (inside? 'hybrid) (in-prog?)) (insert "<#3001>") (make-hybrid)))
+ ("、 var" "<#3001>")
+```
+
+- 文本模式默认同 `\`：进 hybrid；hybrid/prog 内插入 、 本身。
+- Tab 变体插入 、 字符本身（未镜像 `\ var var` 的 `<setminus>`，
+  变体循环为两级：hybrid ↔ 、）。
+
+`TeXmacs/progs/math/math-kbd.scm`（`(:mode in-math?)` 块）：
+
+```scheme
+  ("￥" (math-make-math))
+```
+
+数学模式下同 $：跳出数学模式（、 在数学模式无独立绑定，走 generic
+无条件块，与 \ 的现状一致）。
+
+## 涉及文件
+
+- `TeXmacs/progs/kernel/gui/kbd-define.scm` — `kbd-binding` 键名归一
+- `TeXmacs/progs/generic/generic-kbd.scm` — ￥ / ￥ var 绑定
+- `TeXmacs/progs/math/math-kbd.scm` — 数学模式 ￥ 绑定
+- `TeXmacs/tests/1199.scm` — GUI 集成测试
+
+## 如何测试
+
+```bash
+xmake b stem
+xmake r 1199                    # headless 冒烟（进程不崩）
+MOGAN_TEST_GUI=1 xmake r 1199   # 真实 GUI，跑断言链
+```
+
+断言（keyboard-press 直调，驱动真实 `key_press` 路径）：
+
+1. 编码契约：`(string-convert "￥" "UTF-8" "Cork")` => `"<#FFE5>"`。
+2. 注册契约：`(kbd-find-key-binding "<#FFE5>")` 有绑定（UTF-8 键名经归一
+   后被 cork 查找命中）。
+3. 文本模式 keyboard-press `<#FFE5>` → mode 变 `"math"`。
+4. 数学模式再次 `<#FFE5>` → mode 回到 `"text"`。
+5. 变体：文本模式 ￥ 后按 tab → 撤销数学模式、文档中插入 ￥ 字符。
+6. 文本模式 keyboard-press `<#3001>`（、）→ 进入 hybrid（同 \）。
+7. 、 后按 tab → 撤销 hybrid、插入 、 字符本身。
+
+## 手动验证清单
+
+1. 中文输入法激活，文本模式 Shift+4 → 进入数学模式（同 $）。
+2. 数学模式中 Shift+4 → 跳出数学模式。
+3. 文本模式 Shift+4 后紧接着按 Tab → 得到 ￥ 字符本身。
+4. 中文输入法下按 \（提交 、）→ 进入 hybrid（同 \）；再按 Tab → 得到 、。
+5. 英文输入法下 Shift+4、\ 行为不变。


### PR DESCRIPTION
## 问题

中文输入法激活时：
- Shift+4 提交全角 ￥（U+FFE5）而非 $，既不触发 $ 的 kbd-map 绑定（进数学模式），还把 ￥ 原样插入文档
- \ 键提交 、（U+3001），同样无法走 kbd-map

根因：kbd-map 查找键是 cork 形式（`<#FFE5>`），scheme 源码里自然的 UTF-8 字面量（`"￥"`）无法命中。

## 方案

- `kbd-binding` 注册键名时做 UTF-8→cork 归一（`TeXmacs/progs/kernel/gui/kbd-define.scm`），kbd-map 可直接书写非 ASCII 键；查找路径不转换（运行时键可能含单字节高位 cork 字符，再转会破坏）
- `￥`：默认 `(make 'math)`（同 $），Tab 变体插入 ￥ 本身（走既有 variant 机制：`mark_cancel` 撤销 + `kbd-insert`）
- `、`：默认同 \（文本模式进 hybrid），Tab 变体插入 、 本身
- 数学模式 `￥` 同 $：`(math-make-math)` 跳出数学

## 测试

- `TeXmacs/tests/1199.scm` GUI 集成测试：`MOGAN_TEST_GUI=1 xmake r 1199`
- 详见 `devel/1199.md`（含手动验证清单）

🤖 Generated with [Claude Code](https://claude.com/claude-code)