### PR TITLE
[0917] 优化 point dist 性能，补充 Doxygen 文档与单元测试

### DIFF
--- a/devel/0917.md
+++ b/devel/0917.md
@@ -1,0 +1,64 @@
+# 0917 优化 point 中 dist 的性能，并撰写其 C++ Doxygen 文档和单元测试
+
+## 任务
+
+`dist`（`moebius/Kernel/Types/point.cpp`）求点到轴（直线）的正交距离，
+是 curve/spacial 等图形模块的热点函数。本任务：
+
+1. 优化 `dist` 的性能（消除临时 `point` 堆分配）；
+2. 为 `dist` 撰写中文 Doxygen 文档；
+3. 补充 `dist` 的单元测试。
+
+## What
+
+- `dist` 由 `norm (p - proj (ax, p))` 重写为免临时 `point` 的单趟计算；
+- `point.hpp` 中 `dist` 补充 Doxygen 文档；
+- `point_test.cpp` 新增 3 个 dist 专项用例；
+- `point_bench.cpp` 补充 `dist` 基准。
+
+## Why
+
+原实现 `norm (p - proj (ax, p))` 每次调用构造两个临时 `point`
+（`proj` 的投影点与 `p - proj` 的差向量），每个临时都是一次堆分配
+加 `array` 引用计数的原子加减。dist 只关心标量结果，投影点与差向量
+本身无需物化。
+
+## How
+
+复用 1212 引入的文件内 `inline` 辅助函数（`inner_ddiff`/`norm2_diff`）：
+沿用 proj 的投影公式 `t = (a·(p-p0)) / (a·a)`，但直接在分量上累加
+残差 `p[i] - p0[i] - t*(p1[i]-p0[i])` 的平方和，全程零堆分配。
+语义与原实现保持一致：
+
+- 退化轴（|p1-p0| < 1e-6）返回 |p - p0|；
+- t 不受 [0,1] 限制，度量到整条直线的距离（区别于 seg_dist）；
+- 仅前 `min(N(p), N(p0), N(p1))` 个分量参与计算。
+
+### bench 前后对比（nanobench，release，ns/op）
+
+| 基准 | 优化前 | 优化后 | 加速比 |
+|---|---:|---:|---:|
+| dist | 34.42 | 9.18 | ~3.7x |
+
+优化前为旧基线（f1e253ec3）实测；优化后为 rebase 到含 #4362（norm
+内联）的最新 main 后实测。优化后 dist 已低于 proj（proj 仍需分配
+投影点数组）。注：#4362 的 norm 优化与本任务正交——旧 dist 中 norm
+仅占约 5% 开销，瓶颈是两次临时 point 堆分配；新实现不再调用 norm。
+
+## 涉及文件
+
+- `moebius/Kernel/Types/point.cpp`：`dist` 免临时 point 重写
+- `moebius/Kernel/Types/point.hpp`：`dist` 的 Doxygen 文档
+- `moebius/tests/Kernel/Types/point_test.cpp`：新增 3 个用例
+  （退化轴、到直线而非线段的距离、维度截断）
+- `moebius/bench/Kernel/Types/point_bench.cpp`：新增 `dist` 基准
+
+## 测试
+
+```bash
+xmake test "moebius_tests/point_test"          # 通过
+xmake test "moebius_tests/*"                   # 16/16 通过
+xmake b stem                                   # 链接通过
+# dist 相关用例：5 个 TEST_CASE、13 条断言全部通过
+# （含 0915 已有的 axis proj/dist、proj oblique axis 中的 dist 断言）
+```

