### PR TITLE
[0916] 优化 point norm 性能并补充 Doxygen 文档与单元测试

### DIFF
--- a/devel/0916.md
+++ b/devel/0916.md
@@ -1,0 +1,71 @@
+# 0916：point norm 性能优化、Doxygen 文档与单元测试
+
+## 上游现状调查（基于 f1e253ec3）
+
+任务开始前 fetch origin 后发现上游已合入相关改动：
+
+- [1212]（#4358）已将 point 全部接口改为 `const point&` 传参，并把
+  `norm` 从 `sqrt (inner (p, p))` 改为直接循环累加平方——按值拷贝与
+  `min(N, N)` 的冗余开销上游已消除，这部分不重复实现；
+- [0915]（#4359）补充了 `proj` 的文档与测试。
+
+上游仍缺失、本任务补齐的部分：
+
+1. `norm` 仍为跨编译单元调用，且无文档注释；
+2. norm 的测试仅 `CHECK_EQ (norm (mkp (3, 4)), 5.0)` 一条断言。
+
+## What
+
+- 将 `norm (const point&)` 从 `point.cpp` 移至 `point.hpp` 内联实现，
+  并为二维点提供无循环快路径。
+- 为 `norm` 补充 Doxygen 中文文档（@brief/@param/@return/@note）。
+- 扩充 `moebius/tests/Kernel/Types/point_test.cpp`，新增独立的
+  `test norm` 用例。
+
+## Why
+
+`norm` 是几何计算热点（mogan 主仓约 117 处调用，`dist`、`seg_dist`、
+`collinear` 等收敛判据均经此），排版与图形场景几乎全是二维点。
+上游实现虽已按 const& 直接累加，但仍是跨编译单元函数调用，且二维
+也要走通用循环；内联到头文件并为二维提供快路径可消除这部分开销。
+
+## How
+
+- `point.hpp`：声明替换为 `inline` 定义。二维走快路径
+  `sqrt (x*x + y*y)`；其余维度循环累加平方。`sqrt` 经由
+  `tree.hpp` → `array.hpp` → `basic.hpp` 链引入的 `<math.h>` 提供。
+- `point.cpp`：删除旧 `norm` 定义（避免与头文件内联定义冲突）。
+- 测试：覆盖空点、零向量、一维、二维（负坐标/小数）、三维、四维，
+  以及 `norm(p)^2 == inner(p, p)` 自洽性。
+- 基准：沿用上游 `moebius/bench/Kernel/Types/point_bench.cpp` 的
+  `norm` 条目，改动前后同机对比。
+
+## 涉及文件
+
+- `moebius/Kernel/Types/point.hpp`
+- `moebius/Kernel/Types/point.cpp`
+- `moebius/tests/Kernel/Types/point_test.cpp`
+- `devel/0916.md`
+
+## 测试说明
+
+```bash
+xmake test moebius_tests/point_test   # 单元测试
+xmake b --yes point_bench && xmake r point_bench   # norm 基准
+xmake b --yes stem                    # 主仓全量构建（norm 有百余处调用）
+```
+
+## 验证
+
+- 基线（f1e253ec3，releasedbg）：`point_bench` 中 `norm` 二维点
+  1.85 ns/op。
+- 改动后同机基准：`norm` 0.31 ns/op，约 6x 提速（内联后调用开销
+  消除，二维快路径可被编译器进一步优化）。
+- `xmake test moebius_tests/point_test`：通过。
+- `xmake test` 全量：51 个测试 50 通过，唯一失败
+  `lolly_test_dynamic_library/shared_lib_test` 为 main 上既有失败，
+  与本改动无关。
+- `xmake b --yes stem`：主仓构建通过（norm 在主仓约 117 处调用，
+  头文件内联改动全量验证）。
+- `gf fmt --changed-since=main`：3 个 C++ 文件，无格式改动。
+- GUI 验证：本任务不涉及用户可见 GUI 行为，有意未运行。

--- a/moebius/Kernel/Types/point.cpp
+++ b/moebius/Kernel/Types/point.cpp
@@ -203,15 +203,6 @@ slanted (const point& p, double slant) {
 }
 
 double
