### PR TITLE
[1214] rectangles operator- 性能优化：逐矩形独立求差

### DIFF
--- a/devel/1214.md
+++ b/devel/1214.md
@@ -273,3 +273,17 @@ correct 基线（含保留旧递归实现的同二进制 A/B），再将递归�
 - `xmake test "moebius_tests/*"` 16/16 通过
 - `xmake r invalidate_test` 6/6 通过（rectangles 消费方）
 - `gf fmt --changed-since=main` 已执行
+
+### 简化复审（/simplify）后的收尾
+
+- `append_difference` 首次切割不再先建种子节点：直接
+  `complement (r, q->item, cur)` 切入空表，省一次即弃分配。
+- `list<T>::append (tail, item)` 融合 `fresh_cell`+`adopt_tail`
+  （`lolly/Kernel/Containers/list.hpp`），rectangles.cpp 全部 5 处
+  调用点改用，配对约定无法被绕过。
+- bench 的 `old_complement` 与本地 min/max 宏删除：生产代码的
+  `complement` 是外部链接，bench 直接原型声明复用。
+- 复审保留意见：尾挂时复用 cur 节点省一次分配的做法需要在引用计数
+  链上偷节点，风险大于收益，不做。
+- 收尾后复验：`xmake test "moebius_tests/*"` 16/16、
+  `xmake r invalidate_test` 6/6 通过。

--- a/devel/1214.md
+++ b/devel/1214.md
@@ -226,3 +226,50 @@ correct 基线（含保留旧递归实现的同二进制 A/B），再将递归�
 
 - `xmake test "moebius_tests/*"` 16/16 通过
 - `gf fmt --changed-since=main` 已执行
+
+## 第八轮：operator- 整表重建改逐矩形独立求差
+
+### What
+
+`operator- (rectangles, rectangles)` 由「对 l2 每个元素把累积整表重建一遍」
+改为「对 l1 每个矩形独立求差、结果尾插直挂」，并在 bench 中加入旧实现的
+同二进制 A/B 基线（稀疏相交、完全不相交两种场景）。同时为 operator-
+在 hpp 补充 Doxygen，新增 4 个差集单元测试；删除不再被使用的内部函数
+`complement (rectangles, rectangle, rectangles&)`。
+
+### Why
+
+旧实现对 l2 的每个元素都要把整个累积列表逐项 `complement` 到新表：每次
+整表重建对每个幸存元素重新分配节点，n1×n2 组合下分配次数是 O(n1·n2) 次
+全表克隆。重绘热路径 `outlines()`（thicken(...) - thicken(...)）与
+`edit_interface.cpp` 的 `selp - selm` 每帧都经过该函数。
+
+### How
+
+- 新增内部辅助 `append_difference (rectangle r, rectangles l2, tail)`：
+  先扫 l2 判交，与全部被减矩形都不相交时原矩形一次 `fresh_cell` 直挂
+  （零差分开销）；被切过则维护碎片表逐个 `complement`，最终尾挂。
+- `operator-` 主体改为迭代 + `adopt_tail` 尾插直挂，l1 元素顺序保持。
+  旧实现每遍头插导致结果顺序被扰乱，新实现按 l1 顺序产出（差集结果
+  顺序无语义，消费方只做 correct/simplify/绘制）。
+
+### bench（同二进制 A/B，nanobench，release，1024 元素，ns/op）
+
+| 场景 | 旧实现 | 新实现 | 加速比 |
+|---|---:|---:|---:|
+| 稀疏相交（l2 16 个，各切 ~11 个元素） | 677,663 | 124,081 | 5.46x |
+| 完全不相交（l2 16 个） | 585,479 | 89,524 | 6.54x |
+
+### 涉及文件
+
+- `moebius/Kernel/Types/rectangles.hpp` / `rectangles.cpp`
+- `moebius/bench/Kernel/Types/rectangles_bench.cpp`
+- `moebius/tests/Kernel/Types/rectangles_ops_test.cpp`
+
+### 验证
+
+- `xmake test moebius_tests/rectangles_ops_test` passed（21 用例，
+  新增 full coverage / disjoint 保序 / 切片分裂 / 多减数 4 例）
+- `xmake test "moebius_tests/*"` 16/16 通过
+- `xmake r invalidate_test` 6/6 通过（rectangles 消费方）
+- `gf fmt --changed-since=main` 已执行

