### PR TITLE
[0828] plugin-math-input 改用独立 string port 捕获，修复日志污染

### DIFF
--- a/TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm
+++ b/TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm
@@ -20,7 +20,7 @@
 (define (maxima-input-var-row r)
   (if (nnull? r)
     (begin
-      (display ", ")
+      (plugin-output ", ")
       (plugin-input (car r))
       (maxima-input-var-row (cdr r))
     ) ;begin
@@ -28,16 +28,16 @@
 ) ;define
 
 (define (maxima-input-row r)
-  (display "[")
+  (plugin-output "[")
   (plugin-input (car r))
   (maxima-input-var-row (cdr r))
-  (display "]")
+  (plugin-output "]")
 ) ;define
 
 (define (maxima-input-var-rows t)
   (if (nnull? t)
     (begin
-      (display ", ")
+      (plugin-output ", ")
       (maxima-input-row (car t))
       (maxima-input-var-rows (cdr t))
     ) ;begin
@@ -45,10 +45,10 @@
 ) ;define
 
 (define (maxima-input-rows t)
-  (display "matrix(")
+  (plugin-output "matrix(")
   (maxima-input-row (car t))
   (maxima-input-var-rows (cdr t))
-  (display ")")
+  (plugin-output ")")
 ) ;define
 
 (define (maxima-input-descend-last args)
@@ -59,32 +59,32 @@
 ) ;define
 
 (define (maxima-input-det args)
-  (display "determinant(")
+  (plugin-output "determinant(")
   (maxima-input-descend-last args)
-  (display ")")
+  (plugin-output ")")
 ) ;define
 
 (define (maxima-input-binom args)
-  (display "binomial(")
+  (plugin-output "binomial(")
   (plugin-input (car args))
-  (display ",")
+  (plugin-output ",")
   (plugin-input (cadr args))
-  (display ")")
+  (plugin-output ")")
 ) ;define
 
 (define (maxima-input-sqrt args)
   (if (= (length args) 1)
     (begin
-      (display "sqrt(")
+      (plugin-output "sqrt(")
       (plugin-input (car args))
-      (display ")")
+      (plugin-output ")")
     ) ;begin
     (begin
-      (display "(")
+      (plugin-output "(")
       (plugin-input (car args))
-      (display ")^(1/(")
+      (plugin-output ")^(1/(")
       (plugin-input (cadr args))
-      (display "))")
+      (plugin-output "))")
     ) ;begin
   ) ;if
 ) ;define
@@ -94,44 +94,44 @@
     (if (nnull? (cdr args))
       (begin
         ;; both lower and upper index
-        (display "tmsum(")
+        (plugin-output "tmsum(")
         (plugin-input (car args))
-        (display ",")
+        (plugin-output ",")
         (plugin-input (cadr args))
-        (display ",")
+        (plugin-output ",")
       ) ;begin
       (begin
         ;; lower index only
-        (display "tmlsum(")
+        (plugin-output "tmlsum(")
         (plugin-input (car args))
-        (display ",")
+        (plugin-output ",")
       ) ;begin
     ) ;if
-    (display "tmsum(")
+    (plugin-output "tmsum(")
   ) ;if
 ) ;define
 
 (define (maxima-input-prod args)
   (if (nnull? args)
     (begin
-      (display "tmprod(")
+      (plugin-output "tmprod(")
       (plugin-input (car args))
-      (if (nnull? (cdr args)) (begin (display ",") (plugin-input (cadr args))))
-      (display ",")
+      (if (nnull? (cdr args)) (begin (plugin-output ",") (plugin-input (cadr args))))
+      (plugin-output ",")
     ) ;begin
-    (display "tmprod(")
+    (plugin-output "tmprod(")
   ) ;if
 ) ;define
 
 (define (maxima-input-int args)
   (if (nnull? args)
     (begin
-      (display "tmint(")
+      (plugin-output "tmint(")
       (plugin-input (car args))
-      (if (nnull? (cdr args)) (begin (display ",") (plugin-input (cadr args))))
-      (display ",")
+      (if (nnull? (cdr args)) (begin (plugin-output ",") (plugin-input (cadr args))))
+      (plugin-output ",")
     ) ;begin
-    (display "integrate(")
+    (plugin-output "integrate(")
   ) ;if
 ) ;define
 
