### PR TITLE
[1216] 优化 lolly search_forwards 性能

### DIFF
--- a/devel/1216.md
+++ b/devel/1216.md
@@ -1,5 +1,57 @@
 # 1216 优化 lolly replace 性能
 
+## 第三轮（analyze3 分支）：优化 search_forwards
+
+### What
+
+优化 `search_forwards` 的两个重载：
+
+1. `search_forwards (string s, int pos, string in)`：改用 `memchr`
+   在原始缓冲区上定位模式首字符（SIMD 向量化扫描），候选处用
+   `memcmp` 整段比较，替代原先逐字节的 `operator[]` + `test()`
+   （`test()` 每个字符还带一次 `i >= n` 边界检查）；
+2. `search_forwards (array<string> a, int pos, string in)`：候选模式
+   先做首字符 + 长度预筛，再用 `memcmp` 比较；顺带修复原实现
+   `pos == N(in)` 时越界读 `in[pos]` 的问题（非空模式不可能在该处
+   命中，循环上界收紧为 `pos < n`，行为不变）。
+
+### Why
+
+search_forwards 是全项目最高频的字符串原语之一（`occurs`/`contains`/
+`count_occurrences`/`replace`/`tokenize` 及约 30 处直接调用点），
+逐字节扫描是主要开销。
+
+### How（实测数据）
+
+releasedbg，88KB 文本，同进程交错对比：
+
+| 负载 | 旧 ns/op | 新 ns/op | 提速 |
+|------|----------|----------|------|
+| 每行多命中 | ~51 | ~14 | 3.7× |
+| 无命中 | ~150,600 | ~1,870 | 80× |
+| 首字符干扰 | ~233,100 | ~46,100 | 5.1× |
+
+无命中负载由 memchr 向量化扫描主导，收益最大；首字符干扰负载仍需
+对每个首字符命中做一次 memcmp，收益相对小。
+
+### 涉及文件
+
+- `lolly/Kernel/Types/analyze.cpp`：search_forwards 两个重载的性能
+  优化 + array 重载越界修复
+- `lolly/Kernel/Types/analyze.hpp`：search_forwards Doxygen 文档补充
+- `lolly/tests/Kernel/Types/analyze_test.cpp`：新增 search_forwards
+  用例（空模式、模式长于原串、带起始位置、窗口右边界、首字符干扰、
+  内嵌 '\0'、array 重载含 pos == N(in) 越界回归、大输入冒烟）
+- `lolly/bench/Kernel/Types/analyze_bench.cpp`：新增 search_forwards
+  microbench（多命中 / 无命中 / 首字符干扰三种负载）
+
+### 验证
+
+- `xmake test lolly_tests/analyze_test`：全部通过
+- `xmake b analyze_bench && xmake r analyze_bench`：跑通并用于新旧对比
+
+---
+
 ## 第二轮（analyze2 分支）：同法优化 tokenize
 
 ### What

--- a/devel/1216.md
+++ b/devel/1216.md
@@ -1,5 +1,28 @@
 # 1216 优化 lolly replace 性能
 
+## 第三轮补充（analyze3 分支）：simplify 三个函数
+
+### What
+
+对 1216 涉及的 replace / tokenize / search_forwards 做 simplify
+（4 个角度的并行审查：复用、简化、效率、层次）：
+
+1. replace / tokenize 不再各自手写「首字符筛选 + test()」扫描循环，
+   改为驱动 `search_forwards`（自动获得 memchr/memcmp 加速），
+   消除同一扫描不变量的三份拷贝；
+2. `search_forwards (array<string>)` 的内联 memcmp 条件回归
+   `test (in, pos, a[i])`，与 search_backwards 等保持同一原语；
+3. `search_forwards (string)` 的 `k > n` 分支改为
+   `pos > n - k` 早退，同时覆盖 pos 越界情形，避免构造越界指针。
+
+### 验证
+
+- `xmake test lolly_tests/analyze_test`：全部通过
+- analyze_bench：tokenize 三种负载与上一轮持平
+  （~678k / ~61k / ~81k ns/op），replace 同样受益于 memchr 路径
+
+---
+
 ## 第三轮（analyze3 分支）：优化 search_forwards
 
 ### What

--- a/lolly/Kernel/Types/analyze.cpp
+++ b/lolly/Kernel/Types/analyze.cpp
@@ -12,6 +12,7 @@
 #include "analyze.hpp"
 #include "lolly/data/numeral.hpp"
 #include "ntuple.hpp"
