### PR TITLE
[1214] rectangles operator- 碎片表整表重建改原地摘链改写

### DIFF
--- a/devel/1214.md
+++ b/devel/1214.md
@@ -339,3 +339,50 @@ widget 的 `invalid_regions = invalid_regions | rectangles (r)`
 - `xmake r invalidate_test` 6/6、`xmake r rectangles_test` 10/10 通过
   （rectangles 消费方）
 - `gf fmt --changed-since=main` 已执行
+
+## 第十轮：operator- 碎片表整表重建改原地摘链改写
+
+### What
+
+`append_difference` 被切过一次后,后续每个相交减数不再把整张碎片表重建
+一遍,改为对碎片表做原地摘链/挂链,只重分配真正与减数相交的碎片;碎片被
+挖空时提前终止。bench 新增碎片化场景(单个大矩形被 64 个散布小矩形反复
+切割)并保留第八轮实现(`r8_subtract`)做同二进制 A/B;测试先行,新增
+4 个差集单元测试(十字切缝、散布多切、部分命中保留未触碎片、多元素混合)。
+
+### Why
+
+第八轮实现中,单矩形首次被切后碎片表 `cur` 逐轮膨胀,而每个后续相交减数
+都把整张 `cur` 逐项 `complement` 到新表——即使只切到 1 个碎片,其余全部
+碎片也重新分配节点,k 个减数切割下是 O(k²) 次节点分配。碎片表节点全部由
+本函数新建(独占,ref_count==1),可沿用第九轮 operator| 的原地改链模式。
+
+### How
+
+- 对 `cur` 用 `rectangles* link` 逐槽位扫描:与减数不相交的碎片零开销跳过;
+  相交的碎片摘链(`*link= (*link)->next`,独占节点槽位赋值即释放),
+  `complement` 产出的新碎片经普通句柄赋值逐个接回 `*link` 槽位,引用计数
+  始终平衡(与 adopt 约定不同,此处全部走带计数的赋值,无裸指针操作)。
+- `cur` 被挖空即 break,后续减数不再扫描。
+- 碎片顺序与第八轮不同(头插接回),差集结果顺序无语义,消费方只做
+  correct/simplify/绘制,26 个既有用例全部通过。
+
+### bench（同二进制 A/B，nanobench，release，ns/op）
+
+| 场景 | 第八轮实现 | 本轮 | 加速比 |
+|---|---:|---:|---:|
+| 碎片化（1024² 大矩形被 64 个 64² 挖洞） | 87,143 | 19,675 | 4.43x |
+| 稀疏相交（l2 16 个，各切 ~11 个元素） | ~114–135（噪声区间） | ~124–135 | 持平 |
+| 完全不相交（l2 16 个） | ~86–95 | ~96–104 | 持平（纯直挂快路径未变） |
+
+### 涉及文件
+
+- `moebius/Kernel/Types/rectangles.cpp`
+- `moebius/bench/Kernel/Types/rectangles_bench.cpp`
+- `moebius/tests/Kernel/Types/rectangles_ops_test.cpp`
+
+### 验证
+
+- 先写测试并在优化前实现上跑通(26 用例),再改实现,26/26 复验通过
+- `xmake test "moebius_tests/*"` 16/16 通过
+- `gf fmt --changed-since=main` 已执行

