### PR TITLE
[0909] 升级内置 Goldfish Scheme 到 v18.11.26

### DIFF
--- a/TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm
+++ b/TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm
@@ -11,64 +11,57 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-library (session gnuplot)
-  (import (scheme base) (liii list))
-  (export init-gnuplot)
-  (begin
-    (use-modules (gnuplot gnuplot-binary) (binary goldfish) (binary gs))
+(use-modules (gnuplot gnuplot-binary) (binary goldfish) (binary gs))
 
-    (lazy-format (gnuplot gnuplot-format) gnuplot)
+(lazy-format (gnuplot gnuplot-format) gnuplot)
 
-    (define (gnuplot-serialize lan t)
-      (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
-        (string-append s "\n<EOF>\n")
-      ) ;let*
-    ) ;define
+(define (gnuplot-serialize lan t)
+  (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
+    (string-append s "\n<EOF>\n")
+  ) ;let*
+) ;define
 
-    (define (gen-launcher image-format)
-      (string-append (string-quote (url->system (find-binary-goldfish)))
-        " "
-        "load"
-        " "
-        (string-quote (string-append (url->system (get-texmacs-path))
-                        "/plugins/gnuplot/goldfish/tm-gnuplot.scm"
-                      ) ;string-append
-        ) ;string-quote
-        " "
-        (string-quote (url->system (find-binary-gnuplot)))
-        " "
-        image-format
-      ) ;string-append
-    ) ;define
+(define (gen-launcher image-format)
+  (string-append (string-quote (url->system (find-binary-goldfish)))
+    " "
+    "load"
+    " "
+    (string-quote (string-append (url->system (get-texmacs-path))
+                    "/plugins/gnuplot/goldfish/tm-gnuplot.scm"
+                  ) ;string-append
+    ) ;string-quote
+    " "
+    (string-quote (url->system (find-binary-gnuplot)))
+    " "
+    image-format
+  ) ;string-append
+) ;define
 
-    (define (gnuplot-launchers)
-      (let ((l (list (list :launch "pdf" (gen-launcher "pdf"))
-                 (list :launch "svg" (gen-launcher "svg"))
-                 (list :launch "png" (gen-launcher "png"))
-               ) ;list
-            ) ;l
-           ) ;
-        (if (has-binary-gs?)
-          (append l (list (list :launch "eps" (gen-launcher "eps"))))
-          l
-        ) ;if
-      ) ;let
-    ) ;define
+(define (gnuplot-launchers)
+  (let ((l (list (list :launch "pdf" (gen-launcher "pdf"))
+             (list :launch "svg" (gen-launcher "svg"))
+             (list :launch "png" (gen-launcher "png"))
+           ) ;list
+        ) ;l
+       ) ;
+    (if (has-binary-gs?)
+      (append l (list (list :launch "eps" (gen-launcher "eps"))))
+      l
+    ) ;if
+  ) ;let
+) ;define
 
-    (define (all-gnuplot-launchers)
-      (cons (list :launch (gen-launcher "pdf")) (gnuplot-launchers))
-    ) ;define
+(define (all-gnuplot-launchers)
+  (cons (list :launch (gen-launcher "pdf")) (gnuplot-launchers))
+) ;define
 
-    (define (init-gnuplot)
-      (plugin-configure gnuplot
-        (:require (and (has-binary-goldfish?) (has-binary-gnuplot?)))
-        ,@(all-gnuplot-launchers)
-        (:serializer ,gnuplot-serialize)
-        (:session "Gnuplot")
-      ) ;plugin-configure
-    ) ;define
-  ) ;begin
-) ;define-library
+(define (init-gnuplot)
+  (plugin-configure gnuplot
+    (:require (and (has-binary-goldfish?) (has-binary-gnuplot?)))
+    ,@(all-gnuplot-launchers)
+    (:serializer ,gnuplot-serialize)
+    (:session "Gnuplot")
+  ) ;plugin-configure
+) ;define
 
-(import (session gnuplot))
 (init-gnuplot)

--- a/TeXmacs/plugins/goldfish/goldfish/guenchi/json.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/guenchi/json.scm
@@ -27,9 +27,9 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-string-unescape string->json json->string
-    json-ref json-ref* json-set json-set* json-push json-push* json-drop
-    json-drop* json-reduce json-reduce*
+  (export json-string-escape string->json json->string json-ref json-ref*
+    json-set json-set* json-push json-push* json-drop json-drop* json-reduce
+    json-reduce*
   ) ;export
   (begin
 

--- a/TeXmacs/plugins/goldfish/goldfish/liii/base.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/liii/base.scm
@@ -5,7 +5,7 @@
     string->keyword symbol->keyword keyword->symbol loose-car loose-cdr compose
     identity any? typed-lambda make-hook hook-functions with-output-to-string
     with-input-from-string call-with-input-string call-with-output-string
-    reverse! format
+    reverse! sort! format
   ) ;export
   (begin
 

--- a/TeXmacs/plugins/goldfish/goldfish/liii/fxmapping.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/liii/fxmapping.scm
@@ -4,7 +4,6 @@
     ;; Constructors
     fxmapping
     fxmapping-unfold
-    fxmapping-accumulate
     alist->fxmapping
     alist->fxmapping/combinator
     ;; Predicates
@@ -23,13 +22,9 @@
     fxmapping-adjust
     fxmapping-delete
     fxmapping-delete-all
-    fxmapping-update
-    fxmapping-alter
     fxmapping-delete-min
-    fxmapping-update-min
     fxmapping-pop-min
     fxmapping-delete-max
-    fxmapping-update-max
     fxmapping-pop-max
     ;; Whole fxmapping
     fxmapping-size
@@ -51,8 +46,6 @@
     fxmapping->decreasing-alist
     fxmapping-keys
     fxmapping-values
-    fxmapping->generator
-    fxmapping->decreasing-generator
     ;; Comparison
     fxmapping=?
     fxmapping<?
@@ -78,6 +71,5 @@
     fxsubmapping>=
     fxmapping-split
     ;; Relations
-    fxmapping-relation-map
   ) ;export
 ) ;define-library

--- a/TeXmacs/plugins/goldfish/goldfish/liii/hash-table.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/liii/hash-table.scm
@@ -1,13 +1,12 @@
 (define-library (liii hash-table)
   (import (srfi srfi-125) (srfi srfi-128))
-  (export make-hash-table hash-table hash-table-unfold alist->hash-table
-    hash-table? hash-table-contains? hash-table-empty? hash-table=?
-    hash-table-mutable? hash-table-ref hash-table-ref/default hash-table-set!
-    hash-table-delete! hash-table-intern! hash-table-update!
-    hash-table-update!/default hash-table-pop! hash-table-clear! hash-table-size
-    hash-table-keys hash-table-values hash-table-entries hash-table-find
-    hash-table-count hash-table-fold hash-table-for-each hash-table-map->list
-    hash-table->alist hash-table-copy
+  (export make-hash-table hash-table alist->hash-table hash-table?
+    hash-table-contains? hash-table-empty? hash-table=? hash-table-ref
+    hash-table-ref/default hash-table-set! hash-table-delete! hash-table-update!
+    hash-table-update!/default hash-table-clear! hash-table-size hash-table-keys
+    hash-table-values hash-table-entries hash-table-find hash-table-count
+    hash-table-fold hash-table-for-each hash-table-map->list hash-table->alist
+    hash-table-copy
   ) ;export
   (begin
   ) ;begin

--- a/TeXmacs/plugins/goldfish/goldfish/scheme/base.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/scheme/base.scm
@@ -183,8 +183,6 @@
     current-error-port
     open-input-file
     open-output-file
-    open-binary-input-file
-    open-binary-output-file
     close-port
     close-input-port
     close-output-port

--- a/TeXmacs/plugins/goldfish/goldfish/scheme/boot.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/scheme/boot.scm
@@ -25,23 +25,27 @@
   ) ;if
 ) ;define
 