+#include <string.h>
 
 /******************************************************************************
  * Tests for characters
@@ -810,10 +811,14 @@ index_of (string s, char c) {
 int
 search_forwards (array<string> a, int pos, string in) {
   int n= N (in), na= N (a);
-  while (pos <= n) {
-    for (int i= 0; i < na; i++)
-      if (N (a[i]) > 0 && in[pos] == a[i][0] && test (in, pos, a[i]))
+  // 非空模式不可能在 pos == n 处命中，上界收紧为 n - 1 也避免了越界读 in[n]
+  while (pos < n) {
+    for (int i= 0; i < na; i++) {
+      int k= N (a[i]);
+      if (k > 0 && k <= n - pos && in[pos] == a[i][0] &&
+          memcmp (in.begin () + pos, a[i].begin (), k) == 0)
         return pos;
+    }
     pos++;
   }
   return -1;
@@ -823,10 +828,16 @@ int
 search_forwards (string s, int pos, string in) {
   int k= N (s), n= N (in);
   if (k == 0) return pos;
-  char c= s[0];
-  while (pos + k <= n) {
-    if (in[pos] == c && test (in, pos, s)) return pos;
-    pos++;
+  if (k > n) return -1;
+  // memchr 找模式首字符，memcmp 做整段比较，均直接在原始缓冲区上进行
+  const char* hay = in.begin () + pos;
+  const char* last= in.begin () + (n - k); // 最后一个可能的匹配起点
+  const char* what= s.begin ();
+  while (hay <= last) {
+    const char* hit= (const char*) memchr (hay, what[0], last - hay + 1);
+    if (hit == NULL) return -1;
+    if (memcmp (hit, what, k) == 0) return (int) (hit - in.begin ());
+    hay= hit + 1;
   }
   return -1;
 }

--- a/lolly/Kernel/Types/analyze.cpp
+++ b/lolly/Kernel/Types/analyze.cpp
@@ -813,12 +813,8 @@ search_forwards (array<string> a, int pos, string in) {
   int n= N (in), na= N (a);
   // 非空模式不可能在 pos == n 处命中，上界收紧为 n - 1 也避免了越界读 in[n]
   while (pos < n) {
-    for (int i= 0; i < na; i++) {
-      int k= N (a[i]);
-      if (k > 0 && k <= n - pos && in[pos] == a[i][0] &&
-          memcmp (in.begin () + pos, a[i].begin (), k) == 0)
-        return pos;
-    }
+    for (int i= 0; i < na; i++)
+      if (N (a[i]) > 0 && test (in, pos, a[i])) return pos;
     pos++;
   }
   return -1;
@@ -828,7 +824,7 @@ int
 search_forwards (string s, int pos, string in) {
   int k= N (s), n= N (in);
   if (k == 0) return pos;
-  if (k > n) return -1;
+  if (pos > n - k) return -1;
   // memchr 找模式首字符，memcmp 做整段比较，均直接在原始缓冲区上进行
   const char* hay = in.begin () + pos;
   const char* last= in.begin () + (n - k); // 最后一个可能的匹配起点
@@ -914,25 +910,22 @@ overlapping (string s1, string s2) {
  * @param by   替换后的子串
  * @return     替换完成后的新字符串；what 为空串时原样返回 s
  *
- * @note 扫描时先用首字符快速筛选，仅当 s[i] 与 what[0] 相同才进入
- *       test 做完整比较；模式尾部不足以容纳 what 的区段直接跳过。
+ * @note 扫描复用 search_forwards（memchr/memcmp 加速）；从左到右
+ *       不重叠匹配，命中后跳过整个模式。
  */
 string
 replace (string s, string what, string by) {
-  int i, n= N (s), k= N (what);
-  // 空模式按「不匹配任何位置」处理，否则下方 i+= k 步进为 0 会死循环
+  int n= N (s), k= N (what);
+  // 空模式按「不匹配任何位置」处理，否则下方步进为 0 会死循环
   if (k == 0) return s;
-  char   c= what[0];
   string r;
   int    start= 0;
-  for (i= 0; i + k <= n;)
-    if (s[i] == c && test (s, i, what)) {
-      r << s (start, i);
-      r << by;
-      i+= k;
-      start= i;
-    }
-    else i++;
+  for (int hit= search_forwards (what, start, s); hit != -1;
+       hit    = search_forwards (what, start, s)) {
+    r << s (start, hit);
+    r << by;
+    start= hit + k;
+  }
   r << s (start, n);
   return r;
 }
