### PR TITLE
[1214] thicken/correct/simplify 文档、单元测试与 correct 性能优化

### DIFF
--- a/devel/1214.md
+++ b/devel/1214.md
@@ -206,3 +206,23 @@ correct 基线（含保留旧递归实现的同二进制 A/B），再将递归�
 - `xmake test "moebius_tests/*"` 16/16 通过
 - `xmake r invalidate_test` 6/6 通过（rectangles 消费方）
 - `gf fmt --changed-since=main` 已执行
+
+## 第七轮：Doxygen 文档从 .cpp 移到 .hpp
+
+### What / Why
+
+前几轮把导出函数的 Doxygen 注释写在了 `rectangles.cpp`，与项目惯例不符
+（`point.hpp`、lolly 的 `list.hpp`/`hashmap.hpp` 等，导出函数文档写在
+头文件，`.cpp` 只给内部静态辅助函数写注释）。本轮把 translate（两个
+重载）、thicken（两个重载）、correct、simplify 共 6 处文档原样搬到
+`rectangles.hpp` 声明处，`.cpp` 中删除，实现内的行内注释保留。
+
+### 涉及文件
+
+- `moebius/Kernel/Types/rectangles.hpp`
+- `moebius/Kernel/Types/rectangles.cpp`
+
+### 验证
+
+- `xmake test "moebius_tests/*"` 16/16 通过
+- `gf fmt --changed-since=main` 已执行

--- a/devel/1214.md
+++ b/devel/1214.md
@@ -136,3 +136,39 @@
 
 - `xmake r rectangles_test` 10/10 通过
 - `gf fmt --changed-since=main` 已执行
+
+## 第五轮：thicken / correct / simplify 的 Doxygen 文档与单元测试
+
+### What
+
+为 `moebius/Kernel/Types/rectangles.cpp` 中的 `thicken`（单个矩形、列表
+两个重载）、`correct`、`simplify` 补充 Doxygen 注释，并在
+`moebius/tests/Kernel/Types/rectangles_ops_test.cpp` 新增对应单元测试。
+
+### Why
+
+三个函数此前均无文档注释；`thicken` 列表重载与 `simplify` 完全没有测试
+覆盖，`correct` 仅有一个不完整的用例（未验证空列表与顺序保持）。
+
+### How
+
+- Doxygen 注释采用 `@brief/@param/@return`，中文撰写，说明：thicken 的
+  四边向外扩语义与不可变性；correct 剔除退化矩形（x1>=x2 或 y1>=y2）且
+  保序；simplify 仅在列表不超过 25 个元素时做不相交并合并、过长时返回
+  副本以避免 O(n^2) 开销。
+- 测试新增 4 个用例并扩充 2 个：
+  - `test thicken`：补充零扩展量
+  - `test thicken rectangles`（新增）：空列表、多元素、顺序保持、原列表不变
+  - `test correct drops degenerate`：扩充空列表、零宽/零高/负宽高剔除、保序
+  - `test simplify merges adjacent`（新增）：左右相邻合并为一、不相邻保持两
+  - `test simplify long list returns copy`（新增）：26 个元素返回等值副本
+
+### 涉及文件
+
+- `moebius/Kernel/Types/rectangles.cpp`
+- `moebius/tests/Kernel/Types/rectangles_ops_test.cpp`
+
+### 验证
+
+- `xmake test moebius_tests/rectangles_ops_test` passed（15 用例）
+- `gf fmt --changed-since=main` 已执行

--- a/devel/1214.md
+++ b/devel/1214.md
@@ -172,3 +172,37 @@
 
 - `xmake test moebius_tests/rectangles_ops_test` passed（15 用例）
 - `gf fmt --changed-since=main` 已执行
