### PR TITLE
[1200] use-package 支持带路径包名直查定位（481 ms -> 227 ms）

### DIFF
--- a/TeXmacs/packages/environment/env-program.ts
+++ b/TeXmacs/packages/environment/env-program.ts
@@ -21,7 +21,7 @@
     </src-license>
   </src-title>>
 
-  <use-package|env-pseudo-code>
+  <use-package|environment/env-pseudo-code>
 
   <\active*>
     <\src-comment>

--- a/TeXmacs/packages/environment/env-theorem.ts
+++ b/TeXmacs/packages/environment/env-theorem.ts
@@ -20,7 +20,7 @@
     </src-license>
   </src-title>>
 
-  <use-package|env-enunciation>
+  <use-package|environment/env-enunciation>
 
   <\active*>
     <\src-comment>

--- a/TeXmacs/packages/environment/env.ts
+++ b/TeXmacs/packages/environment/env.ts
@@ -20,7 +20,7 @@
     </src-license>
   </src-title>>
 
-  <use-package|env-base|env-math|env-theorem|env-float|env-program>
+  <use-package|environment/env-base|environment/env-math|environment/env-theorem|environment/env-float|environment/env-program>
 
   \;
 </body>

--- a/TeXmacs/packages/header/title-generic.ts
+++ b/TeXmacs/packages/header/title-generic.ts
@@ -21,7 +21,7 @@
     </src-license>
   </src-title>>
 
-  <use-package|title-base>
+  <use-package|header/title-base>
 
   \;
 </body>

--- a/TeXmacs/packages/section/section-generic.ts
+++ b/TeXmacs/packages/section/section-generic.ts
@@ -20,7 +20,7 @@
     </src-license>
   </src-title>>
 
-  <use-package|section-base>
+  <use-package|section/section-base>
 
   <\active*>
     <\src-comment>

--- a/TeXmacs/packages/standard/std.ts
+++ b/TeXmacs/packages/standard/std.ts
@@ -20,7 +20,7 @@
     </src-license>
   </src-title>>
 
-  <use-package|std-counter|std-markup|std-utils|std-symbol|std-math|std-list|std-automatic|std-pattern|std-fold|std-graphics|std-security|std-animate|session|scripts|calc|program>
+  <use-package|standard/std-counter|standard/std-markup|standard/std-utils|standard/std-symbol|standard/std-math|standard/std-list|standard/std-automatic|standard/std-pattern|standard/std-fold|standard/std-graphics|standard/std-animate|compute/session|compute/scripts|compute/calc|compute/program>
 
   \;
 </body>

--- a/TeXmacs/styles/generic.ts
+++ b/TeXmacs/styles/generic.ts
@@ -24,7 +24,7 @@
     </src-title>
   </active*>
 
-  <use-package|std|env|title-generic|header-generic|section-generic>
+  <use-package|standard/std|environment/env|header/title-generic|header/header-generic|section/section-generic>
 
   \;
 