-(define-macro (define-library libname . body)
-  `(define ,(symbol (object->string libname))
-     (with-let (sublet (unlet)
-                 (cons 'import import)
-                 (cons '*export* ())
-                 (cons 'export
-                   (define-macro (,(gensym) . names)
-                     `(set! *export* (append (quote ,names) *export*)))))
-       ,@body
-       (apply inlet
-         (map (lambda (entry)
-                (if (or (member (car entry) '(*export* export import))
-                      (and (pair? *export*) (not (member (car entry) *export*))))
-                  (values)
-                  entry))
-           (curlet)))))
-) ;define-macro
+;; C 实现的 define-library（src/s7_r7rs_library.c）已注册时，此后备版本不生效
+(unless (defined? 'define-library)
+  (define-macro (define-library libname . body)
+    `(define ,(symbol (object->string libname))
+       (with-let (sublet (unlet)
+                   (cons 'import import)
+                   (cons '*export* ())
+                   (cons 'export
+                     (define-macro (,(gensym) . names)
+                       `(set! *export* (append (quote ,names) *export*)))))
+         ,@body
+         (apply inlet
+           (map (lambda (entry)
+                  (if (or (member (car entry) '(*export* export import))
+                        (and (pair? *export*)
+                          (not (member (car entry) *export*))))
+                    (values)
+                    entry))
+             (curlet)))))
+  ) ;define-macro
+) ;unless
 
 (unless (defined? 'r7rs-import-library-filename)
   (define (r7rs-import-library-filename libs)
@@ -69,56 +73,59 @@
   ) ;define
 ) ;unless
 
-(define-macro (import . libs)
-  `(begin
-     (r7rs-import-library-filename (quote ,libs))
-     (varlet (curlet)
-       ,@(map (lambda (lib)
-                (case (car lib)
-                      ((only)
-                       `((lambda (e names)
-                           (apply inlet
-                             (map (lambda (name) (cons name (e name))) names)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (cddr (quote ,lib))))
-                      ((except)
-                       `((lambda (e names)
-                           (apply inlet
-                             (map (lambda (entry)
-                                    (if (member (car entry) names)
-                                      (values)
-                                      entry))
-                               e)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (cddr (quote ,lib))))
-                      ((prefix)
-                       `((lambda (e prefx)
-                           (apply inlet
-                             (map (lambda (entry)
-                                    (cons (string->symbol (string-append (symbol->string prefx)
-                                                            (symbol->string (car entry))))
-                                      (cdr entry)))
-                               e)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (caddr (quote ,lib))))
-                      ((rename)
-                       `((lambda (e names)
-                           (apply inlet
-                             (map (lambda (entry)
-                                    (let ((info (assoc (car entry) names)))
-                                      (if info
-                                        (cons (cadr info) (cdr entry))
-                                        entry)))
-                               e)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (cddr (quote ,lib))))
-                      (else `(let ((sym (symbol (object->string (quote ,lib)))))
-                               (if (not (defined? sym))
-                                 (format () "~A not loaded~%" sym)
-                                 (symbol->value sym))))))
-           libs)))
-) ;define-macro
+;; C 实现的 import（src/s7_r7rs_library.c）已注册时，此后备版本不生效
+(unless (defined? 'import)
+  (define-macro (import . libs)
+    `(begin
+       (r7rs-import-library-filename (quote ,libs))
+       (varlet (curlet)
+         ,@(map (lambda (lib)
+                  (case (car lib)
+                        ((only)
+                         `((lambda (e names)
+                             (apply inlet
+                               (map (lambda (name) (cons name (e name))) names)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (cddr (quote ,lib))))
+                        ((except)
+                         `((lambda (e names)
+                             (apply inlet
+                               (map (lambda (entry)
+                                      (if (member (car entry) names)
+                                        (values)
+                                        entry))
+                                 e)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (cddr (quote ,lib))))
+                        ((prefix)
+                         `((lambda (e prefx)
+                             (apply inlet
+                               (map (lambda (entry)
+                                      (cons (string->symbol (string-append (symbol->string prefx)
+                                                              (symbol->string (car entry))))
+                                        (cdr entry)))
+                                 e)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (caddr (quote ,lib))))
+                        ((rename)
+                         `((lambda (e names)
+                             (apply inlet
+                               (map (lambda (entry)
+                                      (let ((info (assoc (car entry) names)))
+                                        (if info
+                                          (cons (cadr info) (cdr entry))
+                                          entry)))
+                                 e)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (cddr (quote ,lib))))
+                        (else `(let ((sym (symbol (object->string (quote ,lib)))))
+                                 (if (not (defined? sym))
+                                   (format () "~A not loaded~%" sym)
+                                   (symbol->value sym))))))
+             libs)))
+  ) ;define-macro
+) ;unless

