### PR TITLE
[1214] translate(rectangles) 递归改迭代：尾插直挂

### DIFF
--- a/devel/1214.md
+++ b/devel/1214.md
@@ -55,3 +55,49 @@
 - `xmake test "moebius_tests/*"` 16/16 通过
 - `xmake b stem` 链接通过（需删除过期的 glue_widget.cpp.o 重新生成）
 - `xmake r invalidate_test` 6/6 通过（rectangles 消费方）
+
+## 第三轮：translate(rectangles) 递归改迭代（尾插法直挂）
+
+### What
+
+列表版 `translate` 由「前向递归」改为「迭代 + 尾槽位直挂」：遍历源列表，
+逐个 `fresh_cell` 新建节点，经 `adopt_tail` 直接挂到结果链尾的 next 槽位。
+
+### Why
+
+- 递归深度等于列表长度，长列表有栈溢出隐患；函数调用开销也不必要。
+- 朴素的迭代改法（先逆序构建再 `reverse`）反而更慢：`reverse` 会对每个
+  节点再做一次堆分配，总分配翻倍。实测 rev+reverse 比递归还慢 ~20%。
+- 尾插直挂每个元素只分配一次：新节点 `ref_count==1`、槽位为 NULL，
+  裸赋值即所有权让渡，无需 INC/DEC（与 `list::adopt` 同一约定）。
+
+### How
+
+- `lolly/Kernel/Containers/list.hpp`：`list<T>` 新增两个静态辅助
+  `fresh_cell(item)`（新建 ref_count==1 的孤立节点）与
+  `adopt_tail(tail, cell)`（挂到尾槽位并推进 tail），沿用 rehang/adopt
+  的所有权让渡模式。
+- `moebius/Kernel/Types/rectangles.cpp`：`translate(const rectangles&, ...)`
+  改为迭代实现，正序构建结果，顺序保持不变。
+- bench 增加 rev+reverse 变体做三方同二进制对比。
+
+### bench（同二进制 A/B，nanobench，release，1024 元素，ns/op）
+
+| 变体 | ns/op |
+|---|---:|
+| 递归（优化前） | 41,673 |
+| 迭代 + reverse（未采用） | 51,047 |
+| **迭代 + 尾插直挂（本方案）** | **25,640** |
+
+加速比约 **1.63x**，同时消除 O(n) 递归深度。
+
+### 涉及文件
+
+- `lolly/Kernel/Containers/list.hpp`
+- `moebius/Kernel/Types/rectangles.cpp`
+- `moebius/bench/Kernel/Types/rectangles_bench.cpp`
+
+### 验证
+
+- `xmake b rectangles_test && xmake r rectangles_test` 10/10 通过
+- `xmake b -r rectangles_bench` 全量重编译通过（lolly 头变更波及）

--- a/lolly/Kernel/Containers/list.hpp
+++ b/lolly/Kernel/Containers/list.hpp
@@ -76,6 +76,25 @@ template <class T> class list {
   }
 
   /**
+   * @brief 新建一个仅含 item 的节点(ref_count==1, next 为 nil)。
+   * @note 配合 adopt_tail 做迭代式尾插构建，供跳过深层递归的
+   * 列表整体映射(如 rectangles 的 translate/thicken)使用。
+   */
+  static list_rep<T>* fresh_cell (T item);
+
+  /**
+   * @brief 把 fresh_cell 新建的节点挂到 tail 槽位,并把 tail 推进到新链尾。
+   * @param tail 当前链尾的 next 槽位(构建期间始终为 nil)
+   * @param cell fresh_cell 新建的节点
+   * @note 槽位为 NULL 且节点 ref_count==1,裸赋值即所有权让渡,
+   * 不经引用计数;正确使用时无需 INC/DEC。
+   */
+  static void adopt_tail (list<T>*& tail, list_rep<T>* cell) {
+    tail->rep= cell;
+    tail     = &cell->next;
+  }
+
+  /**
    * @brief Construct a new list object with a single item.
    *
    * @param item The item to be stored in the list.
@@ -171,6 +190,10 @@ TMPL inline list<T>::list (T item1, T item2, list<T> next)
     : rep (tm_new<list_rep<T>> (item1, list<T> (item2, next))) {}
 TMPL inline list<T>::list (T item1, T item2, T item3, list<T> next)
     : rep (tm_new<list_rep<T>> (item1, list<T> (item2, item3, next))) {}
+TMPL inline list_rep<T>*
+list<T>::fresh_cell (T item) {
+  return tm_new<list_rep<T>> (item, list<T> ());
+}
 TMPL inline bool
 is_atom (list<T> l) {
   return (!is_nil (l)) && is_nil (l->next);

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -253,10 +253,16 @@ operator| (rectangles l1, rectangles l2) {
  */
 rectangles
 translate (const rectangles& l, SI x, SI y) {
-  if (is_nil (l)) return l;
-  rectangle& r= l->item;
-  return rectangles (rectangle (r->x1 + x, r->y1 + y, r->x2 + x, r->y2 + y),
-                     translate (l->next, x, y));
+  // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
+  rectangles  out;
+  rectangles* tail= &out;
+  for (rectangles p= l; !is_nil (p); p= p->next) {
+    rectangle& r= p->item;
+    rectangles::adopt_tail (
+        tail, rectangles::fresh_cell (
+                  rectangle (r->x1 + x, r->y1 + y, r->x2 + x, r->y2 + y)));
+  }
+  return out;
 }
 
 rectangles

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -35,6 +35,15 @@ main () {
   bench.run ("translate rectangle", [&] {
     ankerl::nanobench::doNotOptimizeAway (translate (r, 5, 7));
   });
+  bench.run ("rev+reverse translate x1024", [&] {
+    rectangles rev;
+    for (rectangles p= large; !is_nil (p); p= p->next) {
+      rectangle& r= p->item;
+      rev= rectangles (rectangle (r->x1 + 5, r->y1 + 7, r->x2 + 5, r->y2 + 7),
+                       rev);
+    }
+    ankerl::nanobench::doNotOptimizeAway (reverse (rev));
+  });
   bench.run ("old translate rectangles x1024", [&] {
     ankerl::nanobench::doNotOptimizeAway (old_translate (large, 5, 7));
   });


### PR DESCRIPTION
## 概要

接续 #4360，把列表版 `translate` 的前向递归改为迭代 + 尾插直挂：

- **lolly `list<T>`** 新增 `fresh_cell` / `adopt_tail` 静态辅助（沿用 rehang/adopt 的所有权让渡约定：新节点 ref_count==1、槽位为 NULL，裸赋值即让渡，不经引用计数）
- **moebius `translate(const rectangles&, ...)`** 迭代正序构建结果，消除 O(n) 递归深度
- bench 增加 rev+reverse 变体做三方同二进制对比

## 为什么不是「逆序构建 + reverse」

朴素迭代改法每元素要多一次堆分配（reverse 重建整链），实测比递归慢 ~20%，故未采用。

## bench（同二进制 A/B，release，1024 元素）

| 变体 | ns/op |
|---|---:|
| 递归（优化前） | 41,673 |
| 迭代 + reverse（未采用） | 51,047 |
| 迭代 + 尾插直挂（本 PR） | **25,640** |

约 **1.63x**。

## 验证

- `xmake r rectangles_test` 10/10 通过
- `xmake b -r rectangles_bench` 全量重编译通过

任务文档：`devel/1214.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)