### PR TITLE
[0903] 云端文档下载默认目录改为系统下载目录

### DIFF
--- a/TeXmacs/progs/kernel/boot/abbrevs.scm
+++ b/TeXmacs/progs/kernel/boot/abbrevs.scm
@@ -233,8 +233,13 @@
             ) ;
             ((url-rooted-tmfs? master)
              ;; tmfs buffer（协作云文档等）master 是 tmfs URL，非本地路径；
-             ;; 用 buffer 标题作默认文件名（propose-name-buffer 已转 UTF-8）
-             (set! opts (list (car opts) (system->url (propose-name-buffer))))
+             ;; 默认落到系统下载目录，buffer 标题作默认文件名
+             ;; （propose-name-buffer 已转 UTF-8）；裸文件名会退化为 cwd
+             (set! opts
+               (list (car opts)
+                 (url-append (get-downloads-path) (system->url (propose-name-buffer)))
+               ) ;list
+             ) ;set!
             ) ;
             (else (set! opts (list (car opts) master)))
       ) ;cond

--- a/devel/0903.md
+++ b/devel/0903.md
@@ -1,0 +1,39 @@
+# 0903: 云端文档下载默认目录改为系统下载目录
+
+## 任务需求
+
+云端（协作）文档执行 Download（协作模式下的 Save as）时，文件对话框的默认
+目录应是系统「下载」目录；当前默认落在项目根目录（即进程 cwd）。
+
+## 现状分析
+
+- 协作 buffer 的 URL 是 `tmfs://collab/<doc_id>`，非本地路径。
+  `propose-name-buffer`（`TeXmacs/progs/texmacs/texmacs/tm-files.scm`）的
+  tmfs 分支只返回 buffer 标题（裸文件名，不含目录）。
+- `save-buffer-as` 的协作覆盖（`tm-collab.scm`）以该裸文件名作 `:default`，
+  经 `choose-file` → `qt_chooser_widget_rep::perform_dialog()` 拼成
+  `directory * "/" * file` 传给 `QFileDialog`；裸文件名解析为相对路径，
+  目录退化为进程 cwd——开发态从仓库根目录启动即表现为「项目根目录」。
+- 代码库中无任何获取系统下载目录的现存实现（无 XDG/Downloads/
+  QStandardPaths::DownloadLocation 相关代码）；`QStandardPaths` 先例见
+  `src/Plugins/Qt/qt_template_utils.cpp`（DocumentsLocation + Home 兜底）。
+
+## 修改方案
+
+1. C++：`src/System/Misc/tm_sys_utils.{hpp,cpp}` 新增
+   `url get_downloads_path()`（该层不依赖 Qt，与 `get_texmacs_home_path`
+   同级）：
+   - Linux：解析 `$XDG_CONFIG_HOME/user-dirs.dirs` 的 `XDG_DOWNLOAD_DIR`
+     （中文系统常为 `~/下载`），失败兜底 `$HOME/Downloads`；
+   - macOS：`$HOME/Downloads`；
+   - Windows：`%USERPROFILE%/Downloads`；
+   - 最终兜底：家目录。
+2. Glue：`src/Scheme/L3/glue_misc.lua` 参照 `get-texmacs-home-path` 增加
+   `get-downloads-path` 绑定（自由函数，L3 层支持）。
+3. Scheme：`tm-collab.scm` 协作下载的 `:default` 改为
+   `<下载目录>/<文档标题>`，仅影响协作 Download 路径，普通 buffer 的
+   Save as 行为不变。
+
+## 改动记录
+
+（完成后按 What/Why/How/涉及文件 追加）

--- a/devel/0903.md
+++ b/devel/0903.md
@@ -7,33 +7,68 @@
 
 ## 现状分析
 
