### PR TITLE
[0918] 绘图模式线段中点绿色吸附点

### DIFF
--- a/TeXmacs/progs/graphics/graphics-ghost.scm
+++ b/TeXmacs/progs/graphics/graphics-ghost.scm
@@ -16,6 +16,8 @@
 
 (define ghost-lines '())
 
+(define midpoints '())
+
 (tm-define (graphics-get-all-previous-points)
   (:state graphics-state)
   (if (and sticky-point (integer? current-point-no) (> current-point-no 0))
@@ -33,6 +35,23 @@
         ) ;if
       ) ;let
     ) ;let*
+    (tm->tree '(tuple))
+  ) ;if
+) ;tm-define
+
+;; 折线（line/cline）绘制中的已落固定点，供 C++ 逐边取中点并按
+;; 鼠标位置过滤。绘制中的对象尚未进入文档树，graphical_select 选不到；
+;; spline 等曲线的控制点连线不是线段，不在此列
+(tm-define (graphics-get-previous-line-points)
+  (:state graphics-state)
+  (if (and sticky-point (integer? current-point-no) (> current-point-no 1))
+    (with obj
+      (stree-radical (car (sketch-get1)))
+      (if (and (pair? obj) (in? (car obj) '(line cline)))
+        (graphics-get-all-previous-points)
+        (tm->tree '(tuple))
+      ) ;if
+    ) ;with
     (tm->tree '(tuple))
   ) ;if
 ) ;tm-define
@@ -87,4 +106,57 @@
     ) ;let
     '()
   ) ;if
+) ;tm-define
+
+;; 把中点列表 (("x1" "y1") ...) 转成绿色圆点装饰，坐标为字符串
+
+(define (midpoint-decorations pts)
+  (map (lambda (p)
+         `(with ,"color"
+            ,"green"
+            ,"point-style"
+            ,"disk"
+            (point ,(car p) ,(cadr p)))
+       ) ;lambda
+    pts
+  ) ;map
+) ;define
+
+(tm-define (graphics-clear-midpoints)
+  (:state graphics-state)
+  (set! midpoints '())
+) ;tm-define
+
+;; 参数 points: (tuple (x y) ...)；C++ 每次鼠标移动都会调用，
+;; 这里做变更检测，仅当中点集合变化时才刷新装饰
+(tm-define (graphics-set-midpoints points)
+  (:state graphics-state)
+  (let* ((l (if (tree? points) (tree->stree points) points))
+         (new (if (and (pair? l) (== (car l) 'tuple))
+                (map (lambda (e) (list (cadr e) (caddr e))) (cdr l))
+                '()
+              ) ;if
+         ) ;new
+        ) ;
+    (if (not (equal? new midpoints))
+      (begin
+        (set! midpoints new)
+        (graphics-decorations-update)
+      ) ;begin
+    ) ;if
+  ) ;let*
+) ;tm-define
+
+(tm-define (graphics-get-decorations-midpoint) (midpoint-decorations midpoints))
+
+(tm-define (graphics-midpoints-active?)
+  (:state graphics-state)
+  (nnull? midpoints)
+) ;tm-define
+
+;; 非绘制态（未落第一个点）悬停线段时，装饰层会被整体重建；此时仅
+;; 保留中点绿点，避免绿点预览被清空
+(tm-define (graphics-render-midpoints)
+  (:state graphics-state)
+  (graphical-object! `(concat ,@(graphics-get-decorations-midpoint)))
 ) ;tm-define

--- a/TeXmacs/progs/graphics/graphics-object.scm
+++ b/TeXmacs/progs/graphics/graphics-object.scm
@@ -332,15 +332,8 @@
                 (va (get-graphical-prop 'basic "text-at-valign"))
                 (mag (get-graphical-prop 'basic "magnify"))
                ) ;
-           (create-graphical-embedding-box o
-             ha
-             va
-             "center"
-             "center"
-             "1par"
-             "min"
-             "0fn"
-             mag
+           (create-graphical-embedding-box o ha va "center" "center" "1par"
+             "min" "0fn" mag
            ) ;create-graphical-embedding-box
          ) ;let*
         ) ;
@@ -525,15 +518,8 @@
                             (va (get-graphical-prop path0 "text-at-valign"))
                             (mag (get-graphical-prop path0 "magnify"))
                            ) ;
-                       (create-graphical-embedding-box o
-                         ha
-                         va
-                         "center"
-                         "center"
-                         "1par"
-                         "min"
-                         "0fn"
-                         mag
+                       (create-graphical-embedding-box o ha va "center" "center"
+                         "1par" "min" "0fn" mag
                        ) ;create-graphical-embedding-box
                      ) ;let*
                    ) ;asc

--- a/TeXmacs/progs/graphics/graphics-object.scm
+++ b/TeXmacs/progs/graphics/graphics-object.scm
@@ -332,8 +332,15 @@
                 (va (get-graphical-prop 'basic "text-at-valign"))
                 (mag (get-graphical-prop 'basic "magnify"))
                ) ;
-           (create-graphical-embedding-box o ha va "center" "center" "1par"
-             "min" "0fn" mag
+           (create-graphical-embedding-box o
+             ha
+             va
+             "center"
+             "center"
+             "1par"
+             "min"
+             "0fn"
+             mag
            ) ;create-graphical-embedding-box
          ) ;let*
         ) ;
@@ -518,8 +525,15 @@
                             (va (get-graphical-prop path0 "text-at-valign"))
                             (mag (get-graphical-prop path0 "magnify"))
                            ) ;
-                       (create-graphical-embedding-box o ha va "center" "center"
-                         "1par" "min" "0fn" mag
+                       (create-graphical-embedding-box o
+                         ha
+                         va
+                         "center"
+                         "center"
+                         "1par"
+                         "min"
+                         "0fn"
+                         mag
                        ) ;create-graphical-embedding-box
                      ) ;let*
                    ) ;asc
@@ -597,6 +611,9 @@
       (graphical-object! (if (or (== no 'group)
                                (and (!= no 'no-group) (graphics-group-mode? (graphics-mode)))
                              ) ;or
+                           ;; group 模式（如绘制完成后自动进入的 edit-props
+                           ;; 选择态）悬停线段时也显示中点绿点；标尺等绘制
+                           ;; 辅助装饰不在此渲染
                            `(with ,"magnify"
                               ,(number->string (magnify->number (graphics-get-property "magnify")))
                               (concat ,@(create-graphical-contours (map (lambda (x)
@@ -605,7 +622,8 @@
                                                                             x))
                                                                      the-sketch)
                                           current-path
-                                          pts)))
+                                          pts)
+                                ,@(graphics-get-decorations-midpoint)))
                            (append props
                              `((concat
                                  . ,(append (cond ((== pts 'points) op)
@@ -617,7 +635,11 @@
                          ) ;if
       ) ;graphical-object!
     ) ;let*
-    (graphical-object! '(concat))
+    ;; 无当前对象时仍保留中点绿点预览，与 edit_move 各模式的行为一致
+    (if (graphics-midpoints-active?)
+      (graphics-render-midpoints)
+      (graphical-object! '(concat))
+    ) ;if
   ) ;if
 ) ;tm-define
 
@@ -675,6 +697,7 @@
 
 (tm-define (graphics-decorations-reset)
   (graphics-clear-ghost-lines)
+  (graphics-clear-midpoints)
   (create-graphical-object #f #f #f #f)
 ) ;tm-define
 
@@ -779,4 +802,8 @@
 
 (tm-define (sketch-cancel) #t)
 
-(tm-define (graphics-extra-decorations) (graphics-get-decorations-ghost-line))
+(tm-define (graphics-extra-decorations)
+  (append (graphics-get-decorations-ghost-line)
+    (graphics-get-decorations-midpoint)
+  ) ;append
+) ;tm-define

--- a/TeXmacs/progs/graphics/graphics-single.scm
+++ b/TeXmacs/progs/graphics/graphics-single.scm
@@ -16,6 +16,7 @@
 (texmacs-module (graphics graphics-single)
   (:use (graphics graphics-object)
     (graphics graphics-env)
+    (graphics graphics-ghost)
     (graphics graphics-main)
   ) ;:use
 ) ;texmacs-module
@@ -499,7 +500,12 @@
     ) ;begin
     (begin
       (set-message "Left click: new object" "Graphics")
-      (graphics-decorations-reset)
+      ;; 鼠标仍贴近线段时保留中点绿点预览（非绘制态悬停），
+      ;; 其余情况整体清空装饰层
+      (if (graphics-midpoints-active?)
+        (graphics-render-midpoints)
+        (graphics-decorations-reset)
+      ) ;if
     ) ;begin
   ) ;if
 ) ;tm-define

--- a/TeXmacs/progs/graphics/tests/graphics-ghost-test.scm
+++ b/TeXmacs/progs/graphics/tests/graphics-ghost-test.scm
@@ -1,0 +1,55 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : graphics-ghost-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：线段中点绿色吸附点装饰树（midpoint-
+;;               decorations）的构造。不弹任何 GUI，headless 可跑。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r graphics-ghost-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/graphics/graphics-ghost.scm")
+
+;; midpoint-decorations：空集中点不产生装饰
+
+(define (test-midpoint-empty)
+  (check (midpoint-decorations '()) => '())
+) ;define
+
+;; 单个中点：绿色 disk 圆点，坐标字符串原样进入 point
+
+(define (test-midpoint-single)
+  (check (midpoint-decorations '(("1" "2")))
+    =>
+    '((with "color" "green" "point-style" "disk" (point "1" "2")))
+  ) ;check
+) ;define
+
+;; 多个中点：与输入顺序一致，各自独立成装饰
+
+(define (test-midpoint-multiple)
+  (check (midpoint-decorations '(("0.5" "-0.5") ("3" "4")))
+    =>
+    '((with "color" "green" "point-style" "disk" (point "0.5" "-0.5"))
+      (with "color" "green" "point-style" "disk" (point "3" "4")))
+  ) ;check
+) ;define
+
+(tm-define (regtest-graphics-ghost)
+  (test-midpoint-empty)
+  (test-midpoint-single)
+  (test-midpoint-multiple)
+  (check-report)
+) ;tm-define

--- a/devel/0918.md
+++ b/devel/0918.md
@@ -1,0 +1,90 @@
+# 0918: 绘图模式下线段中点绿色吸附点（参考 0911 重做）
+
+## 任务需求
+
+在绘图模式中，鼠标贴近线段（吸附距离的一半以内，不要求完全压线）时，
+在该线段中点处显示一个绿色圆点；该点是有效的吸附目标（鼠标靠近中点时，
+绘制点被吸附到中点上）。
+
+本任务参考 0911 的实现（PR MoganLab/mogan#4345，已关闭未合入）在当前
+main 上重做；与 0911 的差异：新增 C++ 函数全部补中文 Doxygen 文档与
+C++ 单元测试。
+
+## What
+
+### C++：吸附候选与中点计算
+
+- `src/Graphics/Types/curve.hpp/.cpp`：新增
+  `straight_edge_midpoints (curve c, point p, double tol)`（纯几何、
+  可单测）：按 `get_control_points` 的控制点区间逐边处理（区间划分与
+  `curve_box_rep::graphical_select` 一致，闭合曲线补首尾相连边），
+  跳过退化边（两端点距离 < 1e-6）、参考点不贴近的边
+  （`seg_dist > tol`）与非直边（`is_straight_line (part (c, t1, t2))`
+  为假），返回各直边参数中值的 `evaluate` 结果。
+- `src/Edit/Interface/edit_graphics.hpp/.cpp`：
+  - 新增 `register_midpoint()`（非静态、可单测）：按文档坐标字符串
+    去重后加入显示集合 `points`；仅当鼠标与中点距离小于吸附距离时
+    追加 `curve-mid-point` 吸附候选（避免长边远端被强拉）。
+  - 新增 `snap_curve_midpoint()`（文件内静态，含 scheme 回调）：扫描
+    命中集合中的 `curve-point`/`curve-handle` 命中，经
+    `straight_edge_midpoints` 逐边取中点；压线容差取吸附距离的一半；
+    折线（line/cline）绘制中的对象尚未进入文档树，由 scheme 侧
+    `graphics-get-previous-line-points` 提供已落固定点（文档坐标系），
+    逐边压线过滤后取中点。每次鼠标移动经 `graphics-set-midpoints`
+    上报中点集合（变更检测与刷新在 scheme 侧）。
+  - `can_snap()`：`curve-mid-point` 复用 "curve point" 吸附开关。
+  - `adjust()`：在 `snap_ghost_line` 之后调用 `snap_curve_midpoint()`。
+
+### Scheme：绿色圆点渲染（复用 ghost line 链路）
+
+- `graphics-ghost.scm`：新增中点状态与 `graphics-set-midpoints`
+  （变更检测，集合变化才刷新装饰）、`graphics-clear-midpoints`、
+  `graphics-get-decorations-midpoint`、`graphics-midpoints-active?`、
+  `graphics-render-midpoints`、`graphics-get-previous-line-points`；
+  装饰构造抽为纯函数 `midpoint-decorations`（绿色 disk 圆点）便于单测。
+- `graphics-object.scm`：`graphics-extra-decorations` 追加中点装饰；
+  `graphics-decorations-reset` 同时清空中点状态；
+  `create-graphical-object` 的 group 分支（绘制完成后自动进入的
+  `group-edit edit-props` 选择态）追加渲染中点绿点；空对象分支在中点
+  仍激活时保留绿点预览。
+- `graphics-single.scm`：`edit_move` 非绘制态在鼠标仍贴近线段时仅渲染
+  中点绿点，避免预览被装饰层整体重建清掉。
+
+## Why
+
+- 中点显示条件是「鼠标贴近该线段本身」（`seg_dist <= 吸附距离/2`），
+  而非落入整个吸附距离即可；吸附候选额外要求鼠标与中点本身的距离
+  小于吸附距离。
+- 完全复用 ghost line 的注册/刷新/清空链路（模块级状态 + 变更检测 +
+  装饰渲染）；吸附开关挂在 "curve point" 上，关闭曲线点吸附时中点
+  同步失效。
+- 为满足「新增 C++ 函数需 Doxygen + 单元测试」，0911 中两个文件内
+  静态函数拆分为：纯几何核心 `straight_edge_midpoints`（放入
+  curve.hpp/.cpp）与非静态 `register_midpoint`，均可直接单测；
+  `snap_curve_midpoint` 保持静态薄封装（`call()` 需 scheme 运行时，
+  无法在纯 C++ 测试中运行），其逻辑全部转调上述两个已测函数。
+
+## How（验证）
+
+```bash
+xmake b curve_midpoint_test && xmake r curve_midpoint_test
+# Totals: 10 passed, 0 failed（nil 曲线/单线段命中与未命中/折线逐边/
+# 顶点双边/cline 闭合边/退化边/非直边）
+xmake b midpoint_snap_test && xmake r midpoint_snap_test
+# Totals: 5 passed, 0 failed（近处追加候选/远处仅显示/坐标字符串去重）
+xmake b stem && xmake r graphics-ghost-test
+# 3 correct, 0 failed（midpoint-decorations 空集/单点/多点输出形状）
+gf fmt --changed-since=main   # 全部变更文件幂等
+```
+
+## 涉及文件
+
+- `devel/0918.md`
+- `src/Graphics/Types/curve.hpp` / `src/Graphics/Types/curve.cpp`
+- `src/Edit/Interface/edit_graphics.hpp` / `src/Edit/Interface/edit_graphics.cpp`
+- `TeXmacs/progs/graphics/graphics-ghost.scm`
+- `TeXmacs/progs/graphics/graphics-object.scm`
+- `TeXmacs/progs/graphics/graphics-single.scm`
+- `TeXmacs/progs/graphics/tests/graphics-ghost-test.scm`（新增）
+- `tests/Graphics/Types/curve_midpoint_test.cpp`（新增）
+- `tests/Edit/Interface/midpoint_snap_test.cpp`（新增）

--- a/src/Edit/Interface/edit_graphics.cpp
+++ b/src/Edit/Interface/edit_graphics.cpp
@@ -99,6 +99,7 @@ can_snap (gr_selection sel) {
   if (type == "ghost-curve-point&curve-point" ||
       type == "curve-point&ghost-curve-point")
     return check_snap_mode ("ghost line") && check_snap_mode ("curve point");
+  if (type == "curve-mid-point") return check_snap_mode ("curve point");
   cout << "Uncaptured snap type " << type << "\n";
   return true;
 }
@@ -411,6 +412,93 @@ snap_ghost_line (edit_graphics_rep* eg, point fp, double snap_distance,
   }
 }
 
+void
+register_midpoint (point fp, double snap_distance, point ms, string sx,
+                   string sy, tree& points, gr_selections& sels, array<path> cp,
+                   array<point> pts) {
+  for (int k= 0; k < N (points); k++)
+    if (points[k][0] == sx && points[k][1] == sy) return;
+  tree en (TUPLE);
+  en << sx;
+  en << sy;
+  points << en;
+  double d= norm (ms - fp);
+  if (d < snap_distance) {
+    gr_selection sel;
+    sel->type= "curve-mid-point";
+    sel->p   = ms;
+    sel->dist= (SI) d;
+    sel->cp  = cp;
+    sel->pts = pts;
+    sels << sel;
+  }
+}
+
+/**
+ * @brief 鼠标贴近线段时收集各直边中点：上报 scheme 显示绿点并追加吸附候选
+ * @param fp            鼠标位置（屏幕/布局坐标系）
+ * @param snap_distance 吸附距离（像素）
+ * @param sels          [inout] 当前命中集合（graphical_select 结果），
+ *                      命中时追加 curve-mid-point 候选
+ * @param f2            文档坐标系到屏幕坐标系的变换（f2[p] 为逆变换）
+ * @note 两条中点来源：一是命中集合中的文档曲线对象（curve-point /
+ *       curve-handle 命中），逐边经 straight_edge_midpoints 取中点；
+ *       二是折线（line/cline）绘制中的已落固定点——绘制中的对象尚未
+ *       进入文档树，graphical_select 选不到，由 scheme 侧
+ *       graphics-get-previous-line-points 提供（文档坐标系）。
+ *       显示条件是「鼠标贴近该线段本身」（seg_dist <= 吸附距离的一半，
+ *       在 straight_edge_midpoints 与本函数第二路径中统一施加），而非
+ *       落入整个吸附距离即可。每次鼠标移动都通过
+ *       graphics-set-midpoints 重新上报中点集合，变更检测与刷新放在
+ *       scheme 侧（C++ 侧缓存会在 graphics-decorations-reset 清空
+ *       scheme 状态后失同步）。
+ */
+static void
+snap_curve_midpoint (point fp, double snap_distance, gr_selections& sels,
+                     frame f2) {
+  tree points (TUPLE);
+  SI   on_line_tol= snap_distance / 2; // 压线容差：吸附距离的一半
+  if (check_snap_mode ("curve point")) {
+    int n= N (sels);
+    for (int i= 0; i < n; i++) {
+      // curve-handle（鼠标近端点）与 curve-point（鼠标近曲线内部）都说明
+      // 鼠标贴近该曲线对象；折线/多边形的每条直边单独取中点
+      string type= sels[i]->type;
+      if (type != "curve-point" && type != "curve-handle") continue;
+      curve c= sels[i]->c;
+      if (is_nil (c)) continue;
+      array<point> mids= straight_edge_midpoints (c, fp, (double) on_line_tol);
+      for (int e= 0; e < N (mids); e++) {
+        point mid_local= f2[mids[e]]; // 转换到文档坐标系供装饰绘制
+        if (N (mid_local) != 2) continue;
+        register_midpoint (fp, snap_distance, mids[e], as_string (mid_local[0]),
+                           as_string (mid_local[1]), points, sels, sels[i]->cp,
+                           sels[i]->pts);
+      }
+    }
+    // 折线绘制中：对象尚未进入文档树，graphical_select 选不到，由
+    // scheme 提供已落固定点（文档坐标系），逐边做压线过滤后取中点
+    tree t_prev= as_tree (call ("graphics-get-previous-line-points"));
+    if (is_tuple (t_prev)) {
+      for (int i= 0; i + 1 < N (t_prev); i++) {
+        point a= as_point (t_prev[i]);
+        point b= as_point (t_prev[i + 1]);
+        if (N (a) != 2 || N (b) != 2) continue;
+        if (norm (b - a) < 1e-6) continue;
+        if (seg_dist (f2 (a), f2 (b), fp) > on_line_tol) continue;
+        point m= 0.5 * (a + b);
+        register_midpoint (fp, snap_distance, f2 (m), as_string (m[0]),
+                           as_string (m[1]), points, sels, array<path> (),
+                           array<point> ());
+      }
+    }
+  }
+  // 每次移动都重新上报，由 scheme 侧做变更检测并触发刷新：
+  // scheme 侧状态可能被 graphics-decorations-reset 清空，C++ 侧缓存
+  // 会与之处不同步（ghost line 每次移动同样会回调 scheme，开销一致）
+  call ("graphics-set-midpoints", points);
+}
+
 point
 edit_graphics_rep::adjust (point p) {
   frame f= find_frame ();
@@ -430,6 +518,7 @@ edit_graphics_rep::adjust (point p) {
   point fp= f2 (p);
 
   snap_ghost_line (this, fp, snap_distance, sels, f2);
+  snap_curve_midpoint (fp, snap_distance, sels, f2);
 
   if ((tree) g != "empty_grid") {
     point q = g->find_point_around (p, snap_distance, f);

--- a/src/Edit/Interface/edit_graphics.cpp
+++ b/src/Edit/Interface/edit_graphics.cpp
@@ -466,7 +466,7 @@ snap_curve_midpoint (point fp, double snap_distance, gr_selections& sels,
       string type= sels[i]->type;
       if (type != "curve-point" && type != "curve-handle") continue;
       curve c= sels[i]->c;
-      if (is_nil (c)) continue;
+      if (!is_polyline_or_segment (c)) continue;
       array<point> mids= straight_edge_midpoints (c, fp, (double) on_line_tol);
       for (int e= 0; e < N (mids); e++) {
         point mid_local= f2[mids[e]]; // 转换到文档坐标系供装饰绘制

--- a/src/Edit/Interface/edit_graphics.hpp
+++ b/src/Edit/Interface/edit_graphics.hpp
@@ -54,4 +54,21 @@ public:
   void back_in_text_at (tree t, path p, bool forward);
 };
 
+/**
+ * @brief 注册一个线段中点：加入显示集合（去重），鼠标足够近时追加吸附候选
+ * @param fp            鼠标位置（屏幕/布局坐标系）
+ * @param snap_distance 吸附距离：鼠标与中点距离小于它才追加吸附候选，
+ *                      避免长边远端被强行拉到中点
+ * @param ms            中点（与 fp 同坐标系），作为吸附候选的位置
+ * @param sx, sy        中点的文档坐标字符串，用作去重键与装饰绘制坐标
+ * @param points        [inout] 中点显示集合（TUPLE 树，元素为 (sx sy)），
+ *                      已含相同 (sx, sy) 时直接返回、不重复注册
+ * @param sels          [inout] 吸附候选集合，命中时追加 curve-mid-point 候选
+ * @param cp            候选的控制点路径（绘制中的折线无文档路径，传空）
+ * @param pts           候选的控制点坐标（同上，可传空）
+ */
+void register_midpoint (point fp, double snap_distance, point ms, string sx,
+                        string sy, tree& points, gr_selections& sels,
+                        array<path> cp, array<point> pts);
+
 #endif // defined EDIT_GRAPHICS_H

--- a/src/Graphics/Types/curve.cpp
+++ b/src/Graphics/Types/curve.cpp
@@ -181,6 +181,28 @@ is_straight_line (curve f) {
   return true;
 }
 
+array<point>
+straight_edge_midpoints (curve c, point p, double tol) {
+  array<point> res;
+  if (is_nil (c)) return res;
+  array<double> abs;
+  array<point>  pts;
+  array<path>   paths;
+  int           np= c->get_control_points (abs, pts, paths);
+  if (np < 2) return res;
+  // 与 curve_box_rep::graphical_select 一致：闭合曲线补上首尾相连边
+  int ne= np - 1;
+  if (abs[0] != 0.0 || abs[np - 1] != 1.0) ne++;
+  for (int e= 0; e < ne; e++) {
+    int j= (e + 1) % np;
+    if (norm (pts[j] - pts[e]) < 1e-6) continue;
+    if (seg_dist (pts[e], pts[j], p) > tol) continue;
+    if (!is_straight_line (part (c, abs[e], abs[j]))) continue;
+    res << c->evaluate ((abs[e] + abs[j]) / 2.0);
+  }
+  return res;
+}
+
 bool
 intersection (curve f, curve g, double& t, double& u) {
   // for two dimensional curves only

--- a/src/Graphics/Types/curve.cpp
+++ b/src/Graphics/Types/curve.cpp
@@ -197,7 +197,6 @@ straight_edge_midpoints (curve c, point p, double tol) {
     int j= (e + 1) % np;
     if (norm (pts[j] - pts[e]) < 1e-6) continue;
     if (seg_dist (pts[e], pts[j], p) > tol) continue;
-    if (!is_straight_line (part (c, abs[e], abs[j]))) continue;
     res << c->evaluate ((abs[e] + abs[j]) / 2.0);
   }
   return res;
@@ -1633,4 +1632,26 @@ struct recontrol_curve_rep : public curve_rep {
 curve
 recontrol (curve c, array<point> a, array<path> cip) {
   return tm_new<recontrol_curve_rep> (c, a, cip);
+}
+
+/**
+ * @brief 判断曲线是否为线段或折线（可被坐标变换/控制点重设包裹）
+ *
+ * 直线类图形只有 segment 与 poly_segment 两种实现；只需处理直边时，
+ * 可先用本函数排除椭圆、样条等曲线，避免逐边做直线性检测。
+ * @param c 待检测的曲线，可为 nil
+ * @return 线段或折线（含被 transformed_curve_rep / recontrol_curve_rep
+ *         包裹的情形）返回 true
+ */
+bool
+is_polyline_or_segment (curve c) {
+  if (is_nil (c)) return false;
+  curve_rep* rep= c.get_rep ();
+  if (dynamic_cast<segment_rep*> (rep) != nullptr) return true;
+  if (dynamic_cast<poly_segment_rep*> (rep) != nullptr) return true;
+  transformed_curve_rep* tr= dynamic_cast<transformed_curve_rep*> (rep);
+  if (tr != nullptr) return is_polyline_or_segment (tr->c);
+  recontrol_curve_rep* rc= dynamic_cast<recontrol_curve_rep*> (rep);
+  if (rc != nullptr) return is_polyline_or_segment (rc->c);
+  return false;
 }

--- a/src/Graphics/Types/curve.hpp
+++ b/src/Graphics/Types/curve.hpp
@@ -177,6 +177,21 @@ array<point> intersection (curve f, curve g, point p0, double eps);
 point        closest (curve f, point p);
 bool         is_straight_line (curve f);
 
+/**
+ * @brief 求曲线各直边的中点，仅返回参考点所贴近的边的中点
+ * @param c   待处理的曲线，可为 nil（返回空数组）
+ * @param p   参考点（通常为鼠标位置），与曲线处于同一坐标系
+ * @param tol 贴近容差：参考点到边的距离（seg_dist）大于该值时忽略该边
+ * @return 满足条件的各直边中点（曲线坐标系），按控制点区间顺序排列
+ * @note 按 get_control_points 的控制点区间逐边处理，区间划分与
+ *       curve_box_rep::graphical_select 一致：闭合曲线（首末控制点参数
+ *       不恰为 0/1）补首尾相连边。退化边（两端点距离 < 1e-6）与非直边
+ *       （is_straight_line 为假）一律跳过；中点取区间参数中值的
+ *       evaluate 结果，而非两端点算术平均（对参数化不均匀的曲线两者
+ *       可能不同）。
+ */
+array<point> straight_edge_midpoints (curve c, point p, double tol);
+
 array<point> simplify_polyline (array<point> a, double eps);
 array<point> std_bezier_fit (array<point> a, int pack_size);
 array<point> alt_bezier_fit (array<point> a, int pack_size);

--- a/src/Graphics/Types/curve.hpp
+++ b/src/Graphics/Types/curve.hpp
@@ -157,7 +157,26 @@ struct parabola_rep : public curve_rep {
                              array<path>& cip) override;
 };
 
+/**
+ * @brief 构造连接两点的直线段曲线
+ *
+ * 参数 t ∈ [0,1] 线性插值：`(1-t)*p1 + t*p2`；曲率恒为无穷大（直线）。
+ * @param p1 起点
+ * @param p2 终点
+ * @return 直线段曲线对象
+ */
 curve segment (point p1, point p2);
+
+/**
+ * @brief 构造依序连接多个控制点的折线（多段直线）曲线
+ *
+ * n+1 个控制点 a[0..n] 构成 n 段直线；参数 t ∈ [0,1] 均匀映射到整条折线
+ * （每段占 1/n），各顶点对应参数 i/n。绘图工具中的「折线」（`<line>` 标签）
+ * 即由此实现。单个 segment 可视为 n=1 的特例。
+ * @param a 控制点序列（至少 2 个点）
+ * @param cip 各控制点在源树中的位置（用于图形编辑时的反向定位）
+ * @return 折线曲线对象
+ */
 curve poly_segment (array<point> a, array<path> cip);
 curve spline (array<point> a, array<path> cip, bool close= false,
               bool interpol= true);
@@ -175,7 +194,26 @@ curve recontrol (curve c, array<point> a, array<path> cip);
 
 array<point> intersection (curve f, curve g, point p0, double eps);
 point        closest (curve f, point p);
-bool         is_straight_line (curve f);
+/**
+ * @brief 判断曲线 f 是否为（近似）直线段
+ *
+ * 在参数 t = 0.25、0.5、0.75 处采样切向量，若所有切向量二维且方向一致
+ * （叉积接近零），则视为直线。单点切向对圆等曲线没有代表性，故采样多处。
+ * @param f 待检测的曲线
+ * @return 曲线近似为直线时返回 true；切向计算失败、非二维或方向不一致返回 false
+ */
+bool is_straight_line (curve f);
+
+/**
+ * @brief 判断曲线是否为线段或折线（可被坐标变换包裹）
+ *
+ * 直线类图形只有 segment 与 poly_segment 两种实现；只需处理直边时，
+ * 可先用本函数排除椭圆、样条等曲线，避免逐边做直线性检测。
+ * @param c 待检测的曲线，可为 nil
+ * @return 线段或折线（含被 transformed_curve_rep / recontrol_curve_rep
+ *         包裹的情形）返回 true
+ */
+bool is_polyline_or_segment (curve c);
 
 /**
  * @brief 求曲线各直边的中点，仅返回参考点所贴近的边的中点
@@ -185,10 +223,10 @@ bool         is_straight_line (curve f);
  * @return 满足条件的各直边中点（曲线坐标系），按控制点区间顺序排列
  * @note 按 get_control_points 的控制点区间逐边处理，区间划分与
  *       curve_box_rep::graphical_select 一致：闭合曲线（首末控制点参数
- *       不恰为 0/1）补首尾相连边。退化边（两端点距离 < 1e-6）与非直边
- *       （is_straight_line 为假）一律跳过；中点取区间参数中值的
- *       evaluate 结果，而非两端点算术平均（对参数化不均匀的曲线两者
- *       可能不同）。
+ *       不恰为 0/1）补首尾相连边。退化边（两端点距离 < 1e-6）跳过；
+ *       中点取区间参数中值的 evaluate 结果，而非两端点算术平均（对
+ *       参数化不均匀的曲线两者可能不同）。调用方须保证传入的是线段或
+ *       折线（is_polyline_or_segment），非直边曲线不做过滤。
  */
 array<point> straight_edge_midpoints (curve c, point p, double tol);
 

--- a/tests/Edit/Interface/midpoint_snap_test.cpp
+++ b/tests/Edit/Interface/midpoint_snap_test.cpp
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * MODULE     : midpoint_snap_test.cpp
+ * DESCRIPTION: Unit tests for register_midpoint (dedup + snap candidate
+ *              registration of curve edge midpoints)
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "base.hpp"
+#include "Interface/edit_graphics.hpp"
+#include <QtTest/QtTest>
+
+static point
+mkp (double x, double y) {
+  point p (2);
+  p[0]= x;
+  p[1]= y;
+  return p;
+}
+
+class TestRegisterMidpoint : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  // 鼠标与中点距离小于吸附距离：加入显示集合并追加 curve-mid-point 候选
+  void test_candidate_appended_when_close ();
+  // 距离不小于吸附距离：只加入显示集合，不追加候选（避免长边远端被强拉）
+  void test_no_candidate_when_far ();
+  // 相同坐标字符串重复注册：显示集合不增长、不重复追加候选
+  void test_dedup_by_coordinate_string ();
+};
+
+void
+TestRegisterMidpoint::test_candidate_appended_when_close () {
+  tree          points (TUPLE);
+  gr_selections sels;
+  array<path>   cp;
+  cp << path (1, 2);
+  array<point> pts;
+  pts << mkp (1, 1);
+  register_midpoint (mkp (0, 0), 10.0, mkp (3, 4), "1.5", "2.5", points, sels,
+                     cp, pts);
+  QCOMPARE (N (points), 1);
+  QVERIFY (points[0][0] == "1.5");
+  QVERIFY (points[0][1] == "2.5");
+  QCOMPARE (N (sels), 1);
+  QVERIFY (sels[0]->type == "curve-mid-point");
+  QVERIFY (N (sels[0]->p) == 2 && sels[0]->p[0] == 3 && sels[0]->p[1] == 4);
+  QCOMPARE (sels[0]->dist, (SI) 5);
+  QCOMPARE (N (sels[0]->cp), 1);
+  QCOMPARE (N (sels[0]->pts), 1);
+}
+
+void
+TestRegisterMidpoint::test_no_candidate_when_far () {
+  tree          points (TUPLE);
+  gr_selections sels;
+  register_midpoint (mkp (0, 0), 10.0, mkp (30, 40), "15", "20", points, sels,
+                     array<path> (), array<point> ());
+  QCOMPARE (N (points), 1);
+  QCOMPARE (N (sels), 0);
+}
+
+void
+TestRegisterMidpoint::test_dedup_by_coordinate_string () {
+  tree          points (TUPLE);
+  gr_selections sels;
+  register_midpoint (mkp (0, 0), 10.0, mkp (3, 4), "1.5", "2.5", points, sels,
+                     array<path> (), array<point> ());
+  register_midpoint (mkp (0, 0), 10.0, mkp (3, 4), "1.5", "2.5", points, sels,
+                     array<path> (), array<point> ());
+  QCOMPARE (N (points), 1);
+  QCOMPARE (N (sels), 1);
+  // 坐标字符串不同则视为不同中点
+  register_midpoint (mkp (0, 0), 10.0, mkp (3, 4), "1.50", "2.5", points, sels,
+                     array<path> (), array<point> ());
+  QCOMPARE (N (points), 2);
+  QCOMPARE (N (sels), 2);
+}
+
+QTEST_MAIN (TestRegisterMidpoint)
+#include "midpoint_snap_test.moc"

--- a/tests/Edit/Interface/midpoint_snap_test.cpp
+++ b/tests/Edit/Interface/midpoint_snap_test.cpp
@@ -9,8 +9,8 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
-#include "base.hpp"
 #include "Interface/edit_graphics.hpp"
+#include "base.hpp"
 #include <QtTest/QtTest>
 
 static point

--- a/tests/Graphics/Types/curve_midpoint_test.cpp
+++ b/tests/Graphics/Types/curve_midpoint_test.cpp
@@ -47,8 +47,10 @@ private slots:
   void test_closed_polyline_closing_edge ();
   // 退化边（两端点重合）跳过，不影响其余边
   void test_degenerate_edge_skipped ();
-  // 非直边（抛物线弧）即使贴近也不取中点
-  void test_non_straight_edge_skipped ();
+
+  // is_polyline_or_segment：线段、折线（含被坐标变换包裹）为真，
+  // 圆弧、样条、nil 为假
+  void test_is_polyline_or_segment ();
 };
 
 void
@@ -75,7 +77,7 @@ void
 TestStraightEdgeMidpoints::test_polyline_per_edge () {
   array<point> a;
   a << mkp (0, 0) << mkp (4, 0) << mkp (4, 4);
-  curve        c= poly_segment (a, array<path> ());
+  curve        c = poly_segment (a, array<path> ());
   array<point> m1= straight_edge_midpoints (c, mkp (2, 0.3), 0.5);
   QCOMPARE (N (m1), 1);
   QVERIFY (pt_eq (m1[0], 2, 0));
@@ -117,12 +119,23 @@ TestStraightEdgeMidpoints::test_degenerate_edge_skipped () {
 }
 
 void
-TestStraightEdgeMidpoints::test_non_straight_edge_skipped () {
+TestStraightEdgeMidpoints::test_is_polyline_or_segment () {
+  curve nil_c;
+  QVERIFY (!is_polyline_or_segment (nil_c));
+  QVERIFY (is_polyline_or_segment (segment (mkp (0, 0), mkp (4, 0))));
   array<point> a;
-  a << mkp (-1, -1) << mkp (1, -1) << mkp (0, 0);
-  curve c= parabola (a, array<path> (), false);
-  // 容差足够大、参考点就在曲线上，但抛物线弧不是直边
-  QVERIFY (N (straight_edge_midpoints (c, mkp (0, -0.5), 100.0)) == 0);
+  a << mkp (0, 0) << mkp (4, 0) << mkp (4, 4);
+  curve poly= poly_segment (a, array<path> ());
+  QVERIFY (is_polyline_or_segment (poly));
+  // curve_box_rep::transform 用 fr(c) 包裹曲线
+  frame fr= shift_2D (mkp (1, 1));
+  QVERIFY (is_polyline_or_segment (fr (poly)));
+  QVERIFY (is_polyline_or_segment (fr (segment (mkp (0, 0), mkp (4, 0)))));
+  array<point> arc_pts;
+  arc_pts << mkp (-1, -1) << mkp (1, -1) << mkp (0, 0);
+  QVERIFY (!is_polyline_or_segment (parabola (arc_pts, array<path> (), false)));
+  QVERIFY (!is_polyline_or_segment (arc (arc_pts, array<path> (), false)));
+  QVERIFY (!is_polyline_or_segment (spline (a, array<path> ())));
 }
 
 QTEST_MAIN (TestStraightEdgeMidpoints)

--- a/tests/Graphics/Types/curve_midpoint_test.cpp
+++ b/tests/Graphics/Types/curve_midpoint_test.cpp
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * MODULE     : curve_midpoint_test.cpp
+ * DESCRIPTION: Unit tests for straight_edge_midpoints (per-edge midpoints of
+ *              a curve's straight edges near a reference point)
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "base.hpp"
+#include "curve.hpp"
+#include "point.hpp"
+#include <QtTest/QtTest>
+
+static point
+mkp (double x, double y) {
+  point p (2);
+  p[0]= x;
+  p[1]= y;
+  return p;
+}
+
+static bool
+pt_eq (point a, double x, double y, double eps= 1e-9) {
+  return N (a) == 2 && fabs (a[0] - x) < eps && fabs (a[1] - y) < eps;
+}
+
+class TestStraightEdgeMidpoints : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  // nil 曲线与无控制点曲线不崩溃、返回空
+  void test_nil_curve ();
+  // 单线段：参考点贴近时返回唯一中点
+  void test_segment_hit ();
+  // 单线段：参考点距离超过容差时返回空
+  void test_segment_miss ();
+  // 开放折线：逐边独立判定，只返回贴近边的中点
+  void test_polyline_per_edge ();
+  // 顶点处两条边都贴近时返回两个中点，顺序与控制点区间一致
+  void test_polyline_vertex_both_edges ();
+  // cline 形式的闭合折线（首尾控制点重复）：闭合边正常取中点
+  void test_closed_polyline_closing_edge ();
+  // 退化边（两端点重合）跳过，不影响其余边
+  void test_degenerate_edge_skipped ();
+  // 非直边（抛物线弧）即使贴近也不取中点
+  void test_non_straight_edge_skipped ();
+};
+
+void
+TestStraightEdgeMidpoints::test_nil_curve () {
+  curve c;
+  QVERIFY (N (straight_edge_midpoints (c, mkp (0, 0), 1.0)) == 0);
+}
+
+void
+TestStraightEdgeMidpoints::test_segment_hit () {
+  curve        c   = segment (mkp (0, 0), mkp (4, 0));
+  array<point> mids= straight_edge_midpoints (c, mkp (2, 0.4), 0.5);
+  QCOMPARE (N (mids), 1);
+  QVERIFY (pt_eq (mids[0], 2, 0));
+}
+
+void
+TestStraightEdgeMidpoints::test_segment_miss () {
+  curve c= segment (mkp (0, 0), mkp (4, 0));
+  QVERIFY (N (straight_edge_midpoints (c, mkp (2, 5), 0.5)) == 0);
+}
+
+void
+TestStraightEdgeMidpoints::test_polyline_per_edge () {
+  array<point> a;
+  a << mkp (0, 0) << mkp (4, 0) << mkp (4, 4);
+  curve        c= poly_segment (a, array<path> ());
+  array<point> m1= straight_edge_midpoints (c, mkp (2, 0.3), 0.5);
+  QCOMPARE (N (m1), 1);
+  QVERIFY (pt_eq (m1[0], 2, 0));
+  array<point> m2= straight_edge_midpoints (c, mkp (3.7, 2), 0.5);
+  QCOMPARE (N (m2), 1);
+  QVERIFY (pt_eq (m2[0], 4, 2));
+}
+
+void
+TestStraightEdgeMidpoints::test_polyline_vertex_both_edges () {
+  array<point> a;
+  a << mkp (0, 0) << mkp (4, 0) << mkp (4, 4);
+  curve        c   = poly_segment (a, array<path> ());
+  array<point> mids= straight_edge_midpoints (c, mkp (4, 0), 0.5);
+  QCOMPARE (N (mids), 2);
+  QVERIFY (pt_eq (mids[0], 2, 0));
+  QVERIFY (pt_eq (mids[1], 4, 2));
+}
+
+void
+TestStraightEdgeMidpoints::test_closed_polyline_closing_edge () {
+  // 文档中 <cline> 的构造方式：首尾控制点重复（concat_graphics.cpp）
+  array<point> a;
+  a << mkp (0, 0) << mkp (4, 0) << mkp (2, 4) << mkp (0, 0);
+  curve        c   = poly_segment (a, array<path> ());
+  array<point> mids= straight_edge_midpoints (c, mkp (1, 2), 0.3);
+  QCOMPARE (N (mids), 1);
+  QVERIFY (pt_eq (mids[0], 1, 2));
+}
+
+void
+TestStraightEdgeMidpoints::test_degenerate_edge_skipped () {
+  array<point> a;
+  a << mkp (0, 0) << mkp (0, 0) << mkp (4, 0);
+  curve        c   = poly_segment (a, array<path> ());
+  array<point> mids= straight_edge_midpoints (c, mkp (0, 0), 0.5);
+  QCOMPARE (N (mids), 1);
+  QVERIFY (pt_eq (mids[0], 2, 0));
+}
+
+void
+TestStraightEdgeMidpoints::test_non_straight_edge_skipped () {
+  array<point> a;
+  a << mkp (-1, -1) << mkp (1, -1) << mkp (0, 0);
+  curve c= parabola (a, array<path> (), false);
+  // 容差足够大、参考点就在曲线上，但抛物线弧不是直边
+  QVERIFY (N (straight_edge_midpoints (c, mkp (0, -0.5), 100.0)) == 0);
+}
+
+QTEST_MAIN (TestStraightEdgeMidpoints)
+#include "curve_midpoint_test.moc"


### PR DESCRIPTION
## 概要

绘图模式下鼠标贴近线段/折线时，在直边中点显示绿色吸附点，光标可吸附到中点。

## 实现

- C++ 侧：`straight_edge_midpoints` 逐控制点区间取直边中点（压线容差 = 吸附距离一半）；`snap_curve_midpoint` 收集命中曲线的中点，经 `graphics-set-midpoints` 上报 scheme 显示并追加 `curve-mid-point` 吸附候选
- 新增 `is_polyline_or_segment`：识别 segment / poly_segment（含 transformed / recontrol 包裹），非直边曲线（椭圆、样条、圆弧）直接跳过；由此移除 `straight_edge_midpoints` 内逐边 `is_straight_line` 检测
- 折线绘制中尚未落定的固定点由 scheme 侧 `graphics-get-previous-line-points` 提供，逐边压线过滤后同样取中点
- scheme 侧渲染链路与变更检测（避免与 `graphics-decorations-reset` 失同步）

## 测试

- `curve_midpoint_test`：10 用例（含闭合折线补边、退化边跳过、`is_polyline_or_segment` 各形态）
- `midpoint_snap_test`、scheme 纯逻辑测试
- 本地全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)