### PR TITLE
[1213] 优化 lolly string 性能

### DIFF
--- a/devel/1213.md
+++ b/devel/1213.md
@@ -1,0 +1,54 @@
+# 1213 优化 lolly string 性能
+
+分支:`da/1213/lolly_string`
+
+## What
+
+先扩充 `lolly/bench/Kernel/Types/string_bench.cpp` 记录基线,再优化
+`lolly/Kernel/Types/string.cpp`:
+
+1. 逐字符拷贝循环全部替换为 `memcpy`(构造器、`copy`、`operator*`、
+   `operator<<`、`operator()`、`as_charp`、`as_double` 的缓冲拷贝)。
+2. `string (char c, int n)` 的填充循环替换为 `memset`。
+3. `as_string (int16_t/int32_t/int64_t)` 去掉 `std::to_string` 中转
+   (其产生 `std::string` 堆分配 + `strlen` + 二次逐字符拷贝),改为
+   `snprintf` 进栈缓冲后直接用 `string (buf, n)` 构造;移除 `<string>`
+   头文件依赖。
+4. `operator()` 子串:先钳位求长度,长度非正直接返回空串(顺带修掉
+   原实现 begin>end 时传入负长度构造的边界问题)。
+
+## Why
+
+bench 显示中长字符串(≥64 字节)的逐字符循环远慢于 `memcpy`;
+整型转字符串时 `std::to_string` 的临时 `std::string` 分配与二次拷贝
+是主要开销。
+
+## 基准数据
+
+linux/x86_64 releasedbg,新增用例,优化前 → 优化后:
+
+| 用例 | 优化前 (ns/op) | 优化后 (ns/op) | 提升 |
+|---|---|---|---|
+| construct from long char* (72B) | 42.2 | 30.4 | -28% |
+| copy (59B) | 50.5 | 12.3 | -76% |
+| concat 1KB strings | 174.9 | 31.2 | -82% |
+
+注:`slice 1KB string` 用例最初把 1KB 填充循环误放在计时 lambda 内,
+基线 1672.8 / 优化后 1070.1 的数字主要是填充开销,不能反映子串拷贝;
+已把填充移到计时区外,修正后该用例约 37 ns/op(800B memcpy)。
+
+原有短串用例(`concat string`、`append string`、`slice string` 等)
+因长度短、分配占大头,数字基本持平或小幅波动。`hash` 未改动,
+1KB 用例 102.6 → 87.6 ns(属噪声级波动)。
+
+## 涉及文件
+
+- `lolly/Kernel/Types/string.cpp`:memcpy/memset 化、as_string 重写
+- `lolly/bench/Kernel/Types/string_bench.cpp`:新增 7 个中长串用例
+
+## 验证
+
+- `xmake test`(lolly):51 个测试 50 通过;
+  `shared_lib_test` 失败为动态库加载的环境问题,与本次改动无关
+  (本次仅改 string.cpp,该测试不涉及 string)
+- string 相关测试全部通过