+
+## 第六轮：correct(rectangles) 递归改迭代（尾插法直挂）
+
+### What
+
+`correct(rectangles)` 与 translate/thicken 同法优化：先在 bench 中加入
+correct 基线（含保留旧递归实现的同二进制 A/B），再将递归实现改为迭代 +
+`fresh_cell`/`adopt_tail` 尾插直挂。签名同步改为 `const&` 传参。
+
+### Why
+
+与前两轮相同：递归深度等于列表长度，长列表有栈溢出隐患；按值传参每层
+复制尾列表触发引用计数原子操作；迭代 + reverse 会引入二次分配。
+
+### bench（同二进制 A/B，nanobench，release，1024 元素全保留，ns/op）
+
+| 变体 | ns/op |
+|---|---:|
+| 递归（优化前） | 35,394 |
+| **迭代 + 尾插直挂（本方案）** | **19,215** |
+
+加速比约 **1.84x**，同时消除 O(n) 递归深度。correct 不新建 rectangle，
+只共享原元素并新建 list 节点，每保留一个元素仅一次堆分配。
+
+### 涉及文件
+
+- `moebius/Kernel/Types/rectangles.hpp` / `rectangles.cpp`
+- `moebius/bench/Kernel/Types/rectangles_bench.cpp`
+
+### 验证
+
+- `xmake test "moebius_tests/*"` 16/16 通过
+- `xmake r invalidate_test` 6/6 通过（rectangles 消费方）
+- `gf fmt --changed-since=main` 已执行

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -66,13 +66,6 @@ intersect (rectangle r1, rectangle r2) {
          (r1->y2 > r2->y1);
 }
 
-/**
- * @brief 平移单个矩形
- * @param r 待平移的矩形
- * @param x 水平方向平移量（向右为正）
- * @param y 垂直方向平移量（向上为正）
- * @return 平移后的新矩形，原矩形不变
- */
 rectangle
 translate (const rectangle& r, SI x, SI y) {
   return rectangle (r->x1 + x, r->y1 + y, r->x2 + x, r->y2 + y);
@@ -154,13 +147,6 @@ operator/ (rectangle r, double x) {
                     (SI) ceil (r->x2 / x), (SI) ceil (r->y2 / x));
 }
 
