### PR TITLE
[0913] 版本弹窗长文本自动换行并自适应高度

### DIFF
--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -1338,6 +1338,7 @@
           对应 QML: <code>versionTitle + versionLines + dialogButtons</code>
           <code>onClicked -> closeBridge.choose(index + 1)</code>
           <code>Scheme 根据确认结果决定是否打开官网</code>
+          <code>单行超宽自动换行（Text.Wrap），弹窗高度随内容自适应（implicitHeight 绑定，C++ 定宽后读值锁高）</code>
         </p>
       </section>
       <section class="panel" id="panel-preferences">

--- a/devel/0913.md
+++ b/devel/0913.md
@@ -1,0 +1,65 @@
+# 0913 修正帮助->版本弹窗
+
+## 2026/08/17 调查「对话框内容没有翻译」+ 长文本自动换行
+
+### What
+
+1. 排查「帮助->版本」弹窗内容显示英文未翻译的问题（重点 1）。
+2. 在保留原有按句号（`\n`）换行的基础上，单行文字超过弹窗宽度时自动换行，
+   弹窗高度随内容自适应（重点 2）。
+
+### Why
+
+**重点 1 结论：当前 main 上翻译链路是完好的，无需改代码。** 用户看到的英文
+弹窗来自 2026/06/05 `0b26a8c05`（[0414]）到 2026/08/03 `fc8c1f398`
+（[2080]）之间的构建：0414/0415 引入「联网自动获取最新版本号」后，消息改
+为英文模板先 `replace` 代入版本号、再交给旧 widget 弹窗 `show-message`，而
+旧弹窗的自动翻译（`make-menu-text` → `translate`）作用在**代入版本号之后**
+的字符串上，撞不上字典 key（字典 key 含 `%1/%2/%3` 占位符），于是整段回退
+英文——用户的「自动更新惹得祸」猜测正是指这次改动。0414 之前是硬编码中文，
+所以「之前都是中文的」。[2080] QML 重构时已把 `translate` 挪到 `replace`
+之前（先译模板再代入版本号），问题随之修复。
+
+实测验证（GUI 截屏确认）：当前 main 中文环境下弹窗标题「版本」、正文
+「您正在使用 v2026.3.1-rc.2。Mogan STEM 的最新稳定版是 v2026.2.6，Liii STEM
+的最新稳定版是 v2026.2.12。请点击确认前往官网下载最新稳定版。」、按钮
+「确认」均为中文；`zh_CN.scm` / `zh_TW.scm` 四个分支模板词条齐全。
+
+**重点 2**:`Version.qml` 消息行原为 `wrapMode: Text.NoWrap`，长行（如英文
+提示）会超出 560 宽弹窗被裁掉。
+
+### How
+
+1. `Version.qml` 消息行 `wrapMode` 改为 `Text.Wrap`（优先词边界折行，超长
+   词/URL 断开；中文无空格也可在字符间断开），`\n` 分行结构不变。
+2. 弹窗高度自适应：`implicitHeight` 绑定为
+   `max(220 * scaleFactor, body.implicitHeight + 2 * Theme.margin)`。
+   注意文本宽度绑定到新增的 `contentW`（定宽弹窗的正文内容宽
+   `560 * scaleFactor - 2 * implicitMargins`）而非实际父宽——C++ 在 show
+   之前就要读 `implicitHeight` 定高，此刻布局宽度尚未就位（隐藏状态下
+   QQuickWidget 不向 root 同步尺寸），绑实际宽度会量出错误的换行结果。
+3. C++ 侧 `run_qml_dialog` 新增 `autofit_height` 参数：true 时走新增的
+   `lock_autofit_height`——先按逻辑宽锁定视图宽度，再读根对象
+   `implicitHeight`（QML 像素，已含 scaleFactor，故不再过
+   `DpiUtils::scaled`）锁定高度，`logic_h` 仅作回退。`cpp_version_dialog`
+   传 `true`。
+4. 测试：`VersionStubBridge` 行内容可配置；新增
+   `test_version_long_line_wraps`（400 字符单行 → 换行后行高成倍、
+   `implicitHeight` 超过最小高度 220）。
+
+### 涉及文件
+
+- `src/Plugins/Qt/qml/Version.qml`
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `src/Plugins/Qt/QTMQmlDialog.hpp`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+- `ai-docs/qml/qml-dialog.html`（Version 面板 legend 补换行/自适应说明）
+
+### Tests
+
+```bash
+gf fmt --changed-since=main
+xmake b qml_load_test && xmake r qml_load_test   # 12 passed
+xmake b stem && xmake r 2080                     # 2 correct, 0 failed
+# GUI 实测：中文短消息 560x228 全中文；英文长消息自动换行、弹窗 560x284
+```

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -29,6 +29,7 @@ using moebius::data::tree_to_scheme_tree;
 #include <QDialog>
 #include <QQmlContext>
 #include <QQmlError>
