### PR TITLE
[0902] 欢迎页最近文档「云端」标签紧跟标题

### DIFF
--- a/devel/0902.md
+++ b/devel/0902.md
@@ -1,0 +1,34 @@
+# 0902: 欢迎页最近文档「云端」标签紧跟标题
+
+## 2026/08/13 云端标签紧跟文档标题
+
+### What（本次改动做了什么）
+
+欢迎页（启动页）「最近文档」列表中，云端（协作）文档的「云端」小标签从行尾
+（时间戳左侧）移到文档标题之后，紧跟标题显示。
+
+### Why（为什么这么做）
+
+- 「云端」是文档来源的标识，语义上属于标题的一部分；原先 `nameLabel` 独占
+  stretch=1，把标签顶到行尾，与时间戳混在一侧，用户难以一眼看出哪份文档是云端文档。
+
+### How（怎么做的）
+
+`QTMHomePage::renderRecentDocs()` 的行布局原为
+`nameLabel(stretch=1) + cloudLabel + timeLabel`，stretch 全给了标题标签，
+导致云端标签被推到右侧。改为
+`nameLabel(stretch=0) + cloudLabel + addStretch(1) + timeLabel`：
+标题与云端标签按内容宽度依次排列、弹性空间由 `addStretch` 吸收，
+时间戳仍右对齐。标题过长时布局仍会压缩 `nameLabel`（其行为不变），
+不影响本地文档行的渲染。
+
+### 涉及文件
+
+- `src/Plugins/Qt/QTMHomePage.cpp`：`renderRecentDocs()` 中最近文档行的布局调整。
+
+### 测试方法
+
+1. 云端标签需要 Loro 协作构建：`xmake f --loro=y`（默认 `--loro=n` 不含协作功能），
+   再 `xmake b stem`。
+2. 打开过云端协作文档后回到欢迎页，「云端」标签应紧跟文档标题之后；
+   本地文档行布局与原来一致。

--- a/src/Plugins/Qt/QTMHomePage.cpp
+++ b/src/Plugins/Qt/QTMHomePage.cpp
@@ -645,8 +645,11 @@ QTMHomePage::renderRecentDocs () {
     DpiUtils::applyScaledFont (timeLabel, kRecentTimeFontPx);
     timeLabel->setAlignment (Qt::AlignRight | Qt::AlignVCenter);
 
-    rowLayout->addWidget (nameLabel, 1, Qt::AlignLeft | Qt::AlignVCenter);
+    // 标题与「云端」标签按内容宽度依次排列，弹性空间留给中间 stretch，
+    // 使标签紧跟标题而非被顶到行尾
+    rowLayout->addWidget (nameLabel, 0, Qt::AlignLeft | Qt::AlignVCenter);
     if (cloudLabel) rowLayout->addWidget (cloudLabel, 0, Qt::AlignVCenter);
+    rowLayout->addStretch (1);
     rowLayout->addWidget (timeLabel, 0, Qt::AlignRight | Qt::AlignVCenter);
     recentList_->setItemWidget (item, rowWidget);
   }


### PR DESCRIPTION
## What

欢迎页（启动页）「最近文档」列表中，云端（协作）文档的「云端」小标签从行尾（时间戳左侧）移到文档标题之后，紧跟标题显示。

## Why

「云端」是文档来源标识，语义上属于标题的一部分。原布局中 `nameLabel` 独占 stretch=1，把标签顶到行尾与时间戳混在一侧，用户难以一眼区分哪份是云端文档。

## How

`QTMHomePage::renderRecentDocs()` 行布局由
`nameLabel(stretch=1) + cloudLabel + timeLabel`
改为
`nameLabel(stretch=0) + cloudLabel + addStretch(1) + timeLabel`：
标题与云端标签按内容宽度依次排列，弹性空间由中间 stretch 吸收，时间戳保持右对齐。本地文档行渲染不变；标题过长时 `nameLabel` 仍会被布局压缩，行为与原来一致。

## 验证

- `xmake f -m releasedbg --loro=y`（含云端协作）+ `xmake b stem` 构建通过（Linux / Debian 13）
- `gf fmt --changed-since=main` 通过（0 文件被格式化改动）
- GUI 人工验证已通过：云端文档的「云端」标签紧跟标题显示，本地文档行渲染不变
