### PR TITLE
[1199] 使用 utf8-kbd-map 支持 ￥、等非 ASCII 键

### DIFF
--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -229,6 +229,12 @@
  ("std j" (toggle-chat-sidebar))
 ) ;kbd-map
 
+(utf8-kbd-map ("、" (if (or (inside? 'hybrid) (in-prog?)) (insert "<#3001>") (make-hybrid)))
+ ("、 var" "<#3001>")
+ ("￥" (make 'math))
+ ("￥ var" "<#FFE5>")
+) ;utf8-kbd-map
+
 (kbd-map (:require (list-structured-insert-context?))
  ("structured:insert delete" (structured-remove-down))
  ("structured:insert backspace" (structured-remove-up))

--- a/TeXmacs/progs/kernel/gui/kbd-define.scm
+++ b/TeXmacs/progs/kernel/gui/kbd-define.scm
@@ -512,9 +512,62 @@
   `(begin ,@(kbd-map-body '() l))
 ) ;tm-define-macro
 
+(tm-define (utf8-kbd-binding conds key2 cmd help)
+  (:synopsis "Helper routine for utf8-kbd-map macro")
+  (with key
+    (kbd-pre-rewrite (string-convert key2 "UTF-8" "Cork"))
+    (kbd-sub-bindings conds key)
+    (kbd-insert-key-binding conds key (list cmd help))
+  ) ;with
+) ;tm-define
+
+(define (utf8-kbd-map-one conds l)
+  (if (not (and (pair? l) (string? (car l)) (pair? (cdr l))))
+    (texmacs-error "utf8-kbd-map-pre-one" "Bad keymap in: ~S" l)
+  ) ;if
+  (with (key action . opt)
+    l
+    (if (string? action)
+      (with help
+        (if (null? opt) "" (car opt))
+        `(utf8-kbd-binding (list ,@conds) ,key ,action ,help)
+      ) ;with
+      `(utf8-kbd-binding (list ,@conds) ,key (lambda ,() ,action ,@opt) ,"")
+    ) ;if
+  ) ;with
+) ;define
+
+(define (utf8-kbd-map-body conds l)
+  (cond ((null? l) '())
+        ((symbol? (car l)) (utf8-kbd-map-body (list 0 (car l)) (cdr l)))
+        ((and (pair? (car l)) (== (caar l) :profile))
+         (if (not (has-look-and-feel? (cdar l)))
+           '((noop))
+           (utf8-kbd-map-body conds (cdr l))
+         ) ;if
+        ) ;
+        ((and (pair? (car l)) (keyword? (caar l)))
+         (utf8-kbd-map-body (kbd-add-condition conds (car l)) (cdr l))
+        ) ;
+        (else (map (lambda (x) (utf8-kbd-map-one conds x)) l))
+  ) ;cond
+) ;define
+
+(tm-define-macro (utf8-kbd-map . l)
+  (:synopsis "Add entries with UTF-8 key names to the keyboard mapping")
+  `(begin ,@(utf8-kbd-map-body '() l))
+) ;tm-define-macro
+
 (tm-define-macro (delayed-kbd-map . l)
   (:synopsis "Like kbd-map, but register bindings in chunks via the event loop")
   `(kbd-enqueue (list ,@(map (lambda (x) `(lambda ,() ,x)) (kbd-map-body '() l))))
+) ;tm-define-macro
+
+(tm-define-macro (utf8-delayed-kbd-map . l)
+  (:synopsis "Like utf8-kbd-map, but register bindings in chunks via the event loop"
+  ) ;:synopsis
+  `(kbd-enqueue (list ,@(map (lambda (x) `(lambda ,() ,x))
+                          (utf8-kbd-map-body '() l))))
 ) ;tm-define-macro
 
 (define (kbd-remove-one conds key)

--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -1229,6 +1229,8 @@
   ("~ = /" "<ncong>")
 ) ;delayed-kbd-map
 
+(utf8-delayed-kbd-map (:mode in-math?) ("￥" (math-make-math)))
+
 (delayed-kbd-map (:mode in-math-or-hybrid?)
  ("/ \\" "<wedge>")
  ("/ \\ var " "<cap>")

--- a/TeXmacs/tests/1199.scm
+++ b/TeXmacs/tests/1199.scm
@@ -1,0 +1,63 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1199.scm
+;; DESCRIPTION : 回归测试：UTF-8 键名通过 utf8-kbd-map 注册，不改变旧 kbd-map。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs tests 1199))
+
+(import (liii check))
+(check-set-mode! 'report-failed)
+
+(define (test-1199-encoding)
+  (check (string-convert "￥" "UTF-8" "Cork") => "<#FFE5>")
+  (check (string-convert "、" "UTF-8" "Cork") => "<#3001>")
+) ;define
+
+(define (test-1199-bindings)
+  (kbd-flush-pending)
+  (check-true (pair? (kbd-find-key-binding "<#FFE5>")))
+  (check-true (pair? (kbd-find-key-binding "<#3001>")))
+  (check-true (pair? (kbd-find-key-binding "<#FFE5> tab")))
+  (check-true (pair? (kbd-find-key-binding "<#3001> tab")))
+) ;define
+
+(define step-delay-ms 300)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((act (cdar rest)))
+        (exec-delayed-at (lambda () (act) (loop (cdr rest) (+ (texmacs-time) step-delay-ms)))
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1199)
+  (test-1199-encoding)
+  (test-1199-bindings)
+  (run-chain (list (cons "new document"
+                     (lambda () (new-document) (check (get-env "mode") => "text"))
+                   ) ;cons
+               (cons "￥ enters math"
+                 (lambda () (keyboard-press "<#FFE5>" 0) (check (get-env "mode") => "math"))
+               ) ;cons
+               (cons "￥ leaves math"
+                 (lambda () (keyboard-press "<#FFE5>" 0) (check (get-env "mode") => "text"))
+               ) ;cons
+               (cons "、 enters hybrid"
+                 (lambda () (keyboard-press "<#3001>" 0) (check-true (inside? 'hybrid)))
+               ) ;cons
+               (cons "report + quit" (lambda () (check-report) (quit-TeXmacs)))
+             ) ;list
+  ) ;run-chain
+) ;tm-define

--- a/devel/1199.md
+++ b/devel/1199.md
@@ -1,0 +1,39 @@
+# [1199] kbd-map 支持 UTF-8 键名
+
+## What
+
+新增 `utf8-kbd-map`，支持中文输入法提交的 `￥`、`、` 键名。
+
+## Why
+
+保留旧 `kbd-map` 的注册逻辑，避免全局 UTF-8 到 Cork 转换影响已有快捷键。
+
+## How
+
+UTF-8 入口在注册键名时转换为 Cork；运行时查找仍使用已有 Cork 键。`￥`、`、`分别复用 `$`、`\\` 的编辑命令。
+
+## 测试
+
+```powershell
+xmake b -y stem
+xmake install -y stem
+xmake r 1199
+```
+
+已验证：`xmake b -y stem`、`xmake install -y stem`、`xmake r 1199` 均通过。
+headless 回归覆盖 UTF-8 到 Cork 的转换、`￥`/`、`及其 Tab 变体的注册可达性；
+实际输入法和编辑状态行为需手动验证。
+
+## 手动验证
+
+1. 中文输入法激活，文本模式下提交 `￥`，确认进入数学模式；再次提交，确认回到文本模式。
+2. 中文输入法激活，文本模式下提交 `、`，确认进入 hybrid；紧接 Tab，确认插入 `、` 本身。
+3. 中文输入法激活，提交普通中文候选词，确认预编辑与候选提交不受影响。
+4. 英文输入法下 `$`、`\\` 及其既有 Tab 变体保持原行为。
+
+## 涉及文件
+
+- `TeXmacs/progs/kernel/gui/kbd-define.scm`
+- `TeXmacs/progs/generic/generic-kbd.scm`
+- `TeXmacs/progs/math/math-kbd.scm`
+- `TeXmacs/tests/1199.scm`


### PR DESCRIPTION
﻿## 问题

#4315 通过修改旧 `kbd-binding`，使全部 `kbd-map` 注册都执行 UTF-8 到 Cork 转换。这会改变已有 `kbd-map` 的行为范围，与「不要更改之前 kbd-map 的逻辑」不符。

## 方案

- 新增独立 `utf8-kbd-map` 与 `utf8-delayed-kbd-map`，仅新入口在注册时做 UTF-8 到 Cork 转换
- 保持原有 `kbd-map`、`kbd-binding` 和 `delayed-kbd-map` 逻辑不变
- `￥`、`、`分别复用 `$`、`\\` 的编辑命令；数学模式下 `￥` 复用 `$` 的退出数学模式行为
- 添加 1199 回归测试，覆盖编码转换、两种按键及其 Tab 变体的注册可达性；GUI 模式异步覆盖编辑状态行为

关联：#4315

## 验证

- `gf fmt --changed-since=main`
- `xmake b -y stem`
- `xmake install -y stem`
- `xmake r 1199`

## 手动验证

- 中文输入法激活时，提交 `￥` 进入/退出数学模式
- 中文输入法激活时，提交 `、` 进入 hybrid，随后 Tab 插入 `、`
- 中文候选预编辑与普通候选提交不受影响
- 英文输入法下 `$`、`\\` 的既有行为不变