+#include <QQuickItem>
 #include <QQuickWidget>
 #include <QString>
 #include <QStringList>
@@ -138,6 +139,26 @@ lock_fixed_size (QQuickWidget* qw, QVBoxLayout* vl, QDialog& d, int logic_w,
 }
 
 /**
+ * @brief 宽度锁定后按 QML 内容自适应锁定弹窗高度。
+ *
+ * 用于正文行数不固定的弹窗（如版本弹窗：长行自动换行后行数变化）。先按
+ * logic_w 锁定视图宽度，让 QML 按最终宽度完成换行布局，再读根对象的
+ * implicitHeight（QML 像素，已含 scaleFactor，故不再过 DpiUtils::scaled）。
+ * QML 未提供有效 implicitHeight 时回退 logic_h。
+ */
+static void
+lock_autofit_height (QQuickWidget* qw, QVBoxLayout* vl, QDialog& d, int logic_w,
+                     int logic_h) {
+  const int w= DpiUtils::scaled (logic_w);
+  qw->setFixedWidth (w);
+  int h= (int) qw->rootObject ()->implicitHeight ();
+  if (h <= 0) h= DpiUtils::scaled (logic_h);
+  qw->setFixedSize (w, h);
+  vl->setSizeConstraint (QLayout::SetFixedSize);
+  d.setFixedSize (w, h);
+}
+
+/**
  * @brief 通用 QML 模态弹窗引擎。
  *
  * 把两类弹窗（确认型 / form 型）共用的 QDialog 拼装 + setSource + 加载检查 +
@@ -152,6 +173,8 @@ lock_fixed_size (QQuickWidget* qw, QVBoxLayout* vl, QDialog& d, int logic_w,
  *        dpScale / isDark（并按需捕获返回的 bridge），再注入弹窗特有项。
  * @param logic_w / logic_h 96 DPI 下的逻辑尺寸（引擎内部统一 DpiUtils::scaled
  *        × DPI 后锁定 QQuickWidget 与 QDialog，调用方不必自己乘 DPI）。
+ * @param autofit_height true 时按 QML 根对象 implicitHeight 自适应高度
+ *        （logic_h 仅作回退），见 lock_autofit_height。
  * @return QDialog::exec 的退出码（即 QML 侧 closeBridge 传给 done() 的值）；
  *         QML 加载失败返回 -1。调用方据此映射结果（确认型 → 按钮下标；form 型
  *         → Accepted/Rejected，表单值另行从 bridge->results() 取）。
@@ -159,7 +182,7 @@ lock_fixed_size (QQuickWidget* qw, QVBoxLayout* vl, QDialog& d, int logic_w,
 static int
 run_qml_dialog (const string& qml_url, const char* debug_tag,
                 std::function<void (QQuickWidget*, QDialog&)> inject_context,
-                int logic_w, int logic_h) {
+                int logic_w, int logic_h, bool autofit_height= false) {
   static const bool resourceInitialized= [] () {
     Q_INIT_RESOURCE (moganqml);
     return true;
@@ -179,7 +202,8 @@ run_qml_dialog (const string& qml_url, const char* debug_tag,
   }
 
   vl->addWidget (qw);
-  lock_fixed_size (qw, vl, d, logic_w, logic_h);
+  if (autofit_height) lock_autofit_height (qw, vl, d, logic_w, logic_h);
+  else lock_fixed_size (qw, vl, d, logic_w, logic_h);
 
   return d.exec ();
 }
@@ -574,7 +598,7 @@ cpp_version_dialog (string title, string message) {
                                                                translate_buttons (buttons));
         qw->rootContext ()->setContextProperty ("versionBridge", bridge);
       },
-      560, 220);
+      560, 220, true);
   delete closeBridge;
   delete bridge;
   return choice == 1;

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -192,6 +192,8 @@ void cpp_statistics_dialog (string title, tree items);
  * @param title 已翻译的对话框标题。
  * @param message 已翻译的版本提示，换行会拆为独立 QML 文本行。
  * @return 确认返回 true；取消、关闭或加载失败返回 false。
+ * @note 单行超过弹窗宽度时 QML 侧自动换行，弹窗高度随内容自适应（定宽 560，
+ *       高度取 QML 根对象 implicitHeight，220 为回退值）。
  * @note MOGAN_TEST_VERSION_DIALOG 用于测试。
  */
 bool cpp_version_dialog (string title, string message);

