### PR TITLE
[1214] thicken(rectangles) 递归改迭代：尾插直挂

### DIFF
--- a/devel/1214.md
+++ b/devel/1214.md
@@ -101,3 +101,38 @@
 
 - `xmake b rectangles_test && xmake r rectangles_test` 10/10 通过
 - `xmake b -r rectangles_bench` 全量重编译通过（lolly 头变更波及）
+
+## 第四轮：thicken(rectangles) 递归改迭代（尾插法直挂）
+
+### What
+
+`thicken(const rectangles&, SI, SI)` 与 translate 同法优化：先在 bench
+中加入 thicken 基线（含保留旧递归实现的同二进制 A/B），再将递归实现改为
+迭代 + `fresh_cell`/`adopt_tail` 尾插直挂。签名同步改为 `const&` 传参。
+
+### Why
+
+与 translate 相同：递归深度等于列表长度，长列表有栈溢出隐患；迭代 + reverse
+会引入二次分配。尾插直挂每元素只分配一次。
+
+### How
+
+- `moebius/bench/Kernel/Types/rectangles_bench.cpp`：新增
+  `thicken rectangle`、`old thicken rectangles x1024`、
+  `thicken rectangles x1024` 三项基准（先加基准测得基线后再改实现）。
+- `moebius/Kernel/Types/rectangles.cpp` / `.hpp`：`thicken` 列表重载改
+  迭代尾插直挂，参数改 `const rectangles&`。
+
+### bench（同二进制 A/B，nanobench，release，1024 元素，ns/op）
+
+| 变体 | ns/op |
+|---|---:|
+| 递归（优化前） | 38,728 |
+| **迭代 + 尾插直挂（本方案）** | **24,167** |
+
+加速比约 **1.60x**，同时消除 O(n) 递归深度。
+
+### 验证
+
+- `xmake r rectangles_test` 10/10 通过
+- `gf fmt --changed-since=main` 已执行

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -266,12 +266,17 @@ translate (const rectangles& l, SI x, SI y) {
 }
 
 rectangles
-thicken (rectangles l, SI width, SI height) {
-  if (is_nil (l)) return l;
-  rectangle& r= l->item;
-  return rectangles (
-      rectangle (r->x1 - width, r->y1 - height, r->x2 + width, r->y2 + height),
-      thicken (l->next, width, height));
+thicken (const rectangles& l, SI width, SI height) {
+  // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
+  rectangles  out;
+  rectangles* tail= &out;
+  for (rectangles p= l; !is_nil (p); p= p->next) {
+    rectangle& r= p->item;
+    rectangles::adopt_tail (tail, rectangles::fresh_cell (rectangle (
+                                      r->x1 - width, r->y1 - height,
+                                      r->x2 + width, r->y2 + height)));
+  }
+  return out;
 }
 
 rectangles

--- a/moebius/Kernel/Types/rectangles.hpp
+++ b/moebius/Kernel/Types/rectangles.hpp
@@ -57,7 +57,7 @@ rectangles disjoint_union (rectangles l, rectangle r);
 rectangles operator* (rectangles l, int d);
 rectangles operator/ (rectangles l, int d);
 rectangles translate (const rectangles& l, SI x, SI y);
-rectangles thicken (rectangles l, SI width, SI height);
+rectangles thicken (const rectangles& l, SI width, SI height);
 rectangles outlines (rectangles l, SI pixel);
 rectangles correct (rectangles l);
 rectangles simplify (rectangles l);

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -24,6 +24,16 @@ old_translate (rectangles l, SI x, SI y) {
                      old_translate (l->next, x, y));
 }
 
+// 优化前的递归按值实现,用于同二进制 A/B 对比
+static rectangles
+old_thicken (rectangles l, SI width, SI height) {
+  if (is_nil (l)) return l;
+  rectangle& r= l->item;
+  return rectangles (
+      rectangle (r->x1 - width, r->y1 - height, r->x2 + width, r->y2 + height),
+      old_thicken (l->next, width, height));
+}
+
 int
 main () {
   ankerl::nanobench::Bench bench;
@@ -49,6 +59,14 @@ main () {
   });
   bench.run ("translate rectangles x1024", [&] {
     ankerl::nanobench::doNotOptimizeAway (translate (large, 5, 7));
+  });
+  bench.run ("thicken rectangle",
+             [&] { ankerl::nanobench::doNotOptimizeAway (thicken (r, 5, 7)); });
+  bench.run ("old thicken rectangles x1024", [&] {
+    ankerl::nanobench::doNotOptimizeAway (old_thicken (large, 5, 7));
+  });
+  bench.run ("thicken rectangles x1024", [&] {
+    ankerl::nanobench::doNotOptimizeAway (thicken (large, 5, 7));
   });
   return 0;
 }


### PR DESCRIPTION
## 概述

沿用 #4363 中 translate(rectangles) 的方法优化 thicken(rectangles)：递归改迭代 + `fresh_cell`/`adopt_tail` 尾插直挂，参数改 `const&`。

## 流程（先 bench 后优化）

1. bench 先行加入 thicken 基线（同二进制 A/B，保留旧递归实现），实测优化前 ~37.4µs
2. 改迭代尾插直挂实现

## bench（nanobench，release，1024 元素）

| 变体 | ns/op |
|---|---:|
| 递归（优化前） | 38,728 |
| 迭代 + 尾插直挂 | **24,167** |

加速比约 1.60x，同时消除 O(n) 递归深度。

## 验证

- `xmake r rectangles_test` 10/10 通过
- `gf fmt --changed-since=main` 已执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)