--- a/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-125.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-125.scm
@@ -16,14 +16,13 @@
 
 (define-library (srfi srfi-125)
   (import (srfi srfi-1) (srfi srfi-128) (liii base) (liii error))
-  (export make-hash-table hash-table hash-table-unfold alist->hash-table
-    hash-table? hash-table-contains? hash-table-empty? hash-table=?
-    hash-table-mutable? hash-table-ref hash-table-ref/default hash-table-set!
-    hash-table-delete! hash-table-intern! hash-table-update!
-    hash-table-update!/default hash-table-pop! hash-table-clear! hash-table-size
-    hash-table-keys hash-table-values hash-table-entries hash-table-find
-    hash-table-count hash-table-fold hash-table-for-each hash-table-map->list
-    hash-table->alist hash-table-copy
+  (export make-hash-table hash-table alist->hash-table hash-table?
+    hash-table-contains? hash-table-empty? hash-table=? hash-table-ref
+    hash-table-ref/default hash-table-set! hash-table-delete! hash-table-update!
+    hash-table-update!/default hash-table-clear! hash-table-size hash-table-keys
+    hash-table-values hash-table-entries hash-table-find hash-table-count
+    hash-table-fold hash-table-for-each hash-table-map->list hash-table->alist
+    hash-table-copy
   ) ;export
   (begin
 

--- a/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-132.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-132.scm
@@ -22,16 +22,9 @@
   (import (liii list) (liii error) (scheme case-lambda))
   (begin
 
+    ;; list-sorted? 复用 liii_sort.cpp 的 C++ 实现 g_list-sorted?
     (define (list-sorted? less-p lis)
-      (if (null? lis)
-        #t
-        (do ((first lis (cdr first))
-             (second (cdr lis) (cdr second))
-             (res #t (not (less-p (car second) (car first))))
-            ) ;
-          ((or (null? second) (not res)) res)
-        ) ;do
-      ) ;if
+      (g_list-sorted? less-p lis)
     ) ;define
 
     (define vector-sorted?
@@ -113,45 +106,12 @@
       ) ;if
     ) ;define
 
-    (define (list-sort! less-p lst)
-      ;; 辅助函数：将列表分成小于和大于 pivot 的部分
-      (define (partition! lst pivot less-p)
-        (let loop
-          ((lst lst) (less '()) (greater '()))
-          (cond ((null? lst) (values (reverse less) (reverse greater)))
-                ;; 返回小于和大于部分
-                ((less-p (car lst) pivot) (loop (cdr lst) (cons (car lst) less) greater))
-                (else (loop (cdr lst) less (cons (car lst) greater)))
-          ) ;cond
-        ) ;let
-      ) ;define
-      ;; 排序函数：原地排序
-      (if (or (null? lst) (null? (cdr lst)))
-        ;; 如果列表为空或只有一个元素，已经排序好
-        lst
-        (let* ((pivot (car lst)))
-          (call-with-values (lambda () (partition! (cdr lst) pivot less-p))
-            ;; 调用 partition 并返回小于和大于部分
-            (lambda (less greater)
-              ;; 对小于和大于部分递归排序
-              (let ((sorted-less (list-sort! less-p less))
-                    (sorted-greater (list-sort! less-p greater))
-                   ) ;
-                ;; 如果 sorted-less 是空，直接返回 sorted-greater
-                (if (null? sorted-less)
-                  sorted-greater
-                  (begin
-                    ;; 原地连接两个部分和 pivot
-                    (set-cdr! (last-pair sorted-less) (cons pivot sorted-greater))
-                    sorted-less
-                    ;; 返回排序后的列表
-                  ) ;begin
-                ) ;if
-              ) ;let
-            ) ;lambda
-          ) ;call-with-values
-        ) ;let*
-      ) ;if
+    ;; list-sort! 复用 S7 内置的 sort!：基于 C qsort 的原地排序，
+    ;; 只重写各 pair 的 car，列表骨架不变，返回值与输入 eq?。
+    ;; 注意参数顺序相反：list-sort! 是 (list-sort! less-p lis)，
+    ;; 内置 sort! 是 (sort! seq less?)。
+    (define (list-sort! less-p lis)
+      (sort! lis less-p)
     ) ;define
 
     (define list-stable-sort!
@@ -195,8 +155,38 @@
 
     (define vector-sort vector-stable-sort)
 
-    (define (vector-sort! . r)
-      (???)
+    ;; vector-sort! 复用 S7 内置的 sort!：基于 C qsort 的原地排序，
+    ;; 直接重写向量元素，返回值与输入 eq?。
+    ;; 注意参数顺序相反：vector-sort! 是 (vector-sort! less-p v)，
+    ;; 内置 sort! 是 (sort! seq less?)。
+    (define vector-sort!
+      (case-lambda
+       ((less-p v)
+        (if (vector? v)
+          (sort! v less-p)
+          (type-error "vector-sort!: expected a vector" v)
+        ) ;if
+       ) ;
+       ((less-p v start)
+        (if (vector? v)
+          (vector-sort! less-p v start (vector-length v))
+          (type-error "vector-sort!: expected a vector" v)
+        ) ;if
+       ) ;
+       ((less-p v start end)
+        (cond ((not (vector? v)) (type-error "vector-sort!: expected a vector" v))
+              ((or (< start 0) (> end (vector-length v)) (> start end))
+               (value-error "Invalid start or end parameters")
+              ) ;
+              (else
+                ;; S7 subvector 与原向量共享存储，
+                ;; 对子区间 sort! 即原地排序原向量的对应区间
+                (sort! (subvector v start end) less-p)
+                v
+              ) ;else
+        ) ;cond
+       ) ;
+      ) ;case-lambda
     ) ;define
 
     (define (vector-stable-sort! . r)

--- a/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-224.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/srfi/srfi-224.scm
@@ -42,7 +42,6 @@
     alist->fxmapping
     alist->fxmapping/combinator
     fxmapping-unfold
-    fxmapping-accumulate
     ;; Predicates
     fxmapping?
     fxmapping-contains?
@@ -59,13 +58,9 @@
     fxmapping-adjust
     fxmapping-delete
     fxmapping-delete-all
-    fxmapping-update
-    fxmapping-alter
     fxmapping-delete-min
-    fxmapping-update-min
     fxmapping-pop-min
     fxmapping-delete-max
-    fxmapping-update-max
     fxmapping-pop-max
     ;; The whole fxmapping
     fxmapping-size

--- a/TeXmacs/plugins/goldfish/src/goldfish.hpp
+++ b/TeXmacs/plugins/goldfish/src/goldfish.hpp
@@ -15,6 +15,7 @@
 //
 
 #include "s7.h"
+#include "s7_r7rs_library.h"
 #include <algorithm>
 #include <argh.h>
 #include <cctype>
@@ -68,7 +69,7 @@
 #include <isocline.h>
 #endif
 
-#define GOLDFISH_VERSION "18.11.22"
+#define GOLDFISH_VERSION "18.11.26"
 
 #define GOLDFISH_PATH_MAXN TB_PATH_MAXN
 
@@ -116,6 +117,7 @@ void glue_scheme_char (s7_scheme* sc);
 void glue_liii_hashlib (s7_scheme* sc);
 void glue_liii_os (s7_scheme* sc);
 void glue_liii_path (s7_scheme* sc);
+void glue_liii_sort (s7_scheme* sc);
 void glue_liii_string (s7_scheme* sc);
 void glue_subprocess_run_values (s7_scheme* sc);
 
@@ -700,6 +702,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_liii_os (sc);
   glue_subprocess_run_values (sc);
   glue_liii_path (sc);
+  glue_liii_sort (sc);
   glue_liii_list (sc);
   glue_liii_string (sc);
   glue_liii_time (sc);
@@ -709,6 +712,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_liii_base64 (sc);
   glue_scheme_base (sc);
   glue_scheme_char (sc);
+  glue_r7rs_library (sc);
   glue_njson (sc);
 #ifdef GOLDFISH_ENABLE_HTTP
   glue_http (sc);

--- a/TeXmacs/plugins/goldfish/src/liii_sort.cpp
+++ b/TeXmacs/plugins/goldfish/src/liii_sort.cpp
@@ -1,0 +1,80 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "s7.h"
+
+namespace goldfish {
+
+// (g_list-sorted? less-p lis) => boolean
+// 判定标准与 SRFI-132 参考实现一致：对所有相邻元素对，
+// (less-p next prev) 为真（非 #f）即视为逆序。
+static s7_pointer
+f_list_sorted_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer less_p= s7_car (args);
+  s7_pointer lis   = s7_cadr (args);
+
+  if (!s7_is_procedure (less_p)) {
+    return s7_wrong_type_arg_error (sc, "list-sorted?", 1, less_p, "a procedure");
+  }
+  if (!s7_is_pair (lis)) {
+    if (s7_is_null (sc, lis)) return s7_t (sc);
+    return s7_wrong_type_arg_error (sc, "list-sorted?", 2, lis, "a proper list");
+  }
+
+  /* args 的 cons 单元在 less_p 回调期间可能被求值器复用，
+   * 因此把 less_p、列表头和我们自建的二元调用列表放进同一个
+   * 栈上保护的 anchor，保证回调触发 GC 时全部可达 */
+  s7_pointer call_args= s7_cons (sc, s7_f (sc), s7_cons (sc, s7_f (sc), s7_nil (sc)));
+  s7_pointer anchor   = s7_cons (sc, less_p, s7_cons (sc, lis, call_args));
+  s7_gc_protect_via_stack (sc, anchor);
+  s7_pointer call_args_second= s7_cdr (call_args);
+
+  bool       sorted= true;
+  s7_pointer prev  = s7_car (lis);
+  s7_pointer p     = s7_cdr (lis);
+  while (s7_is_pair (p)) {
+    s7_pointer cur= s7_car (p);
+    s7_set_car (call_args, cur);
+    s7_set_car (call_args_second, prev);
+    if (s7_apply_function (sc, less_p, call_args) != s7_f (sc)) {
+      sorted= false;
+      break;
+    }
+    prev= cur;
+    p   = s7_cdr (p);
+  }
+  s7_gc_unprotect_via_stack (sc, anchor);
+
+  if (!sorted) return s7_f (sc);
+  if (!s7_is_null (sc, p)) {
+    return s7_wrong_type_arg_error (sc, "list-sorted?", 2, lis, "a proper list");
+  }
+  return s7_t (sc);
+}
+
+static void
+glue_list_sorted_p (s7_scheme* sc) {
+  const char* name= "g_list-sorted?";
+  const char* desc= "(g_list-sorted? less-p lis) => boolean";
+  s7_define_function (sc, name, f_list_sorted_p, 2, 0, false, desc);
+}
+
+void
+glue_liii_sort (s7_scheme* sc) {
+  glue_list_sorted_p (sc);
+}
+
+} // namespace goldfish

--- a/TeXmacs/plugins/goldfish/src/s7_r7rs_library.c
+++ b/TeXmacs/plugins/goldfish/src/s7_r7rs_library.c
@@ -1,0 +1,784 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+/* s7_r7rs_library.c - R7RS library registry for Goldfish Scheme
+ *
+ * The registry maps an R7RS library name (a proper list of symbols and
+ * non-negative integers, e.g. (liii base)) to the let environment holding
+ * the library's exported bindings.  It lives in the rootlet variable
+ * *r7rs-libraries* so that it is reachable by the garbage collector.
+ */
+
+#include "s7_r7rs_library.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define R7RS_LIBRARIES_NAME "*r7rs-libraries*"
+
+static s7_pointer
+r7rs_library_error (s7_scheme* sc, const char* kind, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, kind), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
+static s7_pointer
+r7rs_library_registry (s7_scheme* sc) {
+  return s7_name_to_value (sc, R7RS_LIBRARIES_NAME);
+}
+
+/* R7RS: a library name is a proper list whose elements are symbols or
+ * exact non-negative integers.  Returns true iff name is valid. */
+static bool
+r7rs_library_name_valid (s7_scheme* sc, s7_pointer name) {
+  if ((!s7_is_null (sc, name)) && (!s7_is_pair (name))) return false; /* not a list at all */
+  if (s7_list_length (sc, name) < 0) return false;                    /* improper or circular list */
+  for (s7_pointer p= name; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer elt= s7_car (p);
+    if (s7_is_symbol (elt)) continue;
+    if (s7_is_integer (elt) && s7_integer (elt) >= 0) continue;
+    return false;
+  }
+  return true;
+}
+
+static s7_pointer
+r7rs_library_check_name (s7_scheme* sc, const char* caller, s7_pointer name) {
+  if (!r7rs_library_name_valid (sc, name))
+    return r7rs_library_error (sc, "wrong-type-arg",
+                               "library name should be a proper list of symbols or non-negative integers, but got ~S",
+                               name);
+  return NULL;
+}
+
+static s7_pointer
+g_library_defined_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-defined?", name);
+  if (err) return err;
+  return s7_make_boolean (sc, s7_is_let (s7_hash_table_ref (sc, r7rs_library_registry (sc), name)));
+}
+
+static s7_pointer
+g_library_ref (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-ref", name);
+  if (err) return err;
+  s7_pointer env= s7_hash_table_ref (sc, r7rs_library_registry (sc), name);
+  return s7_is_let (env) ? env : s7_f (sc);
+}
+
+static s7_pointer
+g_library_register (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-register!", name);
+  if (err) return err;
+  s7_pointer env= s7_cadr (args);
+  if (!s7_is_let (env))
+    return r7rs_library_error (sc, "wrong-type-arg", "library environment should be a let, but got ~S", env);
+  s7_hash_table_set (sc, r7rs_library_registry (sc), name, env);
+  return env;
+}
+
+static s7_pointer
+g_library_unregister (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-unregister!", name);
+  if (err) return err;
+  /* s7 hash tables have no delete; storing #f marks the entry as absent
+   * (g_library-defined?/g_library-ref only accept let values). */
+  s7_hash_table_set (sc, r7rs_library_registry (sc), name, s7_f (sc));
+  return s7_unspecified (sc);
+}
+
+/* -------- define-library helpers (defined below) -------- */
+
+static bool       r7rs_decl_named (s7_pointer decl, const char* name);
+static s7_pointer r7rs_export_spec_names (s7_scheme* sc, s7_pointer spec, s7_pointer* internal);
+static s7_pointer r7rs_entries_find (s7_pointer entries, s7_pointer sym);
+static char*      r7rs_library_name_to_path (s7_scheme* sc, s7_pointer libname);
+
+/* -------- cond-expand (library declarations) -------- */
+
+/* is the library available: registered, or present as a file in some *load-path* directory? */
+static bool
+r7rs_library_available (s7_scheme* sc, s7_pointer libname) {
+  if (s7_is_let (s7_hash_table_ref (sc, r7rs_library_registry (sc), libname))) return true;
+  char*      relpath  = r7rs_library_name_to_path (sc, libname);
+  bool       found    = false;
+  s7_pointer load_path= s7_name_to_value (sc, "*load-path*");
+  for (s7_pointer p= load_path; (s7_is_pair (p)) && (!found); p= s7_cdr (p)) {
+    if (!s7_is_string (s7_car (p))) continue;
+    const char* dir= s7_string (s7_car (p));
+    size_t      n  = strlen (dir) + strlen (relpath) + 2;
+    char*       full= (char*) malloc (n);
+    snprintf (full, n, "%s/%s", dir, relpath);
+    FILE* fp= fopen (full, "r");
+    if (fp) {
+      fclose (fp);
+      found= true;
+    }
+    free (full);
+  }
+  free (relpath);
+  return found;
+}
+
+/* evaluate an R7RS feature requirement: a feature identifier, (library name),
+ * or (and/or/not ...) compositions */
+static bool
+r7rs_feature_satisfied (s7_scheme* sc, s7_pointer req) {
+  if (s7_is_symbol (req)) return s7_is_provided (sc, s7_symbol_name (req));
+  if (!s7_is_pair (req)) {
+    r7rs_library_error (sc, "syntax-error", "cond-expand: invalid feature requirement ~S", req);
+    return false;
+  }
+  s7_pointer head= s7_car (req);
+  if (!s7_is_symbol (head)) {
+    r7rs_library_error (sc, "syntax-error", "cond-expand: invalid feature requirement ~S", req);
+    return false;
+  }
+  const char* op= s7_symbol_name (head);
+  if (strcmp (op, "library") == 0) {
+    if ((s7_list_length (sc, req) != 2) || (!r7rs_library_name_valid (sc, s7_cadr (req)))) {
+      r7rs_library_error (sc, "syntax-error", "cond-expand: malformed (library ...) requirement ~S", req);
+      return false;
+    }
+    return r7rs_library_available (sc, s7_cadr (req));
+  }
+  if (strcmp (op, "and") == 0) {
+    for (s7_pointer p= s7_cdr (req); s7_is_pair (p); p= s7_cdr (p))
+      if (!r7rs_feature_satisfied (sc, s7_car (p))) return false;
+    return true;
+  }
+  if (strcmp (op, "or") == 0) {
+    for (s7_pointer p= s7_cdr (req); s7_is_pair (p); p= s7_cdr (p))
+      if (r7rs_feature_satisfied (sc, s7_car (p))) return true;
+    return false;
+  }
+  if (strcmp (op, "not") == 0) {
+    if (s7_list_length (sc, req) != 2) {
+      r7rs_library_error (sc, "syntax-error", "cond-expand: (not ...) takes exactly one requirement, got ~S", req);
+      return false;
+    }
+    return !r7rs_feature_satisfied (sc, s7_cadr (req));
+  }
+  r7rs_library_error (sc, "syntax-error", "cond-expand: unknown feature requirement ~S", req);
+  return false;
+}
+
+/* choose the body (a list of declarations) of the first matching clause of a
+ * cond-expand declaration; returns NULL (no allocation) if nothing matches */
+static s7_pointer
+r7rs_cond_expand_choose (s7_scheme* sc, s7_pointer clauses) {
+  for (s7_pointer p= clauses; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer clause= s7_car (p);
+    if (!s7_is_pair (clause)) {
+      r7rs_library_error (sc, "syntax-error", "cond-expand: clause is not a list: ~S", clause);
+      return NULL;
+    }
+    s7_pointer req= s7_car (clause);
+    if ((s7_is_symbol (req)) && (strcmp (s7_symbol_name (req), "else") == 0)) return s7_cdr (clause);
+    if (r7rs_feature_satisfied (sc, req)) return s7_cdr (clause);
+  }
+  return NULL;
+}
+
+/* R7RS cond-expand, replacing s7's built-in read-time expansion (which neither
+ * supports (library ...) requirements nor clauses with multiple body forms).
+ * Registered as a plain c-macro, so the reader no longer expands cond-expand
+ * forms and define-library bodies can process them as declarations. */
+static s7_pointer
+g_cond_expand_r7rs (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+  s7_pointer chosen   = r7rs_cond_expand_choose (sc, args);
+  s7_pointer expansion=
+    chosen ? s7_cons (sc, s7_make_symbol (sc, "begin"), chosen) : s7_unspecified (sc);
+  s7_gc_unprotect_via_stack (sc, args);
+  return expansion;
+}
+
+/* -------- define-library passes -------- */
+
+enum { R7RS_PASS_EVAL, R7RS_PASS_VALIDATE, R7RS_PASS_POPULATE };
+
+typedef struct {
+  s7_pointer lib_env;
+  s7_pointer entries;
+  s7_pointer export_env;
+  bool       saw_export;
+} r7rs_define_library_ctx;
+
+static void r7rs_walk_library_decls (s7_scheme* sc, s7_pointer decls, int mode, r7rs_define_library_ctx* ctx);
+
+/* -------- include -------- */
+
+static bool
+r7rs_file_readable (const char* path) {
+  FILE* fp= fopen (path, "r");
+  if (!fp) return false;
+  fclose (fp);
+  return true;
+}
+
+static char*
+r7rs_str_dup (const char* s) {
+  size_t n= strlen (s) + 1;
+  char*  r= (char*) malloc (n);
+  memcpy (r, s, n);
+  return r;
+}
+
+/* resolve an include file: first relative to the directory of the file
+ * currently being loaded, then each *load-path* directory, then the name
+ * as-is.  Returns a malloc'd path, or NULL if not found. */
+static char*
+r7rs_find_include_file (s7_scheme* sc, const char* name) {
+  s7_pointer port= s7_current_input_port (sc);
+  const char* current= s7_port_filename (sc, port);
+  if (current) {
+    const char* sep= strrchr (current, '/');
+    if (!sep) sep= strrchr (current, '\\');
+    if (sep) {
+      size_t dir_len= (size_t) (sep - current);
+      char* candidate= (char*) malloc (dir_len + 1 + strlen (name) + 1);
+      memcpy (candidate, current, dir_len);
+      candidate[dir_len]= '/';
+      strcpy (candidate + dir_len + 1, name);
+      if (r7rs_file_readable (candidate)) return candidate;
+      free (candidate);
+    }
+  }
+  s7_pointer load_path= s7_name_to_value (sc, "*load-path*");
+  for (s7_pointer p= load_path; s7_is_pair (p); p= s7_cdr (p)) {
+    if (!s7_is_string (s7_car (p))) continue;
+    const char* dir= s7_string (s7_car (p));
+    size_t      n  = strlen (dir) + strlen (name) + 2;
+    char* candidate= (char*) malloc (n);
+    snprintf (candidate, n, "%s/%s", dir, name);
+    if (r7rs_file_readable (candidate)) return candidate;
+    free (candidate);
+  }
+  if (r7rs_file_readable (name)) return r7rs_str_dup (name);
+  return NULL;
+}
+
+/* read an entire file; returns a malloc'd NUL-terminated string, or NULL */
+static char*
+r7rs_read_file_text (const char* path) {
+  FILE* fp= fopen (path, "rb");
+  if (!fp) return NULL;
+  fseek (fp, 0, SEEK_END);
+  long size= ftell (fp);
+  if (size < 0) {
+    fclose (fp);
+    return NULL;
+  }
+  rewind (fp);
+  char* text= (char*) malloc ((size_t) size + 1);
+  size_t got= fread (text, 1, (size_t) size, fp);
+  fclose (fp);
+  text[got]= '\0';
+  return text;
+}
+
+/* validate the filename arguments of an include declaration */
+static s7_pointer
+r7rs_include_check_files (s7_scheme* sc, s7_pointer files) {
+  for (s7_pointer p= files; s7_is_pair (p); p= s7_cdr (p))
+    if (!s7_is_string (s7_car (p)))
+      return r7rs_library_error (sc, "wrong-type-arg", "include: filename should be a string, got ~S", s7_car (p));
+  return NULL;
+}
+
+/* (include "file" ...) / (include-ci "file" ...): the file contents are library
+ * body forms, as if wrapped in begin.  Note: the s7 reader has no case-folding
+ * mode, so include-ci currently behaves exactly like include. */
+static void
+r7rs_include_files (s7_scheme* sc, s7_pointer files, s7_pointer lib_env) {
+  s7_pointer err= r7rs_include_check_files (sc, files);
+  if (err) return;
+  for (s7_pointer p= files; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer name= s7_car (p);
+    char*      path= r7rs_find_include_file (sc, s7_string (name));
+    if (!path) {
+      r7rs_library_error (sc, "io-error", "include: cannot find file ~S", name);
+      return;
+    }
+    char* text= r7rs_read_file_text (path);
+    free (path);
+    if (!text) {
+      r7rs_library_error (sc, "io-error", "include: cannot read file ~S", name);
+      return;
+    }
+    s7_pointer port= s7_open_input_string (sc, text); /* the port references text */
+    s7_gc_protect_via_stack (sc, port);
+    s7_pointer eof= s7_eof_object (sc);
+    s7_pointer form;
+    while ((form= s7_read (sc, port)) != eof)
+      s7_eval (sc, form, lib_env);
+    s7_gc_unprotect_via_stack (sc, port);
+    free (text);
+  }
+}
+
+/* (include-library-declarations "file" ...): the file contents are library
+ * declarations, spliced into the declaration stream */
+static void
+r7rs_include_library_declarations (s7_scheme* sc, s7_pointer files, int mode, r7rs_define_library_ctx* ctx) {
+  s7_pointer err= r7rs_include_check_files (sc, files);
+  if (err) return;
+  for (s7_pointer p= files; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer name= s7_car (p);
+    char*      path= r7rs_find_include_file (sc, s7_string (name));
+    if (!path) {
+      r7rs_library_error (sc, "io-error", "include-library-declarations: cannot find file ~S", name);
+      return;
+    }
+    char* text= r7rs_read_file_text (path);
+    free (path);
+    if (!text) {
+      r7rs_library_error (sc, "io-error", "include-library-declarations: cannot read file ~S", name);
+      return;
+    }
+    s7_pointer port= s7_open_input_string (sc, text); /* the port references text */
+    s7_gc_protect_via_stack (sc, port);
+    s7_pointer eof  = s7_eof_object (sc);
+    s7_pointer forms= s7_nil (sc);
+    s7_gc_protect_via_stack (sc, forms);
+    s7_pointer form;
+    while ((form= s7_read (sc, port)) != eof) {
+      s7_gc_protect_via_stack (sc, form);
+      forms= s7_cons (sc, form, forms); /* reversed */
+      s7_gc_unprotect_via_stack (sc, form);
+      s7_gc_unprotect_via_stack (sc, forms);
+      s7_gc_protect_via_stack (sc, forms);
+    }
+    /* reverse in place (no allocation, so no GC risk): restore source order */
+    s7_pointer rev= s7_nil (sc);
+    for (s7_pointer q= forms; s7_is_pair (q);) {
+      s7_pointer next= s7_cdr (q);
+      s7_set_cdr (q, rev);
+      rev= q;
+      q  = next;
+    }
+    /* the last cons cell (old head) is still on the protect stack and anchors
+     * the whole chain, which now starts at rev */
+    r7rs_walk_library_decls (sc, rev, mode, ctx);
+    s7_gc_unprotect_via_stack (sc, forms);
+    s7_gc_unprotect_via_stack (sc, port);
+    free (text);
+  }
+}
+
+/* pass 2 helper: every export spec must be well-formed and name a binding of the
+ * library body, or a binding that falls through to the rootlet */
+static void
+r7rs_validate_export_decl (s7_scheme* sc, s7_pointer decl, s7_pointer entries) {
+  for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
+    s7_pointer internal= NULL;
+    r7rs_export_spec_names (sc, s7_car (specs), &internal);
+    if ((!r7rs_entries_find (entries, internal)) && (!s7_is_defined (sc, s7_symbol_name (internal))))
+      r7rs_library_error (sc, "unbound-variable", "define-library: cannot export ~S: it is not defined in "
+                          "the library body",
+                          internal);
+  }
+}
+
+/* pass 3 helper: materialize the exported bindings into export_env */
+static void
+r7rs_populate_export_decl (s7_scheme* sc, s7_pointer decl, s7_pointer entries, s7_pointer export_env, s7_pointer lib_env) {
+  for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
+    s7_pointer internal= NULL;
+    s7_pointer external= r7rs_export_spec_names (sc, s7_car (specs), &internal);
+    s7_pointer entry   = r7rs_entries_find (entries, internal);
+    /* only the library body's own bindings are materialized in the export
+     * environment.  Names that fall through to the rootlet (pass 2 allows
+     * them, e.g. (scheme base) re-exporting eqv?) stay virtual: the export
+     * environment's outlet chain resolves them, exactly like the old
+     * Scheme implementation.  Copying hundreds of rootlet bindings into
+     * every export environment (and from there into every importer) would
+     * be a measurable slowdown. */
+    if (entry) s7_varlet (sc, export_env, external, s7_cdr (entry));
+    else
+      if (external != internal) {
+        /* a renamed rootlet re-export (export (rename eqv? same?)): the new
+         * name does not exist in the rootlet, so it must be materialized */
+        s7_pointer value= s7_let_ref (sc, lib_env, internal);
+        /* syntactic rootlet bindings (define* etc.) cannot be let slots in s7;
+         * skip them, matching the old Scheme implementation */
+        if (!s7_is_syntax (value)) s7_varlet (sc, export_env, external, value);
+      }
+  }
+}
+
+static void
+r7rs_walk_library_decls (s7_scheme* sc, s7_pointer decls, int mode, r7rs_define_library_ctx* ctx) {
+  for (s7_pointer p= decls; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer decl= s7_car (p);
+    if (r7rs_decl_named (decl, "cond-expand")) {
+      s7_pointer chosen= r7rs_cond_expand_choose (sc, s7_cdr (decl));
+      if (chosen) r7rs_walk_library_decls (sc, chosen, mode, ctx);
+      continue;
+    }
+    /* include-library-declarations splices declarations: handle in every pass */
+    if (r7rs_decl_named (decl, "include-library-declarations")) {
+      r7rs_include_library_declarations (sc, s7_cdr (decl), mode, ctx);
+      continue;
+    }
+    /* include/include-ci splice body forms: only the eval pass cares */
+    if ((r7rs_decl_named (decl, "include")) || (r7rs_decl_named (decl, "include-ci"))) {
+      if (mode == R7RS_PASS_EVAL) r7rs_include_files (sc, s7_cdr (decl), ctx->lib_env);
+      continue;
+    }
+    switch (mode) {
+    case R7RS_PASS_EVAL:
+      if (!r7rs_decl_named (decl, "export")) s7_eval (sc, decl, ctx->lib_env);
+      break;
+    case R7RS_PASS_VALIDATE:
+      if (r7rs_decl_named (decl, "export")) {
+        ctx->saw_export= true;
+        r7rs_validate_export_decl (sc, decl, ctx->entries);
+      }
+      break;
+    case R7RS_PASS_POPULATE:
+      if (r7rs_decl_named (decl, "export"))
+        r7rs_populate_export_decl (sc, decl, ctx->entries, ctx->export_env, ctx->lib_env);
+      break;
+    }
+  }
+}
+
+static bool
+r7rs_decl_named (s7_pointer decl, const char* name) {
+  return (s7_is_pair (decl)) && (s7_is_symbol (s7_car (decl))) &&
+         (strcmp (s7_symbol_name (s7_car (decl)), name) == 0);
+}
+
+/* An export spec is either a symbol (external == internal) or (rename old new).
+ * On success stores the internal name in *internal and returns the external name;
+ * on a malformed spec an error is signalled. */
+static s7_pointer
+r7rs_export_spec_names (s7_scheme* sc, s7_pointer spec, s7_pointer* internal) {
+  if (s7_is_symbol (spec)) {
+    *internal= spec;
+    return spec;
+  }
+  if ((s7_is_pair (spec)) && (r7rs_decl_named (spec, "rename")) && (s7_list_length (sc, spec) == 3) &&
+      (s7_is_symbol (s7_cadr (spec))) && (s7_is_symbol (s7_caddr (spec)))) {
+    *internal= s7_cadr (spec);
+    return s7_caddr (spec);
+  }
+  return r7rs_library_error (sc, "syntax-error", "define-library: invalid export spec ~S", spec);
+}
+
+/* Find the binding entry (a (symbol . value) pair of s7_let_to_list) for sym
+ * among the own slots of env, or NULL if sym is not bound in env itself
+ * (outlets are deliberately not searched: only definitions and imports of the
+ * library body count). */
+static s7_pointer
+r7rs_entries_find (s7_pointer entries, s7_pointer sym) {
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer entry= s7_car (p);
+    if (s7_car (entry) == sym) return entry;
+  }
+  return NULL;
+}
+
+static s7_pointer
+g_define_library (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+  s7_pointer libname= s7_car (args);
+  if (!r7rs_library_name_valid (sc, libname))
+    return r7rs_library_error (sc, "wrong-type-arg",
+                               "define-library: invalid library name ~S (a proper list of symbols or non-negative "
+                               "integers expected)",
+                               libname);
+
+  r7rs_define_library_ctx ctx;
+  ctx.saw_export= false;
+
+  /* the working environment: definitions and imports of the library body land here */
+  ctx.lib_env= s7_sublet (sc, s7_rootlet (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, ctx.lib_env);
+
+  /* pass 1: evaluate every declaration except export in lib_env
+   * (cond-expand clauses are resolved and recursed into by the walker) */
+  r7rs_walk_library_decls (sc, s7_cdr (args), R7RS_PASS_EVAL, &ctx);
+
+  /* the own slots of lib_env, as (symbol . value) entries */
+  ctx.entries= s7_let_to_list (sc, ctx.lib_env);
+  s7_gc_protect_via_stack (sc, ctx.entries);
+
+  /* pass 2: validate export specs before mutating any visible state */
+  r7rs_walk_library_decls (sc, s7_cdr (args), R7RS_PASS_VALIDATE, &ctx);
+
+  ctx.export_env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, ctx.export_env);
+
+  /* make the library reachable before populating it: the registry entry and the
+   * compatibility global symbol (used by the Scheme import implementation) */
+  s7_hash_table_set (sc, r7rs_library_registry (sc), libname, ctx.export_env);
+  char* name_str= s7_object_to_c_string (sc, libname);
+  s7_define (sc, s7_rootlet (sc), s7_make_symbol (sc, name_str), ctx.export_env);
+  free (name_str);
+
+  /* populate: with no export declaration every binding is exported */
+  if (!ctx.saw_export) {
+    for (s7_pointer p= ctx.entries; s7_is_pair (p); p= s7_cdr (p)) {
+      s7_pointer entry= s7_car (p);
+      s7_varlet (sc, ctx.export_env, s7_car (entry), s7_cdr (entry));
+    }
+  }
+  else r7rs_walk_library_decls (sc, s7_cdr (args), R7RS_PASS_POPULATE, &ctx);
+
+  s7_gc_unprotect_via_stack (sc, ctx.export_env);
+  s7_gc_unprotect_via_stack (sc, ctx.entries);
+  s7_gc_unprotect_via_stack (sc, ctx.lib_env);
+  s7_gc_unprotect_via_stack (sc, args);
+  return s7_t (sc);
+}
+
+/* -------- import -------- */
+
+/* map a library name (liii base) to the file path "liii/base.scm" */
+static char*
+r7rs_library_name_to_path (s7_scheme* sc, s7_pointer libname) {
+  size_t len= 1; /* NUL */
+  for (s7_pointer p= libname; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer elt= s7_car (p);
+    len+= (s7_is_symbol (elt) ? strlen (s7_symbol_name (elt)) : 24) + 1; /* '/' or ".scm" */
+  }
+  char* path= (char*) malloc (len + 4);
+  char* w   = path;
+  for (s7_pointer p= libname; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer elt= s7_car (p);
+    if (w != path) *w++= '/';
+    if (s7_is_symbol (elt)) {
+      size_t n= strlen (s7_symbol_name (elt));
+      memcpy (w, s7_symbol_name (elt), n);
+      w+= n;
+    }
+    else w+= sprintf (w, "%lld", (long long) s7_integer (elt));
+  }
+  memcpy (w, ".scm", 5); /* with NUL */
+  return path;
+}
+
+/* return the exported environment of libname, loading its file on first use */
+static s7_pointer
+r7rs_library_env (s7_scheme* sc, s7_pointer libname) {
+  s7_pointer env= s7_hash_table_ref (sc, r7rs_library_registry (sc), libname);
+  if (s7_is_let (env)) return env;
+  char* path= r7rs_library_name_to_path (sc, libname);
+  s7_load (sc, path); /* errors if the file cannot be found */
+  free (path);
+  env= s7_hash_table_ref (sc, r7rs_library_registry (sc), libname);
+  if (!s7_is_let (env))
+    return r7rs_library_error (sc, "unbound-variable", "import: loading did not define the library ~S", libname);
+  return env;
+}
+
+static s7_pointer r7rs_import_set_env (s7_scheme* sc, s7_pointer iset);
+
+/* is sym a member of the symbol list names? */
+static bool
+r7rs_symbol_member (s7_pointer names, s7_pointer sym) {
+  for (s7_pointer p= names; s7_is_pair (p); p= s7_cdr (p))
+    if (s7_car (p) == sym) return true;
+  return false;
+}
+
+static s7_pointer
+r7rs_import_check_names (s7_scheme* sc, s7_pointer names) {
+  for (s7_pointer p= names; s7_is_pair (p); p= s7_cdr (p))
+    if (!s7_is_symbol (s7_car (p)))
+      return r7rs_library_error (sc, "wrong-type-arg", "import: expected an identifier, got ~S", s7_car (p));
+  return NULL;
+}
+
+/* (only import-set identifier ...) */
+static s7_pointer
+r7rs_import_only (s7_scheme* sc, s7_pointer iset) {
+  s7_pointer rest= s7_cdr (iset);
+  if (!s7_is_pair (rest))
+    return r7rs_library_error (sc, "syntax-error", "import: (only ...) needs an import set, got ~S", iset);
+  s7_pointer err= r7rs_import_check_names (sc, s7_cdr (rest));
+  if (err) return err;
+  s7_pointer sub= r7rs_import_set_env (sc, s7_car (rest));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  for (s7_pointer names= s7_cdr (rest); s7_is_pair (names); names= s7_cdr (names)) {
+    s7_pointer name= s7_car (names);
+    s7_varlet (sc, env, name, s7_let_ref (sc, sub, name)); /* let-ref errors if name is missing */
+  }
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* (except import-set identifier ...) */
+static s7_pointer
+r7rs_import_except (s7_scheme* sc, s7_pointer iset) {
+  s7_pointer rest= s7_cdr (iset);
+  if (!s7_is_pair (rest))
+    return r7rs_library_error (sc, "syntax-error", "import: (except ...) needs an import set, got ~S", iset);
+  s7_pointer err= r7rs_import_check_names (sc, s7_cdr (rest));
+  if (err) return err;
+  s7_pointer sub= r7rs_import_set_env (sc, s7_car (rest));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  s7_pointer entries= s7_let_to_list (sc, sub);
+  s7_gc_protect_via_stack (sc, entries);
+  s7_pointer names= s7_cdr (rest);
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer entry= s7_car (p);
+    if (!r7rs_symbol_member (names, s7_car (entry))) s7_varlet (sc, env, s7_car (entry), s7_cdr (entry));
+  }
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* (prefix import-set prefix-identifier) */
+static s7_pointer
+r7rs_import_prefix (s7_scheme* sc, s7_pointer iset) {
+  if ((s7_list_length (sc, iset) != 3) || (!s7_is_symbol (s7_caddr (iset))))
+    return r7rs_library_error (sc, "syntax-error",
+                               "import: (prefix ...) needs an import set and a prefix identifier, got ~S", iset);
+  s7_pointer sub= r7rs_import_set_env (sc, s7_cadr (iset));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  s7_pointer entries= s7_let_to_list (sc, sub);
+  s7_gc_protect_via_stack (sc, entries);
+  const char* pre= s7_symbol_name (s7_caddr (iset));
+  size_t      pre_len= strlen (pre);
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer  entry= s7_car (p);
+    const char* name = s7_symbol_name (s7_car (entry));
+    size_t      name_len= strlen (name);
+    char*       buf= (char*) malloc (pre_len + name_len + 1);
+    memcpy (buf, pre, pre_len);
+    memcpy (buf + pre_len, name, name_len + 1);
+    s7_varlet (sc, env, s7_make_symbol (sc, buf), s7_cdr (entry));
+    free (buf);
+  }
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* (rename import-set (old new) ...) */
+static s7_pointer
+r7rs_import_rename (s7_scheme* sc, s7_pointer iset) {
+  s7_pointer rest= s7_cdr (iset);
+  if (!s7_is_pair (rest))
+    return r7rs_library_error (sc, "syntax-error", "import: (rename ...) needs an import set, got ~S", iset);
+  for (s7_pointer specs= s7_cdr (rest); s7_is_pair (specs); specs= s7_cdr (specs)) {
+    s7_pointer spec= s7_car (specs);
+    if ((s7_list_length (sc, spec) != 2) || (!s7_is_symbol (s7_car (spec))) || (!s7_is_symbol (s7_cadr (spec))))
+      return r7rs_library_error (sc, "syntax-error", "import: rename expects (old new) pairs, got ~S", spec);
+  }
+  s7_pointer sub= r7rs_import_set_env (sc, s7_car (rest));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  s7_pointer entries= s7_let_to_list (sc, sub);
+  s7_gc_protect_via_stack (sc, entries);
+  s7_pointer specs= s7_cdr (rest);
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer entry= s7_car (p);
+    s7_pointer name = s7_car (entry);
+    for (s7_pointer q= specs; s7_is_pair (q); q= s7_cdr (q)) {
+      s7_pointer spec= s7_car (q);
+      if (s7_car (spec) == name) {
+        name= s7_cadr (spec);
+        break;
+      }
+    }
+    s7_varlet (sc, env, name, s7_cdr (entry));
+  }
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* resolve an import set to the environment of bindings it denotes */
+static s7_pointer
+r7rs_import_set_env (s7_scheme* sc, s7_pointer iset) {
+  if (r7rs_decl_named (iset, "only")) return r7rs_import_only (sc, iset);
+  if (r7rs_decl_named (iset, "except")) return r7rs_import_except (sc, iset);
+  if (r7rs_decl_named (iset, "prefix")) return r7rs_import_prefix (sc, iset);
+  if (r7rs_decl_named (iset, "rename")) return r7rs_import_rename (sc, iset);
+  /* plain library name */
+  if (!r7rs_library_name_valid (sc, iset))
+    return r7rs_library_error (sc, "wrong-type-arg", "import: invalid import set ~S", iset);
+  return r7rs_library_env (sc, iset);
+}
+
+static s7_pointer
+g_import (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+  /* s7 applies a c-macro without changing sc->curlet, so the current let is
+   * exactly the environment in which the import form appears. */
+  s7_pointer target= s7_curlet (sc);
+  for (s7_pointer sets= args; s7_is_pair (sets); sets= s7_cdr (sets)) {
+    s7_pointer env= r7rs_import_set_env (sc, s7_car (sets));
+    s7_gc_protect_via_stack (sc, env);
+    s7_pointer entries= s7_let_to_list (sc, env);
+    s7_gc_protect_via_stack (sc, entries);
+    /* varlet prepends slots, so bindings of later import sets shadow earlier ones */
+    for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+      s7_pointer entry= s7_car (p);
+      s7_varlet (sc, target, s7_car (entry), s7_cdr (entry));
+    }
+    s7_gc_unprotect_via_stack (sc, entries);
+    s7_gc_unprotect_via_stack (sc, env);
+  }
+  s7_gc_unprotect_via_stack (sc, args);
+  return s7_t (sc); /* the "expansion" #t evaluates to itself */
+}
+
+void
+glue_r7rs_library (s7_scheme* sc) {
+  s7_define_variable (sc, R7RS_LIBRARIES_NAME, s7_make_hash_table (sc, 64));
+  s7_define_safe_function (sc, "g_library-defined?", g_library_defined_p, 1, 0, false,
+                           "(g_library-defined? libname) returns #t if the R7RS library named libname is registered");
+  s7_define_safe_function (sc, "g_library-ref", g_library_ref, 1, 0, false,
+                           "(g_library-ref libname) returns the exported environment of the R7RS library named libname, "
+                           "or #f if it is not registered");
+  s7_define_safe_function (sc, "g_library-register!", g_library_register, 2, 0, false,
+                           "(g_library-register! libname env) registers env as the exported environment of the R7RS "
+                           "library named libname, replacing any previous registration");
+  s7_define_safe_function (sc, "g_library-unregister!", g_library_unregister, 1, 0, false,
+                           "(g_library-unregister! libname) removes the R7RS library named libname from the registry");
+  s7_define_macro (sc, "define-library", g_define_library, 1, 0, true,
+                   "(define-library libname decl ...) defines the R7RS library libname from the given declarations "
+                   "(export, import, begin, ...) and registers its exported environment");
+  s7_define_macro (sc, "import", g_import, 0, 0, true,
+                   "(import import-set ...) imports the bindings denoted by each import set (a library name, "
+                   "optionally modified by only/except/prefix/rename) into the current environment");
+  s7_define_macro (sc, "cond-expand", g_cond_expand_r7rs, 0, 0, true,
+                   "(cond-expand clause ...) chooses the first clause whose feature requirement (a feature "
+                   "identifier, (library name), or an and/or/not composition) is satisfied");
+}

--- a/TeXmacs/plugins/goldfish/src/s7_r7rs_library.h
+++ b/TeXmacs/plugins/goldfish/src/s7_r7rs_library.h
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#ifndef S7_R7RS_LIBRARY_H
+#define S7_R7RS_LIBRARY_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void glue_r7rs_library (s7_scheme* sc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_R7RS_LIBRARY_H */

--- a/TeXmacs/plugins/quiver/progs/init-quiver.scm
+++ b/TeXmacs/plugins/quiver/progs/init-quiver.scm
@@ -10,42 +10,35 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-library (session quiver)
-  (import (scheme base) (liii list))
-  (export init-quiver)
-  (begin
-    (use-modules (binary pdflatex) (binary goldfish))
+(use-modules (binary pdflatex) (binary goldfish))
 
-    (define (quiver-serialize lan t)
-      (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
-        (string-append s "\n<EOF>\n")
-      ) ;let*
-    ) ;define
+(define (quiver-serialize lan t)
+  (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
+    (string-append s "\n<EOF>\n")
+  ) ;let*
+) ;define
 
-    (define (quiver-launcher)
-      (string-append (string-quote (url->system (find-binary-goldfish)))
-        " "
-        "load"
-        " "
-        (string-quote (string-append (url->system (get-texmacs-path))
-                        "/plugins/quiver/goldfish/tm-quiver.scm"
-                      ) ;string-append
-        ) ;string-quote
-        " "
-        (string-quote (url->system (find-binary-pdflatex)))
-      ) ;string-append
-    ) ;define
+(define (quiver-launcher)
+  (string-append (string-quote (url->system (find-binary-goldfish)))
+    " "
+    "load"
+    " "
+    (string-quote (string-append (url->system (get-texmacs-path))
+                    "/plugins/quiver/goldfish/tm-quiver.scm"
+                  ) ;string-append
+    ) ;string-quote
+    " "
+    (string-quote (url->system (find-binary-pdflatex)))
+  ) ;string-append
+) ;define
 
-    (define (init-quiver)
-      (plugin-configure quiver
-        (:require (and (has-binary-goldfish?) (has-binary-pdflatex?)))
-        (:launch ,(quiver-launcher))
-        (:serializer ,quiver-serialize)
-        (:session "Quiver")
-      ) ;plugin-configure
-    ) ;define
-  ) ;begin
-) ;define-library
+(define (init-quiver)
+  (plugin-configure quiver
+    (:require (and (has-binary-goldfish?) (has-binary-pdflatex?)))
+    (:launch ,(quiver-launcher))
+    (:serializer ,quiver-serialize)
+    (:session "Quiver")
+  ) ;plugin-configure
+) ;define
 
-(import (session quiver))
 (init-quiver)

--- a/TeXmacs/plugins/tikz/progs/init-tikz.scm
+++ b/TeXmacs/plugins/tikz/progs/init-tikz.scm
@@ -12,44 +12,37 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-library (session tikz)
-  (import (scheme base) (liii list))
-  (export init-tikz)
-  (begin
-    (use-modules (binary pdflatex) (binary goldfish))
+(use-modules (binary pdflatex) (binary goldfish))
 
-    (define (tikz-serialize lan t)
-      (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
-        (string-append s "\n<EOF>\n")
-      ) ;let*
-    ) ;define
+(define (tikz-serialize lan t)
+  (let* ((u (pre-serialize lan t)) (s (texmacs->utf8raw (stree->tree u))))
+    (string-append s "\n<EOF>\n")
+  ) ;let*
+) ;define
 
-    (define (tikz-launcher)
-      (string-append (string-quote (url->system (find-binary-goldfish)))
-        " "
-        "load"
-        " "
-        (string-quote (string-append (url->system (get-texmacs-path))
-                        "/plugins/tikz/goldfish/tm-tikz.scm"
-                      ) ;string-append
-        ) ;string-quote
-        " "
-        (string-quote (url->system (find-binary-pdflatex)))
-      ) ;string-append
-    ) ;define
+(define (tikz-launcher)
+  (string-append (string-quote (url->system (find-binary-goldfish)))
+    " "
+    "load"
+    " "
+    (string-quote (string-append (url->system (get-texmacs-path))
+                    "/plugins/tikz/goldfish/tm-tikz.scm"
+                  ) ;string-append
+    ) ;string-quote
+    " "
+    (string-quote (url->system (find-binary-pdflatex)))
+  ) ;string-append
+) ;define
 
-    (define (init-tikz)
-      (plugin-configure tikz
-        (:require (and (has-binary-goldfish?) (has-binary-pdflatex?)))
-        (:launch ,(tikz-launcher))
-        (:serializer ,tikz-serialize)
-        (:session "TikZ")
-      ) ;plugin-configure
-    ) ;define
-  ) ;begin
-) ;define-library
+(define (init-tikz)
+  (plugin-configure tikz
+    (:require (and (has-binary-goldfish?) (has-binary-pdflatex?)))
+    (:launch ,(tikz-launcher))
+    (:serializer ,tikz-serialize)
+    (:session "TikZ")
+  ) ;plugin-configure
+) ;define
 
-(import (session tikz))
 (init-tikz)
 (lazy-format (tikz tikz-format) tikz)
 (use-modules (tikz tikz-mode) (tikz tikz-edit))

--- a/TeXmacs/progs/kernel/boot/boot-s7.scm
+++ b/TeXmacs/progs/kernel/boot/boot-s7.scm
@@ -233,7 +233,15 @@
   ) ;cons
 ) ;set!
 
