### PR TITLE
[0912] 保存无标题文件默认路径改为 Documents/LiiiSTEM

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -33,7 +33,13 @@
 
 (tm-define (get-last-file-dialog-directory)
   "Get the last directory used in file dialog"
-  (or last-file-dialog-directory (get-preference "last-file-dialog-directory"))
+  ;; 偏好未设置时 get-preference 返回哨兵字符串 "default"，须视为「无记录」，
+  ;; 否则 choose-file 会把 "default" 当目录解析成进程 cwd
+  (let ((dir (or last-file-dialog-directory (get-preference "last-file-dialog-directory"))
+        ) ;dir
+       ) ;
+    (and (!= dir "default") dir)
+  ) ;let
 ) ;tm-define
 
 (tm-define (set-last-file-dialog-directory dir)

--- a/devel/0912.md
+++ b/devel/0912.md
@@ -1,0 +1,82 @@
+# 0912 保存无标题文件时默认路径为 Documents/LiiiSTEM
+
+## What
+
+保存「无标题」（No name / scratch）文档时，另存为对话框的默认目录应为
+`~/Documents/LiiiSTEM`，而不是 Mogan 的安装路径。
+
+## Why
+
+无标题 buffer 没有真实的磁盘路径，`tm_frame_rep::choose_file`
+（`src/Texmacs/Window/tm_dialogue.cpp`）对 scratch buffer 走特殊分支设置
+对话框目录：`[101_1]` 之后该分支固定为 `$HOME`，再早是 `"."`（进程 cwd，
+从安装目录启动时即安装路径）。
+
+scratch buffer 本身存放在 `get_documents_path () * "LiiiSTEM/no_name"`
+（见 `url_scratch`，`src/System/Files/tm_file.cpp`），主页/模板等模块也统一以
+`Documents/LiiiSTEM` 作为用户文档主目录（`QTMHomePage.cpp`、
+`qt_template_utils.cpp`）。因此对话框默认目录应落在同一处
+`Documents/LiiiSTEM`，而不是 `$HOME` 或 cwd。
+
+另外该分支在目录缺失时应先创建：QFileDialog 收到不存在的目录会回退到
+默认位置（Windows 下常为 cwd，即安装目录），恰好复现本任务要修的现象。
+
+## How
+
+`src/Texmacs/Window/tm_dialogue.cpp`：`tm_frame_rep::choose_file` 的
+scratch 分支改为 `get_documents_path () * "LiiiSTEM"`（与 `url_scratch` /
+`is_scratch` 使用同一 `get_documents_path`，遵循
+`TEXMACS_DOCUMENTS_PATH` 环境变量覆盖）。目录无需在此创建——scratch
+buffer 由 `url_scratch`→`url_numbered` 创建时已 `make_dir` 递归建出
+`Documents/LiiiSTEM/no_name`（含父目录），走到此分支时目录必然存在。
+
+不弹对话框的测试钩子 `MOGAN_TEST_CHOOSE_FILE` 在该分支之前返回，不受影响。
+Scheme 侧 Issue #327 的「记住上次文件对话框目录」逻辑
+（`TeXmacs/progs/kernel/boot/abbrevs.scm`）优先级更高，保持不变：已有
+上次目录记录时仍优先用上次目录。
+
+### 真正的根因（GUI 实测定位后补充）
+
+初版只改了上述 C++ scratch 分支，实测发现无标题文档的另存为对话框仍开在
+进程 cwd（项目根目录）。逐层埋点（C++ `choose_file` 收到的 `name` +
+scheme `choose-file` 各分支）后定位到真正的根因在 Scheme 侧：
+
+`choose-file`（`abbrevs.scm`）对 scratch buffer 优先用「上次文件对话框目录」：
+
+```scheme
+(let* ((master (buffer-get-master (current-buffer)))
+       (last-dir (and (url-scratch? master)
+                   (get-last-file-dialog-directory))))
+  (cond ((and last-dir (string? last-dir) (not (string-null? last-dir)))
+         (set! opts (list (car opts) (system->url last-dir))))  ; ← 命中
+        ...))
+```
+
+而 `get-last-file-dialog-directory`（`tm-files.scm`）在偏好**未设置**时，
+`get-preference` 返回哨兵字符串 `"default"`（mogan 偏好系统的「未设置」
+标记，见 `tm-preferences.scm`），该函数原样返回了 `"default"`。它非空，
+分支①命中，`system->url "default"` 得相对 URL `<url default>`，C++ 侧
+`head("default")` = `.` = 进程 cwd —— 对话框于是开在 cwd（从安装目录/
+项目根启动时即该目录）。C++ 的 scratch 分支因此从未被触发。
+
+修复：`get-last-file-dialog-directory` 把 `"default"` 哨兵视为「无记录」
+返回 `#f`，分支①跳过，scratch buffer 落回 else 分支（dir=master 的
+scratch 绝对路径），C++ `is_scratch` 为真，才走到 `Documents/LiiiSTEM`。
+
+## 涉及文件
+
+- `src/Texmacs/Window/tm_dialogue.cpp`：scratch 分支默认目录 `$HOME` →
+  `Documents/LiiiSTEM`。
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`：
+  `get-last-file-dialog-directory` 过滤偏好哨兵值 `"default"`（真正的修复点）。
+
+## 测试
+
+- `xmake b stem` 编译通过。
+- headless 验证：`(get-last-file-dialog-directory)` 在偏好未设置时返回 `#f`，
+  choose-file 分支①条件为 `#f`（不再误入 `"default"` 分支）。
+- 逻辑验证（`gf eval`）：哨兵 `"default"` → `#f`；正常路径原样保留；
+  内存变量 `last-file-dialog-directory` 优先于偏好。
+- GUI 手动验证（弹真实对话框，未在本任务自动执行）：新建无标题文档 →
+  Ctrl+S，另存为对话框应默认打开 `~/Documents/LiiiSTEM`。
+

--- a/src/Texmacs/Window/tm_dialogue.cpp
+++ b/src/Texmacs/Window/tm_dialogue.cpp
@@ -160,8 +160,9 @@ tm_frame_rep::choose_file (object fun, string title, string type, string prompt,
     }
   }
   else {
-    // The env HOME is set for Windows in research.cpp
-    set_directory (wid, as_system_string (url_system ("$HOME")));
+    // scratch buffer 无真实路径，默认打开其宿主目录 Documents/LiiiSTEM
+    // （url_scratch 创建 scratch 文件时已确保该目录存在）
+    set_directory (wid, as_system_string (get_documents_path () * "LiiiSTEM"));
   }
 #ifdef __EMSCRIPTEN__
   // WASM: 自身处理保存（同步保存+下载）/打开（JS 文件选择器），不需要