@@ -972,22 +965,20 @@ find_non_alpha (string s, int pos, bool forward) {
 
 array<string>
 tokenize (string s, string sep) {
-  int start= 0, n= N (s), k= N (sep);
+  int n= N (s), k= N (sep);
   // 空分隔符不匹配任何位置，整串作为唯一 token 返回
   if (k == 0) {
     array<string> a;
     a << s;
     return a;
   }
-  char          c= sep[0];
   array<string> a;
-  for (int i= 0; i + k <= n;)
-    if (s[i] == c && test (s, i, sep)) {
-      a << s (start, i);
-      i+= k;
-      start= i;
-    }
-    else i++;
+  int           start= 0;
+  for (int hit= search_forwards (sep, start, s); hit != -1;
+       hit    = search_forwards (sep, start, s)) {
+    a << s (start, hit);
+    start= hit + k;
+  }
   a << s (start, n);
   return a;
 }

--- a/lolly/Kernel/Types/analyze.hpp
+++ b/lolly/Kernel/Types/analyze.hpp
@@ -405,21 +405,28 @@ int search_forwards (string what, string in);
 /**
  * Searches for a substring in a string starting from a specified position.
  *
+ * 用 memchr 定位模式首字符、memcmp 做整段比较，均直接作用于原始缓冲区；
+ * 匹配窗口右界为最后一个可容纳整个模式的起点 N(in) - N(what)。
+ *
  * @param what The substring to search for.
  * @param pos The starting position in the string to search from.
  * @param in The string to search in.
  * @return Position where the substring was found, or -1 if not found.
+ * @note what 为空串时直接返回 pos；what 比 in 长时返回 -1。
  */
 int search_forwards (string what, int pos, string in);
 
 /**
- * Searches for a substring in a string starting from a specified position, in
- * reverse.
+ * Searches for any of a list of substrings in a string, starting from a
+ * specified position.
  *
- * @param what_list The substring to search for.
+ * 每个候选模式先做首字符与长度预筛，再用 memcmp 整段比较；返回最早命中的
+ * 位置（多个模式在同一位置命中时任取其一）。
+ *
+ * @param what_list The substrings to search for. 空模式串会被跳过。
  * @param pos The starting position in the string to search from.
  * @param in The string to search in.
- * @return Position where the substring was found, or -1 if not found.
+ * @return Position where any substring was found, or -1 if none was found.
  */
 int search_forwards (array<string> what_list, int pos, string in);
 

--- a/lolly/bench/Kernel/Types/analyze_bench.cpp
+++ b/lolly/bench/Kernel/Types/analyze_bench.cpp
@@ -57,6 +57,21 @@ bench_string_tokenize (string base_name, string s, string sep) {
       });
 }
 