--- a/lolly/Kernel/Containers/list.hpp
+++ b/lolly/Kernel/Containers/list.hpp
@@ -95,6 +95,15 @@ template <class T> class list {
   }
 
   /**
+   * @brief 新建仅含 item 的节点并尾挂到 tail(等价 fresh_cell + adopt_tail)。
+   * @param tail 当前链尾的 next 槽位(构建期间始终为 nil)
+   * @note 融合封装,使「adopt_tail 只接受 fresh_cell 节点」的约定无法被绕过。
+   */
+  static void append (list<T>*& tail, T item) {
+    adopt_tail (tail, fresh_cell (item));
+  }
+
+  /**
    * @brief Construct a new list object with a single item.
    *
    * @param item The item to be stored in the list.

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -106,12 +106,6 @@ complement (rectangle r1, rectangle r2, rectangles& l) {
 }
 
 void
-complement (rectangles l1, rectangle r2, rectangles& l) {
-  for (; !is_nil (l1); l1= l1->next)
-    complement (l1->item, r2, l);
-}
-
-void
 intersection (rectangle r1, rectangle r2, rectangles& l) {
   if (!intersect (r1, r2)) return;
   rectangle (max (r1->x1, r2->x1), max (r1->y1, r2->y1), min (r1->x2, r2->x2),
@@ -157,15 +151,38 @@ thicken (rectangle r, SI width, SI height) {
  * Exported routines for rectangles
  ******************************************************************************/
 
+// 单个矩形对 l2 求差,结果尾挂到 tail:
+// 与 l2 全不交时原矩形一次直挂,零差分开销
+static void
+append_difference (rectangle r, rectangles l2, rectangles*& tail) {
+  rectangles cur;
+  bool       cut= false;
+  for (rectangles q= l2; !is_nil (q); q= q->next) {
+    if (!intersect (r, q->item)) continue;
+    if (!cut) {
+      cur= rectangles (r, rectangles ());
+      cut= true;
+    }
+    rectangles next;
+    for (rectangles p= cur; !is_nil (p); p= p->next)
+      complement (p->item, q->item, next);
+    cur= next;
+  }
+  if (!cut) rectangles::adopt_tail (tail, rectangles::fresh_cell (r));
+  else
+    for (rectangles p= cur; !is_nil (p); p= p->next)
+      rectangles::adopt_tail (tail, rectangles::fresh_cell (p->item));
+}
+
 rectangles
 operator- (rectangles l1, rectangles l2) {
-  rectangles a= l1;
-  for (; !is_nil (l2); l2= l2->next) {
-    rectangles b;
-    complement (a, l2->item, b);
-    a= b;
-  }
-  return a;
+  // 逐矩形独立求差:未与任何被减矩形相交的元素一次直挂,
+  // 避免旧实现对 l2 每个元素整表重建的 O(n1*n2) 次全表克隆
+  rectangles  out;
+  rectangles* tail= &out;
+  for (; !is_nil (l1); l1= l1->next)
+    append_difference (l1->item, l2, tail);
+  return out;
 }
 
 rectangles

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -160,18 +160,19 @@ append_difference (rectangle r, rectangles l2, rectangles*& tail) {
   for (rectangles q= l2; !is_nil (q); q= q->next) {
     if (!intersect (r, q->item)) continue;
     if (!cut) {
-      cur= rectangles (r, rectangles ());
+      complement (r, q->item, cur);
       cut= true;
+      continue;
     }
     rectangles next;
     for (rectangles p= cur; !is_nil (p); p= p->next)
       complement (p->item, q->item, next);
     cur= next;
   }
-  if (!cut) rectangles::adopt_tail (tail, rectangles::fresh_cell (r));
+  if (!cut) rectangles::append (tail, r);
   else
     for (rectangles p= cur; !is_nil (p); p= p->next)
-      rectangles::adopt_tail (tail, rectangles::fresh_cell (p->item));
+      rectangles::append (tail, p->item);
 }
 
 rectangles
@@ -261,9 +262,8 @@ translate (const rectangles& l, SI x, SI y) {
   rectangles* tail= &out;
   for (rectangles p= l; !is_nil (p); p= p->next) {
     rectangle& r= p->item;
-    rectangles::adopt_tail (
-        tail, rectangles::fresh_cell (
-                  rectangle (r->x1 + x, r->y1 + y, r->x2 + x, r->y2 + y)));
+    rectangles::append (tail,
+                        rectangle (r->x1 + x, r->y1 + y, r->x2 + x, r->y2 + y));
   }
   return out;
 }
@@ -275,9 +275,8 @@ thicken (const rectangles& l, SI width, SI height) {
   rectangles* tail= &out;
   for (rectangles p= l; !is_nil (p); p= p->next) {
     rectangle& r= p->item;
-    rectangles::adopt_tail (tail, rectangles::fresh_cell (rectangle (
-                                      r->x1 - width, r->y1 - height,
-                                      r->x2 + width, r->y2 + height)));
+    rectangles::append (tail, rectangle (r->x1 - width, r->y1 - height,
+                                         r->x2 + width, r->y2 + height));
   }
   return out;
 }