--- a/moebius/Kernel/Types/point.cpp
+++ b/moebius/Kernel/Types/point.cpp
@@ -226,7 +226,17 @@ proj (const axis& ax, const point& p) {
 
 double
 dist (const axis& ax, const point& p) {
-  return norm (p - proj (ax, p));
+  // 与 proj 同公式，但直接累加残差平方和，不构造投影点与差向量
+  double aa= inner_ddiff (ax.p1, ax.p0, ax.p1, ax.p0);
+  if (sqrt (aa) < 1.0e-6) return sqrt (norm2_diff (p, ax.p0));
+  double t= inner_ddiff (ax.p1, ax.p0, p, ax.p0) / aa;
+  int    i, n= min (N (p), min (N (ax.p0), N (ax.p1)));
+  double r= 0;
+  for (i= 0; i < n; i++) {
+    double d= p[i] - ax.p0[i] - t * (ax.p1[i] - ax.p0[i]);
+    r+= d * d;
+  }
+  return sqrt (r);
 }
 
 double

--- a/moebius/Kernel/Types/point.hpp
+++ b/moebius/Kernel/Types/point.hpp
@@ -92,7 +92,23 @@ typedef struct {
  * @param p 待投影的点
  * @return  p 在轴上的正交投影点
  */
-point  proj (const axis& a, const point& p);
+point proj (const axis& a, const point& p);
+/**
+ * @brief 求点 p 到轴 a（过 p0、p1 的直线）的正交距离
+ *
+ * 距离为 |p - proj(a, p)|，即 p 与其在轴上正交投影点之间的欧氏距离。
+ * 与 proj 一样，投影参数 t 不受 [0,1] 限制，因此本函数度量的是到
+ * 整条直线的距离，而非到线段 p0p1 的距离（后者见 seg_dist）。
+ * 若 p0 与 p1 几乎重合（|p1 - p0| < 1e-6），退化为 |p - p0|。
+ * 只有前 min(N(p), N(p0), N(p1)) 个分量参与计算。
+ *
+ * @note 实现上与 proj 使用同一公式，但直接在分量上累加残差平方和，
+ *       不构造投影点与差向量等临时 point，适用于高频调用场景。
+ *
+ * @param a 轴（过 a.p0 与 a.p1 的直线）
+ * @param p 待测点
+ * @return  p 到轴 a 所在直线的正交距离
+ */
 double dist (const axis& a, const point& p);
 double seg_dist (const axis& a, const point& p);
 double seg_dist (const point& p1, const point& p2, const point& p);

--- a/moebius/bench/Kernel/Types/point_bench.cpp
+++ b/moebius/bench/Kernel/Types/point_bench.cpp
@@ -35,6 +35,7 @@ main () {
   ax.p0= mkp (0, 0);
   ax.p1= mkp (10, 0);
   bench.run ("proj", [&] { proj (ax, a); });
+  bench.run ("dist", [&] { dist (ax, a); });
   bench.run ("seg_dist", [&] { seg_dist (ax, a); });
   bench.run ("rotate_2D", [&] { rotate_2D (a, o, 0.5); });
 

--- a/moebius/tests/Kernel/Types/point_test.cpp
+++ b/moebius/tests/Kernel/Types/point_test.cpp
@@ -222,6 +222,48 @@ TEST_CASE ("test proj dim mismatch") {
   CHECK (r == mkp (3, 0));
 }
 
+TEST_CASE ("test dist degenerate axis") {
+  // 轴退化为单点（|p1-p0| < 1e-6）时，dist 退化为 |p - p0|
+  axis a;
+  a.p0= mkp (1, 1);
+  a.p1= mkp (1, 1);
+  CHECK (fabs (dist (a, mkp (4, 5)) - 5.0) < 1e-9);
+}
+
+TEST_CASE ("test dist to line not segment") {
+  // 垂足落在延长线上时，dist 仍取到直线的距离（与 seg_dist 不同）
+  axis a;
+  a.p0= mkp (0, 0);
+  a.p1= mkp (10, 0);
+  CHECK (fabs (dist (a, mkp (-3, 4)) - 4.0) < 1e-9);
+  CHECK (fabs (dist (a, mkp (13, 4)) - 4.0) < 1e-9);
+  // 轴上的点距离为零
+  CHECK (fabs (dist (a, mkp (5, 0))) < 1e-9);
+  CHECK (fabs (dist (a, mkp (-7, 0))) < 1e-9);
+}
+
+TEST_CASE ("test dist dim mismatch") {
+  // 只有前 min(N(p), N(p0), N(p1)) 个分量参与计算：p 多出的分量不影响结果
+  axis a;
+  a.p0= mkp (0, 0);
+  a.p1= mkp (10, 0);
+  point p3 (3);
+  p3[0]= 3;
+  p3[1]= 4;
+  p3[2]= 100;
+  CHECK (fabs (dist (a, p3) - 4.0) < 1e-9);
+  // p 维度小于轴时同样按截断维度计算（一维轴上的距离）
+  axis  b;
+  point b0 (1), b1 (1);
+  b0[0]= 0;
+  b1[0]= 10;
+  b.p0 = b0;
+  b.p1 = b1;
+  point p1d (1);
+  p1d[0]= 3;
+  CHECK (fabs (dist (b, p1d)) < 1e-9);
+}
+
 TEST_CASE ("test linearly_dependent") {
   CHECK (linearly_dependent (mkp (0, 0), mkp (1, 1), mkp (2, 2)));
   CHECK (!linearly_dependent (mkp (0, 0), mkp (1, 0), mkp (0, 1)));


### PR DESCRIPTION
# [0917] 优化 point dist 性能，补充 Doxygen 文档与单元测试

## What

- `moebius/Kernel/Types/point.cpp`:`dist` 由 `norm (p - proj (ax, p))` 重写为免临时 `point` 的单趟计算;
- `moebius/Kernel/Types/point.hpp`:`dist` 补充中文 Doxygen 文档;
- `moebius/tests/Kernel/Types/point_test.cpp`:新增 3 个 `dist` 专项用例;
- `moebius/bench/Kernel/Types/point_bench.cpp`:补充 `dist` 基准。

## Why

`dist` 求点到轴（直线）的正交距离，是 curve/spacial 等图形模块的热点函数。原实现每次调用构造两个临时 `point`（`proj` 的投影点与 `p - proj` 的差向量），每个临时都是一次堆分配加 `array` 引用计数的原子加减；而 dist 只关心标量结果，投影点与差向量无需物化。

注：#4362（0916）将 `norm` 内联并加二维快路径，但旧 dist 中 `norm` 仅占约 5% 开销（基线实测：dist 34.4 ns 中 proj 约 17.6 ns、差向量构造约 15 ns、norm 仅 1.85 ns），瓶颈是两次临时 point 堆分配，故 dist 的消除临时分配重写仍然必要，与 #4362 正交且互不冲突（新实现不再调用 norm）。

## How

复用 1212 引入的文件内 `inline` 辅助函数（`inner_ddiff`/`norm2_diff`），沿用 proj 的投影公式 `t = (a·(p-p0)) / (a·a)`，直接在分量上累加残差 `p[i] - p0[i] - t*(p1[i]-p0[i])` 的平方和，全程零堆分配。语义与原实现保持一致：

- 退化轴（|p1-p0| < 1e-6）返回 |p - p0|;
- t 不受 [0,1] 限制，度量到整条直线的距离（区别于 `seg_dist`）;
- 仅前 `min(N(p), N(p0), N(p1))` 个分量参与计算。

### bench 前后对比（nanobench，release，ns/op）

| 基准 | 优化前 | 优化后 | 加速比 |
|---|---:|---:|---:|
| dist | 34.42 | 9.18 | ~3.7x |

优化前为旧基线（f1e253ec3）实测；优化后为含 #4362 的最新 main 上实测，优化后 dist 已低于 proj（proj 仍需分配投影点数组）。

## 验证

- `xmake test "moebius_tests/point_test"` 通过（dist 相关 5 个用例、13 条断言全过，含 0915 已有断言）;
- `xmake test "moebius_tests/*"` 16/16 通过;
- `xmake b stem` 链接通过;
- 已 rebase 到最新 `origin/main`（含 #4361/#4362/#4363，其中 #4362 与本 PR 同改 point.cpp/point.hpp，rebase 无冲突）后复跑上述验证，全部通过。

无 GUI 行为变更，未做 GUI 验证。
