### PR TITLE
[1201] 启动时不预载 plugin-convert（184 ms -> 164 ms）

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -167,7 +167,6 @@
 (lazy-define (utils cas cas-out) cas->stree)
 (lazy-define (utils plugins plugin-cmd) pre-serialize utf8raw-serialize)
 (use-modules (utils library smart-table))
-(use-modules (utils plugins plugin-convert))
 (use-modules (utils misc markup-funcs))
 (use-modules (utils handwriting handwriting))
 (lazy-tmfs-handler (utils automate auto-tmfs) automate)

--- a/devel/1201.md
+++ b/devel/1201.md
@@ -1,0 +1,125 @@
+# 1201 启动性能打点与优化
+
+> 注：分析过程中加的临时打点（`chain/*`、`utils/*` 子打点、`tm-server/*` 子打点）
+> 已全部移除，仅保留本文件的分析结论。最终代码改动只有
+> `init-research.scm` 删除 `plugin-convert` 预载一处。
+
+
+## 目标
+
+定位并压缩 Mogan 启动耗时，通过 `boot-bench-mark` 打点逐步细化定位热点。
+
+## 2026-08-13 细化 tm-server/tm-view 打点
+
+**What**：把 `init-research.scm` 中 `tm-server/tm-view` 合并打点拆成两个模块各自计时，
+并在两个模块内部（`texmacs-module` 依赖链后、`define-preferences` 前后）加子打点，
+用 `(when (defined? 'boot-bench-mark) ...)` 守卫避免测试直接 load 模块时报错。
+
+**Why**：原合并打点 54ms，无法判断是模块加载、偏好注册还是依赖链的问题。
+
+**How / 结论**（headless 实测）：
+
+- `tm-server/use-chain`: 36ms —— 几乎全部耗时在 `(:use (generic document-edit))` 的依赖链加载
+- `tm-server/notify-defs` / `preferences`：各约 1ms
+- `tm-view`：4ms（无 `:use`，纯定义）
+
+下一步：在 `generic/document-edit` 依赖链内递归打点。
+
+**涉及文件**：
+
+- `TeXmacs/progs/init-research.scm`（拆分 use-modules 与打点）
+- `TeXmacs/progs/texmacs/texmacs/tm-server.scm`（use-chain / notify-defs / preferences 子打点）
+- `TeXmacs/progs/texmacs/texmacs/tm-view.scm`（notify-defs / preferences 子打点）
+
+## 2026-08-13 递归打点 document-edit 依赖链
+
+**What**：在 `document-edit` 的 5 个 `:use` 依赖、`generic-edit` 的 5 个子依赖的
+`texmacs-module` 声明后各加守卫打点；`environment` / `generic-edit` 文件末尾补 body 打点；
+`generic-edit.scm` 内部按 6 个 section 边界再细分。全部 `(when (defined? 'boot-bench-mark) ...)` 守卫。
+
+**结论**（headless 实测，tm-server 链共 ~36ms）：
+
+- `environment` body：9ms（`logic-table` 大表定义）
+- `variants`+`tooltip`：7ms
+- `generic-edit` body：15ms，内部按 section 拆开后**均匀分布、无单点热点**
+  （最大段 ge-kbd-edit ~1400 行仅 5ms），即 s7 解释执行顶层定义的固定成本
+- `utils/library/tree` 的 26ms 属于 utils 阶段（被更早加载，document-edit 命中缓存）
+- `define-preferences` 全程 ~1ms，排除偏好注册嫌疑
+
+**优化方向**：无局部热点可修，耗时与模块体积成正比。要压缩只能走
+lazy 化（推迟 `(:use (generic document-edit))`）或预编译/缓存求值结果的路线。
+
+**涉及文件**（仅打点，无行为改动）：
+
+- `TeXmacs/progs/utils/base/environment.scm`、`utils/library/{tree,length,cursor}.scm`
+- `TeXmacs/progs/utils/edit/variants.scm`、`utils/misc/tooltip.scm`
+- `TeXmacs/progs/generic/{generic-edit,document-style,document-edit}.scm`
+- `TeXmacs/progs/source/macro-search.scm`
+- `TeXmacs/plugins/latex/progs/latex/bibtex-bib-complete.scm`
+
+## 2026-08-13 utils 阶段细化 + plugin-convert 定位
+
+**What**：`init-research.scm` utils 阶段 5 个 `use-modules` 各自打点；`tmtm-brackets` /
+`plugin-convert` 声明后与文件末尾打点；`plugin-convert.scm` 的
+`(plugin-input-converters generic ...)` 块前加 `chain/pc-defs` 打点。
+
+**Why**：之前观测到 `chain/tree: 26ms`，实际是 utils 阶段的耗时被记在了
+`tree` 打点上（`markup-funcs` 触发加载 `utils/library/tree` 时，前面模块的耗时
+都算在它头上）。
+
+**结论**：
+
+- utils 阶段 26ms 中 **`utils/plugin-convert` 占 22~28ms**，且全部来自文件末尾一个顶层形式
+  `(plugin-input-converters generic ...)`（60 条 DRD 规则注册）；`tree`/`markup-funcs`/
+  `tmtm-brackets` 本身都 ≈0ms
+- 重复注册实验（同文件追加 60 条 + 10 条规则块，测完已还原）：
+  首个 60 规则块 ~25ms，第二个 60 规则块 +10ms，第三个 10 规则块 +2ms
+  → 成本 = **一次性 warmup ~15ms**（`tm-define-macro` + `logic-rules` 宏展开链
+  首次编译）+ 每条规则 ~0.17ms（quasiquote 求值 + DRD ahash 插入）
+- 注意：中间出现过一次 96ms 的离群读数，核实为格式化导致插入静默失败的抖动运行，
+  结论以重复稳定的 24~28ms 为准
+
+**优化方向**：`plugin-input-converters` 的 generic 规则块可以 lazy 化
+（模块里已有 `lazy-input-converter` 机制），或把规则注册推迟到首个插件会话；
+warming 成本若属 s7 宏展开编译，可考虑在 kernel/logic 阶段预热。
+
+**涉及文件**（在上一轮基础上新增）：
+
+- `TeXmacs/progs/init-research.scm`（utils 阶段 5 个子打点）
+- `TeXmacs/progs/convert/rewrite/tmtm-brackets.scm`（声明后 + 末尾打点）
+- `TeXmacs/progs/utils/plugins/plugin-convert.scm`（pc-defs + 末尾打点）
+
+## 2026-08-13 移除 plugin-convert 的启动预载
+
+**What**：删除 `init-research.scm` utils 阶段的
+`(use-modules (utils plugins plugin-convert))` 及对应打点。
+
+**Why**：`plugin-convert` 只在插件会话中使用。对外入口
+`plugin-math-input` / `plugin-supports-math-input-ref` 已由
+`kernel/texmacs/tm-plugins.scm:24-25` 的 `lazy-define` 覆盖；插件侧
+（`maxima-kbd.scm` 的 `:use` + `lazy-input-converter`、`maxima-input.scm`
+的 `:use`）也各自声明依赖，用到时会按需加载。启动预载纯属浪费。
+
+**效果**：utils 阶段 ~30ms → ~4ms，headless 启动总计 166ms，启动日志无报错。
+`plugin-convert` 及其 `:use` 的 `tmtm-brackets` 不再出现在启动链中。
+
+**涉及文件**：
+
+- `TeXmacs/progs/init-research.scm`（删除 eager use-modules）
+
+**待验证**：插件会话的数学输入路径（如启动 maxima 会话输入公式），
+确认 lazy 加载在真实插件场景下正常触发。
+
+## 2026-08-13 启动性能对比（baseline ~/git/mogan vs 本分支）
+
+方法：各 5 次 headless 启动（`-headless -d`），汇总 `boot-bench-mark`
+各阶段增量之和（TOTAL），同一台机器交替测量。
+
+| | baseline | 本分支 | Δ |
+|---|---|---|---|
+| utils 阶段 | 27~28ms | 3~4ms | **−24ms** |
+| TOTAL（5 次） | 172/188/190/184/188 | 157/162/164/170/168 | |
+| TOTAL 均值 | **184.4ms** | **164.2ms** | **−20.2ms（−11%）** |
+
+其余阶段两版一致（`tm-server/tm-view` 37~41ms、`plugins` 28~33ms 等），
+收益全部来自 `plugin-convert` 不预载；TOTAL 收益略小于 utils 阶段收益属正常抖动。