--- a/devel/1200.md
+++ b/devel/1200.md
@@ -1,0 +1,97 @@
+# 1200 use-package 支持带路径包名（直查定位）
+
+## 背景
+
+`use-package` 是样式语言原语（`.ts` 文件中的 `<use-package|std|env|...>`），
+作用是把一组样式包的宏定义、环境变量、DRD 规则合并进当前环境，
+类似 LaTeX 的 `\usepackage`。核心实现在
+`edit_env_rep::exec_use_package`（`src/Typeset/Env/env_exec.cpp`）。
+
+原有解析方式：把包名拼上 `.stem`/`.ts` 后在 `$TEXMACS_STYLE_PATH`
+（style/package 根下所有子目录的并集，含插件目录）里 `resolve` 扫描，
+目录多、逐个 stat，解析慢。
+
+## 2026-08-13 use-package 打点
+
+**What**：`exec_use_package` 循环体开头加 `bench_start`，加载执行完
+`bench_end`，任务名为 `use-package <包名>`，覆盖「路径解析 + resolve +
+读文件 + 解析 + exec」全程。
+
+**Why**：量化每个包的加载耗时，确认 resolve 扫描的占比。
+
+**涉及文件**：
+
+- `src/Typeset/Env/env_exec.cpp`（新增 `#include "tm_debug.hpp"`）
+
+## 2026-08-13 带路径包名语法
+
+**What**：`use-package` 参数含 `/` 时（如 `<use-package|standard/std>`），
+走新增的 `resolve_dotted_package` 直查，跳过 `$TEXMACS_STYLE_PATH` 全目录扫描：
+
+1. `$TEXMACS_PATH/packages/a/b/c.stem` → `$TEXMACS_PATH/packages/a/b/c.ts`
+2. `$TEXMACS_PATH/plugins/a/packages/a/b/c.stem` → `.ts`（首段 `a` 作为插件名）
+
+显式带 `.ts`/`.stem` 后缀同样支持；不含 `/` 的包名走原有逻辑，完全兼容
+（现有全部样式文件均为裸包名，无一带 `/`）。
+
+**Why**：resolve 对 or-url 逐目录扫描是包加载的主要开销；带路径包名可以
+O(1) 定位。
+
+**How**：新增两个 static 辅助函数 `resolve_pack_in`（单根目录下
+`.stem`/`.ts` 直查）、`resolve_dotted_package`（两个根依次尝试），
+`exec_use_package` 里按 `occurs ("/", pi)` 分派。
+
+**涉及文件**：
+
+- `src/Typeset/Env/env_exec.cpp`
+
+## 2026-08-13 generic.ts 改用新语法
+
+**What**：`TeXmacs/styles/generic.ts` 的 use-package 改为带路径形式：
+
+```
+<use-package|standard/std|environment/env|header/title-generic|header/header-generic|section/section-generic>
+```
+
+映射关系（均相对 `TeXmacs/packages`，文件未移动）：
+
+- `std` → `standard/std`
+- `env` → `environment/env`
+- `title-generic` → `header/title-generic`
+- `header-generic` → `header/header-generic`
+- `section-generic` → `section/section-generic`
+
+**涉及文件**：
+
+- `TeXmacs/styles/generic.ts`
+
+## 如何测试
+
+相关文档：`devel/1200.md`（本文档）
+
+1. 编译：
+
+   ```bash
+   xmake b stem
+   ```
+
+2. 清除样式缓存（直接删整个缓存目录，用 trash 避免误删；
+   字体/插件缓存会随下次启动自动重建）：
+
+   ```bash
+   trash ~/.cache/MoganLab/2026.3.0-rc12
+   ```
+
+3. 启动 mogan，终端应打印每个包的加载打点：
+
+   ```
+   Task 'use-package standard/std' took N ms
+   Task 'use-package environment/env' took N ms
+   ...
+   ```
+
+4. 打开任意文档（generic 是基础样式），确认排版渲染正常。
+
+5. 性能对比：把 `generic.ts` 的 use-package 临时改回裸包名
+   （`std|env|title-generic|header-generic|section-generic`），清缓存后重启，
+   对比两种语法的打点耗时。

--- a/devel/1200.md
+++ b/devel/1200.md
@@ -15,7 +15,7 @@
 
 **What**：`exec_use_package` 循环体开头加 `bench_start`，加载执行完
 `bench_end`，任务名为 `use-package <包名>`，覆盖「路径解析 + resolve +
-读文件 + 解析 + exec」全程。
+读文件 + 解析 + exec」全程；`bench_end` 阈值 10 ms，小于 10 ms 不打印。
 
 **Why**：量化每个包的加载耗时，确认 resolve 扫描的占比。
 
@@ -64,6 +64,64 @@ O(1) 定位。
 **涉及文件**：
 
 - `TeXmacs/styles/generic.ts`
