### PR TITLE
[0904] 远程文档搜索和替换功能无法使用

### DIFF
--- a/TeXmacs/progs/generic/search-widgets.scm
+++ b/TeXmacs/progs/generic/search-widgets.scm
@@ -1860,8 +1860,9 @@
                  ) ;if
                ) ;let*
               ) ;
-              ((string-starts? (url->system buf) "tmfs:")
-               ;; 其他 tmfs:// 缓冲区保持禁用搜索
+              ((and (string-starts? (url->system buf) "tmfs:") (not (collab-buffer? buf)))
+               ;; 协作（远程）文档是完整可编辑的 CRDT 文档，可搜索；
+               ;; 其余 tmfs:// 缓冲区（aux / window 等辅助/系统 buffer）保持禁用
                (noop)
               ) ;
               (else (set! search-replace-text
@@ -1883,7 +1884,9 @@
 (tm-define (interactive-replace)
   (:interactive #t)
   (with-buffer (search-command-target-buffer (current-buffer))
-    (unless (string-starts? (url->system (current-buffer)) "tmfs:")
+    (unless (and (string-starts? (url->system (current-buffer)) "tmfs:")
+              (not (collab-buffer? (current-buffer)))
+            ) ;and
       (set! search-replace-text
         (cond ((in-math?) "Only search and replace in math mode")
               ((in-prog?) "Only search and replace in Program mode")

--- a/devel/0904.md
+++ b/devel/0904.md
@@ -1,0 +1,68 @@
+# 0904: 远程文档搜索和替换功能无法使用
+
+## 任务需求
+
+在云端（协作/远程）文档中点击菜单「Search」「Replace」（或对应工具栏按钮），
+搜索/替换窗口打不开，点击后无任何反应。
+
+## 现状分析（复现）
+
+- 协作 buffer 的 URL 是 `tmfs://collab/<doc_id>`（见 `tm-collab.scm`
+  `collab-buffer-url->tmfs`），与本地文件 buffer 不同。
+- 编辑菜单「Search」→ `(interactive-search)`，「Replace」→
+  `(interactive-replace)`（`edit-menu.scm:76-77`）。
+- `interactive-search`（`search-widgets.scm:1841`）内有一个 cond 分派：
+  1. `tmfs://chat` → 聊天 tab 悬浮搜索；
+  2. **`tmfs:` → `(noop)`**（注释「其他 tmfs:// 缓冲区保持禁用搜索」）；
+  3. else → 正常 `open-search`。
+- 协作 buffer 命中第 2 条 `tmfs:` 前缀，直接 `noop`，故搜索窗口永远打不开。
+- `interactive-replace`（`search-widgets.scm:1883`）同样用
+  `(unless (string-starts? (url->system (current-buffer)) "tmfs:") ...)`
+  整体跳过，替换窗口也打不开。
+
+### 复现验证（dispatch 级，确定性）
+
+用 `gf eval` 复跑该 cond 的纯字符串分派逻辑（`string-starts?` 取自
+`(liii string)`）：
+
+```
+collab  tmfs://collab/550e8400-...  -> NOOP-no-search   （bug）
+chat    tmfs://chat/x               -> chat-search      （正常）
+local   /home/user/doc.tmu          -> normal-search    （正常）
+```
+
+即协作文档落入 `noop` 分支，与「打不开」现象一致。真正的 collab 服务端
+连接非必需——bug 是 scheme 分派层的，URL 前缀即决定行为。
+
+## 2026/08/13 允许协作文档使用搜索/替换
+
+### What（本次改动做了什么）
+
+- `interactive-search`：在 `tmfs:` 整体禁用分支之前，新增对协作 buffer
+  （`collab-buffer?`）的白名单——协作文档走正常 `open-search` 路径，
+  其余 `tmfs:` buffer（`tmfs://aux`、`tmfs://window` 等）仍保持禁用。
+- `interactive-replace`：`unless` 的跳过条件由「任何 `tmfs:`」收窄为
+  「`tmfs:` 且不是协作 buffer」，使协作文档可打开替换窗口。
+
+### Why（为什么这么做）
+
+- 协作文档是完整可编辑的 CRDT 文档（非只读），搜索/替换本应可用；
+  原先的 `tmfs:` 一刀切禁用是历史遗留，未区分协作文档与辅助/系统 buffer。
+- `collab-buffer?`（`tm-collab.scm`）正是为该判定量身定义的谓词
+  （`url-rooted-tmfs-protocol? u "collab"`），跨模块可见（tm-define）。
+- 改动最小，只放宽白名单，不影响 chat tab 悬浮搜索与其他 tmfs buffer
+  的既有禁用语义。
+
+### How（怎么做的）
+
+- `interactive-search` cond 新增分支：
+  `(collab-buffer? buf)` → 落到与本地文档相同的 `else` 逻辑（设置提示 +
+    `open-search`）。为避免重复，把协作文档归并进正常分支：判断条件改为
+  `tmfs:` 且「非 chat 且非 collab」才 `noop`。
+- `interactive-replace` 的 `unless` 条件改为：
+  `(and (string-starts? ... "tmfs:") (not (collab-buffer? ...)))`。
+
+### 涉及文件
+
+- `TeXmacs/progs/generic/search-widgets.scm`：`interactive-search`、
+  `interactive-replace` 两个入口的分派条件。


### PR DESCRIPTION
## 问题

在云端（协作/远程）文档中，点击菜单「Search」「Replace」（或对应工具栏按钮）
搜索/替换窗口打不开，点击后无任何反应。

## 根因

协作 buffer 的 URL 是 `tmfs://collab/<doc_id>`（见 `tm-collab.scm`
`collab-buffer-url->tmfs`）。编辑菜单「Search」→ `(interactive-search)`、
「Replace」→ `(interactive-replace)`（`edit-menu.scm`）。

- `interactive-search` 内有一个 cond 分派：`tmfs://chat` → 聊天悬浮搜索；
  **`tmfs:` → `(noop)`**；else → 正常 `open-search`。协作 buffer 命中 `tmfs:` 分支，
  被静默禁用。
- `interactive-replace` 用 `(unless (string-starts? ... "tmfs:") ...)` 整体跳过，
  同样打不开。

## 修复

- `interactive-search`：`tmfs:` 一刀切禁用分支收窄为
  `(and (string-starts? "tmfs:") (not (collab-buffer? buf)))`——协作（远程）文档
  走正常 `open-search` 路径，其余 `tmfs://aux` / `tmfs://window` 等辅助/系统 buffer
  仍保持禁用。
- `interactive-replace`：`unless` 跳过条件同步收窄为
  `(and (string-starts? "tmfs:") (not (collab-buffer? ...)))`。

`collab-buffer?`（`tm-collab.scm`，`url-rooted-tmfs-protocol? u "collab"`）是纯谓词、
tm-define 全局可见，随 `file-menu` → `tm-collab` 在启动期加载，与既有调用点用法一致。

## 验证

- **人工 GUI 验证**：已通过（远程文档中打开 Search/Replace 正常）。
- `gf eval` dispatch 级复现与回归：collab → 正常搜索、chat → 悬浮、
  aux/window → 仍禁用、本地 → 正常。
- `gf fmt --changed-since=main` 已格式化。
- `xmake build --yes stem` → `build ok`。

## 涉及文件

- `TeXmacs/progs/generic/search-widgets.scm`：`interactive-search`、
  `interactive-replace` 两处分派条件（+6/-3）。
- `devel/0904.md`：任务文档（新增）。