-(load "scheme/boot.scm")
+;; goldfish v18.11.26 起 define-library/import 为 C 实现
+;; （s7_r7rs_library.c）。其 export 校验对本 body 未定义的名字依赖
+;; 「落入 rootlet」的兜底（s7_is_defined）：scheme/boot.scm 顶层定义的
+;; delete-file、(scheme base) 的 list-copy 等经此通道被 srfi-1、
+;; (scheme file) 等库传递性 re-export。goldfish 自身在 rootlet 求值，
+;; 这些定义天然全局；mogan 顶层是 *texmacs-user-module*，故 boot.scm
+;; 与基础库需显式装入 rootlet。
+(load "scheme/boot.scm" (rootlet))
+(with-let (rootlet) (import (scheme base)))
 (import (scheme base))
 (import (scheme char))
 (import (liii os))

--- a/devel/0909.md
+++ b/devel/0909.md
@@ -1,0 +1,127 @@
+# 0909: 升级内置 Goldfish Scheme 到 v18.11.26
+
+## 任务需求
+
+将 Mogan 内置的 Goldfish Scheme 从 v18.11.22 升级到上游 v18.11.26。
+
+## 现状分析
+
+- 内置 Goldfish 源码位于 `TeXmacs/plugins/goldfish/`：C/C++ 与 s7 源码在
+  `src/`，Scheme 库（`scheme/`、`liii/`、`srfi/`、`guenchi/`）在
+  `goldfish/`。当前版本 `GOLDFISH_VERSION` 为 `"18.11.22"`。
+- 构建脚本 `xmake/goldfish.lua` 显式枚举编译单元（`libgoldfish` 的 s7 `.c`
+  列表、`goldfish` 的 C++ `.cpp` 列表），新增源文件必须手工登记到对应
+  target，否则不会被编译。
+- 项目自带升级脚本 `bin/bump_goldfish`（elvish）即采用覆盖式：`rm -rf`
+  受管子目录后从上游 tag 全量拷入。历史升级 PR（v18.11.20~v18.11.22）
+  均沿用此方式。
+- 上游 `MoganLab/goldfish` v18.11.26 相对 v18.11.22 的结构性变化：
+  - 新增 `src/liii_sort.cpp`（`list-sorted?` 等 list 排序 C 实现）；
+  - 新增 `src/s7_r7rs_library.{c,h}`：`define-library` / `import` /
+    `cond-expand` 改为 C 实现（导出 `glue_r7rs_library`），取代旧
+    `scheme/boot.scm` 里的纯 scheme 宏（宏体以 `(unless (defined? 'import)
+    ...)` 保留为后备）；
+  - Scheme 库文件集合不变（无新增/删除 `.scm`），仅内容更新。
+
+## 2026/08/14 升级到 v18.11.26（覆盖式）+ 启动兼容适配
+
+### What（本次改动做了什么）
+
+1. 从 GitHub `MoganLab/goldfish` tag `v18.11.26` 克隆到 `/tmp` 临时目录，
+   按 `bin/bump_goldfish` 的覆盖式约定，清空并全量拷入：
+   - `TeXmacs/plugins/goldfish/src/`（C/C++/s7 源码，含版本号 bump 到
+     `18.11.26`）；
+   - `TeXmacs/plugins/goldfish/goldfish/{scheme,liii,srfi,guenchi}/`
+     （Scheme 库）。vendored 副本保持上游原格式，未按 mogan 的 gf fmt
+     重排（与历次升级一致，减小对上游 diff）。
+2. `xmake/goldfish.lua` 登记两个新增编译单元，使其进入构建：
+   - `libgoldfish` 的 s7 `.c` 列表新增 `s7_r7rs_library.c`；
+   - `goldfish` 的 C++ `.cpp` 列表新增 `liii_sort.cpp`。
+3. 启动兼容适配（详见 Why）：
+   - `TeXmacs/progs/kernel/boot/boot-s7.scm`：`scheme/boot.scm` 改为显式
+     装入 `(rootlet)`，并把 `(scheme base)` 注入 rootlet；
+   - `TeXmacs/plugins/{quiver,tikz,gnuplot}/progs/init-*.scm`：由
+     `define-library` 风格改回标准插件顶层风格（与其余 20 个插件一致）。
+
+### Why（为什么这么做）
+
+- **覆盖式而非增量**：与 `bin/bump_goldfish` 及历次升级 PR 一致，避免漏带
+  新增文件；本次恰好新增 `liii_sort.cpp` / `s7_r7rs_library`，增量式极易
+  遗漏。来源用 GitHub 克隆而非本地 goldfish 仓库，保证可复现。
+- **登记新源文件到 xmake**：`xmake/goldfish.lua` 不用 glob，新增 `.c/.cpp`
+  必须显式登记，否则 `glue_liii_sort` / `glue_r7rs_library` 符号不会被编
+  译进库，运行期缺实现。两个新模块的注册（`glue_liii_sort(sc)`、
+  `glue_r7rs_library(sc)`）已由上游 `goldfish.hpp` 的 `init_goldfish_scheme`
+  调用序列接好（goldfish.hpp:705 / :715），无需额外接线。
+
+- **启动兼容适配的根因**：v18.11.26 起 `define-library`/`import` 为 C 实现
+  （`s7_r7rs_library.c`），与 mogan 的自定义 module 系统有两处不兼容，
+  覆盖升级后启动即崩溃（`unbound variable os-sep` 等连锁错误）：
+
+  1. **export 校验的 rootlet 兜底**：C 实现 pass 2
+     （`r7rs_validate_export_decl`）要求 export 的名字要么在本 library
+     body 定义，要么「落入 rootlet」（`s7_is_defined`）。goldfish 自身
+     启动在 rootlet 求值，`scheme/boot.scm` 顶层定义的 `delete-file`、
+     `(scheme base)` 的 `list-copy` 等天然全局可见，srfi-1、(scheme file)
+     等库对这些名字的传递性 re-export 校验能通过；而 mogan 顶层是
+     `*texmacs-user-module*`（`init-research.scm` 的自定义 load/eval 都进
+     这里），rootlet 里没有这些名字，校验直接报
+     `define-library: cannot export ...`，library 注册失败，import 链断
+     裂。适配：boot-s7.scm 把 `scheme/boot.scm` 与 `(scheme base)` 显式
+     装入 rootlet，对齐 goldfish 自身的环境语义。
+  2. **body 求值环境的可见性**：C 实现 pass 1 把 body 放进
+     `sublet(rootlet)` 求值（旧 scheme 宏是 `with-let (sublet (unlet) ...)`
+     ，s7 中 unlet 链对符号查找有特殊语义），mogan 顶层环境里的函数与宏
+     （`use-modules`、`plugin-configure`、`pre-serialize` 等）在该环境不可
+     见。受影响的是 3 个用 `define-library` 风格写的插件 init 文件
+     （quiver / tikz / gnuplot，全部 23 个插件中仅此 3 个），其 body 里调
+     `use-modules` 与 mogan 函数。适配：把这 3 个文件改回与其余 20 个插件
+     相同的标准顶层风格（顶层 `use-modules` + `define` + 末尾
+     `init-xxx`），`(session xxx)` 库名无外部引用者，转换安全。这比在
+     rootlet 里堆砌 mogan 符号或改 goldfish C 源都更符合「插件 init 就是
+     顶层加载」的既有约定。
+
+### How（如何验证）
+
+1. `xmake b stem` 全量构建通过（含新增的 `s7_r7rs_library.c` 与
+   `liii_sort.cpp`）。
+2. headless 启动 `moganstem -headless -d -x "(quit-TeXmacs)"`：exit 0，
+   无 `unbound variable` / `cannot export`（升级后适配前启动即崩）。
+3. 用户报告的故障符号逐一恢复：`(os-sep)` → `/`、
+   `new-document-with-style` / `startup-tab-get-recent-docs` 为 procedure、
+   `get-preference` 可用。
+4. Scheme 纯逻辑测试全绿（与基线 v18.11.22 结果一致）：
+   - style-package-load-test：14 correct, 0 failed
+   - preferences-widgets-test：409 correct, 0 failed（适配前因 quiver
+     use-modules 报 unbound 而 fail，基线同为 409/0）
+   - print-widgets-test：23 correct, 0 failed
+   - version-test：20 correct, 0 failed
+   - tm-collab-test：61 correct, 0 failed
+5. goldfish-bin `--version` → `Goldfish Scheme 18.11.26`；新特性冒烟：
+   `(import (liii sort)) (list-sorted? < ...)` 可用；R7RS
+   `define-library`/`import` 可用。
+6. 基线对照实验：适配前在 v18.11.22 基线上重跑同一测试集确认差异均由
+   v18.11.26 行为变更引入（preferences-widgets-test 基线 409/0 通过）。
+
+### 涉及文件
+
+- `TeXmacs/plugins/goldfish/src/`：s7/C++ 源码全量更新（版本号 → 18.11.26），
+  新增 `liii_sort.cpp`、`s7_r7rs_library.{c,h}`。
+- `TeXmacs/plugins/goldfish/goldfish/{scheme,liii,srfi,guenchi}/`：Scheme
+  库内容更新（保持上游原格式）。
+- `xmake/goldfish.lua`：登记 `s7_r7rs_library.c`（libgoldfish）、
+  `liii_sort.cpp`（goldfish）。
+- `TeXmacs/progs/kernel/boot/boot-s7.scm`：`scheme/boot.scm` 装入 rootlet
+  + `(scheme base)` 注入 rootlet（C define-library export 校验兼容）。
+- `TeXmacs/plugins/quiver/progs/init-quiver.scm`、
+  `TeXmacs/plugins/tikz/progs/init-tikz.scm`、
+  `TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm`：define-library 风格
+  改回标准插件顶层风格。
+
+### 遗留风险
+
+- 上游 goldfish 若后续放宽 export 校验（允许传递性 import 链查找）或恢复
+  unlet 语义的 body 环境，mogan 侧的 rootlet 注入与 3 个 init 文件的转换
+  仍然兼容，无需回退；可考虑向上游反馈 mogan 嵌入场景的这两个兼容点。
+- GUI 模式与真实 quiver/tikz/gnuplot 会话的端到端验证：已由开发者人工
+  验证通过（2026/08/14）。