+
+## 2026-08-13 std.ts 改用新语法
+
+**What**：`TeXmacs/packages/standard/std.ts` 的依赖改为带路径形式：
+11 个 `standard/std-*` + 4 个 `compute/{session,scripts,calc,program}`
+（原 16 个中的 `std-security` 文件不存在，已移除）。
+
+**注意**：`std-security` 在整个 TeXmacs 树中不存在，原本就是解析失败、
+静默跳过；debug_io 日志上线后暴露为
+`use-package: package not found: standard/std-security`，已直接从
+std.ts 的依赖列表中移除。
+
+**实测**（清缓存后首次启动，generic.ts 顶层打点）：
+
+- 改造前（裸包名）:481 ms
+- generic.ts 改造后：452 ms（−29 ms）
+- generic.ts + std.ts 改造后：275 ms
+- generic 链全链路改造后：**227 ms（−254 ms，−53%）**
+
+**涉及文件**：
+
+- `TeXmacs/packages/standard/std.ts`
+
+## 2026-08-13 包找不到时输出 debug_io
+
+**What**：`exec_use_package` 解析结束若 `is_none (name)`，无条件输出
+`use-package: package not found: <包名>` 到 `debug_io`（不带 DEBUG_IO
+开关，新旧两种解析路径都覆盖）。
+
+**涉及文件**：
+
+- `src/Typeset/Env/env_exec.cpp`
+
+## 2026-08-13 env/title-generic/section-generic 改用新语法
+
+**What**：generic 链第二层包同步改造：
+
+- `environment/env.ts`:5 个依赖 → `environment/env-base|env-math|env-theorem|env-float|env-program`
+- `header/title-generic.ts`:`title-base` → `header/title-base`
+- `section/section-generic.ts`:`section-base` → `section/section-base`
+- `header/header-generic.ts`：无 use-package，无需改动
+
+叶子包同步改造：`env-theorem.ts` → `environment/env-enunciation`,
+`env-program.ts` → `environment/env-pseudo-code`。至此 generic 链
+（generic → std/env/title-generic/header-generic/section-generic → 叶子）
+已全部走直查路径。
+
+剩余裸包名（不在 generic 链，未动）：`env-flush-math.ts`、`title-book.ts`、
+`title-seminar.ts`、`header-exam.ts`、`header-letter.ts`、`section-*.ts`
+（article/book/beamer/seminar）、`std-latex.ts`，属其他样式链，可后续批量处理。
+
+**涉及文件**：
+
+- `TeXmacs/packages/environment/env.ts`
+- `TeXmacs/packages/environment/env-theorem.ts`
+- `TeXmacs/packages/environment/env-program.ts`
+- `TeXmacs/packages/header/title-generic.ts`
+- `TeXmacs/packages/section/section-generic.ts`
 
 ## 如何测试
 

--- a/src/Typeset/Env/env_exec.cpp
+++ b/src/Typeset/Env/env_exec.cpp
@@ -22,6 +22,7 @@
 
 using moebius::data::page_get_feature;
 #include "scheme.hpp"
+#include "tm_debug.hpp"
 #include "tm_file.hpp"
 #include "typesetter.hpp"
 
@@ -1206,25 +1207,57 @@ filter_style (tree t) {
     }
 }
 
