### PR TITLE
[0516] Velopack 更新源按社区版/商业版区分

### DIFF
--- a/devel/0516.md
+++ b/devel/0516.md
@@ -1,0 +1,39 @@
+# 0516: 更新源按社区版/商业版区分
+
+## 2026/08/17 更新源按社区版/商业版区分
+
+### What（本次改动做了什么）
+
+Velopack 自动更新的 feed 根 URL（`default_feed_url`）由单一写死地址改为按
+社区版/商业版编译期二选一：
+
+- 社区版（`IS_COMMUNITY`）：`https://liiistem.cn/api/v1/public/update/win-x64`（不变）
+- 商业版：`https://liiistem.cn/api/v1/public/commercial/update/win-x64`
+
+### Why（为什么这么做）
+
+社区版与商业版需要走不同的更新通道，各自发布各自的版本节奏；此前共用一个
+feed URL，商业版构建无法指向商业版更新服务器。
+
+### How（怎么做的）
+
+1. 利用构建期已有的版本开关：`xmake/options.lua` 的 `is_community` 选项经
+   `xmake/targets/libmogan.lua` 注入 `IS_COMMUNITY` 宏，`tm_velopack.cpp` 中
+   以 `#ifdef IS_COMMUNITY` 选定 `default_feed_url`，其余检查/下载/应用逻辑
+   完全复用，无需任何运行期配置。
+2. 跨通道升级依赖 Velopack 资产匹配机制：两通道 packageId 一致时，社区版
+   切到商业版 feed 后，Velopack 找不到匹配 baseVersion 的 delta 会自动回退
+   full 包，可直接跨通道升级；无需商业版以社区版为基线打 delta。
+   注意反向（商业版降回社区版）不可行：版本号不高于本机版本时视为无更新。
+
+### 涉及文件
+
+- `src/Plugins/Updater/tm_velopack.cpp`：`default_feed_url` 按 `IS_COMMUNITY` 二选一。
+
+### 验证与遗留
+
+- 该代码块仅在 `USE_PLUGIN_VELOPACK && OS_WIN` 下编译，Linux 上不参与构建，
+  本机无法编译验证；待 Windows 构建机分别以 `--is_community=y/n` 构建后
+  `strings MoganSTEM.exe | grep liiistem.cn` 确认各含且仅含对应 URL。
+- 商业版后端（`/api/v1/public/commercial/`）尚未开发，商业版 feed 联调待
+  后端上线后进行；当前商业版构建检查更新会进入 `UPDATER_FAILED`，属预期。

--- a/src/Plugins/Updater/tm_velopack.cpp
+++ b/src/Plugins/Updater/tm_velopack.cpp
@@ -31,11 +31,18 @@
 #include <thread>
 #include <vector>
 
-// 默认更新源（feed 根 URL）。当前按静态 feed 设计编译期写死；若将来要运行时
-// 切源（stable/beta 渠道、内网镜像），需改为可配置并在 setAppcast 里重建 mgr。
-// 当前为内网联调源（上游 OSS 更新服务器），与 CD 上传目录对应。
+// 默认更新源（feed 根 URL）。按社区版/商业版（IS_COMMUNITY 宏）编译期选定；
+// 若将来要运行时切源（stable/beta 渠道、内网镜像），需改为可配置并在
+// setAppcast 里重建 mgr。
+// 两通道 packageId 一致：社区版切到商业版 feed 后，Velopack 找不到匹配
+// baseVersion 的 delta 会自动回退 full 包，可直接跨通道升级。
+#ifdef IS_COMMUNITY
 static const std::string default_feed_url=
     "https://liiistem.cn/api/v1/public/update/win-x64";
+#else
+static const std::string default_feed_url=
+    "https://liiistem.cn/api/v1/public/commercial/update/win-x64";
+#endif
 
 static std::string
 exception_message () {


### PR DESCRIPTION
## 概要

Velopack 自动更新的 feed 根 URL 按社区版/商业版编译期二选一：

- 社区版（`IS_COMMUNITY`）：`https://liiistem.cn/api/v1/public/update/win-x64`（不变）
- 商业版：`https://liiistem.cn/api/v1/public/commercial/update/win-x64`

利用 `xmake/options.lua` 已有的 `is_community` 选项注入的 `IS_COMMUNITY` 宏，仅改 `default_feed_url` 一处，检查/下载/应用逻辑完全复用。

## 说明

- 两通道 packageId 一致，社区版切商业版 feed 后 Velopack 自动回退 full 包，可直接跨通道升级
- 商业版后端尚未开发，商业版构建检查更新当前会进入 `UPDATER_FAILED`，属预期
- 该代码块仅 Windows 编译，待 Windows 构建机验证（详见 devel/0516.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)