-norm (const point& p) {
-  int    i, n= N (p);
-  double r= 0;
-  for (i= 0; i < n; i++)
-    r+= p[i] * p[i];
-  return sqrt (r);
-}
-
-double
 arg (point p) {
   double n= norm (p);
   p       = p / n;

--- a/moebius/Kernel/Types/point.hpp
+++ b/moebius/Kernel/Types/point.hpp
@@ -43,7 +43,32 @@ double inner (const point& p1, const point& p2);
 point  rotate_2D (const point& p, const point& o, double angle);
 point  slanted (const point& p, double slant);
 
-double norm (const point& p);
+/**
+ * @brief 计算点的欧几里得范数（各分量平方和的平方根）
+ *
+ * 即 sqrt(p[0]^2 + p[1]^2 + ... + p[N(p)-1]^2)，几何意义为点到原点的
+ * 距离。二维点走无循环快路径；其余维度逐分量平方累加后开方。
+ * 实现内联于头文件：norm 是几何计算的热点函数（dist、seg_dist、
+ * collinear 等均经此收敛），内联可消除跨编译单元的函数调用开销。
+ *
+ * @param p 输入点，可为任意维度（排版与图形场景通常为二维）
+ * @return  点的欧几里得范数；空点（N(p) == 0）返回 0
+ * @note 直接对分量平方求和，坐标绝对值过大（约 1e154 以上）时平方
+ *       会上溢为 inf，此时返回 inf；调用方如需避免溢出应自行缩放
+ */
+inline double
+norm (const point& p) {
+  int n= N (p);
+  if (n == 2) {
+    double x= p[0], y= p[1];
+    return sqrt (x * x + y * y);
+  }
+  double r= 0;
+  for (int i= 0; i < n; i++)
+    r+= p[i] * p[i];
+  return sqrt (r);
+}
+
 double arg (point p);
 bool   collinear (const point& p1, const point& p2);
 bool   linearly_dependent (const point& p1, const point& p2, const point& p3);

--- a/moebius/tests/Kernel/Types/point_test.cpp
+++ b/moebius/tests/Kernel/Types/point_test.cpp
@@ -41,6 +41,33 @@ TEST_CASE ("test inner and norm") {
   CHECK_EQ (norm (mkp (3, 4)), 5.0);
 }
 
+TEST_CASE ("test norm") {
+  // 空点与零向量的范数为 0
+  CHECK_EQ (norm (point ()), 0.0);
+  CHECK (fnull (norm (mkp (0, 0)), 1e-12));
+  // 一维点的范数即分量绝对值
+  CHECK_EQ (norm (as_point (-3.0)), 3.0);
+  // 二维：分量符号不影响结果
+  CHECK_EQ (norm (mkp (-3, -4)), 5.0);
+  CHECK_EQ (norm (mkp (-3, 4)), 5.0);
+  CHECK (fnull (norm (mkp (1.5, 2.0)) - 2.5, 1e-12));
+  // 三维及更高维走通用累加路径
+  point p3 (3);
+  p3[0]= 1;
+  p3[1]= 2;
+  p3[2]= 2;
+  CHECK_EQ (norm (p3), 3.0);
+  point p4 (4);
+  p4[0]= 1;
+  p4[1]= 1;
+  p4[2]= 1;
+  p4[3]= 1;
+  CHECK_EQ (norm (p4), 2.0);
+  // 范数与 inner 自洽：norm(p)^2 == inner(p, p)
+  point p= mkp (6, 8);
+  CHECK (fnull (norm (p) * norm (p) - inner (p, p), 1e-9));
+}
+
 TEST_CASE ("test min/max/abs") {
   CHECK_EQ (min (mkp (3, -1)), -1.0);
   CHECK_EQ (max (mkp (3, -1)), 3.0);


### PR DESCRIPTION
## 任务

0916：优化 point 的 norm 性能，并撰写 norm 的 C++ Doxygen 文档和测试用例。

## 上游现状说明

任务开始时上游 [1212]（#4358）已将 point 接口改为 `const point&` 传参并把
`norm` 从 `sqrt (inner (p, p))` 改为直接循环累加平方，按值拷贝的冗余开销
已被上游消除，本 PR 不重复该部分，只做剩余增量：内联 + 二维快路径 + 文档
+ 测试。调查证据见 `devel/0916.md`。

## 改动内容

- `moebius/Kernel/Types/point.hpp`：`norm (const point&)` 移至头文件内联
  实现，二维点走无循环快路径 `sqrt (x*x + y*y)`，其余维度循环累加平方；
  补充中文 Doxygen 文档（@brief/@param/@return/@note，含坐标绝对值超过
  约 1e154 时平方上溢为 inf 的说明）。
- `moebius/Kernel/Types/point.cpp`：删除旧 `norm` 定义。
- `moebius/tests/Kernel/Types/point_test.cpp`：新增 `test norm` 用例，
  覆盖空点、零向量、一维、二维（负坐标/小数）、三维、四维，以及
  `norm(p)^2 == inner(p, p)` 自洽性。

## 性能

`moebius/bench/Kernel/Types/point_bench.cpp` 的 `norm` 条目，同机
releasedbg 对比：

| 基线（f1e253ec3） | 本 PR | 提速 |
|------------------:|------:|-----:|
| 1.85 ns/op | 0.31 ns/op | 约 6x |

norm 是几何计算热点（主仓约 117 处调用，`dist`、`seg_dist`、`collinear`
等收敛判据均经此），内联消除了跨编译单元调用开销。

## 验证

- `xmake test moebius_tests/point_test`：通过
- `xmake test` 全量：51 中 50 通过，唯一失败
  `lolly_test_dynamic_library/shared_lib_test` 为 main 上既有失败，与本
  改动无关
- `xmake b --yes stem`：构建通过
- `gf fmt --changed-since=main`：无格式改动
- GUI 验证：本任务不涉及用户可见 GUI 行为，未运行
