### PR TITLE
[0900] 导出 PDF 后默认打开文件

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-print.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-print.scm
@@ -145,7 +145,7 @@
 
 (define (user-confirm-open-pdf fname)
   (user-simple-confirm "Open PDF?"
-    #f
+    #t
     (lambda (open?) (when open? (preview-file fname)))
   ) ;user-simple-confirm
 ) ;define

--- a/devel/0900.md
+++ b/devel/0900.md
@@ -1,24 +1,21 @@
-# [0900] PDF export opens by default
+# [0900] 导出 PDF 后默认打开文件
 
-## Related issue
-- PDF export completion confirmation should default to opening the exported file.
-
-## Task files
+## 任务相关的代码文件
 - `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
 
-## How to test
-1. Build and install Mogan STEM.
-2. Open any document and select File -> Export -> Pdf.
-3. After export completes, verify that the "Open PDF?" dialog defaults to Yes.
-4. Press Enter and verify that the exported PDF opens.
+## 如何测试
+1. 构建并安装 Mogan STEM。
+2. 打开任意文档，选择“文件 -> 导出 -> Pdf”。
+3. 导出完成后，确认“打开 PDF？”对话框默认选中“是”。
+4. 直接按 Enter，确认导出的 PDF 被打开。
 
-## 2026/08/12 Default to opening exported PDF
+## 2026/08/12 导出 PDF 后默认打开文件
 
 ### What
-- Make the PDF export completion confirmation default to Yes.
+- 将 PDF 导出完成后的确认对话框默认选项改为“是”。
 
 ### Why
-- The confirmation currently defaults to No, which adds an unnecessary action for the common workflow of viewing the exported PDF.
+- 用户通常需要立即查看刚导出的 PDF，默认“否”会增加一次不必要的确认操作。
 
 ### How
-- Pass `#t` as the default choice to `user-simple-confirm` in `user-confirm-open-pdf`.
+- 在 `user-confirm-open-pdf` 中向 `user-simple-confirm` 传入 `#t`，使“是”成为默认选项。

--- a/devel/0900.md
+++ b/devel/0900.md
@@ -1,0 +1,24 @@
+# [0900] PDF export opens by default
+
+## Related issue
+- PDF export completion confirmation should default to opening the exported file.
+
+## Task files
+- `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
+
+## How to test
+1. Build and install Mogan STEM.
+2. Open any document and select File -> Export -> Pdf.
+3. After export completes, verify that the "Open PDF?" dialog defaults to Yes.
+4. Press Enter and verify that the exported PDF opens.
+
+## 2026/08/12 Default to opening exported PDF
+
+### What
+- Make the PDF export completion confirmation default to Yes.
+
+### Why
+- The confirmation currently defaults to No, which adds an unnecessary action for the common workflow of viewing the exported PDF.
+
+### How
+- Pass `#t` as the default choice to `user-simple-confirm` in `user-confirm-open-pdf`.


### PR DESCRIPTION
## 修改内容

- 将 PDF 导出完成后的确认对话框默认选项设为“是”。
- 新增 0900 任务文档。

## 验证

- `xmake build --yes stem` 构建成功。
- `xmake install --yes stem` 安装成功。

## 手动验证

- 导出 PDF 后，确认“打开 PDF？”对话框默认选中“是”。
- 直接按 Enter，确认导出的 PDF 被打开。