@@ -307,8 +306,7 @@ correct (const rectangles& l) {
   rectangles* tail= &out;
   for (rectangles p= l; !is_nil (p); p= p->next) {
     rectangle& r= p->item;
-    if ((r->x1 < r->x2) && (r->y1 < r->y2))
-      rectangles::adopt_tail (tail, rectangles::fresh_cell (r));
+    if ((r->x1 < r->x2) && (r->y1 < r->y2)) rectangles::append (tail, r);
   }
   return out;
 }

--- a/moebius/Kernel/Types/rectangles.hpp
+++ b/moebius/Kernel/Types/rectangles.hpp
@@ -68,6 +68,15 @@ bool      is_zero (rectangle r);
 
 typedef list<rectangle> rectangles;
 
+/**
+ * @brief 矩形列表差集：从 l1 中挖去所有与 l2 相交的部分
+ * @param l1 被减列表
+ * @param l2 减数列表
+ * @return 差集结果的新列表，元素按 l1 顺序逐个产出，原列表不变
+ * @note 与 l2 全不交的 l1 元素原样保留；完全被覆盖的元素被丢弃；
+ *   部分相交的元素被切成至多数块碎片。结果可能含相邻可合并的碎片，
+ *   需要时由调用方再用 simplify 收敛。
+ */
 rectangles operator- (rectangles l1, rectangles l2);
 rectangles operator& (rectangles l1, rectangles l2);
 rectangles operator| (rectangles l1, rectangles l2);

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -43,22 +43,8 @@ old_correct (rectangles l) {
   return rectangles (l->item, old_correct (l->next));
 }
 
-// 优化前的按值实现,用于同二进制 A/B 对比
-#define min(x, y) ((x) <= (y) ? (x) : (y))
-#define max(x, y) ((x) <= (y) ? (y) : (x))
-static void
-old_complement (rectangle r1, rectangle r2, rectangles& l) {
-  if (!intersect (r1, r2)) {
-    r1 >> l;
-    return;
-  }
-  if (r1->x1 < r2->x1) rectangle (r1->x1, r1->y1, r2->x1, r1->y2) >> l;
-  if (r1->x2 > r2->x2) rectangle (r2->x2, r1->y1, r1->x2, r1->y2) >> l;
-  if (r1->y1 < r2->y1)
-    rectangle (max (r1->x1, r2->x1), r1->y1, min (r1->x2, r2->x2), r2->y1) >> l;
-  if (r1->y2 > r2->y2)
-    rectangle (max (r1->x1, r2->x1), r2->y2, min (r1->x2, r2->x2), r1->y2) >> l;
-}
+// 生产代码中的单矩形差分辅助(外部链接,rectangles.cpp 未导出到 hpp)
+void complement (rectangle r1, rectangle r2, rectangles& l);
 
 // 优化前的按值实现,用于同二进制 A/B 对比
 static rectangles