+/**
+ * @brief 在指定根目录下按相对路径定位包文件，优先 .stem 后 .ts
+ * @param root 包根目录
+ * @param pi   带路径的包名（如 a/b/c），可显式带 .ts/.stem 后缀
+ * @return 解析到的文件 url，未找到返回 url_none
+ */
+static url
+resolve_pack_in (url root, string pi) {
+  if (ends (pi, ".ts") || ends (pi, ".stem")) return resolve (root * pi);
+  url name= resolve (root * (pi * string (".stem")));
+  if (is_none (name)) name= resolve (root * (pi * string (".ts")));
+  return name;
+}
+
+/**
+ * @brief 带路径包名（含 /）的直查解析，避免 resolve 对 $TEXMACS_STYLE_PATH
+ * 全部子目录逐一扫描
+ * @note 依次尝试 $TEXMACS_PATH/packages 与
+ * $TEXMACS_PATH/plugins/<首段>/packages
+ */
+static url
+resolve_dotted_package (string pi) {
+  url name= resolve_pack_in (url ("$TEXMACS_PATH/packages"), pi);
+  if (!is_none (name)) return name;
+  int pos= search_forwards ("/", 0, pi);
+  return resolve_pack_in (
+      url ("$TEXMACS_PATH/plugins") * pi (0, pos) * "packages", pi);
+}
+
 tree
 edit_env_rep::exec_use_package (tree t) {
   int i, n= N (t);
   for (i= 0; i < n; i++) {
-    // cout << "Package " << as_string (t[i]) << "\n";
     url    name= url_none ();
     url    styp= "$TEXMACS_STYLE_PATH";
     string pi  = as_string (t[i]);
-    if (is_rooted (base_file_name, "default"))
-      styp= styp | ::expand (head (base_file_name) * url_ancestor ());
-    else styp= styp | head (base_file_name);
-    if (ends (pi, ".ts") || ends (pi, ".stem")) name= url_system (pi);
+    string task= "use-package " * pi;
+    bench_start (task);
+    if (occurs ("/", pi)) name= resolve_dotted_package (pi);
     else {
-      url stem_name= styp * (pi * string (".stem"));
-      name         = resolve (stem_name);
-      if (is_none (name)) name= styp * (pi * string (".ts"));
+      if (is_rooted (base_file_name, "default"))
+        styp= styp | ::expand (head (base_file_name) * url_ancestor ());
+      else styp= styp | head (base_file_name);
+      if (ends (pi, ".ts") || ends (pi, ".stem")) name= url_system (pi);
+      else {
+        url stem_name= styp * (pi * string (".stem"));
+        name         = resolve (stem_name);
+        if (is_none (name)) name= styp * (pi * string (".ts"));
+      }
+      name= resolve (name);
     }
-    name= resolve (name);
-    // cout << as_string (t[i]) << " -> " << name << "\n";
     string doc_s;
     if (!load_string (name, doc_s, false)) {
       tree doc;
@@ -1236,6 +1269,7 @@ edit_env_rep::exec_use_package (tree t) {
       }
       if (is_compound (doc)) exec (filter_style (extract (doc, "body")));
     }
+    bench_end (task);
   }
   return "";
 }

--- a/src/Typeset/Env/env_exec.cpp
+++ b/src/Typeset/Env/env_exec.cpp
@@ -1258,6 +1258,9 @@ edit_env_rep::exec_use_package (tree t) {
       }
       name= resolve (name);
     }
+    if (is_none (name)) {
+      debug_io << "use-package: package not found: " << pi << LF;
+    }
     string doc_s;
     if (!load_string (name, doc_s, false)) {
       tree doc;
@@ -1269,7 +1272,7 @@ edit_env_rep::exec_use_package (tree t) {
       }
       if (is_compound (doc)) exec (filter_style (extract (doc, "body")));
     }
-    bench_end (task);
+    bench_end (task, 10);
   }
   return "";
 }


### PR DESCRIPTION
## What

`use-package` 新增带路径包名语法（如 `<use-package|standard/std>`）：参数含 `/` 时直查固定根目录，跳过 `$TEXMACS_STYLE_PATH` 全目录 resolve 扫描：

1. `$TEXMACS_PATH/packages/a/b/c.stem` → `.ts`
2. `$TEXMACS_PATH/plugins/a/packages/a/b/c.stem` → `.ts`（首段作为插件名）

不含 `/` 的裸包名走原有逻辑，完全兼容（现有样式文件原本均无 `/` 用法）。

同时：

- generic 样式链（generic → std/env/title-generic/section-generic → 叶子包）全部改用新语法
- 移除 std.ts 中不存在的 `std-security` 依赖
- `exec_use_package` 增加 bench 打点（`use-package <包名>`，阈值 10 ms）
- 包找不到时输出 `debug_io` 警告

## 性能

清缓存后首次启动，generic.ts 顶层打点：**481 ms → 227 ms（−53%）**

## 如何测试

见 `devel/1200.md`「如何测试」一节。

🤖 Generated with [Claude Code](https://claude.com/claude-code)