--- a/xmake/goldfish.lua
+++ b/xmake/goldfish.lua
@@ -39,6 +39,7 @@ target("libgoldfish") do
         "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_dtoa.c",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_module.c",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_op_names.c",
+        "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_r7rs_library.c",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_scheme_base.c",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_scheme_char.c",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/s7_scheme_complex.c",
@@ -76,6 +77,7 @@ target ("goldfish") do
         "$(projectdir)/TeXmacs/plugins/goldfish/src/liii_os.cpp",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/liii_path.cpp",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/liii_subprocess.cpp",
+        "$(projectdir)/TeXmacs/plugins/goldfish/src/liii_sort.cpp",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/scheme_base.cpp",
         "$(projectdir)/TeXmacs/plugins/goldfish/src/scheme_char.cpp",
     })


### PR DESCRIPTION
## 任务

将 Mogan 内置的 Goldfish Scheme 从 v18.11.22 升级到上游 v18.11.26（任务编号 0909，`devel/0909.md`）。

## 改动内容

### 1. 覆盖式同步上游 v18.11.26

- `TeXmacs/plugins/goldfish/src/`、`goldfish/{scheme,liii,srfi,guenchi}/`：按 `bin/bump_goldfish` 约定覆盖式全量同步（vendored 副本保持上游原格式）。
- `xmake/goldfish.lua`：登记两个新增编译单元（xmake 不用 glob，不登记则符号不进库）：
  - `libgoldfish`：`s7_r7rs_library.c`
  - `goldfish`：`liii_sort.cpp`