@@ -67,7 +53,7 @@ old_subtract (rectangles l1, rectangles l2) {
   for (; !is_nil (l2); l2= l2->next) {
     rectangles b;
     for (rectangles p= a; !is_nil (p); p= p->next)
-      old_complement (p->item, l2->item, b);
+      complement (p->item, l2->item, b);
     a= b;
   }
   return a;

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -43,6 +43,36 @@ old_correct (rectangles l) {
   return rectangles (l->item, old_correct (l->next));
 }
 
+// 优化前的按值实现,用于同二进制 A/B 对比
+#define min(x, y) ((x) <= (y) ? (x) : (y))
+#define max(x, y) ((x) <= (y) ? (y) : (x))
+static void
+old_complement (rectangle r1, rectangle r2, rectangles& l) {
+  if (!intersect (r1, r2)) {
+    r1 >> l;
+    return;
+  }
+  if (r1->x1 < r2->x1) rectangle (r1->x1, r1->y1, r2->x1, r1->y2) >> l;
+  if (r1->x2 > r2->x2) rectangle (r2->x2, r1->y1, r1->x2, r1->y2) >> l;
+  if (r1->y1 < r2->y1)
+    rectangle (max (r1->x1, r2->x1), r1->y1, min (r1->x2, r2->x2), r2->y1) >> l;
+  if (r1->y2 > r2->y2)
+    rectangle (max (r1->x1, r2->x1), r2->y2, min (r1->x2, r2->x2), r1->y2) >> l;
+}
+
+// 优化前的按值实现,用于同二进制 A/B 对比
+static rectangles
+old_subtract (rectangles l1, rectangles l2) {
+  rectangles a= l1;
+  for (; !is_nil (l2); l2= l2->next) {
+    rectangles b;
+    for (rectangles p= a; !is_nil (p); p= p->next)
+      old_complement (p->item, l2->item, b);
+    a= b;
+  }
+  return a;
+}
+
 int
 main () {
   ankerl::nanobench::Bench bench;
@@ -50,6 +80,16 @@ main () {
 
   rectangle  r (0, 0, 10, 10);
   rectangles large= mk_rects (1024);
+
+  // l2 取 large 的稀疏子集,每个被减矩形切到约 11 个相邻元素
+  rectangles sparse;
+  for (int i= 1024 - 64; i >= 0; i-= 64)
+    sparse= rectangles (rectangle (i, i, i + 10, i + 10), sparse);
+  // 与 large 完全不相交的减数列表(全走直挂快路径)
+  rectangles faraway;
+  for (int i= 0; i < 16; i++)
+    faraway= rectangles (rectangle (100000 + i, 100000, 100010 + i, 100010),
+                         faraway);
 
   bench.run ("translate rectangle", [&] {
     ankerl::nanobench::doNotOptimizeAway (translate (r, 5, 7));
@@ -82,5 +122,15 @@ main () {
   });
   bench.run ("correct x1024",
              [&] { ankerl::nanobench::doNotOptimizeAway (correct (large)); });
+  bench.run ("old subtract x1024 sparse16", [&] {
+    ankerl::nanobench::doNotOptimizeAway (old_subtract (large, sparse));
+  });
+  bench.run ("subtract x1024 sparse16",
+             [&] { ankerl::nanobench::doNotOptimizeAway (large - sparse); });
+  bench.run ("old subtract x1024 disjoint16", [&] {
+    ankerl::nanobench::doNotOptimizeAway (old_subtract (large, faraway));
+  });
+  bench.run ("subtract x1024 disjoint16",
+             [&] { ankerl::nanobench::doNotOptimizeAway (large - faraway); });
   return 0;
 }

--- a/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
+++ b/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
@@ -116,6 +116,43 @@ TEST_CASE ("test union and difference") {
   CHECK_EQ (area (d), 8.0);
 }
 
+TEST_CASE ("test difference full coverage") {
+  // 被完全覆盖的矩形被整块丢弃,结果为空
+  rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
+  rectangles l2= rectangles (rectangle (-1, -1, 11, 11), rectangles ());
+  rectangles d = l1 - l2;
+  CHECK (is_nil (d));
+}
+
+TEST_CASE ("test difference disjoint keeps order") {
+  // 与被减列表全不交的元素原样保留且保序
+  rectangles l1=
+      rectangles (rectangle (0, 0, 2, 2),
+                  rectangles (rectangle (5, 5, 8, 8), rectangles ()));
+  rectangles l2= rectangles (rectangle (20, 20, 30, 30), rectangles ());
+  CHECK ((l1 - l2) == l1);
+}
+
+TEST_CASE ("test difference splits pieces") {
+  // 中间被挖掉一条,切成上下两块,面积守恒
+  rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
+  rectangles l2= rectangles (rectangle (0, 4, 10, 6), rectangles ());
+  rectangles d = l1 - l2;
+  CHECK_EQ (N (d), 2);
+  CHECK_EQ (area (d), 80.0);
+  CHECK (least_upper_bound (d) == rectangle (0, 0, 10, 10));
+}
+
+TEST_CASE ("test difference multiple subtrahends") {
+  // 依次被两个减数切割:先挖右侧,再从剩余碎片中挖一块
+  rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
+  rectangles l2=
+      rectangles (rectangle (6, 0, 12, 10),
+                  rectangles (rectangle (0, 0, 2, 4), rectangles ()));
+  rectangles d= l1 - l2;
+  CHECK_EQ (area (d), 60.0 - 8.0);
+}
+
 TEST_CASE ("test correct drops degenerate") {
   CHECK (correct (rectangles ()) == rectangles ());
   // 零宽/零高/负宽高的矩形均被剔除，其余顺序保持


### PR DESCRIPTION
## 概要

- [x] 优化 \`operator- (rectangles, rectangles)\`：由「对 l2 每个元素整表重建」改为「逐矩形独立求差 + 尾插直挂」，不交元素零差分开销直挂
- [x] bench 增加旧实现同二进制 A/B（稀疏相交 / 完全不相交两场景）
- [x] 新增 4 个差集单元测试；hpp 补充 Doxygen；删除不再使用的内部 \`complement\` 列表重载

## 性能（nanobench，release，1024 元素，ns/op）

| 场景 | 旧 | 新 | 加速比 |
|---|---:|---:|---:|
| 稀疏相交（l2×16） | 677,663 | 124,081 | 5.46x |
| 完全不相交（l2×16） | 585,479 | 89,524 | 6.54x |

\`operator-\` 位于重绘热路径（\`outlines()\` 内部的 \`thicken(...) - thicken(...)\`）。

## 验证

- \`xmake test "moebius_tests/*"\` 16/16（21 用例）通过
- \`xmake r invalidate_test\` 6/6 通过（rectangles 消费方）
- \`gf fmt --changed-since=main\` 已执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)