-- 协作 buffer 的 URL 是 `tmfs://collab/<doc_id>`，非本地路径。
-  `propose-name-buffer`（`TeXmacs/progs/texmacs/texmacs/tm-files.scm`）的
-  tmfs 分支只返回 buffer 标题（裸文件名，不含目录）。
-- `save-buffer-as` 的协作覆盖（`tm-collab.scm`）以该裸文件名作 `:default`，
-  经 `choose-file` → `qt_chooser_widget_rep::perform_dialog()` 拼成
-  `directory * "/" * file` 传给 `QFileDialog`；裸文件名解析为相对路径，
-  目录退化为进程 cwd——开发态从仓库根目录启动即表现为「项目根目录」。
+- 协作 buffer 的 URL 是 `tmfs://collab/<doc_id>`，非本地路径。菜单
+  「Download」调 `(choose-file save-buffer-as "Save TeXmacs file"
+  "action_save_as")`（不带默认路径），由 `abbrevs.scm` 的 `choose-file`
+  封装在 tmfs 分支用 `(system->url (propose-name-buffer))` 补默认——
+  即裸文件名（buffer 标题，不含目录）。
+- 裸文件名进入 `tm_frame_rep::choose_file` 后 `head(name)` 为相对目录，
+  `QFileDialog` 初始目录退化为进程 cwd——开发态从仓库根目录启动即表现为
+  「项目根目录」。
 - 代码库中无任何获取系统下载目录的现存实现（无 XDG/Downloads/
-  QStandardPaths::DownloadLocation 相关代码）；`QStandardPaths` 先例见
-  `src/Plugins/Qt/qt_template_utils.cpp`（DocumentsLocation + Home 兜底）。
+  QStandardPaths::DownloadLocation 相关代码）。
 
-## 修改方案
+## 2026/08/13 下载默认目录改为系统下载目录
 
-1. C++：`src/System/Misc/tm_sys_utils.{hpp,cpp}` 新增
-   `url get_downloads_path()`（该层不依赖 Qt，与 `get_texmacs_home_path`
-   同级）：
-   - Linux：解析 `$XDG_CONFIG_HOME/user-dirs.dirs` 的 `XDG_DOWNLOAD_DIR`
-     （中文系统常为 `~/下载`），失败兜底 `$HOME/Downloads`；
-   - macOS：`$HOME/Downloads`；
-   - Windows：`%USERPROFILE%/Downloads`；
-   - 最终兜底：家目录。
-2. Glue：`src/Scheme/L3/glue_misc.lua` 参照 `get-texmacs-home-path` 增加
-   `get-downloads-path` 绑定（自由函数，L3 层支持）。
-3. Scheme：`tm-collab.scm` 协作下载的 `:default` 改为
-   `<下载目录>/<文档标题>`，仅影响协作 Download 路径，普通 buffer 的
-   Save as 行为不变。
+### What（本次改动做了什么）
 
-## 改动记录
+1. C++ 新增 `get_downloads_path()`（`tm_sys_utils.{hpp,cpp}`），经 L3 glue
+   暴露为 scheme 的 `get-downloads-path`：
+   - 环境变量 `TEXMACS_DOWNLOADS_PATH` 可覆盖（与 `get_documents_path`
+     的 `TEXMACS_DOCUMENTS_PATH` 先例一致）；
+   - Windows 取 `%USERPROFILE%/Downloads`；macOS 取 `$HOME/Downloads`；
+   - Linux/BSD 先解析 xdg `user-dirs.dirs` 的 `XDG_DOWNLOAD_DIR`
+     （中文发行版常是 `~/下载`，值中 `$HOME` 会展开），失败兜底
+     `$HOME/Downloads`。
+2. `abbrevs.scm` `choose-file` 封装的 tmfs 分支，默认路径由裸文件名改为
+   `<下载目录>/<buffer 标题>`。
 
