### PR TITLE
[1216] 优化 lolly tokenize 性能

### DIFF
--- a/devel/1216.md
+++ b/devel/1216.md
@@ -1,5 +1,52 @@
 # 1216 优化 lolly replace 性能
 
+## 第二轮（analyze2 分支）：同法优化 tokenize
+
+### What
+
+用与 replace 相同的手法优化 `tokenize (string s, string sep)`：
+
+1. 扫描前取出 `sep[0]` 与 `N(sep)`，仅当 `s[i] == sep[0]` 才进入
+   `test()` 完整比较；
+2. 循环上界由 `i < N(s)` 收紧为 `i + k <= n`；
+3. 顺带修复空分隔符死循环：原实现 `test(s,i,"")` 恒真且 `i+=0`
+   不前进，现按「整串唯一 token」处理。
+
+### Why
+
+tokenize 有 73 处 C++ 调用点（TeX 导入导出、排版核心、字体系统、
+URL 解析）+ 35 处 scheme 调用，每字节一次 `test()` 调用是主要开销。
+
+### How（实测数据）
+
+同进程交错对比（releasedbg，88KB 文本）：
+
+| 负载 | 旧 ns/op | 新 ns/op | 提速 |
+|------|----------|----------|------|
+| 每行多命中 | ~894,000 | ~638,000 | 1.4× |
+| 无命中 | ~218,000 | ~61,000 | 3.6× |
+| 首字符干扰 | ~321,000 | ~78,000 | 4.1× |
+
+扫描主导的负载（无命中/首字符干扰）收益最大；命中多的负载因
+token 拷贝占比上升，收益相对小。
+
+### 涉及文件
+
+- `lolly/Kernel/Types/analyze.cpp`：tokenize 性能优化
+- `lolly/Kernel/Types/analyze.hpp`：tokenize Doxygen 文档
+- `lolly/tests/Kernel/Types/analyze_test.cpp`：新增边界用例（分隔符
+  长于原串、尾部残片、首字符干扰、空分隔符）与大输入冒烟用例
+- `lolly/bench/Kernel/Types/analyze_bench.cpp`：新增 tokenize
+  microbench（多命中 / 无命中 / 首字符干扰三种负载）
+
+### 验证
+
+- `xmake test lolly_tests/analyze_test`：全部通过
+- `xmake b analyze_bench && xmake r analyze_bench`：跑通并用于对比
+
+----
+
+
 ## What
 
 优化 `lolly/Kernel/Types/analyze.cpp` 中的 `replace (string s, string what, string by)`：

--- a/lolly/Kernel/Types/analyze.cpp
+++ b/lolly/Kernel/Types/analyze.cpp
@@ -961,16 +961,23 @@ find_non_alpha (string s, int pos, bool forward) {
 
 array<string>
 tokenize (string s, string sep) {
-  int           start= 0;
+  int start= 0, n= N (s), k= N (sep);
+  // 空分隔符不匹配任何位置，整串作为唯一 token 返回
+  if (k == 0) {
+    array<string> a;
+    a << s;
+    return a;
+  }
+  char          c= sep[0];
   array<string> a;
-  for (int i= 0; i < N (s);)
-    if (test (s, i, sep)) {
+  for (int i= 0; i + k <= n;)
+    if (s[i] == c && test (s, i, sep)) {
       a << s (start, i);
-      i+= N (sep);
+      i+= k;
       start= i;
     }
     else i++;
-  a << s (start, N (s));
+  a << s (start, n);
   return a;
 }
 

--- a/lolly/Kernel/Types/analyze.hpp
+++ b/lolly/Kernel/Types/analyze.hpp
@@ -523,11 +523,15 @@ int fuzzy_match_score (string pattern, string target);
 int find_non_alpha (string s, int pos, bool forward);
 
 /**
- * Splits a string into an array of strings based on a separator string.
+ * @brief 将字符串 s 按分隔符 sep 拆分为子串数组
  *
- * @param s The string to split.
- * @param sep The separator string.
- * @return An array of strings split based on the separator.
+ * @param s   原字符串
+ * @param sep 分隔符（非空）
+ * @return    拆分后的子串数组；sep 为空串时返回仅含 s 自身的数组
+ *
+ * @note 扫描时先用首字符快速筛选，仅当 s[i] 与 sep[0] 相同才进入
+ *       test 做完整比较；模式尾部不足以容纳 sep 的区段直接跳过。
+ *       空分隔符原实现会死循环，现按整串唯一 token 处理。
  */
 array<string> tokenize (string s, string sep);
 

--- a/lolly/bench/Kernel/Types/analyze_bench.cpp
+++ b/lolly/bench/Kernel/Types/analyze_bench.cpp
@@ -43,6 +43,20 @@ bench_string_replace (string base_name, string s, string what, string by) {
       });
 }
 