--- a/lolly/Kernel/Types/string.cpp
+++ b/lolly/Kernel/Types/string.cpp
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 
 /******************************************************************************
  * Low level routines and constructors
@@ -60,22 +59,18 @@ string::string (char c) {
 
 string::string (char c, int n) {
   rep= tm_new<string_rep> (n);
-  for (int i= 0; i < n; i++)
-    rep->a[i]= c;
+  if (n > 0) memset (rep->a, c, n);
 }
 
 string::string (const char* a) {
-  int i, n= strlen (a);
-  rep= tm_new<string_rep> (n);
-  for (i= 0; i < n; i++)
-    rep->a[i]= a[i];
+  int n= (int) strlen (a);
+  rep  = tm_new<string_rep> (n);
+  if (n > 0) memcpy (rep->a, a, n);
 }
 
 string::string (const char* a, int n) {
-  int i;
   rep= tm_new<string_rep> (n);
-  for (i= 0; i < n; i++)
-    rep->a[i]= a[i];
+  if (n > 0) memcpy (rep->a, a, n);
 }
 
 /******************************************************************************
@@ -116,14 +111,12 @@ string::operator!= (string a) {
 
 string
 string::operator() (int begin, int end) const {
-  if (end <= begin) return string ();
-
-  int i;
   begin= max (min (rep->n, begin), 0);
   end  = max (min (rep->n, end), 0);
+  if (end <= begin) return string ();
+
   string r (end - begin);
-  for (i= begin; i < end; i++)
-    r[i - begin]= rep->a[i];
+  memcpy (r.rep->a, rep->a + begin, end - begin);
   return r;
 }
 
@@ -134,10 +127,9 @@ string::operator() (int begin, int end) {
 
 string
 copy (string s) {
-  int    i, n= N (s);
+  int    n= N (s);
   string r (n);
-  for (i= 0; i < n; i++)
-    r[i]= s[i];
+  if (n > 0) memcpy (r.begin (), s.begin (), n);
   return r;
 }
 
@@ -150,21 +142,18 @@ operator<< (string& a, char x) {
 
 string&
 operator<< (string& a, string b) {
-  int i, k1= N (a), k2= N (b);
+  int k1= N (a), k2= N (b);
   a->resize (k1 + k2);
-  for (i= 0; i < k2; i++)
-    a[i + k1]= b[i];
+  if (k2 > 0) memcpy (a.begin () + k1, b.begin (), k2);
   return a;
 }
 
 string
 operator* (string a, string b) {
-  int    i, n1= N (a), n2= N (b);
+  int    n1= N (a), n2= N (b);
   string c (n1 + n2);
-  for (i= 0; i < n1; i++)
-    c[i]= a[i];
-  for (i= 0; i < n2; i++)
-    c[i + n1]= b[i];
+  if (n1 > 0) memcpy (c.begin (), a.begin (), n1);
+  if (n2 > 0) memcpy (c.begin () + n1, b.begin (), n2);
   return c;
 }
 
@@ -246,10 +235,9 @@ double
 as_double (string s) {
   double x= 0.0;
   {
-    int i, n= N (s);
+    int n= N (s);
     STACK_NEW_ARRAY (buf, char, n + 1);
-    for (i= 0; i < n; i++)
-      buf[i]= s[i];
+    if (n > 0) memcpy (buf, s.begin (), n);
     buf[n]= '\0';
     sscanf (buf, "%lf", &x);
     STACK_DELETE_ARRAY (buf);
@@ -259,10 +247,9 @@ as_double (string s) {
 
 char*
 as_charp (string s) {
-  int   i, n= N (s);
+  int   n = N (s);
   char* s2= tm_new_array<char> (n + 1);
-  for (i= 0; i < n; i++)
-    s2[i]= s[i];
+  if (n > 0) memcpy (s2, s.begin (), n);
   s2[n]= '\0';
   return s2;
 }
@@ -273,19 +260,27 @@ as_string_bool (bool f) {
   else return string ("false");
 }
 
+// 直接 snprintf 进栈缓冲,避免 std::to_string 的堆分配与二次拷贝
+static string
+as_string_int (long long v) {
+  char buf[24];
+  int  n= snprintf (buf, sizeof (buf), "%lld", v);
+  return string (buf, n);
+}
+
 string
 as_string (int16_t i) {
-  return string ((std::to_string (i)).c_str ());
+  return as_string_int (i);
 }
 
 string
 as_string (int32_t i) {
-  return string ((std::to_string (i)).c_str ());
+  return as_string_int (i);
 }
 
 string
 as_string (int64_t i) {
-  return string ((std::to_string (i)).c_str ());
+  return as_string_int (i);
 }
 
 string

--- a/lolly/bench/Kernel/Types/string_bench.cpp
+++ b/lolly/bench/Kernel/Types/string_bench.cpp
@@ -64,4 +64,42 @@ main () {
     static string a ("H\"ello TeXmacs\"");
     is_quoted (a);
   });
+  bench.run ("construct from long char*", [&] {
+    const char* s= "construct from long char*: the quick brown fox jumps over "
+                   "the lazy dog";
+    string      a (s);
+    ankerl::nanobench::doNotOptimizeAway (a);
+  });
+  bench.run ("copy", [&] {
+    static string a ("copy this string, copy this string, copy this string");
+    auto          c= copy (a);
+    ankerl::nanobench::doNotOptimizeAway (c);
+  });
+  bench.run ("append char", [&] {
+    static string a ("abcdefg");
+    a << 'x';
+    a->resize (7);
+  });
+  // 填充移到计时区外,避免每轮迭代重复 1KB 写入
+  static string a_1k (1024);
+  for (int i= 0; i < N (a_1k); i++)
+    a_1k[i]= (char) ('a' + (i % 26));
+  bench.run ("slice 1KB string", [&] {
+    auto s= a_1k (100, 900);
+    ankerl::nanobench::doNotOptimizeAway (s);
+  });
+  bench.run ("concat 1KB strings", [&] {
+    static string a (1024, 'a'), b (1024, 'b');
+    auto          c= a * b;
+    ankerl::nanobench::doNotOptimizeAway (c);
+  });
+  bench.run ("equality with char*", [&] {
+    static string a ("equality with char* string");
+    (void) (a == "equality with char* strinG");
+  });
+  bench.run ("hash 1KB string", [&] {
+    static string a (1024, 'a');
+    auto          h= hash (a);
+    ankerl::nanobench::doNotOptimizeAway (h);
+  });
 }


### PR DESCRIPTION
## 概要

先扩充 `lolly/bench/Kernel/Types/string_bench.cpp` 记录基线，再优化 `lolly/Kernel/Types/string.cpp`：

- 逐字符拷贝循环全部替换为 `memcpy`/`memset`（构造器、`copy`、`operator*`、`operator<<`、子串、`as_charp`、`as_double`）
- `as_string(int16/32/64)` 去掉 `std::to_string` 中转，改为 `snprintf` 栈缓冲直连 `string(buf, n)`，移除 `<string>` 依赖
- 子串 `operator()` 钳位各算一次，非正长度返回空串（修掉原 begin>end 时负长度构造的边界问题）
- 所有 memcpy/memset 对 n==0（缓冲为 NULL）统一加守卫

## 基准（linux/x86_64 releasedbg，ns/op）

| 用例 | 优化前 | 优化后 | 提升 |
|---|---|---|---|
| copy (59B) | 50.5 | 12.3 | -76% |
| concat 1KB | 174.9 | 31.2 | -82% |
| construct long char* (72B) | 42.2 | 30.4 | -28% |

## 验证

- lolly 全量测试 51 个中 50 通过（`shared_lib_test` 失败为动态库加载环境问题，与本次改动无关）
- `gf fmt --changed-since=main` 已通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)