-（完成后按 What/Why/How/涉及文件 追加）
+### Why（为什么这么做）
+
+- 云端文档无本地目录，裸文件名默认路径在文件对话框中退化为 cwd，
+  不符合用户对「下载」行为的预期。
+- 平台判断用运行时 `os_win()/os_macos()/os_wasm()` 而非
+  `OS_GNU_LINUX` 等宏：`config.h` 不在该编译单元的包含链中，宏实际不可见
+  （同文件 `get_tm_cache_path` 的宏分支即为死代码），运行时判断与同文件
+  `init_texmacs_home_path` 的写法一致。
+
+### How（怎么做的）
+
+- `xdg_download_dir()` 用 `load_string` 读 `user-dirs.dirs`，
+  `search_forwards` 提取 `XDG_DOWNLOAD_DIR="..."` 的值并展开 `$HOME`；
+  文件不存在先 `exists` 挡一层，避免 load_string 打告警日志。
+- scheme 侧 `(url-append (get-downloads-path) (system->url
+  (propose-name-buffer)))` 拼出绝对默认路径，`choose_file` 据此
+  `head`/`tail` 拆出目录与文件名。普通本地 buffer 走 `master` 分支，
+  行为不变。
+- 修复点选在 `abbrevs.scm` 的公共封装而非 `tm-collab.scm`：菜单 Download
+  及 `tm-files.scm` 中所有 `choose-file save-buffer-as` 调用都经此
+  fallback，一处修复全部覆盖。
+
+### 涉及文件
+
+- `src/System/Misc/tm_sys_utils.{hpp,cpp}`：新增 `get_downloads_path()`。
+- `src/Scheme/L3/glue_misc.lua`：新增 `get-downloads-path` 绑定。
+- `TeXmacs/progs/kernel/boot/abbrevs.scm`：tmfs 分支默认路径锚定到下载目录。
+- `tests/System/Misc/tm_sys_utils_test.cpp`：新增 3 个用例（env 覆盖 /
+  xdg 解析含 $HOME 展开与中文目录 / 兜底 home）。注意 lolly `set_env`
+  对空值是 no-op，测试里清除环境变量须用 `qunsetenv`。
+
+### 测试方法
+
+1. `xmake b tm_sys_utils_test && xmake r tm_sys_utils_test`：6 个用例全过。
+2. headless 验证 glue：
+   `(url-append (get-downloads-path) (system->url "我的文档"))`
+   → `/home/shuli/Downloads/我的文档`。
+3. 手工验证（需 loro=y 构建）：打开云端协作文档 → File → Download，
+   文件对话框初始目录应为系统下载目录，文件名为文档标题。

