### PR TITLE
[1212] 优化 point 的性能并补充单元测试

### DIFF
--- a/devel/1212.md
+++ b/devel/1212.md
@@ -1,0 +1,20 @@
+# 1212 优化 point 的性能，并适当添加单元测试
+
+## 任务
+
+`point`（`array<double>` 的别名，定义于 `moebius/Kernel/Types/point.hpp`）是
+图形系统中最基础的热点类型：curve/grid/spacial 等模块大量使用其算术运算、
+内积、范数与距离函数。本任务：
+
+1. 先编写 nanobench 基准（`moebius/bench/Kernel/Types/point_bench.cpp`），
+   建立优化前的性能基线；
+2. 依据基线优化 `moebius/Kernel/Types/point.cpp` 中的热点实现；
+3. 适当补充单元测试（`moebius/tests/Kernel/Types/point_test.cpp`）。
+
+## 进展
+
+- [x] 任务文档
+- [ ] point 基准测试 + 基线数据
+- [ ] 性能优化 + bench 前后对比
+- [ ] 单元测试补充
+- [ ] 提交 PR

--- a/devel/1212.md
+++ b/devel/1212.md
@@ -14,7 +14,64 @@
 ## 进展
 
 - [x] 任务文档
-- [ ] point 基准测试 + 基线数据
-- [ ] 性能优化 + bench 前后对比
-- [ ] 单元测试补充
+- [x] point 基准测试 + 基线数据
+- [x] 性能优化 + bench 前后对比
+- [x] 单元测试补充
 - [ ] 提交 PR
+
+## What
+
+优化 `point`（`array<double>`）相关运算的性能，并补充单元测试。
+
+## Why
+
+`point` 是图形系统（curve/grid/spacial/handwriting）最基础的值类型，
+其算术、内积、范数、距离、共线判定等函数在排版与图形交互中被高频调用。
+原实现存在两类开销：
+
+1. 所有函数参数按值传递 `point`，每次调用触发 `array` 引用计数的
+   原子加减（INC_COUNT/DEC_COUNT）；
+2. `proj`/`seg_dist`/`linearly_dependent`/`orthogonalize` 等复合函数
+   为求差向量构造大量临时 `point`（每次临时都是一次堆分配 + 引用计数）。
+
+## How
+
+1. **参数改为 `const point&`/`const axis&`**：`point.hpp`/`point.cpp`
+   中所有只读参数改为常量引用，消除每次调用的引用计数原子操作。
+2. **免临时差向量计算**：新增文件内 `inline` 辅助函数
+   `inner_diff`/`inner_ddiff`/`norm2_diff`，直接在分量上计算
+   差向量内积/范数平方；`proj`、`seg_dist`、`linearly_dependent`
+   改用它们，不再构造中间 `point`。
+3. **`orthogonalize`/`midperp` 单次分配重写**：Gram-Schmidt
+   归一化与中垂线构造改为每个结果数组只分配一次。
+4. **`norm` 直接累加平方和**，不再经过 `inner`。
+5. **清理 `poly_line.hpp` 中的过时重复声明**：改为直接
+   `#include "point.hpp"`，避免签名不一致导致的链接错误。
+
+### bench 前后对比（nanobench，releasedbg，ns/op）
+
+| 基准 | 优化前 | 优化后 | 加速比 |
+|---|---:|---:|---:|
+| proj | 93.91 | 22.98 | 4.1x |
+| seg_dist | 234.24 | 55.97 | 4.2x |
+| linearly_dependent | 184.49 | 18.85 | 9.8x |
+| midperp | 832.86 | 140.37 | 5.9x |
+| norm | 5.89 | 2.60 | 2.3x |
+| inner | 5.21 | 3.75 | 1.4x |
+| operator== | 6.22 | 4.61 | 1.3x |
+| operator+ | 15.13 | 13.00 | 1.2x |
+
+## 涉及文件
+
+- `moebius/bench/Kernel/Types/point_bench.cpp`（新增，nanobench 基准）
+- `moebius/Kernel/Types/point.hpp` / `point.cpp`（签名与实现优化）
+- `moebius/tests/Kernel/Types/point_test.cpp`（新增 8 个测试用例：
+  逐点乘除、seg_dist 端点情形、退化轴投影、linearly_dependent、
+  orthogonalize、midperp、intersection、arg）
+- `src/Graphics/Handwriting/poly_line.hpp`（去除重复声明）
+
+## 验证
+
+- `xmake test "moebius_tests/*"` 16/16 通过
+- `xmake b stem` 链接通过
+- 根项目 `--group=tests` 全部测试目标编译通过