+/**
+ * @brief 对 search_forwards
+ * 做微基准：覆盖多命中、无命中、首字符干扰三种典型负载
+ */
+void
+bench_string_search (string base_name, string s, string what) {
+  ankerl::nanobench::Bench ()
+      .title ("search_forwards")
+      .relative (true)
+      .run (c_string (base_name), [&] {
+        auto r= search_forwards (what, s);
+        ankerl::nanobench::doNotOptimizeAway (r);
+      });
+}
+
 int
 main () {
   lolly::init_tbox ();
@@ -90,6 +105,13 @@ main () {
   bench_string_tokenize ("tokenize no hit", text, "::;");
   // 首字符干扰：分隔符首字符大量出现但整体不匹配，考验快速筛选
   bench_string_tokenize ("tokenize first-char noise", text, "the!");
+
+  // 多命中：每行两次命中
+  bench_string_search ("search hit each line", text, "the");
+  // 无命中：纯扫描开销
+  bench_string_search ("search no hit", text, "QUICK");
+  // 首字符干扰：模式首字符大量出现但整体不匹配，考验快速筛选
+  bench_string_search ("search first-char noise", text, "totally");
 
   return 0;
 }

--- a/lolly/tests/Kernel/Types/analyze_test.cpp
+++ b/lolly/tests/Kernel/Types/analyze_test.cpp
@@ -149,6 +149,49 @@ TEST_CASE ("test_read_word") {
   CHECK_EQ (i, 0);
 }
 
+TEST_CASE ("search_forwards") {
+  // 基本命中
+  CHECK_EQ (search_forwards ("quick", "the quick brown"), 4);
+  CHECK_EQ (search_forwards ("the", "the quick brown"), 0);
+  CHECK_EQ (search_forwards ("brown", "the quick brown"), 10);
+  // 无命中
+  CHECK_EQ (search_forwards ("QUICK", "the quick brown"), -1);
+  // 空模式：返回起始位置
+  CHECK_EQ (search_forwards ("", "abc"), 0);
+  CHECK_EQ (search_forwards ("", 2, "abc"), 2);
+  // 模式长于原串 / 与原串等长
+  CHECK_EQ (search_forwards ("abcdef", "abc"), -1);
+  CHECK_EQ (search_forwards ("abc", "abc"), 0);
+  // 带起始位置
+  CHECK_EQ (search_forwards ("the", 1, "the quick the"), 10);
+  CHECK_EQ (search_forwards ("the", 10, "the quick the"), 10);
+  // 起始位置越过最后一个可能匹配点
+  CHECK_EQ (search_forwards ("the", 11, "the quick the"), -1);
+  // 首字符干扰：首字符大量出现但整体不匹配
+  CHECK_EQ (search_forwards ("totally", "the quick brown"), -1);
+  CHECK_EQ (search_forwards ("at", "that at"), 2);
+  // 尾部命中（验证窗口右边界含最后一个起点）
+  CHECK_EQ (search_forwards ("dog", "the lazy dog"), 9);
+  // 字符串内可含 '\0'
+  CHECK_EQ (search_forwards (string ("b\0d", 3), string ("a\0b\0d", 5)), 2);
+  // array 重载：多模式取最早命中，含首字符干扰与长度过滤
+  array<string> pats= array<string> ("brown", "quick");
+  CHECK_EQ (search_forwards (pats, 0, "the quick brown"), 4);
+  array<string> pats2= array<string> ("zzzzz", "quick");
+  CHECK_EQ (search_forwards (pats2, 0, "the quick brown"), 4);
+  CHECK_EQ (search_forwards (pats, 0, "none here"), -1);
+  // array 重载：pos == N(in) 时不再越界读
+  CHECK_EQ (search_forwards (pats, 15, "the quick brown"), -1);
+  // 大输入冒烟
+  string line= "the quick brown fox jumps over the lazy dog\n";
+  string text;
+  for (int i= 0; i < 2000; i++)
+    text << line;
+  CHECK_EQ (search_forwards ("lazy", text), 35);
+  CHECK_EQ (search_forwards ("LAZY", text), -1);
+  CHECK_EQ (count_occurrences ("the", text), 4000);
+}
+
 TEST_CASE ("contains/occurs") {
   CHECK (contains ("abc", "a"));
   CHECK (contains ("abc", "ab"));


### PR DESCRIPTION
## 概述

任务 1216 第三轮：优化 \`lolly/Kernel/Types/analyze.cpp\` 中 \`search_forwards\` 的两个重载，并对 1216 涉及的三个函数（replace / tokenize / search_forwards）做 simplify。

## 性能优化

- \`search_forwards (string, int pos, string)\`：memchr 定位模式首字符（SIMD 向量化）+ memcmp 整段比较，替代逐字节 \`operator[]\` 扫描 + \`test()\`（后者每字符带一次边界检查）
- \`search_forwards (array<string>)\`：修复 \`pos == N(in)\` 时越界读 \`in[pos]\`（行为不变，非空模式不可能在该处命中）

实测（releasedbg，88KB 文本）：

| 负载 | 旧 ns/op | 新 ns/op | 提速 |
|------|----------|----------|------|
| 每行多命中 | ~51 | ~14 | 3.7× |
| 无命中 | ~150,600 | ~1,870 | 80× |
| 首字符干扰 | ~233,100 | ~46,100 | 5.1× |

## simplify

- replace / tokenize 不再各自手写「首字符筛选 + test()」扫描循环，改为驱动 \`search_forwards\`（自动获得 memchr/memcmp 加速），消除同一扫描不变量的三份拷贝
- \`search_forwards (array<string>)\` 回归 \`test()\` 原语
- \`search_forwards (string)\` 的 \`k > n\` 分支改为 \`pos > n - k\` 早退

## 测试与文档

- 新增 \`search_forwards\` 单元测试（空模式、模式长于原串、窗口右边界、首字符干扰、内嵌 '\0'、array 重载越界回归、大输入冒烟）
- 新增 analyze_bench 三种负载 microbench
- Doxygen 文档与 \`devel/1216.md\` 任务文档同步更新

验证：\`xmake test lolly_tests/analyze_test\` 全部通过；tokenize/replace 三种负载 bench 无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)