### PR TITLE
[1214] rectangles operator- 性能优化：operator- 整表克隆改原地改链

### DIFF
--- a/devel/1214.md
+++ b/devel/1214.md
@@ -287,3 +287,55 @@ correct 基线（含保留旧递归实现的同二进制 A/B），再将递归�
   链上偷节点，风险大于收益，不做。
 - 收尾后复验：`xmake test "moebius_tests/*"` 16/16、
   `xmake r invalidate_test` 6/6 通过。
+
+## 第九轮：operator| 整表克隆改原地改链
+
+### What
+
+`operator| (rectangles, rectangles)` 由「对 l2 每个元素调用
+`disjoint_union` 克隆整个前缀」改为「对 `l1 - l2` 的结果链表原地
+摘链/改写」。bench 加入旧实现（经导出的 `disjoint_union` 复现）的
+同二进制 A/B 基线（纯尾插累积、含相邻合并两种场景）；hpp 补充
+Doxygen；新增 5 个并集单元测试。
+
+### Why
+
+`operator-` 的输出全部经由 `rectangles::append` 新建节点（无共享），
+`operator|` 可安全原地改链。旧实现对 l2 的每个元素都把累积列表中
+不合并的前缀逐节点克隆一遍（disjoint_union_inplace 的 scratch_rev +
+reverse_append），n2 个元素即 n2 遍前缀克隆。业务热路径：Qt/ImGui
+widget 的 `invalid_regions = invalid_regions | rectangles (r)`
+（每次交互逐矩形累积失效区域，无规模上界），以及 `simplify_bis`
+逐元素 `|`（每帧 repaint 的 `outlines()`/`stored_rects` 合并）。
+
+### How
+
+- 对 `l1 - l2` 的结果用 `rectangles* link` 逐槽位扫描：与 r 相邻的
+  节点被吸收进 `r = least_upper_bound (...)` 并摘链，继续向后扫；
+  与旧实现不同，合并后的 r 可继续吸收表中更后方再遇的相邻碎片
+  （旧实现在遇到首个不相邻元素后即停止），合并更彻底，结果仍为
+  合法 disjoint union。扫描结束后 `rectangles::append (link, r)` 尾挂。
+- 全不相邻时仅一次 append，零中间克隆；`disjoint_union` /
+  `disjoint_union_inplace` 保持导出不变，其它调用方不受影响。
+
+### bench（同二进制 A/B，nanobench，release，1024 元素，ns/op）
+
+| 场景 | 旧实现 | 新实现 | 加速比 |
+|---|---:|---:|---:|
+| 纯尾插累积（l2 16 个全不相邻） | 1,091,242 | 176,891 | 6.17x |
+| 含相邻合并（l2 16 个各与 1 块相邻） | 751,742 | 211,635 | 3.55x |
+
+### 涉及文件
+
+- `moebius/Kernel/Types/rectangles.hpp` / `rectangles.cpp`
+- `moebius/bench/Kernel/Types/rectangles_bench.cpp`
+- `moebius/tests/Kernel/Types/rectangles_ops_test.cpp`
+
+### 验证
+
+- `xmake test moebius_tests/rectangles_ops_test` passed（26 用例，
+  新增原地合并 / 尾插保序 / 重叠吸收 / 链式多块吸收 / 面积守恒 5 例）
+- `xmake test "moebius_tests/*"` 16/16 通过
+- `xmake r invalidate_test` 6/6、`xmake r rectangles_test` 10/10 通过
+  （rectangles 消费方）
+- `gf fmt --changed-since=main` 已执行

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -247,10 +247,22 @@ disjoint_union (rectangles l, rectangle r) {
 
 rectangles
 operator| (rectangles l1, rectangles l2) {
-  rectangles l (l1 - l2);
-  while (!is_nil (l2)) {
-    l = disjoint_union (l, l2->item);
-    l2= l2->next;
+  // operator- 的结果全是新鲜节点,可原地改链:
+  // 每个 l2 元素只做摘链/改写,不再克隆整个前缀
+  rectangles l= l1 - l2;
+  for (; !is_nil (l2); l2= l2->next) {
+    rectangle   r   = l2->item;
+    rectangles* link= &l;
+    while (!is_nil (*link)) {
+      if (!adjacent ((*link)->item, r)) {
+        link= &(*link)->next;
+        continue;
+      }
+      // 相邻则并入 r 并把被吸收的节点摘链,继续向后扫
+      r    = least_upper_bound ((*link)->item, r);
+      *link= (*link)->next;
+    }
+    rectangles::append (link, r);
   }
   return l;
 }

--- a/moebius/Kernel/Types/rectangles.hpp
+++ b/moebius/Kernel/Types/rectangles.hpp
@@ -79,6 +79,16 @@ typedef list<rectangle> rectangles;
  */
 rectangles operator- (rectangles l1, rectangles l2);
 rectangles operator& (rectangles l1, rectangles l2);
+
+/**
+ * @brief 矩形列表并集：先求 l1 - l2 去掉重叠，再把 l2 各矩形逐个并入
+ * @param l1 第一个列表
+ * @param l2 第二个列表
+ * @return 并集结果的新列表，原列表不变
+ * @note 并入时与累积列表中相邻的矩形会被合并（disjoint union 语义），
+ *   与全部元素都不相邻的矩形追加到尾部。典型用于失效/重绘区域的
+ *   逐矩形累积合并。
+ */
 rectangles operator| (rectangles l1, rectangles l2);
 rectangles disjoint_union (rectangles l, rectangle r);
 rectangles operator* (rectangles l, int d);

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -59,6 +59,17 @@ old_subtract (rectangles l1, rectangles l2) {
   return a;
 }
 
+// 优化前的实现:每个 l2 元素经 disjoint_union 克隆整个前缀,用于同二进制 A/B 对比
+static rectangles
+old_union (rectangles l1, rectangles l2) {
+  rectangles l (l1 - l2);
+  while (!is_nil (l2)) {
+    l = disjoint_union (l, l2->item);
+    l2= l2->next;
+  }
+  return l;
+}
+
 int
 main () {
   ankerl::nanobench::Bench bench;
@@ -118,5 +129,20 @@ main () {
   });
   bench.run ("subtract x1024 disjoint16",
              [&] { ankerl::nanobench::doNotOptimizeAway (large - faraway); });
+  // 并集场景:模拟失效区域逐矩形累积,16 块均不与 large 相邻(全走尾插)
+  bench.run ("old union x1024 append16", [&] {
+    ankerl::nanobench::doNotOptimizeAway (old_union (large, faraway));
+  });
+  bench.run ("union x1024 append16",
+             [&] { ankerl::nanobench::doNotOptimizeAway (large | faraway); });
+  // 并集场景:与 large 部分元素相邻,触发合并路径
+  rectangles touchy;
+  for (int i= 1024 - 64; i >= 0; i-= 64)
+    touchy= rectangles (rectangle (i + 10, i, i + 12, i + 10), touchy);
+  bench.run ("old union x1024 adjacent16", [&] {
+    ankerl::nanobench::doNotOptimizeAway (old_union (large, touchy));
+  });
+  bench.run ("union x1024 adjacent16",
+             [&] { ankerl::nanobench::doNotOptimizeAway (large | touchy); });
   return 0;
 }

--- a/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
+++ b/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
@@ -189,3 +189,54 @@ TEST_CASE ("test simplify long list returns copy") {
   CHECK_EQ (N (s), 26);
   CHECK (s == l);
 }
+
+TEST_CASE ("test union merges adjacent in place") {
+  // l2 元素与累积列表相邻时被吸收合并,不产生重复
+  rectangles l1= rectangles (rectangle (0, 0, 2, 2), rectangles ());
+  rectangles l2= rectangles (rectangle (2, 0, 4, 2), rectangles ());
+  rectangles u = l1 | l2;
+  CHECK_EQ (N (u), 1);
+  CHECK (u->item == rectangle (0, 0, 4, 2));
+}
+
+TEST_CASE ("test union appends disjoint") {
+  // 与累积列表全不相邻的元素追加到尾部,原有元素原样保留
+  rectangles l1=
+      rectangles (rectangle (0, 0, 2, 2),
+                  rectangles (rectangle (5, 5, 8, 8), rectangles ()));
+  rectangles l2= rectangles (rectangle (20, 20, 30, 30), rectangles ());
+  rectangles u = l1 | l2;
+  CHECK_EQ (N (u), 3);
+  CHECK (u->item == rectangle (0, 0, 2, 2));
+  CHECK ((u->next)->item == rectangle (5, 5, 8, 8));
+  CHECK ((u->next->next)->item == rectangle (20, 20, 30, 30));
+}
+
+TEST_CASE ("test union absorbs overlapping l2") {
+  // l2 与 l1 重叠:先做 l1 - l2 去重叠,再并入 l2,面积等于并集面积
+  rectangles l1= rectangles (rectangle (0, 0, 4, 4), rectangles ());
+  rectangles l2= rectangles (rectangle (2, 0, 6, 4), rectangles ());
+  rectangles u = l1 | l2;
+  CHECK_EQ (N (u), 1);
+  CHECK (u->item == rectangle (0, 0, 6, 4));
+}
+
+TEST_CASE ("test union chain merges multiple") {
+  // 链式相邻:l2 一次并入时把累积列表中多块相邻碎片逐个吸收
+  rectangles l1= rectangles (
+      rectangle (0, 0, 2, 2),
+      rectangles (rectangle (2, 0, 4, 2),
+                  rectangles (rectangle (10, 0, 12, 2), rectangles ())));
+  rectangles l2= rectangles (rectangle (4, 0, 10, 2), rectangles ());
+  rectangles u = l1 | l2;
+  CHECK_EQ (N (u), 2);
+  CHECK (u->item == rectangle (0, 0, 2, 2));
+  CHECK ((u->next)->item == rectangle (2, 0, 12, 2));
+}
+
+TEST_CASE ("test union area conservation") {
+  // 不相交并集面积守恒
+  rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
+  rectangles l2= rectangles (rectangle (0, 20, 10, 30), rectangles ());
+  CHECK_EQ (area (l1 | l2), 200.0);
+}


### PR DESCRIPTION
## 概述

rectangles 系列性能优化第九轮（devel/1214.md）：`operator- (rectangles, rectangles)` 同族的最后一个整表克隆热点。

## 改动

- `operator|` 由「对 l2 每个元素调用 `disjoint_union` 克隆整个前缀」改为「对 `l1 - l2` 的新鲜节点链表原地摘链/改写」：相邻节点吸收进 `least_upper_bound` 后直接摘链，扫描结束一次尾挂
- 合并后的矩形会继续吸收表中更后方的相邻碎片（旧实现遇首个不相邻元素即停），合并更彻底，结果仍为合法 disjoint union
- hpp 补充 Doxygen；bench 加入旧实现同二进制 A/B 基线；新增 5 个并集单元测试

## 动机

业务热路径：Qt/ImGui widget 的 `invalid_regions = invalid_regions | rectangles(r)`（每次交互逐矩形累积失效区域，无规模上界），以及 `simplify_bis` 逐元素 `|`（每帧 repaint 的 `outlines()` / `stored_rects` 合并）。

## bench（release，1024 元素，ns/op）

| 场景 | 旧实现 | 新实现 | 加速比 |
|---|---:|---:|---:|
| 纯尾插累积（l2 16 个全不相邻） | 1,091,242 | 176,891 | 6.17x |
| 含相邻合并（l2 16 个各与 1 块相邻） | 751,742 | 211,635 | 3.55x |

## 验证

- `xmake test moebius_tests/rectangles_ops_test` 26/26 通过（新增 5 例）
- `xmake test "moebius_tests/*"` 16/16 通过
- `xmake r invalidate_test` 6/6、`xmake r rectangles_test` 10/10 通过
- `gf fmt --changed-since=main` 已执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)