--- a/moebius/Kernel/Types/rectangles.cpp
+++ b/moebius/Kernel/Types/rectangles.cpp
@@ -152,22 +152,38 @@ thicken (rectangle r, SI width, SI height) {
  ******************************************************************************/
 
 // 单个矩形对 l2 求差,结果尾挂到 tail:
-// 与 l2 全不交时原矩形一次直挂,零差分开销
+// 与 l2 全不交时原矩形一次直挂,零差分开销;
+// 被切过后碎片表由本函数独占(全为新鲜节点),后续切割原地摘链改写,
+// 只重分配真正与减数相交的碎片,不再整表重建
 static void
 append_difference (rectangle r, rectangles l2, rectangles*& tail) {
   rectangles cur;
   bool       cut= false;
   for (rectangles q= l2; !is_nil (q); q= q->next) {
-    if (!intersect (r, q->item)) continue;
     if (!cut) {
+      if (!intersect (r, q->item)) continue;
       complement (r, q->item, cur);
       cut= true;
       continue;
     }
-    rectangles next;
-    for (rectangles p= cur; !is_nil (p); p= p->next)
-      complement (p->item, q->item, next);
-    cur= next;
+    rectangles* link= &cur;
+    while (!is_nil (*link)) {
+      rectangle frag= (*link)->item;
+      if (!intersect (frag, q->item)) {
+        link= &(*link)->next;
+        continue;
+      }
+      *link= (*link)->next; // 独占节点,槽位赋值即摘链并释放原节点
+      rectangles frags;
+      complement (frag, q->item, frags); // 头插产出,独占新节点
+      while (!is_nil (frags)) {
+        rectangles cell= frags;
+        frags          = frags->next; // 摘头,普通赋值保证引用计数平衡
+        cell->next     = *link;
+        *link          = cell;
+      }
+    }
+    if (is_nil (cur)) break; // 碎片已被挖空,后续减数无事可做
   }
   if (!cut) rectangles::append (tail, r);
   else

--- a/moebius/bench/Kernel/Types/rectangles_bench.cpp
+++ b/moebius/bench/Kernel/Types/rectangles_bench.cpp
@@ -59,6 +59,39 @@ old_subtract (rectangles l1, rectangles l2) {
   return a;
 }
 
+// 第八轮实现:单矩形独立求差,但被切过后每个相交 q 仍整表重建碎片表,
+// 用于同二进制 A/B 对比
+static void
+r8_append_difference (rectangle r, rectangles l2, rectangles*& tail) {
+  rectangles cur;
+  bool       cut= false;
+  for (rectangles q= l2; !is_nil (q); q= q->next) {
+    if (!intersect (r, q->item)) continue;
+    if (!cut) {
+      complement (r, q->item, cur);
+      cut= true;
+      continue;
+    }
+    rectangles next;
+    for (rectangles p= cur; !is_nil (p); p= p->next)
+      complement (p->item, q->item, next);
+    cur= next;
+  }
+  if (!cut) rectangles::append (tail, r);
+  else
+    for (rectangles p= cur; !is_nil (p); p= p->next)
+      rectangles::append (tail, p->item);
+}
+
+static rectangles
+r8_subtract (rectangles l1, rectangles l2) {
+  rectangles  out;
+  rectangles* tail= &out;
+  for (; !is_nil (l1); l1= l1->next)
+    r8_append_difference (l1->item, l2, tail);
+  return out;
+}
+
 // 优化前的实现:每个 l2 元素经 disjoint_union 克隆整个前缀,用于同二进制 A/B 对比
 static rectangles
 old_union (rectangles l1, rectangles l2) {
@@ -129,6 +162,19 @@ main () {
   });
   bench.run ("subtract x1024 disjoint16",
              [&] { ankerl::nanobench::doNotOptimizeAway (large - faraway); });
+  // 碎片化场景:单个大矩形被 64 个散布小矩形反复切割,碎片表逐轮膨胀,
+  // 第八轮实现每个相交减数都整表重建碎片
+  rectangles big= rectangles (rectangle (0, 0, 1024, 1024), rectangles ());
+  rectangles holes;
+  for (int i= 63; i >= 0; i--) {
+    int x= (i % 8) * 128 + 32, y= (i / 8) * 128 + 32;
+    holes= rectangles (rectangle (x, y, x + 64, y + 64), holes);
+  }
+  bench.run ("r8 subtract fragmentation64", [&] {
+    ankerl::nanobench::doNotOptimizeAway (r8_subtract (big, holes));
+  });
+  bench.run ("subtract fragmentation64",
+             [&] { ankerl::nanobench::doNotOptimizeAway (big - holes); });
   // 并集场景:模拟失效区域逐矩形累积,16 块均不与 large 相邻(全走尾插)
   bench.run ("old union x1024 append16", [&] {
     ankerl::nanobench::doNotOptimizeAway (old_union (large, faraway));

--- a/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
+++ b/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
@@ -153,6 +153,69 @@ TEST_CASE ("test difference multiple subtrahends") {
   CHECK_EQ (area (d), 60.0 - 8.0);
 }
 
+// 逐对校验碎片列表互不相交(差集结果的基本不变量)
+static bool
+pairwise_disjoint (rectangles l) {
+  for (rectangles p= l; !is_nil (p); p= p->next)
+    for (rectangles q= p->next; !is_nil (q); q= q->next)
+      if (intersect (p->item, q->item)) return false;
+  return true;
+}
+
+TEST_CASE ("test difference cross cuts") {
+  // 十字切缝:先竖一刀再横一刀,切成 4 块,面积守恒且互不相交
+  rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
+  rectangles l2=
+      rectangles (rectangle (4, 0, 6, 10),
+                  rectangles (rectangle (0, 4, 10, 6), rectangles ()));
+  rectangles d= l1 - l2;
+  CHECK (pairwise_disjoint (d));
+  CHECK_EQ (area (d), 68.0);
+  CHECK (least_upper_bound (d) == rectangle (0, 0, 10, 10));
+}
+
+TEST_CASE ("test difference scattered cuts") {
+  // 大矩形内散布多个减数,每个减数只切到部分碎片;
+  // 结果互不相交且面积守恒(总面积减去被挖面积)
+  rectangles l1= rectangles (rectangle (0, 0, 30, 30), rectangles ());
+  rectangles l2;
+  for (int i= 4; i >= 0; i--)
+    l2= rectangles (rectangle (i * 6, i * 6, i * 6 + 4, i * 6 + 4), l2);
+  rectangles d= l1 - l2;
+  CHECK (pairwise_disjoint (d));
+  CHECK_EQ (area (d), 900.0 - 5 * 16.0);
+}
+
+TEST_CASE ("test difference partial hit keeps untouched fragment") {
+  // 第二个减数只切到部分碎片:未命中碎片原样保留(元素级相等)
+  rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
+  rectangles l2= rectangles (
+      rectangle (4, 0, 6, 10), // 竖切:左 4x10 + 右 4x10
+      rectangles (rectangle (0, 0, 2, 4), rectangles ())); // 再挖左块一角
+  rectangles d= l1 - l2;
+  CHECK (pairwise_disjoint (d));
+  CHECK_EQ (area (d), 100.0 - 20.0 - 8.0);
+  bool has_right= false;
+  for (rectangles p= d; !is_nil (p); p= p->next)
+    if (p->item == rectangle (6, 0, 10, 10)) has_right= true;
+  CHECK (has_right);
+}
+
+TEST_CASE ("test difference mixed elements") {
+  // 多元素 l1:一个不交、一个被完全覆盖、一个被切,均独立处理
+  rectangles l1= rectangles (
+      rectangle (0, 0, 2, 2),
+      rectangles (rectangle (5, 5, 8, 8),
+                  rectangles (rectangle (20, 20, 30, 30), rectangles ())));
+  rectangles l2=
+      rectangles (rectangle (4, 4, 9, 9),
+                  rectangles (rectangle (22, 22, 24, 24), rectangles ()));
+  rectangles d= l1 - l2;
+  CHECK_EQ (area (d), 4.0 + (100.0 - 4.0));
+  CHECK (pairwise_disjoint (d));
+  CHECK (d->item == rectangle (0, 0, 2, 2)); // 不交元素保序直挂
+}
+
 TEST_CASE ("test correct drops degenerate") {
   CHECK (correct (rectangles ()) == rectangles ());
   // 零宽/零高/负宽高的矩形均被剔除，其余顺序保持

--- a/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
+++ b/moebius/tests/Kernel/Types/rectangles_ops_test.cpp
@@ -164,13 +164,14 @@ pairwise_disjoint (rectangles l) {
 
 TEST_CASE ("test difference cross cuts") {
   // 十字切缝:先竖一刀再横一刀,切成 4 块,面积守恒且互不相交
+  // (挖去 20+20-4,两条切缝的 2x2 交集只计一次)
   rectangles l1= rectangles (rectangle (0, 0, 10, 10), rectangles ());
   rectangles l2=
       rectangles (rectangle (4, 0, 6, 10),
                   rectangles (rectangle (0, 4, 10, 6), rectangles ()));
   rectangles d= l1 - l2;
   CHECK (pairwise_disjoint (d));
-  CHECK_EQ (area (d), 68.0);
+  CHECK_EQ (area (d), 64.0);
   CHECK (least_upper_bound (d) == rectangle (0, 0, 10, 10));
 }
 


### PR DESCRIPTION
## 概要

`append_difference` 被切过一次后，后续每个相交减数不再把整张碎片表重建一遍，改为原地摘链/挂链，只重分配真正与减数相交的碎片；碎片挖空即提前终止。

- 测试先行：新增 4 个差集单元测试（十字切缝 / 散布多切 / 部分命中 / 多元素混合），先在优化前实现上跑通
- bench 新增碎片化场景并保留第八轮实现（`r8_subtract`）做同二进制 A/B
- 接回碎片全部走带引用计数的句柄赋值，无裸指针操作

## bench（同二进制 A/B，nanobench，release，ns/op）

| 场景 | 第八轮实现 | 本轮 | 加速比 |
|---|---:|---:|---:|
| 碎片化（1024² 被重 64 个 64² 挖洞） | 87,143 | 19,675 | 4.43x |
| 稀疏相交 / 完全不相交 | — | — | 持平（快路径未变） |

## 验证

- `xmake test "moebius_tests/*"` 16/16 通过（rectangles_ops_test 26 用例含新增 4 例）
- `gf fmt --changed-since=main` 已执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)