@@ -147,10 +147,10 @@
     (cond ((== op "sum") (maxima-input-sum l))
           ((== op "prod") (maxima-input-prod l))
           ((== op "int") (maxima-input-int l))
-          (else (display op) (display "("))
+          (else (plugin-output op) (plugin-output "("))
     ) ;cond
     (plugin-input body)
-    (display ")")
+    (plugin-output ")")
   ) ;let*
 ) ;define
 

--- a/TeXmacs/progs/utils/plugins/plugin-cmd-test.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-cmd-test.scm
@@ -1,0 +1,65 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : plugin-cmd-test.scm
+;; DESCRIPTION : Regression test for plugin-cmd serialization support
+;; COPYRIGHT   : (C) 2026 Liii Network
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(use-modules (utils plugins plugin-cmd))
+(load "./TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm")
+
+;; test-pre-serialize-passthrough
+;; 普通字符串与多段落 document 原样透传
+
+(define (test-pre-serialize-passthrough)
+  (check (pre-serialize "python" "1+1") => "1+1")
+  (check (pre-serialize "python" "print('中文')") => "print('中文')")
+  (check (pre-serialize "python" '(document "a" "b")) => '(document "a" "b"))
+) ;define
+
+;; test-pre-serialize-document
+;; 单层 document 剥壳，递归到内容本身
+
+(define (test-pre-serialize-document)
+  (check (pre-serialize "python" '(document "1+1")) => "1+1")
+) ;define
+
+;; test-pre-serialize-math
+;; math 输入按 lan 的转换规则渲染成插件语言文本（generic 规则兜底）
+
+(define (test-pre-serialize-math)
+  (check (pre-serialize "python" '(math (frac "1" "2"))) => "(1/2)")
+  (check (pre-serialize "python" '(math (concat "x" (rsup "2")))) => "x^2")
+  (check (pre-serialize "python" '(math "<alpha>")) => "alpha")
+  (check (pre-serialize "python" '(math "<mathpi>")) => "(4*atan(1))")
+) ;define
+
+;; test-pre-serialize-document-math
+;; document 剥壳后递归进入 math 分支
+
+(define (test-pre-serialize-document-math)
+  (check (pre-serialize "python" '(document (math (frac "1" "2")))) => "(1/2)")
+) ;define
+
+;; test-pre-serialize-math-maxima
+;; 插件自定义 handler（maxima-input.scm）的输出同样写入独立 port
+
+(define (test-pre-serialize-math-maxima)
+  (check (pre-serialize "maxima" '(math "<mathi>")) => "%i")
+  (check (pre-serialize "maxima" '(math (binom "n" "k"))) => "binomial(n,k)")
+  (check (pre-serialize "maxima" '(math (sqrt "2"))) => "sqrt(2)")
+) ;define
+
+(tm-define (regtest-plugin-cmd)
+  (test-pre-serialize-passthrough)
+  (test-pre-serialize-document)
+  (test-pre-serialize-math)
+  (test-pre-serialize-document-math)
+  (test-pre-serialize-math-maxima)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/utils/plugins/plugin-convert.scm
+++ b/TeXmacs/progs/utils/plugins/plugin-convert.scm
@@ -21,10 +21,23 @@
 
 (define current-plugin-input-stree "")
 
-(define (convert-test)
-  (set! current-plugin-input-stree (tree->stree (selection-tree)))
-  (write (tm-with-output-to-string plugin-input-caller))
-  (display "\n")
+;; 捕获期间所有 handler 经 plugin-output 写往独立的 string port，
+;; 与全局 cout（C++ 日志）隔离，避免日志混入插件输入
+
+(define plugin-input-port (current-output-port))
+
+(tm-define (plugin-output s) (display s plugin-input-port))
+
+(define (call-with-plugin-output-string thunk)
+  (call-with-output-string (lambda (p)
+                             (let ((saved plugin-input-port))
+                               (dynamic-wind (lambda () (set! plugin-input-port p))
+                                 thunk
+                                 (lambda () (set! plugin-input-port saved))
+                               ) ;dynamic-wind
+                             ) ;let
+                           ) ;lambda
+  ) ;call-with-output-string
 ) ;define
 
 (tm-define (plugin-math-input l)
@@ -32,7 +45,7 @@
   (:argument l "A list of the form @(tuple plugin expr)")
   (set! current-plugin-input-stree (caddr l))
   (set! plugin-input-current-plugin (cadr l))
-  (tm-with-output-to-string plugin-input-caller)
+  (call-with-plugin-output-string plugin-input-caller)
 ) ;tm-define
 
 (define (plugin-input-caller)
@@ -55,9 +68,9 @@
   (if (and (string? t) (= (length (string->tmtokens t 0 (string-length t))) 1))
     (plugin-input t)
     (begin
-      (display "(")
+      (plugin-output "(")
       (plugin-input t)
-      (display ")")
+      (plugin-output ")")
     ) ;begin
   ) ;if
 ) ;tm-define
@@ -105,10 +118,10 @@
   (let ((im (plugin-input-ref s)))
     (if (== im #f)
       (if (and (!= s "") (== (string-ref s 0) #\<))
-        (display (substring s 1 (- (string-length s) 1)))
-        (display s)
+        (plugin-output (substring s 1 (- (string-length s) 1)))
+        (plugin-output s)
       ) ;if
-      (if (procedure? im) (im s) (display im))
+      (if (procedure? im) (im s) (plugin-output im))
     ) ;if
   ) ;let
 ) ;define
@@ -154,37 +167,37 @@
 ) ;define
 
 (define (plugin-input-frac args)
-  (display "(")
+  (plugin-output "(")
   (plugin-input-arg (car args))
-  (display "/")
+  (plugin-output "/")
   (plugin-input-arg (cadr args))
-  (display ")")
+  (plugin-output ")")
 ) ;define
 
 (define (plugin-input-sqrt args)
   (if (= (length args) 1)
     (begin
-      (display "sqrt(")
+      (plugin-output "sqrt(")
       (plugin-input (car args))
-      (display ")")
+      (plugin-output ")")
     ) ;begin
     (begin
       (plugin-input-arg (car args))
-      (display "^(1/")
+      (plugin-output "^(1/")
       (plugin-input-arg (cadr args))
-      (display ")")
+      (plugin-output ")")
     ) ;begin
   ) ;if
 ) ;define
 
 (define (plugin-input-rsub args)
-  (display "[")
+  (plugin-output "[")
   (plugin-input (car args))
-  (display "]")
+  (plugin-output "]")
 ) ;define
 
 (define (plugin-input-rsup args)
-  (display "^")
+  (plugin-output "^")
   (plugin-input-arg (car args))
 ) ;define
 
@@ -203,27 +216,27 @@
          (sup (big-supscript b))
          (body (big-body b))
         ) ;
-    (display name)
-    (display "(")
+    (plugin-output name)
+    (plugin-output "(")
     (when sub
       (plugin-input sub)
-      (display ",")
+      (plugin-output ",")
     ) ;when
     (when (and sub sup)
       (plugin-input sup)
-      (display ",")
+      (plugin-output ",")
     ) ;when
     (plugin-input body)
-    (display ")")
+    (plugin-output ")")
   ) ;let*
 ) ;define
 
 (define (plugin-input-large args)
-  (display (car args))
+  (plugin-output (car args))
 ) ;define
 
 (define (plugin-input-script-assign args)
-  (display ":=")
+  (plugin-output ":=")
 ) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -238,9 +251,9 @@
 ) ;define
 
 (define (plugin-input-det args)
-  (display "matdet(")
+  (plugin-output "matdet(")
   (plugin-input-descend-last args)
-  (display ")")
+  (plugin-output ")")
 ) ;define
 
 (define (rewrite-cell c)
@@ -260,7 +273,7 @@
     (plugin-input (car r))
     (begin
       (plugin-input (car r))
-      (display ", ")
+      (plugin-output ", ")
       (plugin-input-row (cdr r))
     ) ;begin
   ) ;if
@@ -269,7 +282,7 @@
 (define (plugin-input-var-rows t)
   (if (nnull? t)
     (begin
-      (display "; ")
+      (plugin-output "; ")
       (plugin-input-row (car t))
       (plugin-input-var-rows (cdr t))
     ) ;begin
@@ -277,10 +290,10 @@
 ) ;define
 
 (define (plugin-input-rows t)
-  (display "[")
+  (plugin-output "[")
   (plugin-input-row (car t))
   (plugin-input-var-rows (cdr t))
-  (display "]")
+  (plugin-output "]")
 ) ;define
 
 (define (plugin-input-table args)

--- a/TeXmacs/tests/tmu/0828.tmu
+++ b/TeXmacs/tests/tmu/0828.tmu
@@ -1,0 +1,21 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  <\cpp-code>
+    #include \<less\>stdio.h\<gtr\>
+
+    int main() {
+
+    \ \ return 0;
+
+    }
+  </cpp-code>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/0828.md
+++ b/devel/0828.md
@@ -18,12 +18,16 @@
 - `TeXmacs/progs/dynamic/session-edit.scm` — `input-done?` 路径在调用 `plugin-serialize` 前把 `pre` 从 Herk 转成 UTF-8
 - `TeXmacs/progs/dynamic/program-edit.scm` — 同上，针对 program session
 - `TeXmacs/tests/0828.scm` — 新增 UTF-8 raw 往返、各插件 serializer UTF-8、输入/输出路径转换测试
+- `TeXmacs/progs/utils/plugins/plugin-convert.scm` — `plugin-math-input` 改用独立 string port 捕获，新增 `plugin-output` / `call-with-plugin-output-string`；顺带移除无调用者的 debug 函数 `convert-test`
+- `TeXmacs/plugins/maxima/progs/maxima/maxima-input.scm` — 自定义 handler 输出改用 `plugin-output`
+- `TeXmacs/progs/utils/plugins/plugin-cmd-test.scm` — 新增 `pre-serialize` 纯逻辑测试
 
 ## 3 如何测试
 
 ### 3.1 确定性测试（单元测试）
 ```bash
 xmake b stem
+xmake r plugin-cmd-test
 xmake r 0801
 xmake r 0804
 xmake r 0827
@@ -51,6 +55,8 @@ xmake r 0828
 9. `edit_complete.cpp` 的 `session_complete_command` 在调用 `utf8raw-serialize` 前加入 `tree_herk_to_utf8`，处理 tab completion 这条旁路。
 10. `session-edit.scm` 与 `program-edit.scm` 的 `input-done?` 路径在调用 `plugin-serialize` 前把 `pre` 从 Herk 转成 UTF-8，避免该查询路径发送 cork 文本给插件。**该转换不可省略：`plugin-serialize` 约定接收 UTF-8 stree**，而编辑器内部字符串为 Herk/cork，省略会让 Herk 的 `<#XXXX>` 字面原样漏给插件——插件收到的是 8 个 ASCII 字符 `<#4E2D>` 而非"中"。`0828.scm` 的 `test-input-done-herk-to-utf8` 用同一 Herk stree 对比了转换与不转换两种结果，断言不转换时 `<#XXXX>` 会漏出，以此证明该转换是必需的而非冗余。当前实现有 `stree->tree->stree` 往返开销，但 `input-done?` 输入通常很小，影响可忽略；若后续出现瓶颈，可改为直接 stree 级转换。
 11. 新增 `TeXmacs/tests/0828.scm`，覆盖 `texmacs->utf8raw` / `utf8raw->texmacs` 往返、各插件 serializer（含 Maxima 的 `;`/`$` 终止符与空输入特例）的 UTF-8 输出、输入端 Herk 转换（含 emoji 落到 `<#XXXX>` 的保留路径）、`<#XXXX>` 与普通文本混合的往返、主写出入口 Herk->UTF-8 转换、以及 `input-done?` 旁路 Herk stree 转 UTF-8 后再序列化（含不转换的反向对照）等场景。
+12. 修复 `plugin-math-input` 的捕获污染 bug：原实现经 `tm-with-output-to-string`（`cout-buffer`/`cout-unbuffer`）捕获，而 mogan 在 boot 层（`boot-s7.scm`）把单参 `display` 重写到 `tm-output`→全局 `cout`，导致捕获窗口内**所有**写 `cout` 的内容（C++ 日志、`lazy-input-converter-force` 触发的模块加载日志等）都会混入发往插件的字符串——会话中首个 math 输入会带上日志前缀。改为 `call-with-output-string` + 动态绑定全局 `plugin-input-port`（`dynamic-wind` 保证恢复），`plugin-convert.scm` 与 `maxima-input.scm` 中所有 handler 的输出统一走 `plugin-output` 写独立 string port，与 `cout` 完全隔离。注意不能直接用 `with-output-to-string`：它只重绑 `current-output-port`，而单参 `display` 的 boot 重写不经过 `current-output-port`，捕获会落空——这正是要显式传 port 的原因（`display` 带 port 参数时走 `original-display` 真 port 语义）。
+13. 新增 `TeXmacs/progs/utils/plugins/plugin-cmd-test.scm` 纯逻辑测试：覆盖 `pre-serialize` 的字符串透传、单层 document 剥壳、多段落 document 不透传、math→generic 规则渲染（`frac`/`rsup`/`<alpha>`/`<mathpi>`）、document 包 math 递归，以及 Maxima 自定义 handler（`<mathi>`→`%i`、`binom`→`binomial(...)`）经独立 port 捕获的路径。
 
 ## PS
 - `TeXmacs/plugins/*/progs/data/*.scm` 中出现的 `(texmacs->verbatim x (acons "texmacs->verbatim:encoding" "SourceCode" '()))` 用于文件格式导入/导出（如 `.py`、`.cpp`、`.scm`），不属于插件 I/O 路径；SourceCode 编码用于文件持久化与往返，0828 不涉及这些路径，保持原样不改。


### PR DESCRIPTION
## What
- 修复 `plugin-math-input` 的捕获污染 bug：原实现经 `tm-with-output-to-string`（cout buffer）捕获，boot 层把单参 `display` 重写到全局 `cout`，导致捕获窗口内 C++ 日志（如 lazy 模块加载日志）混入发往插件的字符串——会话中首个 math 输入会带日志前缀。
- 改为 `call-with-output-string` + `dynamic-wind` 动态绑定 `plugin-input-port`，`plugin-convert.scm` 与 `maxima-input.scm` 的 handler 输出统一走 `plugin-output`，与 `cout` 完全隔离。
- 新增 `TeXmacs/progs/utils/plugins/plugin-cmd-test.scm` 纯逻辑测试：覆盖 `pre-serialize` 各分支（透传/document 剥壳/math 渲染/maxima 自定义 handler）。
- 新增 `TeXmacs/tests/tmu/0828.tmu` 测试文档。

## Why
单参 `display` 被 boot-s7.scm 重写到 `tm-output`→`cout`，不经过 `current-output-port`，故 `with-output-to-string` 捕获会落空，必须显式传 port。

## How
- `plugin-output`：`(display s plugin-input-port)`，带 port 参数的 display 走 original-display 真 port 语义。
- `call-with-plugin-output-string`：独立 string port 捕获，`dynamic-wind` 保证异常时恢复端口。

## 测试
- `xmake r plugin-cmd-test`：13/13 通过（含首个 math 调用无污染验证）
- `xmake r 0828`：63/63 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)