--- a/src/Plugins/Qt/qml/Version.qml
+++ b/src/Plugins/Qt/qml/Version.qml
@@ -1,6 +1,12 @@
 // Version.qml -- 「帮助 -> 版本」模态弹窗。
 //
 // Scheme 侧负责翻译和组织 versionMessage；本组件仅渲染文本并回传确认结果。
+// 正文按 \n 分行；单行超过弹窗宽度时自动换行，弹窗高度随内容自适应（见
+// implicitHeight 绑定，C++ 定宽后读取该值锁定弹窗高度）。
+//
+// 文本宽度绑定到 contentW（定宽弹窗的正文内容宽），而非实际父宽：弹窗 show
+// 之前 C++ 就要读 implicitHeight 定高，此刻布局宽度尚未就位，绑实际宽度会
+// 量出错误的换行结果。
 
 import QtQuick
 import "atoms"
@@ -8,8 +14,12 @@ import "atoms"
 DialogShell {
     id: root
     implicitWidth: 560
-    implicitHeight: 220
+    implicitHeight: Math.max(220 * Theme.scaleFactor,
+                             body.implicitHeight + 2 * Theme.margin)
     implicitMargins: Theme.margin
+
+    // 定宽弹窗的正文内容宽（QML 像素）：窗口物理宽 = 逻辑宽 × scaleFactor
+    readonly property real contentW: implicitWidth * Theme.scaleFactor - 2 * implicitMargins
 
     property string title: versionBridge.title
     property var lines: versionBridge.lines
@@ -28,7 +38,7 @@ DialogShell {
             spacing: Theme.pad
 
             Text {
-                width: body.width
+                width: root.contentW
                 text: root.title
                 color: Theme.fg
                 horizontalAlignment: Text.AlignHCenter
@@ -40,7 +50,7 @@ DialogShell {
             Column {
                 id: messageLines
                 objectName: "versionMessageLines"
-                width: parent.width
+                width: root.contentW
                 spacing: Theme.gapS
 
                 Repeater {
@@ -53,7 +63,9 @@ DialogShell {
                         text: modelData
                         color: Theme.fg
                         horizontalAlignment: Text.AlignLeft
-                        wrapMode: Text.NoWrap
+                        // Wrap：优先按词边界折行，超长词（URL/版本号）断开；
+                        // 中文无空格也可在字符间断开
+                        wrapMode: Text.Wrap
                         font.pixelSize: Theme.fontBody
                         lineHeight: 1.35
                     }

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -47,13 +47,15 @@ class VersionStubBridge : public QObject {
 public:
   explicit VersionStubBridge (QObject* p= nullptr) : QObject (p) {}
   QString     title () const { return QString ("Version"); }
-  QStringList lines () const {
-    return {"You are using v2026.2.6.",
-            "The latest stable version is v2026.2.6."};
-  }
+  QStringList lines () const { return m_lines; }
   QStringList buttonLabels () const { return {"OK"}; }
+  void        setLines (const QStringList& lines) { m_lines= lines; }
 
   Q_INVOKABLE void confirm () {}
+
+private:
+  QStringList m_lines{"You are using v2026.2.6.",
+                      "The latest stable version is v2026.2.6."};
 };
 
 // live 弹窗（FontSelector / ParagraphFormat）bridge 占位：加载阶段 QML 顶层会调
@@ -205,6 +207,7 @@ private slots:
   void test_preferences_loads ();
   void test_version_loads ();
   void test_version_escape_cancels ();
+  void test_version_long_line_wraps ();
   void test_statistics_loads ();
 };
 
@@ -396,6 +399,38 @@ TestQmlLoad::test_version_escape_cancels () {
   QTRY_VERIFY (qw->rootObject ()->hasActiveFocus ());
   QTest::keyClick (qw, Qt::Key_Escape);
   QCOMPARE (close->cancelCount, 1);
+}
+
+void
+TestQmlLoad::test_version_long_line_wraps () {
+  // 单行远超弹窗宽度：应自动换行（行高成倍）、弹窗 implicitHeight 超出最小高度
+  QDialog            host;
+  QQuickWidget*      qw    = new QQuickWidget (&host);
+  StubBridge*        close = new StubBridge (qw);
+  VersionStubBridge* bridge= new VersionStubBridge (qw);
+  bridge->setLines ({QString (400, 'x')});
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  qw->rootContext ()->setContextProperty ("closeBridge", close);
+  qw->rootContext ()->setContextProperty ("versionBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->setSource (QUrl ("qrc:/qml/Version.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  // 隐藏状态下 QQuickWidget 不向 root 同步尺寸，show 后视图定宽、root 跟随
+  host.show ();
+  qw->resize (560, 480);
+  QTRY_VERIFY (qw->rootObject ()->implicitHeight () > 220.0);
+  QQuickItem* messageLines=
+      qw->rootObject ()->findChild<QQuickItem*> ("versionMessageLines");
+  QVERIFY (messageLines);
+  QQuickItem* line= nullptr;
+  for (QQuickItem* item : messageLines->childItems ())
+    if (item->objectName () == "versionMessageLine") {
+      line= item;
+      break;
+    }
+  QVERIFY (line);
+  QTRY_VERIFY (line->height () > 40.0); // 单行 14*1.35≈19，换行后显著更高
 }
 
 QTEST_MAIN (TestQmlLoad)


### PR DESCRIPTION
## What

1. 排查「帮助 -> 版本」弹窗内容显示英文未翻译的问题（结论：当前 main 翻译链路完好，无需改代码，见下）。
2. 版本弹窗在保留原有按句号（`\n`）换行的基础上，单行文字超过弹窗宽度时自动换行，弹窗高度随内容自适应。

## Why

**翻译问题排查结论**：用户看到的英文弹窗来自 [0414]（0b26a8c05，2026/06/05）到 [2080]（fc8c1f398，2026/08/03）之间的构建：0414/0415 引入「联网自动获取最新版本号」后，消息改为英文模板先 `replace` 代入版本号、再交给旧 widget 弹窗 `show-message`，而旧弹窗的自动翻译（`make-menu-text` → `translate`）作用在代入版本号**之后**的字符串上，撞不上字典 key（key 含 `%1/%2/%3` 占位符），整段回退英文；0414 之前是硬编码中文。[2080] QML 重构已把 `translate` 挪到 `replace` 之前（先译模板再代入版本号），问题随之修复。本 PR 在最新 main 上实测确认弹窗标题、正文、按钮均为中文。

**自动换行**:`Version.qml` 消息行原为 `wrapMode: Text.NoWrap`，长行（如英文提示）会超出 560 宽弹窗被裁掉。

## How

1. `Version.qml` 消息行 `wrapMode` 改为 `Text.Wrap`（优先词边界折行，超长词/URL 断开；中文无空格也可在字符间断开），`\n` 分行结构不变。
2. 弹窗高度自适应：`implicitHeight` 绑定为 `max(220 * scaleFactor, body.implicitHeight + 2 * Theme.margin)`。文本宽度绑定到新增的 `contentW`（定宽弹窗的正文内容宽 `560 * scaleFactor - 2 * implicitMargins`）而非实际父宽——C++ 在 show 之前就要读 `implicitHeight` 定高，此刻布局宽度尚未就位（隐藏状态下 QQuickWidget 不向 root 同步尺寸），绑实际宽度会量出错误的换行结果。
3. `run_qml_dialog` 新增 `autofit_height` 参数：true 时走新增的 `lock_autofit_height`——先按逻辑宽锁定视图宽度，再读根对象 `implicitHeight`（QML 像素，已含 scaleFactor，故不再过 `DpiUtils::scaled`）锁定高度，`logic_h` 仅作回退。`cpp_version_dialog` 传 `true`。
4. `ai-docs/qml/qml-dialog.html` 的 Version 面板 legend 同步补换行/自适应说明。

## Tests

- `gf fmt --changed-since=main`：0 实际改动
- `xmake b qml_load_test && xmake r qml_load_test`：12 passed / 0 failed（新增 `test_version_long_line_wraps`：400 字符单行 → 换行后行高成倍、`implicitHeight` 超过最小高度 220）
- `xmake b stem && xmake r 2080`：2 correct / 0 failed
- 已基于最新 `origin/main`（7bba28489）rebase，rebase 后重跑上述验证通过

## 手动 GUI 验证（已完成，截屏确认）

- 中文环境真实流程（帮助 -> 版本，联网取版本号）：弹窗 560x228，标题「版本」、正文「您正在使用 v2026.3.1-rc.2。Mogan STEM 的最新稳定版是…」、按钮「确认」全中文。
- 英文长消息（3 个 `\n` 分段含长行）：长行按词边界折行，弹窗 560x220 撑高到 560x284。
- 单句超长英文（约 300 字符无手动换行）：折成 4 行，撑高到 560x244。
- 单句超长中文（约 160 字无手动换行）：中文字符间断行折成 4 行，撑高到 560x244；较短中文长句折 3 行时保持最小高度 220，排版不挤。
