### PR TITLE
[0910] 修复新建文档时标签页显示两个修改标记星号

### DIFF
--- a/devel/0910.md
+++ b/devel/0910.md
@@ -55,7 +55,8 @@ ActionChanged 回写路径），断言按钮文本与 action 文本始终保持�
 
 运行：`xmake b qt_tab_page_test && xmake r qt_tab_page_test`
 
-GUI 手动验证（新建文档 → 标签页只显示一个 `*`）待人工确认。
+GUI 手动验证：已由开发者人工确认——新建文档后标签页只显示一个 `*`
+（位于关闭按钮位置，鼠标移入该区域时变为关闭按钮）。
 
 ## 涉及文件
 

--- a/devel/0910.md
+++ b/devel/0910.md
@@ -1,0 +1,65 @@
+# 0910 新建文档时标签页出现两个修改标记 `*`
+
+## What
+
+新建文档后，标签页会同时显示两个 `*`（未保存修改标记），预期最多只出现一个。
+
+## Why
+
+标签页的修改标记链路分两段：
+
+1. Scheme 侧 `tabpage-display-title`（`TeXmacs/progs/texmacs/menus/tabpage-menu.scm`）
+   在 buffer 已修改时给标题追加尾部 `" *"`；
+2. Qt 侧 `QTMTabPage::applyDisplayTitle` 剥离该尾部 `*`，干净标题存入按钮
+   文本，dirty 状态由 `paintEvent` 在关闭按钮位置画一个 `*`。
+
+问题出在第 2 段只清理了**按钮**文本，`defaultAction` 的文本仍带 ` *`。
+`QTMTabPage` 基于 `QToolButton`：
+
+- `updateActiveTab` 调 `QTMTabPage::setChecked(true)` 激活标签页；
+- `QToolButton::checkStateSet` 把勾选状态写回 defaultAction；
+- action 发出 `ActionChanged` 并同步派发给关联 widget（Qt 6.8.2
+  `QAction::event` → `sendEvent`，逐个派发到 `setDefaultAction` 时经
+  `addAction` 注册的按钮）；
+- `QToolButton::actionEvent` 收到后重新执行 `setDefaultAction`，而 Qt 6.8 的
+  `setDefaultAction` 对同一 action 无早退，无条件 `setText(action->iconText())`，
+  把带 ` *` 的原始标题写回按钮。
+
+于是按钮文本自带一个 `*`（第 1 个），`paintEvent` 又因 `m_isDirty` 在关闭按钮
+位置画一个 `*`（第 2 个），叠加显示成两个星号。新建文档的 buffer 立即处于
+已修改状态（未保存），且新 tab 必然经历 `updateActiveTab` 的
+`false → true` 勾选翻转，因此稳定复现。
+
+## How
+
+在 `QTMTabPage` 剥离尾部 `*` 的同时，把干净标题同步回 `defaultAction` 的
+文本（新增私有方法 `syncActionText`），使 Qt 的任何 ActionChanged 文本回写
+都拿到干净标题，从根上消除叠加：
+
+- `src/Plugins/Qt/QTMTabPage.cpp`：`applyDisplayTitle` / `syncDisplay` 在
+  `setText` 后调用 `syncActionText`；`syncActionText` 仅在 action 文本与
+  干净标题不一致时 `setText`（相同值不触发 ActionChanged，无回环）。
+- `src/Plugins/Qt/QTMTabPage.hpp`：声明 `syncActionText`。
+
+说明：`QTMAction::doRefresh`（语言切换触发的 `gui_refresh`）会用缓存的
+`str` 把原始带 `*` 文本写回 action，但语言切换本身会全量重建菜单/标签栏，
+复用分支经 `syncDisplay` 再次清理，不构成残留路径。
+
+## 测试
+
+`tests/Plugins/Qt/qt_tab_page_test.cpp` 新增回归用例
+`test_checked_state_sync_keeps_title_clean`：构造带尾部 ` *` 的脏标签页，
+模拟 `updateActiveTab` 的 `setChecked(true/false)` 勾选翻转（即触发
+ActionChanged 回写路径），断言按钮文本与 action 文本始终保持干净（无尾部
+`*`）且 dirty 状态不变。
+
+运行：`xmake b qt_tab_page_test && xmake r qt_tab_page_test`
+
+GUI 手动验证（新建文档 → 标签页只显示一个 `*`）待人工确认。
+
+## 涉及文件
+
+- `src/Plugins/Qt/QTMTabPage.hpp`
+- `src/Plugins/Qt/QTMTabPage.cpp`
+- `tests/Plugins/Qt/qt_tab_page_test.cpp`
+- `devel/0910.md`

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -210,6 +210,21 @@ QTMTabPage::applyDisplayTitle (const QString& rawTitle) {
   QString cleanTitle;
   m_isDirty= extract_dirty_suffix (rawTitle, cleanTitle);
   setText (cleanTitle);
+  syncActionText (cleanTitle);
+}
+
+/**
+ * @brief 把干净标题同步回 defaultAction 的文本。
+ *
+ * QToolButton 在 defaultAction 触发 ActionChanged（如 setChecked 经
+ * checkStateSet 把勾选状态写回 action）时会重新执行 setDefaultAction，用
+ * action 文本覆盖按钮文本。action 若保留尾部 ` *`，按钮文本会重新带 `*`，
+ * 与关闭按钮位置的脏标记叠加显示成两个星号，这里同步清掉使回写无害。
+ */
+void
+QTMTabPage::syncActionText (const QString& cleanTitle) {
+  QAction* act= defaultAction ();
+  if (act != nullptr && act->text () != cleanTitle) act->setText (cleanTitle);
 }
 
 void
