### PR TITLE
[1210] inside_rectangle 补充 Doxygen 文档并扩充单元测试

### DIFF
--- a/devel/1210.md
+++ b/devel/1210.md
@@ -1,0 +1,34 @@
+# 1210：inside_rectangle 文档与单元测试
+
+## What
+
+- 为 `moebius/Kernel/Types/point.hpp` 中的 `inside_rectangle` 声明补充
+  Doxygen 中文文档（@brief/@param/@return），说明闭边界语义与对角
+  顶点的方向约定。
+- 扩充 `moebius/tests/Kernel/Types/point_test.cpp` 中已有的
+  `test inside_rectangle` 用例。
+
+## Why
+
+原声明无任何注释，闭边界（点落在边上算在内）与 p1/p2 需各分量
+较小/较大这一约定只能读实现才知道。原测试仅两条断言，未覆盖边界、
+四角与退化矩形情形。
+
+## How
+
+- 文档直接写在 `point.hpp` 声明上方，Doxygen 块注释，中文撰写。
+- 测试沿用现有 doctest `TEST_CASE` 风格，覆盖：
+  - 内部点、四条边外侧各一个反例；
+  - 判定含边界：四角与四边中点均在矩形内；
+  - 退化矩形（对角顶点重合为单点、零高度线段）。
+
+## 涉及文件
+
+- `moebius/Kernel/Types/point.hpp`
+- `moebius/tests/Kernel/Types/point_test.cpp`
+
+## 验证
+
+`xmake test`：`moebius_tests/point_test` passed（51 个测试中仅
+`lolly_test_dynamic_library/shared_lib_test` 失败，与本改动无关，
+main 上同样失败）。

--- a/moebius/Kernel/Types/point.hpp
+++ b/moebius/Kernel/Types/point.hpp
@@ -59,6 +59,18 @@ double seg_dist (point p1, point p2, point p);
 axis   midperp (point p1, point p2, point p3);
 point  intersection (axis A, axis B);
 
+/**
+ * @brief 判断二维点是否位于闭合矩形内
+ *
+ * 矩形由其对角顶点 p1（左下角）与 p2（右上角）确定，要求
+ * p1[0] <= p2[0] 且 p1[1] <= p2[1]。判定含边界：坐标恰好落在
+ * 矩形边上的点视为在矩形内。
+ *
+ * @param p  待判断的二维点
+ * @param p1 矩形的一个对角顶点（各分量取较小值的一角）
+ * @param p2 矩形的另一个对角顶点（各分量取较大值的一角）
+ * @return   点在矩形内（含边界）时返回 true，否则返回 false
+ */
 bool inside_rectangle (point p, point p1, point p2);
 
 #endif // defined POINT_H

--- a/moebius/tests/Kernel/Types/point_test.cpp
+++ b/moebius/tests/Kernel/Types/point_test.cpp
@@ -56,8 +56,29 @@ TEST_CASE ("test rotate_2D") {
 TEST_CASE ("test slanted") { CHECK (slanted (mkp (2, 4), 0.5) == mkp (4, 4)); }
 
 TEST_CASE ("test inside_rectangle") {
-  CHECK (inside_rectangle (mkp (1, 1), mkp (0, 0), mkp (2, 2)));
-  CHECK (!inside_rectangle (mkp (3, 1), mkp (0, 0), mkp (2, 2)));
+  point pmin= mkp (0, 0), pmax= mkp (2, 2);
+  // 内部点
+  CHECK (inside_rectangle (mkp (1, 1), pmin, pmax));
+  // 四条边外侧各排除一个方向
+  CHECK (!inside_rectangle (mkp (-1, 1), pmin, pmax));
+  CHECK (!inside_rectangle (mkp (3, 1), pmin, pmax));
+  CHECK (!inside_rectangle (mkp (1, -1), pmin, pmax));
+  CHECK (!inside_rectangle (mkp (1, 3), pmin, pmax));
+  // 判定含边界：四角与四边中点均在矩形内
+  CHECK (inside_rectangle (mkp (0, 0), pmin, pmax));
+  CHECK (inside_rectangle (mkp (2, 2), pmin, pmax));
+  CHECK (inside_rectangle (mkp (0, 2), pmin, pmax));
+  CHECK (inside_rectangle (mkp (2, 0), pmin, pmax));
+  CHECK (inside_rectangle (mkp (1, 0), pmin, pmax));
+  CHECK (inside_rectangle (mkp (1, 2), pmin, pmax));
+  CHECK (inside_rectangle (mkp (0, 1), pmin, pmax));
+  CHECK (inside_rectangle (mkp (2, 1), pmin, pmax));
+  // 退化矩形：对角顶点重合为单点，仅该点自身在内
+  CHECK (inside_rectangle (mkp (1, 1), mkp (1, 1), mkp (1, 1)));
+  CHECK (!inside_rectangle (mkp (1, 1.5), mkp (1, 1), mkp (1, 1)));
+  // 退化矩形：零高度线段，x 方向含边界、y 必须等于 1
+  CHECK (inside_rectangle (mkp (1.5, 1), mkp (0, 1), mkp (2, 1)));
+  CHECK (!inside_rectangle (mkp (1.5, 1.5), mkp (0, 1), mkp (2, 1)));
 }
 
 TEST_CASE ("test collinear") {


### PR DESCRIPTION
## 概述

为 `inside_rectangle` 补充中文 Doxygen 文档，并扩充其单元测试。

## 改动

- `moebius/Kernel/Types/point.hpp`：声明上方新增 Doxygen 注释（@brief/@param/@return），说明闭边界语义与对角顶点方向约定
- `moebius/tests/Kernel/Types/point_test.cpp`：扩充 `test inside_rectangle`，新增四边外侧反例、四角/四边中点边界判定、退化矩形（单点、零高度线段）用例
- `devel/1210.md`：任务文档

## 验证

`xmake test`：`moebius_tests/point_test` passed（51 个测试中仅 `lolly_test_dynamic_library/shared_lib_test` 失败，与本改动无关，main 上同样失败）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)