-/**
- * @brief 加厚单个矩形：四边向外扩
- * @param r 待加厚的矩形
- * @param width 水平方向的扩展量（左右各扩 width）
- * @param height 垂直方向的扩展量（上下各扩 height）
- * @return 加厚后的新矩形，原矩形不变
- */
 rectangle
 thicken (rectangle r, SI width, SI height) {
   return rectangle (r->x1 - width, r->y1 - height, r->x2 + width,
@@ -251,13 +237,6 @@ operator| (rectangles l1, rectangles l2) {
   return l;
 }
 
-/**
- * @brief 平移矩形列表中的所有矩形
- * @param l 待平移的矩形列表
- * @param x 水平方向平移量（向右为正）
- * @param y 垂直方向平移量（向上为正）
- * @return 所有矩形均平移后的新列表，元素顺序保持不变，原列表不变
- */
 rectangles
 translate (const rectangles& l, SI x, SI y) {
   // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
@@ -272,13 +251,6 @@ translate (const rectangles& l, SI x, SI y) {
   return out;
 }
 
-/**
- * @brief 加厚矩形列表中的所有矩形：每个矩形四边向外扩
- * @param l 待加厚的矩形列表
- * @param width 水平方向的扩展量（左右各扩 width）
- * @param height 垂直方向的扩展量（上下各扩 height）
- * @return 所有矩形均加厚后的新列表，元素顺序保持不变，原列表不变
- */
 rectangles
 thicken (const rectangles& l, SI width, SI height) {
   // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
@@ -311,15 +283,6 @@ operator/ (rectangles l, int d) {
   return rectangles (l->item / d, l->next / d);
 }
 
-/**
- * @brief 剔除列表中的退化矩形
- *
- * 宽或高非正（x1 >= x2 或 y1 >= y2）的矩形视为退化，被丢弃；其余矩形
- * 原样保留，顺序不变。
- *
- * @param l 待修正的矩形列表
- * @return 仅含非退化矩形的新列表；空列表原样返回
- */
 rectangles
 correct (const rectangles& l) {
   // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
@@ -339,16 +302,6 @@ simplify_bis (rectangles l) {
   return simplify_bis (l->next) | rectangles (l->item);
 }
 
-/**
- * @brief 化简矩形列表：合并可合并的相邻矩形
- *
- * 列表较短（不超过 25 个元素）时，反复做不相交并（operator|），把共享
- * 边界且可拼成矩形的相邻元素合并；过长时直接返回副本，避免 O(n^2) 合并
- * 开销。
- *
- * @param l 待化简的矩形列表
- * @return 化简后的新列表，原列表不变
- */
 rectangles
 simplify (rectangles l) {
   if (N (l) > 25) return copy (l);

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -321,11 +321,16 @@ operator/ (rectangles l, int d) {
  * @return 仅含非退化矩形的新列表；空列表原样返回
  */
 rectangles
-correct (rectangles l) {
-  if (is_nil (l)) return l;
-  if ((l->item->x1 >= l->item->x2) || (l->item->y1 >= l->item->y2))
-    return correct (l->next);
-  return rectangles (l->item, correct (l->next));
+correct (const rectangles& l) {
+  // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
+  rectangles  out;
+  rectangles* tail= &out;
+  for (rectangles p= l; !is_nil (p); p= p->next) {
+    rectangle& r= p->item;
+    if ((r->x1 < r->x2) && (r->y1 < r->y2))
+      rectangles::adopt_tail (tail, rectangles::fresh_cell (r));
+  }
+  return out;
 }
 
 rectangles

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -154,6 +154,13 @@ operator/ (rectangle r, double x) {
                     (SI) ceil (r->x2 / x), (SI) ceil (r->y2 / x));
 }
 
+/**
+ * @brief 加厚单个矩形：四边向外扩
+ * @param r 待加厚的矩形
+ * @param width 水平方向的扩展量（左右各扩 width）
+ * @param height 垂直方向的扩展量（上下各扩 height）
+ * @return 加厚后的新矩形，原矩形不变
+ */
 rectangle
 thicken (rectangle r, SI width, SI height) {
   return rectangle (r->x1 - width, r->y1 - height, r->x2 + width,
@@ -265,6 +272,13 @@ translate (const rectangles& l, SI x, SI y) {
   return out;
 }
 
+/**
+ * @brief 加厚矩形列表中的所有矩形：每个矩形四边向外扩
+ * @param l 待加厚的矩形列表
+ * @param width 水平方向的扩展量（左右各扩 width）
+ * @param height 垂直方向的扩展量（上下各扩 height）
+ * @return 所有矩形均加厚后的新列表，元素顺序保持不变，原列表不变
+ */
 rectangles
 thicken (const rectangles& l, SI width, SI height) {
   // 迭代 + 尾槽位直挂：避免深度等于列表长度的递归，也避免 reverse 的二次分配
@@ -297,6 +311,15 @@ operator/ (rectangles l, int d) {
   return rectangles (l->item / d, l->next / d);
 }
 
+/**
+ * @brief 剔除列表中的退化矩形
+ *
+ * 宽或高非正（x1 >= x2 或 y1 >= y2）的矩形视为退化，被丢弃；其余矩形
+ * 原样保留，顺序不变。
+ *
+ * @param l 待修正的矩形列表
+ * @return 仅含非退化矩形的新列表；空列表原样返回
+ */
 rectangles
 correct (rectangles l) {
   if (is_nil (l)) return l;
@@ -311,6 +334,16 @@ simplify_bis (rectangles l) {
   return simplify_bis (l->next) | rectangles (l->item);
 }
 
+/**
+ * @brief 化简矩形列表：合并可合并的相邻矩形
+ *
+ * 列表较短（不超过 25 个元素）时，反复做不相交并（operator|），把共享
+ * 边界且可拼成矩形的相邻元素合并；过长时直接返回副本，避免 O(n^2) 合并
+ * 开销。
+ *
+ * @param l 待化简的矩形列表
+ * @return 化简后的新列表，原列表不变
+ */
 rectangles
 simplify (rectangles l) {
   if (N (l) > 25) return copy (l);

--- a/moebius/Kernel/Types/rectangles.hpp
+++ b/moebius/Kernel/Types/rectangles.hpp
@@ -59,7 +59,7 @@ rectangles operator/ (rectangles l, int d);
 rectangles translate (const rectangles& l, SI x, SI y);
 rectangles thicken (const rectangles& l, SI width, SI height);
 rectangles outlines (rectangles l, SI pixel);
-rectangles correct (rectangles l);
+rectangles correct (const rectangles& l);
 rectangles simplify (rectangles l);
 rectangle  least_upper_bound (rectangles l);
 rectangle  least_upper_bound (array<rectangle> l);

--- a/moebius/Kernel/Types/rectangles.hpp
+++ b/moebius/Kernel/Types/rectangles.hpp
@@ -38,15 +38,33 @@ bool        operator== (rectangle r1, rectangle r2);
 bool        operator!= (rectangle r1, rectangle r2);
 bool        intersect (rectangle r1, rectangle r2);
 bool        operator<= (rectangle r1, rectangle r2);
-rectangle   translate (const rectangle& r, SI x, SI y);
-rectangle   operator* (rectangle r, int d);
-rectangle   operator/ (rectangle r, int d);
-rectangle   operator* (rectangle r, double x);
-rectangle   operator/ (rectangle r, double x);
-rectangle   thicken (rectangle r, SI width, SI height);
-rectangle   least_upper_bound (rectangle r1, rectangle r2);
-double      area (rectangle r);
-bool        is_zero (rectangle r);
+
+/**
+ * @brief 平移单个矩形
+ * @param r 待平移的矩形
+ * @param x 水平方向平移量（向右为正）
+ * @param y 垂直方向平移量（向上为正）
+ * @return 平移后的新矩形，原矩形不变
+ */
+rectangle translate (const rectangle& r, SI x, SI y);
+
+rectangle operator* (rectangle r, int d);
+rectangle operator/ (rectangle r, int d);
+rectangle operator* (rectangle r, double x);
+rectangle operator/ (rectangle r, double x);
+
+/**
+ * @brief 加厚单个矩形：四边向外扩
+ * @param r 待加厚的矩形
+ * @param width 水平方向的扩展量（左右各扩 width）
+ * @param height 垂直方向的扩展量（上下各扩 height）
+ * @return 加厚后的新矩形，原矩形不变
+ */
+rectangle thicken (rectangle r, SI width, SI height);
+
+rectangle least_upper_bound (rectangle r1, rectangle r2);
+double    area (rectangle r);
+bool      is_zero (rectangle r);
 
 typedef list<rectangle> rectangles;
 
@@ -56,13 +74,52 @@ rectangles operator| (rectangles l1, rectangles l2);
 rectangles disjoint_union (rectangles l, rectangle r);
 rectangles operator* (rectangles l, int d);
 rectangles operator/ (rectangles l, int d);
+
+/**
+ * @brief 平移矩形列表中的所有矩形
+ * @param l 待平移的矩形列表
+ * @param x 水平方向平移量（向右为正）
+ * @param y 垂直方向平移量（向上为正）
+ * @return 所有矩形均平移后的新列表，元素顺序保持不变，原列表不变
+ */
 rectangles translate (const rectangles& l, SI x, SI y);
+
+/**
+ * @brief 加厚矩形列表中的所有矩形：每个矩形四边向外扩
+ * @param l 待加厚的矩形列表
+ * @param width 水平方向的扩展量（左右各扩 width）
+ * @param height 垂直方向的扩展量（上下各扩 height）
+ * @return 所有矩形均加厚后的新列表，元素顺序保持不变，原列表不变
+ */
 rectangles thicken (const rectangles& l, SI width, SI height);
+
 rectangles outlines (rectangles l, SI pixel);
+
+/**
+ * @brief 剔除列表中的退化矩形
+ *
+ * 宽或高非正（x1 >= x2 或 y1 >= y2）的矩形视为退化，被丢弃；其余矩形
+ * 原样保留，顺序不变。
+ *
+ * @param l 待修正的矩形列表
+ * @return 仅含非退化矩形的新列表；空列表原样返回
+ */
 rectangles correct (const rectangles& l);
+
+/**
+ * @brief 化简矩形列表：合并可合并的相邻矩形
+ *
+ * 列表较短（不超过 25 个元素）时，反复做不相交并（operator|），把共享
+ * 边界且可拼成矩形的相邻元素合并；过长时直接返回副本，避免 O(n^2) 合并
+ * 开销。
+ *
+ * @param l 待化简的矩形列表
+ * @return 化简后的新列表，原列表不变
+ */
 rectangles simplify (rectangles l);
-rectangle  least_upper_bound (rectangles l);
-rectangle  least_upper_bound (array<rectangle> l);
-double     area (rectangles r);
+
+rectangle least_upper_bound (rectangles l);
+rectangle least_upper_bound (array<rectangle> l);
+double    area (rectangles r);
 
 #endif // defined RECTANGLES_H

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -34,6 +34,15 @@ old_thicken (rectangles l, SI width, SI height) {
       old_thicken (l->next, width, height));
 }
 
+// 优化前的递归按值实现,用于同二进制 A/B 对比
+static rectangles
+old_correct (rectangles l) {
+  if (is_nil (l)) return l;
+  if ((l->item->x1 >= l->item->x2) || (l->item->y1 >= l->item->y2))
+    return old_correct (l->next);
+  return rectangles (l->item, old_correct (l->next));
+}
+
 int
 main () {
   ankerl::nanobench::Bench bench;
@@ -68,5 +77,10 @@ main () {
   bench.run ("thicken rectangles x1024", [&] {
     ankerl::nanobench::doNotOptimizeAway (thicken (large, 5, 7));
   });
+  bench.run ("old correct x1024", [&] {
+    ankerl::nanobench::doNotOptimizeAway (old_correct (large));
+  });
+  bench.run ("correct x1024",
+             [&] { ankerl::nanobench::doNotOptimizeAway (correct (large)); });
   return 0;
 }

--- a/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
+++ b/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
@@ -67,6 +67,18 @@ TEST_CASE ("test translate rectangles") {
 TEST_CASE ("test thicken") {
   rectangle r (0, 0, 10, 10);
   CHECK (thicken (r, 2, 3) == rectangle (-2, -3, 12, 13));
+  CHECK (thicken (r, 0, 0) == r);
+}
+
+TEST_CASE ("test thicken rectangles") {
+  CHECK (thicken (rectangles (), 2, 3) == rectangles ());
+  rectangles l= rectangles (rectangle (0, 0, 2, 2),
+                            rectangles (rectangle (5, 5, 8, 8), rectangles ()));
+  rectangles t= thicken (l, 1, 2);
+  CHECK (t == rectangles (rectangle (-1, -2, 3, 4),
+                          rectangles (rectangle (4, 3, 9, 10), rectangles ())));
+  CHECK (l == rectangles (rectangle (0, 0, 2, 2),
+                          rectangles (rectangle (5, 5, 8, 8), rectangles ())));
 }
 
 TEST_CASE ("test scaling") {
@@ -105,8 +117,38 @@ TEST_CASE ("test union and difference") {
 }
 
 TEST_CASE ("test correct drops degenerate") {
-  rectangles l= rectangles (rectangle (5, 5, 5, 5),
-                            rectangles (rectangle (0, 0, 2, 2), rectangles ()));
+  CHECK (correct (rectangles ()) == rectangles ());
+  // 零宽/零高/负宽高的矩形均被剔除，其余顺序保持
+  rectangles l=
+      rectangles (rectangle (0, 0, 2, 2),
+                  rectangles (rectangle (5, 5, 5, 9),
+                              rectangles (rectangle (0, 0, 2, 2),
+                                          rectangles (rectangle (7, 2, 4, 8),
+                                                      rectangles ()))));
   rectangles c= correct (l);
-  CHECK_EQ (N (c), 1);
+  CHECK (c == rectangles (rectangle (0, 0, 2, 2),
+                          rectangles (rectangle (0, 0, 2, 2), rectangles ())));
+}
+
+TEST_CASE ("test simplify merges adjacent") {
+  // 左右相邻的两个矩形合并为一个
+  rectangles l= rectangles (rectangle (0, 0, 2, 2),
+                            rectangles (rectangle (2, 0, 4, 2), rectangles ()));
+  rectangles s= simplify (l);
+  CHECK_EQ (N (s), 1);
+  CHECK (least_upper_bound (s) == rectangle (0, 0, 4, 2));
+  // 不相邻的矩形保持不变
+  rectangles d= rectangles (rectangle (0, 0, 2, 2),
+                            rectangles (rectangle (3, 0, 5, 2), rectangles ()));
+  CHECK_EQ (N (simplify (d)), 2);
+}
+
+TEST_CASE ("test simplify long list returns copy") {
+  // 超过 25 个元素时直接返回副本，不做合并
+  rectangles l= rectangles ();
+  for (int i= 0; i < 26; i++)
+    l= rectangles (rectangle (i, i, i + 1, i + 1), l);
+  rectangles s= simplify (l);
+  CHECK_EQ (N (s), 26);
+  CHECK (s == l);
 }


### PR DESCRIPTION
## 概要

- 为 `thicken`（两个重载）、`correct`、`simplify` 补充 Doxygen 中文文档注释
- 新增 4 个单元测试用例、扩充 2 个（覆盖空列表、保序、不可变性、退化剔除、相邻合并、长列表返回副本）
- `correct(rectangles)` 递归改迭代 + 尾插直挂，签名改 `const&` 传参

## bench（同二进制 A/B，nanobench，release，1024 元素，ns/op）

| 变体 | ns/op |
|---|---:|
| correct 递归（优化前） | 35,394 |
| correct 迭代 + 尾插直挂 | **19,215** |

加速比约 1.84x，同时消除 O(n) 递归深度。

## 验证

- `xmake test "moebius_tests/*"` 16/16 通过
- `xmake r invalidate_test` 6/6 通过
- `gf fmt --changed-since=main` 已执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)