--- a/moebius/Kernel/Types/point.cpp
+++ b/moebius/Kernel/Types/point.cpp
@@ -14,7 +14,7 @@
 #include "tree_helper.hpp"
 
 point
-operator- (point p) {
+operator- (const point& p) {
   int   i, n= N (p);
   point r (n);
   for (i= 0; i < n; i++)
@@ -23,7 +23,7 @@ operator- (point p) {
 }
 
 point
-operator+ (point p1, point p2) {
+operator+ (const point& p1, const point& p2) {
   int   i, n= min (N (p1), N (p2));
   point r (n);
   for (i= 0; i < n; i++)
@@ -32,7 +32,7 @@ operator+ (point p1, point p2) {
 }
 
 point
-operator- (point p1, point p2) {
+operator- (const point& p1, const point& p2) {
   int   i, n= min (N (p1), N (p2));
   point r (n);
   for (i= 0; i < n; i++)
@@ -41,7 +41,7 @@ operator- (point p1, point p2) {
 }
 
 point
-operator* (double x, point p) {
+operator* (double x, const point& p) {
   int   i, n= N (p);
   point r (n);
   for (i= 0; i < n; i++)
@@ -50,7 +50,7 @@ operator* (double x, point p) {
 }
 
 point
-operator* (point p1, point p2) {
+operator* (const point& p1, const point& p2) {
   int   i, n= min (N (p1), N (p2));
   point r (n);
   for (i= 0; i < n; i++)
@@ -59,7 +59,7 @@ operator* (point p1, point p2) {
 }
 
 point
-operator/ (point p, double x) {
+operator/ (const point& p, double x) {
   int   i, n= N (p);
   point r (n);
   for (i= 0; i < n; i++)
@@ -68,7 +68,7 @@ operator/ (point p, double x) {
 }
 
 point
-operator/ (point p1, point p2) {
+operator/ (const point& p1, const point& p2) {
   int   i, n= min (N (p1), N (p2));
   point r (n);
   for (i= 0; i < n; i++)
@@ -77,7 +77,7 @@ operator/ (point p1, point p2) {
 }
 
 bool
-operator== (point p1, point p2) {
+operator== (const point& p1, const point& p2) {
   if (N (p1) != N (p2)) return false;
   int i, n= N (p1);
   for (i= 0; i < n; i++)
@@ -86,7 +86,7 @@ operator== (point p1, point p2) {
 }
 
 point
-abs (point p) {
+abs (const point& p) {
   int   i, n= N (p);
   point r (n);
   for (i= 0; i < n; i++)
@@ -95,7 +95,7 @@ abs (point p) {
 }
 
 double
-min (point p) {
+min (const point& p) {
   int i, n= N (p);
   ASSERT (N (p) > 0, "non empty point expected");
   double r= p[0];
@@ -105,7 +105,7 @@ min (point p) {
 }
 
 double
-max (point p) {
+max (const point& p) {
   int i, n= N (p);
   ASSERT (N (p) > 0, "non empty point expected");
   double r= p[0];
@@ -132,7 +132,7 @@ as_point (tree t) {
 }
 
 tree
-as_tree (point p) {
+as_tree (const point& p) {
   int  i, n= N (p);
   tree t (moebius::POINT, n);
   for (i= 0; i < n; i++)
@@ -141,11 +141,47 @@ as_tree (point p) {
 }
 
 double
-inner (point p1, point p2) {
+inner (const point& p1, const point& p2) {
   int    i, n= min (N (p1), N (p2));
   double r= 0;
   for (i= 0; i < n; i++)
     r+= p1[i] * p2[i];
+  return r;
+}
+
+// 以下三个内联辅助函数在不构造临时 point 的情况下直接计算
+// 差向量的内积与范数平方，供距离/共线等热点路径使用
+
+/** @brief 计算 (a1-a0) 与 q 的内积 */
+static inline double
+inner_diff (const point& a1, const point& a0, const point& q) {
+  int    i, n= min (N (a1), min (N (a0), N (q)));
+  double r= 0;
+  for (i= 0; i < n; i++)
+    r+= (a1[i] - a0[i]) * q[i];
+  return r;
+}
+
+/** @brief 计算 (a1-a0) 与 (b1-b0) 的内积 */
+static inline double
+inner_ddiff (const point& a1, const point& a0, const point& b1,
+             const point& b0) {
+  int    i, n= min (min (N (a1), N (a0)), min (N (b1), N (b0)));
+  double r= 0;
+  for (i= 0; i < n; i++)
+    r+= (a1[i] - a0[i]) * (b1[i] - b0[i]);
+  return r;
+}
+
+/** @brief 计算 (p1-p0) 的范数平方 */
+static inline double
+norm2_diff (const point& p1, const point& p0) {
+  int    i, n= min (N (p1), N (p0));
+  double r= 0;
+  for (i= 0; i < n; i++) {
+    double d= p1[i] - p0[i];
+    r+= d * d;
+  }
   return r;
 }
 
@@ -157,18 +193,22 @@ mult (double re, double im, point p) {
 }
 
 point
-rotate_2D (point p, point o, double angle) {
+rotate_2D (const point& p, const point& o, double angle) {
   return mult (cos (angle), sin (angle), p - o) + o;
 }
 
 point
-slanted (point p, double slant) {
+slanted (const point& p, double slant) {
   return point (p[0] + p[1] * slant, p[1]);
 }
 
 double
-norm (point p) {
-  return sqrt (inner (p, p));
+norm (const point& p) {
+  int    i, n= N (p);
+  double r= 0;
+  for (i= 0; i < n; i++)
+    r+= p[i] * p[i];
+  return sqrt (r);
 }
 
 double
@@ -180,34 +220,35 @@ arg (point p) {
 }
 
 point
-proj (axis ax, point p) {
-  int   i, n= min (N (ax.p0), N (ax.p1));
-  point a (n), b (n);
-  for (i= 0; i < n; i++) {
-    a[i]= ax.p1[i] - ax.p0[i];
-    b[i]= ax.p0[i];
-  }
-  if (norm (a) < 1.0e-6) return ax.p0;
-  else return b + ((inner (a, p) - inner (a, b)) / inner (a, a)) * a;
+proj (const axis& ax, const point& p) {
+  int n= min (N (ax.p0), N (ax.p1));
+  // t = (a·p - a·p0) / (a·a)，a = p1 - p0，全程不构造差向量
+  double aa= inner_ddiff (ax.p1, ax.p0, ax.p1, ax.p0);
+  if (sqrt (aa) < 1.0e-6) return ax.p0;
+  double t=
+      (inner_diff (ax.p1, ax.p0, p) - inner_diff (ax.p1, ax.p0, ax.p0)) / aa;
+  point r (n);
+  for (int i= 0; i < n; i++)
+    r[i]= ax.p0[i] + t * (ax.p1[i] - ax.p0[i]);
+  return r;
 }
 
 double
-dist (axis ax, point p) {
+dist (const axis& ax, const point& p) {
   return norm (p - proj (ax, p));
 }
 
 double
-seg_dist (axis ax, point p) {
-  point ab= ax.p1 - ax.p0;
-  point ba= ax.p0 - ax.p1;
-  point ap= p - ax.p0;
-  point bp= p - ax.p1;
-  if (inner (ab, ap) > 0 && inner (ba, bp) > 0) return dist (ax, p);
-  else return min (norm (ap), norm (bp));
+seg_dist (const axis& ax, const point& p) {
+  // inner(ab,ap)>0 && inner(ba,bp)>0 等价于两个差向量内积均为正
+  if (inner_ddiff (ax.p1, ax.p0, p, ax.p0) > 0 &&
+      inner_ddiff (ax.p0, ax.p1, p, ax.p1) > 0)
+    return dist (ax, p);
+  else return min (sqrt (norm2_diff (p, ax.p0)), sqrt (norm2_diff (p, ax.p1)));
 }
 
 double
-seg_dist (point p1, point p2, point p) {
+seg_dist (const point& p1, const point& p2, const point& p) {
   axis ax;
   ax.p0= p1;
   ax.p1= p2;
@@ -215,41 +256,71 @@ seg_dist (point p1, point p2, point p) {
 }
 
 bool
-collinear (point p1, point p2) {
+collinear (const point& p1, const point& p2) {
   return fnull (fabs (inner (p1, p2)) - norm (p1) * norm (p2), 1.0e-6);
 }
 
 bool
-linearly_dependent (point p1, point p2, point p3) {
-  return fnull (norm (p1 - p2), 1e-6) || fnull (norm (p2 - p3), 1e-6) ||
-         fnull (norm (p3 - p1), 1e-6) || collinear (p2 - p1, p3 - p1);
+linearly_dependent (const point& p1, const point& p2, const point& p3) {
+  // norm(p1-p2)<eps 等价于 norm2_diff < eps*eps，避免构造差向量
+  if (norm2_diff (p1, p2) < 1e-12 || norm2_diff (p2, p3) < 1e-12 ||
+      norm2_diff (p3, p1) < 1e-12)
+    return true;
+  double c= inner_ddiff (p2, p1, p3, p1);
+  return fnull (fabs (c) - sqrt (norm2_diff (p2, p1) * norm2_diff (p3, p1)),
+                1.0e-6);
 }
 
 bool
-orthogonalize (point& i, point& j, point p1, point p2, point p3) {
+orthogonalize (point& i, point& j, const point& p1, const point& p2,
+               const point& p3) {
   if (linearly_dependent (p1, p2, p3)) return false;
-  i= (p2 - p1) / norm (p2 - p1);
-  j= (p3 - p1) - inner (p3 - p1, i) * i;
-  j= j / norm (j);
+  // i = (p2-p1)/|p2-p1|，j = Gram-Schmidt 归一化，均只分配一次结果数组
+  int    n  = min (N (p2), N (p1));
+  double inv= 1.0 / sqrt (norm2_diff (p2, p1));
+  i         = point (n);
+  for (int k= 0; k < n; k++)
+    i[k]= (p2[k] - p1[k]) * inv;
+  int    m= min (N (p3), N (p1));
+  point  d (m);
+  double c= 0;
+  for (int k= 0; k < m; k++) {
+    d[k]= p3[k] - p1[k];
+    c+= d[k] * i[k];
+  }
+  j       = point (m);
+  double s= 0;
+  for (int k= 0; k < m; k++) {
+    j[k]= d[k] - c * i[k];
+    s+= j[k] * j[k];
+  }
+  double invj= 1.0 / sqrt (s);
+  for (int k= 0; k < m; k++)
+    j[k]*= invj;
   return true;
 }
 
 // perpendicular bisector of P1 and P2. P3 is meaningless!!
 axis
-midperp (point p1, point p2, point p3) {
+midperp (const point& p1, const point& p2, const point& p3) {
   axis a;
   if (linearly_dependent (p1, p2, p3)) a.p0= a.p1= point (0);
   else {
     point i, j;
     orthogonalize (i, j, p1, p2, p3);
-    a.p0= (p1 + p2) / 2;
-    a.p1= a.p0 + j;
+    int n= min (N (p1), N (p2));
+    a.p0 = point (n);
+    a.p1 = point (n);
+    for (int k= 0; k < n; k++) {
+      a.p0[k]= (p1[k] + p2[k]) / 2;
+      a.p1[k]= a.p0[k] + j[k];
+    }
   }
   return a;
 }
 
 point
-intersection (axis A, axis B) {
+intersection (const axis& A, const axis& B) {
   point i, j;
   if (!orthogonalize (i, j, A.p0, A.p1, B.p0)) {
     if (orthogonalize (i, j, A.p0, A.p1, B.p1)) return B.p0;
@@ -274,6 +345,6 @@ intersection (axis A, axis B) {
 }
 
 bool
-inside_rectangle (point p, point p1, point p2) {
+inside_rectangle (const point& p, const point& p1, const point& p2) {
   return p[0] >= p1[0] && p[1] >= p1[1] && p[0] <= p2[0] && p[1] <= p2[1];
 }

--- a/moebius/Kernel/Types/point.hpp
+++ b/moebius/Kernel/Types/point.hpp
@@ -15,18 +15,19 @@
 
 typedef array<double> point;
 
-point operator- (point p);
-point operator+ (point p1, point p2);
-point operator- (point p1, point p2);
-point operator* (double x, point p);
-point operator* (point p1, point p2);
-point operator/ (point p, double x);
-point operator/ (point p1, point p2);
-bool  operator== (point p1, point p2);
+// 只读参数一律按 const 引用传递，避免 array 引用计数的原子加减
+point operator- (const point& p);
+point operator+ (const point& p1, const point& p2);
+point operator- (const point& p1, const point& p2);
+point operator* (double x, const point& p);
+point operator* (const point& p1, const point& p2);
+point operator/ (const point& p, double x);
+point operator/ (const point& p1, const point& p2);
+bool  operator== (const point& p1, const point& p2);
 
-point  abs (point p);
-double min (point p);
-double max (point p);
+point  abs (const point& p);
+double min (const point& p);
+double max (const point& p);
 
 bool is_point (tree t);
 inline point
@@ -36,28 +37,29 @@ as_point (double x) {
   return p;
 }
 point as_point (tree t);
-tree  as_tree (point p);
+tree  as_tree (const point& p);
 
-double inner (point p1, point p2);
-point  rotate_2D (point p, point o, double angle);
-point  slanted (point p, double slant);
+double inner (const point& p1, const point& p2);
+point  rotate_2D (const point& p, const point& o, double angle);
+point  slanted (const point& p, double slant);
 
-double norm (point p);
+double norm (const point& p);
 double arg (point p);
-bool   collinear (point p1, point p2);
-bool   linearly_dependent (point p1, point p2, point p3);
-bool   orthogonalize (point& i, point& j, point p1, point p2, point p3);
+bool   collinear (const point& p1, const point& p2);
+bool   linearly_dependent (const point& p1, const point& p2, const point& p3);
+bool   orthogonalize (point& i, point& j, const point& p1, const point& p2,
+                      const point& p3);
 
 typedef struct {
   point p0, p1;
 } axis;
 
-point  proj (axis a, point p);
-double dist (axis a, point p);
-double seg_dist (axis a, point p);
-double seg_dist (point p1, point p2, point p);
-axis   midperp (point p1, point p2, point p3);
-point  intersection (axis A, axis B);
+point  proj (const axis& a, const point& p);
+double dist (const axis& a, const point& p);
+double seg_dist (const axis& a, const point& p);
+double seg_dist (const point& p1, const point& p2, const point& p);
+axis   midperp (const point& p1, const point& p2, const point& p3);
+point  intersection (const axis& A, const axis& B);
 
 /**
  * @brief 判断二维点是否位于闭合矩形内
@@ -71,6 +73,6 @@ point  intersection (axis A, axis B);
  * @param p2 矩形的另一个对角顶点（各分量取较大值的一角）
  * @return   点在矩形内（含边界）时返回 true，否则返回 false
  */
-bool inside_rectangle (point p, point p1, point p2);
+bool inside_rectangle (const point& p, const point& p1, const point& p2);
 
 #endif // defined POINT_H

--- a/moebius/bench/Kernel/Types/point_bench.cpp
+++ b/moebius/bench/Kernel/Types/point_bench.cpp
@@ -1,0 +1,52 @@
+/** \file point_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for point (array<double>) operations
+ *  \date   2026
+ */
+
+#include "math_util.hpp"
+#include "nanobench.h"
+#include "point.hpp"
+
+static point
+mkp (double x, double y) {
+  point p (2);
+  p[0]= x;
+  p[1]= y;
+  return p;
+}
+
+int
+main () {
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (1000).unit ("op");
+
+  point a= mkp (1.25, -2.5), b= mkp (0.75, 3.125), o= mkp (0, 0);
+
+  bench.run ("operator+", [&] { a + b; });
+  bench.run ("operator-", [&] { a - b; });
+  bench.run ("scalar operator*", [&] { 2.0 * a; });
+  bench.run ("operator/", [&] { a / 2.0; });
+  bench.run ("operator==", [&] { a == b; });
+  bench.run ("inner", [&] { inner (a, b); });
+  bench.run ("norm", [&] { norm (a); });
+
+  axis ax;
+  ax.p0= mkp (0, 0);
+  ax.p1= mkp (10, 0);
+  bench.run ("proj", [&] { proj (ax, a); });
+  bench.run ("seg_dist", [&] { seg_dist (ax, a); });
+  bench.run ("rotate_2D", [&] { rotate_2D (a, o, 0.5); });
+
+  point p1= mkp (0, 0), p2= mkp (1, 0), p3= mkp (2, 1);
+  bench.run ("linearly_dependent",
+             [&] { linearly_dependent (p1, p2, p3); });
+  bench.run ("midperp", [&] { midperp (p1, p2, p3); });
+
+  point acc= mkp (0, 0);
+  bench.run ("composite a-b+2*c",
+             [&] { acc= (a - b) + 2.0 * (b + a); });
+
+  ankerl::nanobench::doNotOptimizeAway (acc);
+  return 0;
+}

--- a/moebius/bench/Kernel/Types/point_bench.cpp
+++ b/moebius/bench/Kernel/Types/point_bench.cpp
@@ -39,13 +39,11 @@ main () {
   bench.run ("rotate_2D", [&] { rotate_2D (a, o, 0.5); });
 
   point p1= mkp (0, 0), p2= mkp (1, 0), p3= mkp (2, 1);
-  bench.run ("linearly_dependent",
-             [&] { linearly_dependent (p1, p2, p3); });
+  bench.run ("linearly_dependent", [&] { linearly_dependent (p1, p2, p3); });
   bench.run ("midperp", [&] { midperp (p1, p2, p3); });
 
   point acc= mkp (0, 0);
-  bench.run ("composite a-b+2*c",
-             [&] { acc= (a - b) + 2.0 * (b + a); });
+  bench.run ("composite a-b+2*c", [&] { acc= (a - b) + 2.0 * (b + a); });
 
   ankerl::nanobench::doNotOptimizeAway (acc);
   return 0;

--- a/moebius/tests/Kernel/Types/point_test.cpp
+++ b/moebius/tests/Kernel/Types/point_test.cpp
@@ -103,3 +103,73 @@ TEST_CASE ("test axis proj/dist") {
   CHECK (fabs (dist (a, p) - 4.0) < 1e-6);
   CHECK (fabs (seg_dist (a, p) - 4.0) < 1e-6);
 }
+
+TEST_CASE ("test point-wise mul/div") {
+  CHECK ((mkp (2, 3) * mkp (4, 5)) == mkp (8, 15));
+  CHECK ((mkp (8, 6) / mkp (2, 3)) == mkp (4, 2));
+}
+
+TEST_CASE ("test seg_dist endpoint cases") {
+  axis a;
+  a.p0= mkp (0, 0);
+  a.p1= mkp (10, 0);
+  // 垂足落在延长线上时，取到端点的距离
+  CHECK (fabs (seg_dist (a, mkp (-3, 4)) - 5.0) < 1e-6);
+  CHECK (fabs (seg_dist (a, mkp (13, 4)) - 5.0) < 1e-6);
+  // 三参数版本与 axis 版本一致
+  CHECK (fabs (seg_dist (mkp (0, 0), mkp (10, 0), mkp (3, 4)) - 4.0) < 1e-6);
+}
+
+TEST_CASE ("test proj degenerate axis") {
+  axis a;
+  a.p0= mkp (1, 1);
+  a.p1= mkp (1, 1);
+  CHECK (proj (a, mkp (5, 5)) == mkp (1, 1));
+}
+
+TEST_CASE ("test linearly_dependent") {
+  CHECK (linearly_dependent (mkp (0, 0), mkp (1, 1), mkp (2, 2)));
+  CHECK (!linearly_dependent (mkp (0, 0), mkp (1, 0), mkp (0, 1)));
+  // 任意两点重合即线性相关
+  CHECK (linearly_dependent (mkp (1, 2), mkp (1, 2), mkp (0, 5)));
+}
+
+TEST_CASE ("test orthogonalize") {
+  point i, j;
+  CHECK (orthogonalize (i, j, mkp (0, 0), mkp (2, 0), mkp (0, 3)));
+  CHECK (i == mkp (1, 0));
+  CHECK (j == mkp (0, 1));
+  // 三点共线时失败
+  CHECK (!orthogonalize (i, j, mkp (0, 0), mkp (1, 1), mkp (2, 2)));
+}
+
+TEST_CASE ("test midperp") {
+  axis a= midperp (mkp (0, 0), mkp (2, 0), mkp (0, 1));
+  // 中垂线过中点 (1,0) 且竖直
+  CHECK (a.p0 == mkp (1, 0));
+  CHECK (fabs (a.p1[0] - 1.0) < 1e-6);
+  // 三点共线时退化为空点 point(0)
+  axis b= midperp (mkp (0, 0), mkp (1, 1), mkp (2, 2));
+  CHECK (N (b.p0) == 0);
+  CHECK (N (b.p1) == 0);
+}
+
+TEST_CASE ("test intersection") {
+  axis A, B;
+  A.p0= mkp (0, 0);
+  A.p1= mkp (4, 0);
+  B.p0= mkp (2, -2);
+  B.p1= mkp (2, 2);
+  CHECK (intersection (A, B) == mkp (2, 0));
+  // 平行轴无交点，返回空点 point(0)
+  axis C;
+  C.p0= mkp (0, 1);
+  C.p1= mkp (4, 1);
+  CHECK (N (intersection (A, C)) == 0);
+}
+
+TEST_CASE ("test arg") {
+  CHECK (fabs (arg (mkp (1, 0)) - 0.0) < 1e-6);
+  CHECK (fabs (arg (mkp (0, 1)) - tm_PI / 2) < 1e-6);
+  CHECK (fabs (arg (mkp (0, -1)) - 3 * tm_PI / 2) < 1e-6);
+}

--- a/src/Graphics/Handwriting/poly_line.hpp
+++ b/src/Graphics/Handwriting/poly_line.hpp
@@ -9,29 +9,17 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
-#include "tree.hpp"
+#include "point.hpp"
 
-typedef array<double>    point;
 typedef array<point>     poly_line;
 typedef array<poly_line> contours;
 
-point operator- (point p);
-point operator+ (point p1, point p2);
-point operator- (point p1, point p2);
-point operator* (double x, point p);
-point operator/ (point p, double x);
-bool  operator== (point p1, point p2);
-
 double l2_norm (point p);
-double min (point p);
-double max (point p);
-double inner (point p, point q);
 double distance (point p, point q);
 point  project (point p, point q1, point q2);
 double distance (point p, point q1, point q2);
 point  inf (point p, point q);
 point  sup (point p, point q);
-point  abs (point p);
 
 double        distance (point p, poly_line pl);
 bool          nearby (point p, poly_line pl);


### PR DESCRIPTION
## 概述

`point`（`array<double>`）是图形系统最基础的热点值类型，本 PR 先建基准、再依基线优化，并补充单元测试。任务文档见 `devel/1212.md`。

## 改动

- 新增 nanobench 基准 `moebius/bench/Kernel/Types/point_bench.cpp`
- `point.hpp`/`point.cpp`：只读参数改为 `const point&`/`const axis&`，消除每次调用的引用计数原子加减
- 新增 `inner_diff`/`inner_ddiff`/`norm2_diff` 内联辅助，`proj`/`seg_dist`/`linearly_dependent` 免临时差向量计算
- `orthogonalize`/`midperp` 单次分配重写
- `poly_line.hpp` 去除与 `point.hpp` 重复的过时声明（改为直接 include）
- `point_test.cpp` 新增 8 个测试用例

## bench 前后对比（releasedbg, ns/op）

| 基准 | 优化前 | 优化后 | 加速比 |
|---|---:|---:|---:|
| midperp | 832.86 | 140.37 | 5.9x |
| linearly_dependent | 184.49 | 18.85 | 9.8x |
| seg_dist | 234.24 | 55.97 | 4.2x |
| proj | 93.91 | 22.98 | 4.1x |
| norm | 5.89 | 2.60 | 2.3x |

## 验证

- `xmake test "moebius_tests/*"` 16/16 通过
- `xmake b stem` 链接通过；根项目 `--group=tests` 全部测试目标编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)