### PR DESCRIPTION
## 问题

保存「无标题」（No name / scratch）文档时，另存为对话框的默认目录落在了进程当前工作目录（从安装目录/项目根启动时即安装路径），而不是用户文档目录 `Documents/LiiiSTEM`。

## 根因

逐层埋点（C++ `tm_frame_rep::choose_file` 收到的 `name` + Scheme `choose-file` 各分支）定位到真正的根因在 Scheme 侧：

`choose-file`（`kernel/boot/abbrevs.scm`）对 scratch buffer 优先使用「上次文件对话框目录」（Issue #327）：

```scheme
(let* ((master (buffer-get-master (current-buffer)))
       (last-dir (and (url-scratch? master)
                   (get-last-file-dialog-directory))))
  (cond ((and last-dir (string? last-dir) (not (string-null? last-dir)))
         (set! opts (list (car opts) (system->url last-dir))))  ; ← 命中
        ...))
```

而 `get-last-file-dialog-directory`（`texmacs/texmacs/tm-files.scm`）在偏好**未设置**时，`get-preference` 返回哨兵字符串 `"default"`（mogan 偏好系统的「未设置」标记），该函数原样返回了 `"default"`。它非空，分支①命中，`system->url "default"` 得到相对 URL `<url default>`，C++ 侧 `head("default")` = `.` = 进程 cwd，对话框于是开在 cwd。C++ 的 scratch 分支因此从未被触发。

## 修复

- `tm-files.scm`：`get-last-file-dialog-directory` 把 `"default"` 哨兵视为「无记录」返回 `#f`（**真正的修复点**），分支①跳过，scratch buffer 落回 else 分支（dir = master 的 scratch 绝对路径）。
- `tm_dialogue.cpp`：`choose_file` 的 scratch 分支默认目录由 `$HOME` 改为 `get_documents_path() * "LiiiSTEM"`（与 `url_scratch`/`is_scratch` 用同一 `get_documents_path`，遵循 `TEXMACS_DOCUMENTS_PATH` 覆盖；目录由 `url_scratch` 创建 scratch 文件时已确保存在，无需重复创建）。

两处配合后，保存无标题文档默认打开 `~/Documents/LiiiSTEM`。

## 验证

- `xmake b stem` 编译通过（含上游 [0515] 偏好 JSON 化的最新 main，已确认 JSON 化未改 `"default"` 哨兵约定）。
- headless 实测：偏好未设置时 `(get-last-file-dialog-directory)` 返回 `#f`，choose-file 分支①条件为 `#f`，不再误入 `"default"` 分支。
- `gf eval` 逻辑验证：哨兵 `"default"` → `#f`；正常路径原样保留；内存变量 `last-file-dialog-directory` 优先于偏好。
- GUI 手动验证：新建无标题文档 → Ctrl+S，另存为对话框默认打开 `~/Documents/LiiiSTEM`（开发者已实测通过）。