上游 v18.11.26 相对 v18.11.22 的结构性变化：`define-library`/`import`/`cond-expand` 改为 C 实现（`s7_r7rs_library.c`），新增 `liii_sort.cpp`（`list-sorted?` 等）。

### 2. 启动兼容适配（必要，否则启动即崩）

C 版 `define-library` 与 mogan 自定义 module 系统有两处不兼容，升级后启动直接崩溃（`unbound variable os-sep` 等连锁错误）：

1. **export 校验的 rootlet 兜底**：C 校验要求 export 名字在本 body 定义或「落入 rootlet」。goldfish 自身启动在 rootlet 求值所以能过；mogan 顶层是 `*texmacs-user-module*`，rootlet 里没有 `list-copy`/`delete-file` 等名字，srfi-1、(scheme file) 等库的传递性 re-export 校验失败 → import 链断裂。
   → `boot-s7.scm`：`scheme/boot.scm` 装入 rootlet + `(scheme base)` 注入 rootlet，对齐 goldfish 自身环境语义。
2. **body 求值环境可见性**：C 版把 body 放在 `sublet(rootlet)` 求值（旧 scheme 宏是 `sublet(unlet)`），mogan 顶层的 `use-modules`/`plugin-configure` 等在该环境不可见。全部 23 个插件中只有 quiver/tikz/gnuplot 三个 init 文件用 `define-library` 风格受影响。
   → 这 3 个文件改回与其余 20 个插件一致的标准顶层风格（`(session xxx)` 库名无外部引用者，转换安全）。

