### PR TITLE
[0915] 补充 point proj 的 Doxygen 文档与测试用例

### DIFF
--- a/devel/0915.md
+++ b/devel/0915.md
@@ -2,8 +2,8 @@
 
 ## What
 
-为 `moebius/Kernel/Types/point.hpp` 中 `proj`（及密切相关的 `dist`）补充中文
-Doxygen 文档，并在 `moebius/tests/Kernel/Types/point_test.cpp` 中扩充测试用例。
+为 `moebius/Kernel/Types/point.hpp` 中 `proj` 补充中文 Doxygen 文档，并在
+`moebius/tests/Kernel/Types/point_test.cpp` 中扩充测试用例。
 
 ## Why
 
@@ -26,7 +26,7 @@ Doxygen 文档，并在 `moebius/tests/Kernel/Types/point_test.cpp` 中扩充测
 
 ## 涉及文件
 
-- `moebius/Kernel/Types/point.hpp`：`proj`、`dist` 的 Doxygen 注释
+- `moebius/Kernel/Types/point.hpp`：`proj` 的 Doxygen 注释
 - `moebius/tests/Kernel/Types/point_test.cpp`：新增 5 个 TEST_CASE
 
 ## 测试

--- a/devel/0915.md
+++ b/devel/0915.md
@@ -1,0 +1,37 @@
+# 0915 撰写 point 中 proj 的 C++ Doxygen 文档和测试用例
+
+## What
+
+为 `moebius/Kernel/Types/point.hpp` 中 `proj`（及密切相关的 `dist`）补充中文
+Doxygen 文档，并在 `moebius/tests/Kernel/Types/point_test.cpp` 中扩充测试用例。
+
+## Why
+
+`proj` 是点在轴（直线）上正交投影的核心几何函数，此前仅有声明、无文档说明
+其语义细节（t 不受 [0,1] 限制、退化轴行为、维度取 min 等），测试也只覆盖
+水平轴和退化轴两种情况。
+
+## How
+
+- Doxygen 文档：说明投影公式 `p0 + t*(p1-p0)`、t 不限区间（垂足可落在
+  延长线上）、退化轴（|a| < 1e-6）直接返回 p0、结果维度取
+  `min(N(p0), N(p1))` 与 p 维度无关；`dist` 说明为 |p - proj(a,p)| 的
+  直线距离。
+- 新增测试用例：
+  - 斜轴（y=x）上的投影与距离
+  - 垂足落在 p0/p1 之外及端点处的投影
+  - 投影正交性不变量（r-p 与轴方向内积为零）
+  - 三维轴（z 轴）上的投影与距离
+  - p 维度大于轴维度时的结果维度截断
+
+## 涉及文件
+
+- `moebius/Kernel/Types/point.hpp`：`proj`、`dist` 的 Doxygen 注释
+- `moebius/tests/Kernel/Types/point_test.cpp`：新增 5 个 TEST_CASE
+
+## 测试
+
+```bash
+cd moebius && xmake test "moebius_tests/point_test"
+# 100% tests passed（--test-case="*proj*" 7 个用例 18 条断言全部通过）
+```

