### PR TITLE
[1201] julia 插件加载时显式 use-modules plugin-convert

### DIFF
--- a/TeXmacs/plugins/julia/progs/init-julia.scm
+++ b/TeXmacs/plugins/julia/progs/init-julia.scm
@@ -49,5 +49,6 @@
 ) ;plugin-configure
 
 (when (supports-julia?)
+  (use-modules (utils plugins plugin-convert))
   (plugin-input-converters julia)
 ) ;when

--- a/devel/1201.md
+++ b/devel/1201.md
@@ -123,3 +123,22 @@ warming 成本若属 s7 宏展开编译，可考虑在 kernel/logic 阶段预热
 
 其余阶段两版一致（`tm-server/tm-view` 37~41ms、`plugins` 28~33ms 等），
 收益全部来自 `plugin-convert` 不预载；TOTAL 收益略小于 utils 阶段收益属正常抖动。
+
+## 2026-08-13 后续修复：julia 插件显式加载 plugin-convert
+
+**What**：`init-julia.scm` 的 `(when (supports-julia?) ...)` 内、
+`(plugin-input-converters julia)` 之前补充
+`(use-modules (utils plugins plugin-convert))`。
+
+**Why**：移除 plugin-convert 启动预载后，julia 插件加载时直接调用
+`plugin-input-converters`，但该模块从未被 julia 侧声明依赖（maxima 通过
+`:use` / `lazy-input-converter` 声明了，julia 漏了），导致符号未定义、
+julia 的数学输入转换规则注册失败。
+
+**How**：调用前显式 `use-modules`，与插件自身按需加载的语义一致。
+
+**验证**：`xmake r preferences-widgets-test` 409 项检查全部通过。
+
+**涉及文件**：
+
+- `TeXmacs/plugins/julia/progs/init-julia.scm`


### PR DESCRIPTION
## What

`init-julia.scm` 的 `(when (supports-julia?) ...)` 内、`(plugin-input-converters julia)` 之前补充 `(use-modules (utils plugins plugin-convert))`。

## Why

#4326 移除 plugin-convert 启动预载后，julia 插件加载时直接调用 `plugin-input-converters`，但该模块从未被 julia 侧声明依赖（maxima 通过 `:use` / `lazy-input-converter` 声明了，julia 漏了），导致符号未定义、julia 的数学输入转换规则注册失败。

## 验证

- `xmake r preferences-widgets-test`：409 项检查全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)