### PR TITLE
[0902] 修复 julia 插件强载时 plugin-input-converters 未定义崩溃

### DIFF
--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -48,6 +48,6 @@
   (:session "Julia")
 ) ;plugin-configure
 
-(when (supports-julia?)
-  (plugin-input-converters julia)
-) ;when
+;; 数学输入支持（plugin-input-converters% 组成员）改由
+;; utils/plugins/plugin-convert.scm 随 generic 规则一并声明，
+;; 避免插件 init 加载时 plugin-convert 尚未预载导致宏未定义

--- a/TeXmacs/progs/utils/plugins/plugin-convert.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-convert.scm
@@ -492,3 +492,9 @@
   ("<Psi>" "Psi")
   ("<Omega>" "Omega")
 ) ;plugin-input-converters
+
+;; julia 无自定义转换规则（走 generic 回退），空规则块仅声明其属于
+;; plugin-input-converters% 组（即会话支持数学输入）。
+;; 1201 后本模块不再随启动预载，插件 init 加载时本宏可能尚未定义，
+;; 故该声明从 init-julia.scm 迁回本模块。
+(plugin-input-converters julia)

--- a/devel/0902.md
+++ b/devel/0902.md
@@ -32,3 +32,44 @@
    再 `xmake b stem`。
 2. 打开过云端协作文档后回到欢迎页，「云端」标签应紧跟文档标题之后；
    本地文档行布局与原来一致。
+
+## 2026/08/13 修复 julia 插件强载崩溃（Debian CI scheme_tests 失败）
+
+### What
+
+CI（Debian，`xmake run --group=scheme_tests`）在 `preferences-widgets-test` 中崩溃：
+`Error: (unbound-variable "[not-implemented]" ... (plugin-input-converters ...))`。
+将 julia 的 `plugin-input-converters%` 组成员声明从 `init-julia.scm` 迁入
+`plugin-convert.scm` 的 generic 规则块之后。
+
+### Why
+
+1201（f5e1d1a2c）移除了启动时对 `utils/plugins/plugin-convert` 的预载，
+而 `plugin-input-converters` 是定义在该模块里的 `tm-define-macro`。
+`init-julia.scm` 顶层在插件初始化时直接调用该宏——测试（及 GUI 空闲初始化）
+强载全部 50 个待初始化插件时宏尚未定义，进程报错退出。
+该问题与平台无关，macOS 上 GUI 启动后的 idle 插件初始化同样会触发。
+julia 的调用不带任何规则（走 generic 回退），唯一效果是把 julia 声明进
+`plugin-input-converters%` 组（即会话支持数学输入），属于转换子系统自身的数据，
+迁回 `plugin-convert.scm` 后语义完全等价。
+
+### How
+
+- `plugin-convert.scm`：generic 规则块后追加空规则块
+  `(plugin-input-converters julia)`，仅作组成员声明。
+- `init-julia.scm`：删除 `(when (supports-julia?) (plugin-input-converters julia))`，
+  以注释指向新声明位置。julia 是唯一在 init 顶层引用 plugin-convert 符号的
+  内置插件（已全量排查 `TeXmacs/plugins/*/progs/init-*.scm`）。
+
+### 验证
+
+- `xmake r preferences-widgets-test`：julia 插件正常加载，409 checks 全过。
+- headless 诊断脚本：强载前 `plugin-input-converters` 未定义（启动提速保留），
+  `lazy-plugin-force` 50 个插件无崩溃；
+  `(plugin-supports-math-input-ref "julia")` 仍为 `#t`（数学输入行为不变）。
+- `xmake run --group=scheme_tests`（与 CI 相同命令）整组通过。
+
+### 涉及文件
+
+- `TeXmacs/progs/utils/plugins/plugin-convert.scm`
+- `TeXmacs/plugins/julia/progs/init-julia.scm`


### PR DESCRIPTION
## 背景

CI 在 `Scheme tests` 步骤崩溃（Debian `31665566448`、macOS arm64 `31665566409` 均复现），报错：

```
Error: (unbound-variable "[not-implemented]" "unbound variable ~S in ~S"
       (plugin-input-converters (plugin-input-converters julia)))
```

崩溃发生在 `regtest-preferences-widgets` 强载全部 50 个待初始化插件、加载 julia 插件时。

## 根因

`f5e1d1a2c`（[1201] 启动时不预载 plugin-convert）删除了启动时对
`utils/plugins/plugin-convert` 的预载以提速启动。但 `plugin-input-converters`
是定义在该模块里的 `tm-define-macro`，而 `init-julia.scm` 顶层在插件初始化时
直接调用它——此时宏尚未定义，进程报错退出。

该问题与平台无关：GUI 启动后空闲强载 julia 插件同样会触发，macOS 也会崩。

## 修复

julia 的 `(plugin-input-converters julia)` 不带任何规则（走 generic 回退），
唯一作用是把 julia 声明进 `plugin-input-converters%` 组（即会话支持数学输入）。
这属于转换子系统自身的数据，将其迁回定义宏的 `plugin-convert.scm`（generic
规则块之后）后语义完全等价，且不依赖插件 init 加载时机。

- `TeXmacs/progs/utils/plugins/plugin-convert.scm`：generic 规则块后追加空规则块
  `(plugin-input-converters julia)`，仅作组成员声明。
- `TeXmacs/plugins/julia/progs/init-julia.scm`：删除
  `(when (supports-julia?) (plugin-input-converters julia))`，留注释指向新位置。

julia 是唯一在 init 顶层引用 plugin-convert 符号的内置插件（已全量排查
`TeXmacs/plugins/*/progs/init-*.scm`）。

## 验证

- `xmake r preferences-widgets-test`：julia 插件正常加载，409 checks 全过。
- headless 诊断脚本：强载前 `plugin-input-converters` 仍为未定义（启动提速保留），
  `lazy-plugin-force` 50 个插件无崩溃；`(plugin-supports-math-input-ref "julia")`
  仍为 `#t`（数学输入行为不变），`"generic"` 为 `#t`、不存在的插件为 `#f`。
- `xmake run --group=scheme_tests`（与 CI 完全相同的命令）整组通过，退出码 0。

修复在本地 Linux 完整验证；Debian / macOS CI 应同步转绿。