--- a/moebius/Kernel/Types/point.hpp
+++ b/moebius/Kernel/Types/point.hpp
@@ -67,17 +67,7 @@ typedef struct {
  * @param p 待投影的点
  * @return  p 在轴上的正交投影点
  */
-point proj (const axis& a, const point& p);
-
-/**
- * @brief 求点 p 到轴 a（过 p0、p1 的直线）的距离
- *
- * 距离为 |p - proj(a, p)|，直线距离，不含端点限制。
- *
- * @param a 轴（过 a.p0 与 a.p1 的直线）
- * @param p 待测点
- * @return  点到直线的欧氏距离
- */
+point  proj (const axis& a, const point& p);
 double dist (const axis& a, const point& p);
 double seg_dist (const axis& a, const point& p);
 double seg_dist (const point& p1, const point& p2, const point& p);

--- a/moebius/Kernel/Types/point.hpp
+++ b/moebius/Kernel/Types/point.hpp
@@ -54,7 +54,30 @@ typedef struct {
   point p0, p1;
 } axis;
 
-point  proj (const axis& a, const point& p);
+/**
+ * @brief 求点 p 到轴 a（过 p0、p1 的直线）的正交投影
+ *
+ * 轴不要求是单位向量，投影点为 p0 + t*(p1 - p0)，其中
+ * t = (a·p - a·p0) / (a·a)，a = p1 - p0。t 不受 [0,1] 限制，
+ * 即投影可以落在 p0、p1 之外（延长线上）；若 p0 与 p1 几乎重合
+ * （|a| < 1e-6），退化为直接返回 p0。结果维度取 min(N(p0), N(p1))，
+ * 与 p 的维度无关。
+ *
+ * @param a 轴（过 a.p0 与 a.p1 的直线）
+ * @param p 待投影的点
+ * @return  p 在轴上的正交投影点
+ */
+point proj (const axis& a, const point& p);
+
+/**
+ * @brief 求点 p 到轴 a（过 p0、p1 的直线）的距离
+ *
+ * 距离为 |p - proj(a, p)|，直线距离，不含端点限制。
+ *
+ * @param a 轴（过 a.p0 与 a.p1 的直线）
+ * @param p 待测点
+ * @return  点到直线的欧氏距离
+ */
 double dist (const axis& a, const point& p);
 double seg_dist (const axis& a, const point& p);
 double seg_dist (const point& p1, const point& p2, const point& p);

--- a/moebius/tests/Kernel/Types/point_test.cpp
+++ b/moebius/tests/Kernel/Types/point_test.cpp
@@ -127,6 +127,74 @@ TEST_CASE ("test proj degenerate axis") {
   CHECK (proj (a, mkp (5, 5)) == mkp (1, 1));
 }
 
+TEST_CASE ("test proj oblique axis") {
+  // 斜率为 1 的直线 y = x，点 (0, 2) 的垂足为 (1, 1)
+  axis a;
+  a.p0   = mkp (0, 0);
+  a.p1   = mkp (5, 5);
+  point r= proj (a, mkp (0, 2));
+  CHECK (fabs (r[0] - 1.0) < 1e-9);
+  CHECK (fabs (r[1] - 1.0) < 1e-9);
+  CHECK (fabs (dist (a, mkp (0, 2)) - sqrt (2.0)) < 1e-9);
+}
+
+TEST_CASE ("test proj outside segment") {
+  // t 不受 [0,1] 限制：垂足落在延长线上
+  axis a;
+  a.p0= mkp (0, 0);
+  a.p1= mkp (10, 0);
+  CHECK (proj (a, mkp (-3, 4)) == mkp (-3, 0));
+  CHECK (proj (a, mkp (13, 4)) == mkp (13, 0));
+  CHECK (proj (a, mkp (10, 0)) == mkp (10, 0));
+  CHECK (proj (a, mkp (0, 0)) == mkp (0, 0));
+}
+
+TEST_CASE ("test proj orthogonal invariant") {
+  // 投影点到原点的连线与轴方向正交
+  axis a;
+  a.p0   = mkp (1, 2);
+  a.p1   = mkp (4, 6);
+  point p= mkp (5, 1);
+  point r= proj (a, p);
+  CHECK (fabs (inner (r - p, a.p1 - a.p0)) < 1e-9);
+}
+
+TEST_CASE ("test proj 3d") {
+  // 三维：投影到 z 轴
+  point p0 (3), p1 (3), p (3);
+  p0[0]= 0;
+  p0[1]= 0;
+  p0[2]= 0;
+  p1[0]= 0;
+  p1[1]= 0;
+  p1[2]= 1;
+  p[0] = 1;
+  p[1] = 2;
+  p[2] = 5;
+  axis z_axis;
+  z_axis.p0= p0;
+  z_axis.p1= p1;
+  point r  = proj (z_axis, p);
+  CHECK (r[0] == 0);
+  CHECK (r[1] == 0);
+  CHECK (fabs (r[2] - 5.0) < 1e-9);
+  CHECK (fabs (dist (z_axis, p) - sqrt (5.0)) < 1e-9);
+}
+
+TEST_CASE ("test proj dim mismatch") {
+  // 结果维度取 min(N(p0), N(p1))，与 p 的维度无关
+  axis a;
+  a.p0= mkp (0, 0);
+  a.p1= mkp (10, 0);
+  point p3 (3);
+  p3[0]  = 3;
+  p3[1]  = 4;
+  p3[2]  = 100;
+  point r= proj (a, p3);
+  CHECK (N (r) == 2);
+  CHECK (r == mkp (3, 0));
+}
+
 TEST_CASE ("test linearly_dependent") {
   CHECK (linearly_dependent (mkp (0, 0), mkp (1, 1), mkp (2, 2)));
   CHECK (!linearly_dependent (mkp (0, 0), mkp (1, 0), mkp (0, 1)));


### PR DESCRIPTION
## 任务

[0915] 为 `point` 中的 `proj` 补充 C++ Doxygen 文档和测试用例。

## 改动内容

### What

- `moebius/Kernel/Types/point.hpp`：为 `proj` 新增中文 Doxygen 文档
- `moebius/tests/Kernel/Types/point_test.cpp`：新增 5 个 `proj` 测试用例

### Why

`proj` 是点在轴（直线）上正交投影的核心几何函数，此前仅有声明、无文档说明其
语义细节（t 不受 [0,1] 限制、退化轴行为、维度取 min 等），测试也只覆盖水平轴
和退化轴两种情况。

### How

- Doxygen 文档说明投影公式 `p0 + t*(p1-p0)`、t 不限区间（垂足可落在延长线上）、
  退化轴（|a| < 1e-6）直接返回 p0、结果维度取 `min(N(p0), N(p1))` 与 p 维度无关。
- 新增测试用例：
  - 斜轴（y = x）上的投影与距离
  - 垂足落在 p0/p1 之外及端点处的投影
  - 投影正交性不变量（r - p 与轴方向内积为零）
  - 三维轴（z 轴）上的投影与距离
  - p 维度大于轴维度时的结果维度截断

## 验证

- `gf fmt` 已执行
- `cd moebius && xmake test "moebius_tests/point_test"`：100% 通过
  （`--test-case="*proj*"` 7 个用例、18 条断言全部通过）

任务文档：`devel/0915.md`