--- a/src/Scheme/L3/glue_misc.lua
+++ b/src/Scheme/L3/glue_misc.lua
@@ -134,6 +134,11 @@ function main()
                 ret_type = "url"
             },
             {
+                scm_name = "get-downloads-path",
+                cpp_name = "get_downloads_path",
+                ret_type = "url"
+            },
+            {
                 scm_name = "get-tm-cache-path",
                 cpp_name = "get_tm_cache_path",
                 ret_type = "url"

--- a/src/System/Misc/tm_sys_utils.cpp
+++ b/src/System/Misc/tm_sys_utils.cpp
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 #include "tm_sys_utils.hpp"
+#include "analyze.hpp"
 #include "file.hpp"
 #include "lolly/system/subprocess.hpp"
 #include "sys_utils.hpp"
@@ -140,6 +141,40 @@ get_documents_path () {
   string docs= get_env ("TEXMACS_DOCUMENTS_PATH");
   if (!is_empty (docs)) return url_system (docs);
   return url_system (get_env ("HOME"), "Documents");
+}
+
+// 解析 xdg user-dirs.dirs 的 XDG_DOWNLOAD_DIR（值形如 "$HOME/下载"），
+// 失败返回空串——中文发行版的下载目录常不是 ~/Downloads。
+static string
+xdg_download_dir () {
+  string config_home= get_env ("XDG_CONFIG_HOME");
+  if (is_empty (config_home)) config_home= get_env ("HOME") * "/.config";
+  url    u= url_system (config_home, "user-dirs.dirs");
+  string content;
+  // load_string 对缺失文件也会打日志，先挡一层
+  if (!exists (u) || load_string (u, content, false)) return "";
+  string key= "XDG_DOWNLOAD_DIR=\"";
+  int    pos= search_forwards (key, 0, content);
+  if (pos < 0) return "";
+  int begin= pos + N (key);
+  int end  = search_forwards (string ("\""), begin, content);
+  if (end < 0) return "";
+  string dir= content (begin, end);
+  if (starts (dir, string ("$HOME"))) dir= get_env ("HOME") * dir (5, N (dir));
+  return dir;
+}
+
+url
+get_downloads_path () {
+  string downloads= get_env ("TEXMACS_DOWNLOADS_PATH");
+  if (!is_empty (downloads)) return url_system (downloads);
+  if (os_win ()) return url_system (get_env ("USERPROFILE"), "Downloads");
+  if (!os_macos () && !os_wasm ()) {
+    // Linux/BSD 遵循 xdg-user-dirs 的本地化下载目录
+    string xdg= xdg_download_dir ();
+    if (!is_empty (xdg)) return url_system (xdg);
+  }
+  return url_system (get_env ("HOME"), "Downloads");
 }
 
 url

--- a/src/System/Misc/tm_sys_utils.hpp
+++ b/src/System/Misc/tm_sys_utils.hpp
@@ -30,6 +30,7 @@ url  get_texmacs_path ();
 url  get_texmacs_home_path ();
 void init_texmacs_home_path ();
 url  get_documents_path ();
+url  get_downloads_path ();
 url  get_tm_cache_path ();
 url  get_tm_preference_path ();
 

--- a/tests/System/Misc/tm_sys_utils_test.cpp
+++ b/tests/System/Misc/tm_sys_utils_test.cpp
@@ -15,6 +15,9 @@
 #include "tm_sys_utils.hpp"
 #include "url.hpp"
 
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
 #include <QtTest/QtTest>
 
 class TestTmSysUtils : public QObject {
@@ -22,18 +25,33 @@ class TestTmSysUtils : public QObject {
 
   string orig_home;
   string orig_docs;
+  string orig_downloads;
+  string orig_xdg_config;
+
+  static void restore_env (const char* name, string val) {
+    if (is_empty (val)) qunsetenv (name);
+    else set_env (string (name), val);
+  }
 
 private slots:
   void init () {
     init_lolly ();
-    orig_home= get_env ("HOME");
-    orig_docs= get_env ("TEXMACS_DOCUMENTS_PATH");
+    orig_home      = get_env ("HOME");
+    orig_docs      = get_env ("TEXMACS_DOCUMENTS_PATH");
+    orig_downloads = get_env ("TEXMACS_DOWNLOADS_PATH");
+    orig_xdg_config= get_env ("XDG_CONFIG_HOME");
   }
   void cleanup () {
-    set_env ("HOME", orig_home);
-    set_env ("TEXMACS_DOCUMENTS_PATH", orig_docs);
+    // set_env 对空值是 no-op，恢复未设置状态须走 qunsetenv
+    restore_env ("HOME", orig_home);
+    restore_env ("TEXMACS_DOCUMENTS_PATH", orig_docs);
+    restore_env ("TEXMACS_DOWNLOADS_PATH", orig_downloads);
+    restore_env ("XDG_CONFIG_HOME", orig_xdg_config);
   }
   void test_get_documents_path_home_root ();
+  void test_get_downloads_path_env_override ();
+  void test_get_downloads_path_xdg_user_dirs ();
+  void test_get_downloads_path_fallback_home ();
 };
 
 void
@@ -50,6 +68,54 @@ TestTmSysUtils::test_get_documents_path_home_root () {
             as_charp ("expected /Documents but got " * docs_s));
   QVERIFY2 (!occurs ("//Documents", docs_s),
             as_charp ("path should not contain //Documents: " * docs_s));
+}
+
+void
+TestTmSysUtils::test_get_downloads_path_env_override () {
+  // 环境变量 TEXMACS_DOWNLOADS_PATH 优先于一切平台探测
+  set_env ("TEXMACS_DOWNLOADS_PATH", "/tmp/mogan-test-downloads");
+  url downloads= get_downloads_path ();
+  QVERIFY2 (as_string (downloads) == "/tmp/mogan-test-downloads",
+            as_charp ("env override broken: " * as_string (downloads)));
+}
+
+void
+TestTmSysUtils::test_get_downloads_path_xdg_user_dirs () {
+  if (os_win () || os_macos () || os_wasm ())
+    QSKIP ("xdg-user-dirs only applies to Linux/BSD");
+  // 中文发行版常见情形：XDG_DOWNLOAD_DIR 指向本地化的 ~/下载，
+  // 且值里带 $HOME 变量引用，需展开
+  QTemporaryDir config_dir;
+  QVERIFY (config_dir.isValid ());
+  QFile f (QDir (config_dir.path ()).filePath ("user-dirs.dirs"));
+  QVERIFY (f.open (QIODevice::WriteOnly));
+  f.write ("XDG_DESKTOP_DIR=\"$HOME/Desktop\"\n"
+           "XDG_DOWNLOAD_DIR=\"$HOME/\xE4\xB8\x8B\xE8\xBD\xBD\"\n");
+  f.close ();
+
+  qunsetenv ("TEXMACS_DOWNLOADS_PATH");
+  set_env ("XDG_CONFIG_HOME",
+           string (config_dir.path ().toUtf8 ().constData ()));
+  set_env ("HOME", "/tmp/mogan-test-home");
+
+  url downloads= get_downloads_path ();
+  QVERIFY2 (as_string (downloads) ==
+                "/tmp/mogan-test-home/\xE4\xB8\x8B\xE8\xBD\xBD",
+            as_charp ("xdg parse broken: " * as_string (downloads)));
+}
+
+void
+TestTmSysUtils::test_get_downloads_path_fallback_home () {
+  if (os_win () || os_macos () || os_wasm ())
+    QSKIP ("xdg-user-dirs only applies to Linux/BSD");
+  // 无 user-dirs.dirs 时兜底 $HOME/Downloads
+  qunsetenv ("TEXMACS_DOWNLOADS_PATH");
+  set_env ("XDG_CONFIG_HOME", "/tmp/mogan-test-nonexistent-config");
+  set_env ("HOME", "/tmp/mogan-test-home");
+
+  url downloads= get_downloads_path ();
+  QVERIFY2 (as_string (downloads) == "/tmp/mogan-test-home/Downloads",
+            as_charp ("fallback broken: " * as_string (downloads)));
 }
 
 QTEST_MAIN (TestTmSysUtils)


### PR DESCRIPTION
## What

云端（协作）文档执行 Download（协作模式下的 Save as）时，文件对话框默认目录由进程 cwd（开发态表现为项目根目录）改为系统「下载」目录。

## How

- C++ 新增 `get_downloads_path()`（`tm_sys_utils`），经 L3 glue 暴露为 `get-downloads-path`：Windows 取 `%USERPROFILE%/Downloads`，macOS 取 `$HOME/Downloads`，Linux/BSD 解析 xdg `user-dirs.dirs` 的 `XDG_DOWNLOAD_DIR`（兼容中文发行版的 `~/下载`），并支持 `TEXMACS_DOWNLOADS_PATH` 环境变量覆盖。
- `abbrevs.scm` 的 `choose-file` 封装中，tmfs buffer 的默认保存路径由裸文件名改为 `<下载目录>/<文档标题>`；普通本地文档的 Save as 行为不变。

## 测试

- `tm_sys_utils_test` 新增 3 用例（env 覆盖 / xdg 解析含 `$HOME` 展开与中文目录 / 兜底），6/6 通过
- headless 实测 `get-downloads-path` 及路径拼接正确