### PR DESCRIPTION
## What

启动时不再 `(use-modules (utils plugins plugin-convert))` 预载。

## Why

`plugin-convert` 仅在插件会话中使用：

- 对外入口 `plugin-math-input` / `plugin-supports-math-input-ref` 已由 `kernel/texmacs/tm-plugins.scm` 的 `lazy-define` 覆盖
- 插件侧（`maxima-kbd.scm` 的 `:use` + `lazy-input-converter`、`maxima-input.scm` 的 `:use`）各自声明依赖，用到时按需加载

启动预载的 ~25ms 纯属浪费（其中 60 条 DRD 规则注册的一次性宏展开 warmup ~15ms + 每条 ~0.17ms）。

## 性能对比

同机各 5 次 headless 启动，`boot-bench-mark` 各阶段增量之和：

| | baseline | 本 PR | Δ |
|---|---|---|---|
| utils 阶段 | 27~28 ms | 3~4 ms | −24 ms |
| 启动总计均值 | **184.4 ms** | **164.2 ms** | **−20.2 ms（−11%）** |

完整分析过程见 `devel/1201.md`。

## Test

- [x] headless 启动无报错，bench 日志确认 `plugin-convert` / `tmtm-brackets` 不再出现在启动链
- [ ] 插件会话数学输入路径（maxima 会话）手工验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)