@@ -218,6 +233,7 @@ QTMTabPage::syncDisplay (const QString& cleanTitle, bool dirty) {
   bool changed= (m_isDirty != dirty) || (text () != cleanTitle);
   m_isDirty   = dirty;
   setText (cleanTitle);
+  syncActionText (cleanTitle);
   if (changed) {
     updateCloseButtonVisibility ();
     update ();

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -76,6 +76,7 @@ protected:
 
 private:
   void applyDisplayTitle (const QString& rawTitle);
+  void syncActionText (const QString& cleanTitle);
   bool isPointerOnCloseArea (const QPoint& pos) const;
   void updateCloseButtonVisibility ();
   void initializeCloseButton (QAction* closeAction= nullptr);

--- a/tests/Plugins/Qt/qt_tab_page_test.cpp
+++ b/tests/Plugins/Qt/qt_tab_page_test.cpp
@@ -104,6 +104,32 @@ private slots:
     QVERIFY (!tab.isDirty ());
   }
 
+  // 回归（0910）：updateActiveTab -> setChecked(true) 经
+  // QToolButton::checkStateSet 把勾选状态写回 defaultAction，ActionChanged
+  // 同步派发回按钮后 QToolButton 重新执行 setDefaultAction，用 action 文本
+  // （若仍带尾部 ` *`）覆盖按钮文本——文本里的 `*` 与关闭按钮位置的脏标记
+  // `*` 叠加显示成两个星号。修复：剥离 `*` 时把干净标题同步回 action 文本。
+  void test_checked_state_sync_keeps_title_clean () {
+    QAction    titleAction ("no_name_1.tmu *", nullptr);
+    QAction    closeAction ("Close", nullptr);
+    QTMTabPage tab (url ("tmfs://view/9"), &titleAction, &closeAction, false);
+    tab.resize (220, 32);
+    tab.show ();
+    QVERIFY (QTest::qWaitForWindowExposed (&tab));
+    QVERIFY (tab.isDirty ());
+    QCOMPARE (tab.text (), QString::fromUtf8 ("no_name_1.tmu"));
+
+    tab.setChecked (true); // 模拟 updateActiveTab 激活该标签页
+    QVERIFY (tab.isDirty ());
+    QCOMPARE (tab.text (), QString::fromUtf8 ("no_name_1.tmu"));
+    QCOMPARE (titleAction.text (), QString::fromUtf8 ("no_name_1.tmu"));
+
+    tab.setChecked (false); // 切走后再切回，回写路径重复触发仍需保持干净
+    tab.setChecked (true);
+    QVERIFY (tab.isDirty ());
+    QVERIFY (!tab.text ().endsWith (QLatin1Char ('*')));
+  }
+
   // 端到端：replaceTabPages 复用 tab 时，新标题的尾部 `*` 必须刷新到既有
   // tab 的 dirty 状态（而非停留在构造时解析的旧值）。这正是 0350+2014 回归
   // bug 的真实触发路径：编辑标脏后上层重发带 `*` 的标题，复用分支需把 dirty


### PR DESCRIPTION
## 问题

新建文档后，标签页会同时显示两个 `*`（未保存修改标记），预期最多只出现一个。

## 根因

标签页的修改标记本应只有一个（`paintEvent` 在关闭按钮位置画的 `*`），但出现了两个：

1. Scheme 侧 `tabpage-display-title`（`TeXmacs/progs/texmacs/menus/tabpage-menu.scm`）在 buffer 已修改时给标题追加尾部 `" *"`；
2. `QTMTabPage::applyDisplayTitle` 剥离该尾部 `*`，干净标题存入**按钮**文本，但 `defaultAction` 的文本仍带 ` *`；
3. 新建文档的 buffer 立即处于已修改状态，且新 tab 必然经历 `updateActiveTab` 的 `false → true` 勾选翻转；
4. `QTMTabPage` 基于 `QToolButton`：`setChecked(true)` 经 `QToolButton::checkStateSet` 把勾选状态写回 defaultAction，action 发出 `ActionChanged` 并同步派发回按钮（Qt 6.8 `QAction::event` → 逐个 `sendEvent` 到 `setDefaultAction` 时 `addAction` 注册过的按钮）；
5. `QToolButton::actionEvent` 收到 `ActionChanged` 后重新执行 `setDefaultAction`，而 Qt 6.8 的 `setDefaultAction` 对同一 action 无早退，无条件 `setText(action->iconText())`，把带 ` *` 的原始标题写回按钮文本。

于是按钮文本自带一个 `*`（第 1 个），`paintEvent` 又因 `m_isDirty` 在关闭按钮位置画一个 `*`（第 2 个），叠加显示成两个星号。

## 修复

在 `QTMTabPage` 剥离尾部 `*` 的同时，把干净标题同步回 `defaultAction` 的文本（新增私有方法 `syncActionText`），使 Qt 的任何 ActionChanged 文本回写都拿到干净标题：

- `src/Plugins/Qt/QTMTabPage.cpp` / `.hpp`：`applyDisplayTitle` / `syncDisplay` 在 `setText` 后调用 `syncActionText`；`syncActionText` 仅在 action 文本与干净标题不一致时才 `setText`（相同值不触发 ActionChanged，无回环）。
- `tests/Plugins/Qt/qt_tab_page_test.cpp`：新增回归用例 `test_checked_state_sync_keeps_title_clean`。

说明：`QTMAction::doRefresh`（语言切换触发的 `gui_refresh`）会用缓存 `str` 把原始带 `*` 文本写回 action，但语言切换本身会全量重建菜单/标签栏，复用分支经 `syncDisplay` 再次清理，不构成残留路径。

## 验证

- `xmake b qt_tab_page_test && xmake r qt_tab_page_test` → **6 passed, 0 failed**, 1 skipped（skip 为既有用例需 LIII_DEBUG，非本次引入）。
- 负向验证：临时撤销修复后，新回归用例如期 FAIL（`setChecked(true)` 后 `tab.text()` 变回 `"no_name_1.tmu *"`），证明用例确实捕获该 bug；恢复修复后再次通过。
- `xmake b stem` ok。
- `gf fmt --changed-since=main` 无变更。

## 手动验证（已确认）

新建文档 → 标签页只显示一个 `*`（位于关闭按钮位置，鼠标移入该区域时变为关闭按钮）。开发者已人工验证通过（2026-08-14）。

## 涉及文件

- `src/Plugins/Qt/QTMTabPage.hpp`
- `src/Plugins/Qt/QTMTabPage.cpp`
- `tests/Plugins/Qt/qt_tab_page_test.cpp`
- `devel/0910.md`
