### PR TITLE
[1208] lolly list 尾追加等操作由递归改为迭代

### DIFF
--- a/devel/1208.md
+++ b/devel/1208.md
@@ -28,6 +28,7 @@
 - `lolly/Kernel/Containers/list.ipp`
 - `lolly/Kernel/Containers/list.hpp`
 - `lolly/tests/Kernel/Containers/list_test.cpp`
+- `lolly/bench/Kernel/Containers/list_bench.cpp`
 
 ## 4 如何测试
 
@@ -37,6 +38,29 @@ xmake test lolly_tests/list_test
 ```
 
 预期：doctest 全部断言通过。
+
+### 基准测试
+
+```bash
+xmake b list_bench
+xmake r list_bench
+```
+
+`list_bench` 新增 `access_last` / `copy` / `gen (append)` 用例，
+对比 main（递归版）与本分支（迭代版），ns/op 越小越好：
+
+| 用例 | main（递归） | 本分支（迭代） | 提升 |
+| --- | --- | --- | --- |
+| access_last 32 | 79.33 | 55.76 | 1.42x |
+| access_last 64 | 143.26 | 105.07 | 1.36x |
+| copy 32 | 539.57 | 275.98 | 1.96x |
+| copy 64 | 1564.64 | 617.05 | 2.54x |
+| gen 64 (append) | 5164.86 | 4622.30 | 1.12x |
+| gen 256 (append) | 67745.84 | 61622.65 | 1.10x |
+
+未改动的 `last_item` 两轮差约 10%（运行噪声），可作对照：
+`access_last` 与 `copy` 的提升显著，`gen`（追加构建）提升约 10%
+（每轮追加仍以走表为主，去递归只省调用开销）。
 
 ## 5 改动记录
 

--- a/devel/1208.md
+++ b/devel/1208.md
@@ -1,0 +1,57 @@
+# [1208] lolly list 尾追加去递归化，消除长链表构建的栈深风险
+
+## 1 相关文档
+
+- [dddd.md](dddd.md)（任务文档模板）
+
+## 2 背景与问题
+
+`lolly/Kernel/Containers/list.ipp` 中尾追加与相关操作均为递归实现：
+
+- `operator<< (list<T>&, T)`：每追加一个元素递归走到表尾，追加 n 个元素
+  总比较次数 O(n²)，且每次追加的递归栈深 O(n)。debug 构建（无尾调用优化）
+  下构建长链表有爆栈风险；
+- `operator<< (list<T>&, list<T>)`、`access_last`、`suppress_last` 同为递归；
+- `copy` 也是 O(n) 递归。
+
+由于 `list` 句柄在 mogan 全库按值拷贝、且直接 `->next` 改写是惯用法，
+无法在句柄或节点上安全缓存尾指针（缓存会被绕过 `operator<<` 的直接改写
+静默失效，导致追加丢失）。因此本任务不改 `list` 的数据结构与追加语义，
+只做：
+
+1. 上述函数全部改为迭代实现，语义完全不变（仍是原地修改共享链表）；
+2. 在 `list.hpp` 为 `operator<< (list<T>&, T)` 补充复杂度说明与长链表
+   构建建议（先头插再 `reverse`，或参照 `copy` 用局部尾句柄）。
+
+## 3 任务相关的代码文件
+
+- `lolly/Kernel/Containers/list.ipp`
+- `lolly/Kernel/Containers/list.hpp`
+- `lolly/tests/Kernel/Containers/list_test.cpp`
+
+## 4 如何测试
+
+```bash
+xmake b lolly_tests
+xmake test lolly_tests/list_test
+```
+
+预期：doctest 全部断言通过。
+
+## 5 改动记录
+
+### What
+
+- `operator<< (list<T>&, T)` / `operator<< (list<T>&, list<T>)` /
+  `access_last` / `suppress_last` / `copy` 由递归改为迭代；
+- `list.hpp` 补充尾追加复杂度文档；
+- `list_test.cpp` 新增尾追加顺序、共享可见性、迭代版 `copy` 的断言。
+
+### Why
+
+消除追加路径上 O(n) 递归栈深与函数调用开销，语义保持不变。
+
+### How
+
+迭代版用局部句柄 `p` 遍历到尾节点后改写 `p->next`；`copy` 参照
+`hashmap_extra.ipp` 中 `copy_list` 的写法，用局部尾句柄顺序构建。

--- a/lolly/Kernel/Containers/list.hpp
+++ b/lolly/Kernel/Containers/list.hpp
@@ -267,6 +267,15 @@ TMPL list<T> remove (list<T> l, T what);
 TMPL bool contains (list<T> l, T what);
 
 TMPL tm_ostream& operator<< (tm_ostream& out, list<T> l);
+/**
+ * @brief Append an item to the end of a list in place.
+ *
+ * @note Each append walks from the head to the tail, i.e. O(n) per call;
+ * appending n items one by one costs O(n^2). To build a long list, prepend
+ * with `list<T> (item, l)` and finish with `reverse (l)`, or keep a local
+ * handle to the last node as `copy (list<T>)` does.
+ * @note The append mutates the (possibly shared) list in place.
+ */
 TMPL list<T>& operator<< (list<T>& l, T item);
 TMPL list<T>& operator<< (list<T>& l1, list<T> l2);
 TMPL list<T>& operator>> (T item, list<T>& l);

--- a/lolly/Kernel/Containers/list.ipp
+++ b/lolly/Kernel/Containers/list.ipp
@@ -47,16 +47,25 @@ list<T>::operator[] (int i) {
 template <class T>
 list<T>&
 operator<< (list<T>& l, T item) {
-  if (is_nil (l)) l= list<T> (item, list<T> ());
-  else l->next << item;
+  if (is_nil (l)) {
+    l= list<T> (item, list<T> ());
+    return l;
+  }
+  list<T> p= l;
+  while (!is_nil (p->next))
+    p= p->next;
+  p->next= list<T> (item, list<T> ());
   return l;
 }
 
 template <class T>
 list<T>&
 operator<< (list<T>& l1, list<T> l2) {
-  if (is_nil (l1)) l1= l2;
-  else l1->next << l2;
+  if (is_nil (l1)) return l1= l2;
+  list<T> p= l1;
+  while (!is_nil (p->next))
+    p= p->next;
+  p->next= l2;
   return l1;
 }
 
@@ -88,16 +97,24 @@ template <class T>
 T&
 access_last (list<T>& l) {
   ASSERT (!is_nil (l), "access_last on nil list");
-  if (is_nil (l->next)) return l->item;
-  return access_last (l->next);
+  list<T> p= l;
+  while (!is_nil (p->next))
+    p= p->next;
+  return p->item;
 }
 
 template <class T>
 list<T>&
 suppress_last (list<T>& l) {
   ASSERT (!is_nil (l), "empty path");
-  if (is_nil (l->next)) l= list<T> ();
-  else suppress_last (l->next);
+  if (is_nil (l->next)) {
+    l= list<T> ();
+    return l;
+  }
+  list<T> p= l;
+  while (!is_nil (p->next->next))
+    p= p->next;
+  p->next= list<T> ();
   return l;
 }
 
@@ -163,7 +180,13 @@ template <class T>
 list<T>
 copy (list<T> l) {
   if (is_nil (l)) return list<T> ();
-  else return list<T> (l->item, copy (l->next));
+  list<T> r (l->item, list<T> ());
+  list<T> tail= r;
+  for (list<T> p= l->next; !is_nil (p); p= p->next) {
+    tail->next= list<T> (p->item, list<T> ());
+    tail      = tail->next;
+  }
+  return r;
 }
 
 template <class T>

--- a/lolly/bench/Kernel/Containers/list_bench.cpp
+++ b/lolly/bench/Kernel/Containers/list_bench.cpp
@@ -31,6 +31,22 @@ main () {
   bench.run ("last_item 4", [&] { last_item (l4); });
   bench.run ("last_item 16", [&] { last_item (l16); });
 
+  bench.run ("access_last 32", [&] { access_last (l32); });
+  bench.run ("access_last 64", [&] { access_last (l64); });
+
+  bench.minEpochIterations (10000);
+  bench.run ("copy 32",
+             [&] { ankerl::nanobench::doNotOptimizeAway (copy (l32)); });
+  bench.run ("copy 64",
+             [&] { ankerl::nanobench::doNotOptimizeAway (copy (l64)); });
+
+  bench.minEpochIterations (1000);
+  bench.run ("gen 64 (append)",
+             [&] { ankerl::nanobench::doNotOptimizeAway (gen (64)); });
+  bench.run ("gen 256 (append)",
+             [&] { ankerl::nanobench::doNotOptimizeAway (gen (256)); });
+
+  bench.minEpochIterations (100000);
   bench.run ("N 32", [&] { N (l32); });
 
   bench.minEpochIterations (100000);

--- a/lolly/tests/Kernel/Containers/list_test.cpp
+++ b/lolly/tests/Kernel/Containers/list_test.cpp
@@ -109,6 +109,35 @@ TEST_CASE ("append") {
   CHECK_EQ (list<long> (1L) * list<long> (2L, 3L, list<long> ()), normal);
 }
 
+TEST_CASE ("operator<< keeps order") {
+  auto l= list<long> ();
+  l << 1L;
+  l << 2L;
+  l << 3L;
+  CHECK_EQ (l, normal);
+
+  auto l2= list<long> (1L);
+  l2 << list<long> (2L, 3L, list<long> ());
+  CHECK_EQ (l2, normal);
+
+  // 追加是原地修改，共享同一链表的句柄可见
+  auto shared= l;
+  l << 4L;
+  CHECK_EQ (N (shared), 4);
+  CHECK_EQ (last_item (shared), 4L);
+}
+
+TEST_CASE ("copy of long list") {
+  auto l= gen (10000);
+  CHECK_EQ (N (l), 10000);
+  auto c= copy (l);
+  CHECK_EQ (c, l);
+  CHECK_EQ (last_item (c), 9999L);
+  // 迭代版 copy 不复用原链节点
+  access_last (c)= -1L;
+  CHECK_EQ (last_item (l), 9999L);
+}
+
 TEST_CASE ("head and tail") {
   // QVERIFY_EXCEPTION_THROWN (head (the_nil_list), string);
   // QVERIFY_EXCEPTION_THROWN (tail (the_nil_list), string);


### PR DESCRIPTION
## 问题

\`lolly/Kernel/Containers/list.ipp\` 中尾追加与相关操作均为递归实现：

- \`operator<< (list<T>&, T)\` 每追加一个元素递归走到表尾，递归栈深 O(n)，debug 构建（无尾调用优化）下构建长链表有爆栈风险；
- \`operator<< (list<T>&, list<T>)\`、\`access_last\`、\`suppress_last\`、\`copy\` 同为 O(n) 递归。

## 改动

- 上述 5 个函数改为迭代实现，语义完全不变（仍是原地修改共享链表）；\`copy\` 参照 \`hashmap_extra.ipp\` 中 \`copy_list\` 的局部尾句柄写法；
- \`list.hpp\` 补充尾追加复杂度文档：单次 O(n)、逐个追加 n 项 O(n²)，建议长链表用「头插 + \`reverse\`」或局部尾句柄构建；
- \`list_test.cpp\` 新增追加保序、共享可见性、长链表 \`copy\` 断言；
- \`list_bench.cpp\` 新增 \`access_last\` / \`copy\` / \`gen (append)\` 用例。

未给句柄/节点加尾指针缓存的原因：\`list\` 句柄全库按值拷贝、绕过 \`operator<<\` 直接改写 \`->next\` 是惯用法，缓存会被静默失效导致追加丢失。

## 基准对比（main 递归 vs 本分支迭代，ns/op）

| 用例 | main | 本分支 | 提升 |
| --- | --- | --- | --- |
| access_last 32 | 79.33 | 55.76 | 1.42x |
| access_last 64 | 143.26 | 105.07 | 1.36x |
| copy 32 | 539.57 | 275.98 | 1.96x |
| copy 64 | 1564.64 | 617.05 | 2.54x |
| gen 64 (append) | 5164.86 | 4622.30 | 1.12x |
| gen 256 (append) | 67745.84 | 61622.65 | 1.10x |

## 测试

- \`xmake test lolly_tests/list_test\` 通过
- 回归：hashmap / hashset / hashtree / iterator / rel_hashmap / hashfunc / url / string / analyze 全部通过

任务文档：devel/1208.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)