+/**
+ * @brief 对 tokenize 做微基准：覆盖多命中、无命中、首字符干扰三种典型负载
+ */
+void
+bench_string_tokenize (string base_name, string s, string sep) {
+  ankerl::nanobench::Bench ()
+      .title ("tokenize")
+      .relative (true)
+      .run (c_string (base_name), [&] {
+        auto r= tokenize (s, sep);
+        ankerl::nanobench::doNotOptimizeAway (r);
+      });
+}
+
 int
 main () {
   lolly::init_tbox ();
@@ -69,6 +83,13 @@ main () {
   bench_string_replace ("replace no hit", text, "QUICK", "BRISK");
   // 首字符干扰：模式首字符大量出现但整体不匹配，考验快速筛选
   bench_string_replace ("replace first-char noise", text, "totally", "missed");
+
+  // 多命中：每行拆出多个 token
+  bench_string_tokenize ("tokenize hit each line", text, " ");
+  // 无命中：纯扫描开销
+  bench_string_tokenize ("tokenize no hit", text, "::;");
+  // 首字符干扰：分隔符首字符大量出现但整体不匹配，考验快速筛选
+  bench_string_tokenize ("tokenize first-char noise", text, "the!");
 
   return 0;
 }

--- a/lolly/tests/Kernel/Types/analyze_test.cpp
+++ b/lolly/tests/Kernel/Types/analyze_test.cpp
@@ -203,6 +203,24 @@ TEST_CASE ("tokenize") {
   CHECK_EQ (tokenize ("hello world", " "), array<string> ("hello", "world"));
   CHECK_EQ (tokenize ("zotero://select/library/items/2AIFJFS7", "://"),
             array<string> ("zotero", "select/library/items/2AIFJFS7"));
+  // 分隔符长于原串：整串作为唯一 token
+  array<string> single;
+  single << "ab";
+  CHECK_EQ (tokenize ("ab", "abc"), single);
+  // 尾部不足以容纳分隔符的片段原样保留
+  CHECK_EQ (tokenize ("a::b:", "::"), array<string> ("a", "b:"));
+  // 首字符干扰：首字符相同但整体不匹配，不拆分
+  array<string> whole;
+  whole << "a:b";
+  CHECK_EQ (tokenize ("a:b", "::"), whole);
+  // 空分隔符：整串作为唯一 token（原实现此处会死循环）
+  CHECK_EQ (tokenize ("a:b", ""), whole);
+  // 大输入冒烟
+  string big;
+  for (int i= 0; i < 2000; i++)
+    big << "key=value;";
+  CHECK_EQ (N (tokenize (big, ";")), 2001);
+  string_eq (tokenize (big, ";")[1999], "key=value");
 }
 
 TEST_CASE ("recompose") {


### PR DESCRIPTION
接续 #4366（replace 优化），用相同手法优化 `tokenize (string s, string sep)`：

## 改动

1. 首字符快速筛选：仅 `s[i] == sep[0]` 才进入 `test()` 完整比较
2. `N(sep)` 提到循环外，循环上界收紧为 `i + k <= n`
3. 修复空分隔符死循环（原实现 `test` 对空模式恒真且 `i+=0` 不前进，现按整串唯一 token 处理）

## 实测（同进程交错，releasedbg，88KB 文本）

| 负载 | 旧 → 新 ns/op | 提速 |
|------|--------------|------|
| 每行多命中 | 894k → 638k | 1.4× |
| 无命中 | 218k → 61k | 3.6× |
| 首字符干扰 | 321k → 78k | 4.1× |

tokenize 有 73 处 C++ 调用点（TeX 导入导出、排版核心、字体系统、URL 解析）+ 35 处 scheme 调用。

## 验证

- `xmake test lolly_tests/analyze_test`：全部通过（含新增边界用例与大输入冒烟）
- `xmake r analyze_bench`：tokenize microbench（多命中 / 无命中 / 首字符干扰）
- `gf fmt --changed-since=main`：已格式化

🤖 Generated with [Claude Code](https://claude.com/claude-code)