## 验证

- `xmake b stem` 构建通过；headless 启动 exit 0、零错误（适配前启动即崩）。
- 故障符号逐一恢复：`(os-sep)`、`new-document-with-style`、`startup-tab-get-recent-docs`、`get-preference`。
- Scheme 纯逻辑测试全绿（与基线 v18.11.22 结果一致）：
  - style-package-load-test：14 correct, 0 failed
  - preferences-widgets-test：409 correct, 0 failed（适配前因 quiver `use-modules` 报 unbound 而 fail）
  - print-widgets-test：23 correct, 0 failed
  - version-test：20 correct, 0 failed
  - tm-collab-test：61 correct, 0 failed
- goldfish-bin `--version` → `18.11.26`；`(liii sort)` `list-sorted?`、R7RS `define-library`/`import` 冒烟通过。
- 基线对照：适配前在 v18.11.22 基线重跑同一测试集，确认差异均由 v18.11.26 行为变更引入。
- **人工验证**：GUI 模式与真实插件会话已由开发者人工验证通过（2026/08/14）。

## 备注

上游 goldfish 若后续放宽 export 校验或恢复 unlet 语义的 body 环境，本 PR 的 mogan 侧适配仍然兼容、无需回退；可考虑向上游反馈这两个嵌入场景兼容点。
