### PR TITLE
[1219] poly_line 补充 Doxygen 文档、单元测试与性能优化

### DIFF
--- a/devel/1219.md
+++ b/devel/1219.md
@@ -1,0 +1,7 @@
+
+### poly_line 文档、单元测试与性能优化
+
+- What: 为 moebius/Kernel/Types/poly_line.hpp 补充 Doxygen 文档；新增 tests/Kernel/Types/poly_line_test.cpp 单元测试；优化 poly_line.cpp 各函数（循环外提 N()、inf/sup 原地分量计算、避免中间 point 分配）。
+- Why: 提升可读性与测试覆盖；inf/sup 逐点两两合并原先每次迭代分配临时 point，热点路径（glyph 手写识别不变量计算）受益。
+- How: 见 poly_line.cpp 实现；测试用 doctest（moe_doctests.hpp），覆盖 point 工具函数、poly_line/contours 全部导出函数。
+- 涉及文件: moebius/Kernel/Types/poly_line.hpp, moebius/Kernel/Types/poly_line.cpp, moebius/tests/Kernel/Types/poly_line_test.cpp

--- a/devel/1219.md
+++ b/devel/1219.md
@@ -64,3 +64,4 @@ xmake b stem
 
 ## 8 附带修复
 - moebius/xmake.lua: moebius_tests 聚合 target 由 binary 改为 phony，修复 `xmake b moebius_tests` 因无 main 的链接失败（#4377 遗留），子测试 `xmake test "moebius_tests/*"` 不受影响
+- poly_line_test.cpp: 两处 `REQUIRE` 改为 `CHECK` + 长度守卫（MSVC 关闭异常时 doctest 的 `REQUIRE` 无法编译：static_assert "Exceptions are disabled"；改用 CHECK 后须自行防止数组越界访问）

--- a/devel/1219.md
+++ b/devel/1219.md
@@ -1,7 +1,50 @@
+# [1219] poly_line 文档、单元测试与性能优化
 
-### poly_line 文档、单元测试与性能优化
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
 
-- What: 为 moebius/Kernel/Types/poly_line.hpp 补充 Doxygen 文档；新增 tests/Kernel/Types/poly_line_test.cpp 单元测试；优化 poly_line.cpp 各函数（循环外提 N()、inf/sup 原地分量计算、避免中间 point 分配）。
-- Why: 提升可读性与测试覆盖；inf/sup 逐点两两合并原先每次迭代分配临时 point，热点路径（glyph 手写识别不变量计算）受益。
-- How: 见 poly_line.cpp 实现；测试用 doctest（moe_doctests.hpp），覆盖 point 工具函数、poly_line/contours 全部导出函数。
-- 涉及文件: moebius/Kernel/Types/poly_line.hpp, moebius/Kernel/Types/poly_line.cpp, moebius/tests/Kernel/Types/poly_line_test.cpp
+## 2 任务相关的代码文件
+- moebius/Kernel/Types/poly_line.hpp
+- moebius/Kernel/Types/poly_line.cpp
+- moebius/tests/Kernel/Types/poly_line_test.cpp
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake test "moebius_tests/poly_line_test"
+xmake test "moebius_tests/*"   # 全量回归
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+xmake b stem   # 头文件签名改动后主工程编译验证
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake test "moebius_tests/*"
+xmake b stem
+```
+
+## 5 What
+1. 为 poly_line.hpp 全部导出函数补充中文 Doxygen 文档（文件级 @file/@brief，函数级 @brief/@param/@return，按点级工具/折线/轮廓分组），文档按项目约定放在头文件
+2. 新增 poly_line_test.cpp（doctest，13 个 TEST_CASE / 60 断言），覆盖 point 工具、poly_line/contours 全部导出函数及 invariants 特征形状
+3. poly_line.cpp 性能优化：
+   - distance(point, poly_line) 改平方距离比较，整条折线只开一次 sqrt，消除 project 临时分配
+   - 公有 distance(p,q1,q2) 收敛为 sqrt(seg_dist2(...))，单一实现并补维数 ASSERT
+   - inf/sup 改原地分量更新，O(n) 次临时 point 分配降为 1 次
+   - 热点签名改 const point& / const poly_line&，消除引用计数原子加减
+   - l2_norm 委托 point.hpp 内联 norm()；删除本地 square，复用 math_util.hpp
+
+## 6 Why
+提升模块可读性与测试覆盖；inf/sup 逐点两两合并原先每次迭代分配临时 point，distance 逐段 sqrt 加两次临时分配，热点路径（glyph 手写识别不变量计算、鼠标命中测试）受益。
+
+## 7 How
+- 段距离平方内联 helper seg_dist2：内联投影参数并夹断到 [0,1]，退化线段（t == 0）取 a = 0 由末循环自然退化为到端点距离，无需单独分支
+- inf/sup 先深拷贝首点，再原地按分量取 min/max
+- 测试用 moe_doctests.hpp（doctest）；注意 doctest 的 CHECK 内不能用 &&

--- a/devel/1219.md
+++ b/devel/1219.md
@@ -21,6 +21,19 @@ xmake test "moebius_tests/*"   # 全量回归
 xmake b stem   # 头文件签名改动后主工程编译验证
 ```
 
+### 3.3 micro bench（性能验证）
+```
+xmake b poly_line_bench && xmake r poly_line_bench
+```
+
+50 顶点锯齿折线（模拟手写笔画采样），新旧实现对比（nanobench，两轮取代表值）：
+
+| 函数 | 优化前 (ns/op) | 优化后 (ns/op) | 加速比 |
+|------|---------------:|---------------:|-------:|
+| distance (point, poly_line) | ~2,720–3,800 | ~460–710 | **5–6×** |
+| inf (poly_line)             | ~1,250–1,560 | ~160–230   | **7×** |
+| sup (poly_line)             | ~1,360–1,590 | ~160–245   | **6–7×** |
+
 ## 4 如何提交
 
 提交前执行以下最少步骤：

--- a/devel/1219.md
+++ b/devel/1219.md
@@ -61,3 +61,6 @@ xmake b stem
 - 段距离平方内联 helper seg_dist2：内联投影参数并夹断到 [0,1]，退化线段（t == 0）取 a = 0 由末循环自然退化为到端点距离，无需单独分支
 - inf/sup 先深拷贝首点，再原地按分量取 min/max
 - 测试用 moe_doctests.hpp（doctest）；注意 doctest 的 CHECK 内不能用 &&
+
+## 8 附带修复
+- moebius/xmake.lua: moebius_tests 聚合 target 由 binary 改为 phony，修复 `xmake b moebius_tests` 因无 main 的链接失败（#4377 遗留），子测试 `xmake test "moebius_tests/*"` 不受影响

--- a/moebius/Kernel/Types/poly_line.cpp
+++ b/moebius/Kernel/Types/poly_line.cpp
@@ -9,11 +9,28 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
+#include "math_util.hpp"
 #include "poly_line.hpp"
 
+// 点到线段距离的平方：内联投影参数并夹断到 [0,1]；
+// t == 0 时 a 取 0，末循环退化为到端点 q1 的距离平方
 inline double
-square (double x) {
-  return x * x;
+seg_dist2 (const point& p, const point& q1, const point& q2) {
+  int    n= N (p);
+  ASSERT (n == N (q1) && n == N (q2), "unequal lengths");
+  double s= 0.0, t= 0.0;
+  for (int i= 0; i < n; i++) {
+    double d= q2[i] - q1[i];
+    s+= d * (p[i] - q1[i]);
+    t+= square (d);
+  }
+  double a= (t == 0.0) ? 0.0 : s / t;
+  if (a < 0.0) a= 0.0;
+  if (a > 1.0) a= 1.0;
+  double m= 0.0;
+  for (int i= 0; i < n; i++)
+    m+= square (q1[i] + a * (q2[i] - q1[i]) - p[i]);
+  return m;
 }
 
 /******************************************************************************
@@ -22,17 +39,15 @@ square (double x) {
 
 double
 l2_norm (point p) {
-  double s= 0.0;
-  for (int i= 0; i < N (p); i++)
-    s+= square (p[i]);
-  return sqrt (s);
+  return norm (p);
 }
 
 double
 distance (point p, point q) {
-  ASSERT (N (p) == N (q), "unequal lengths");
+  int n= N (p);
+  ASSERT (n == N (q), "unequal lengths");
   double s= 0.0;
-  for (int i= 0; i < N (p); i++)
+  for (int i= 0; i < n; i++)
     s+= square (q[i] - p[i]);
   return sqrt (s);
 }
@@ -54,8 +69,7 @@ project (point p, point q1, point q2) {
 
 double
 distance (point p, point q1, point q2) {
-  if (q1 == q2) return distance (p, q1);
-  else return distance (p, project (p, q1, q2));
+  return sqrt (seg_dist2 (p, q1, q2));
 }
 
 point
@@ -81,12 +95,13 @@ sup (point p, point q) {
  ******************************************************************************/
 
 double
-distance (point p, poly_line pl) {
-  double m= 1.0e10;
-  if (N (pl) == 1) return distance (p, pl[0]);
-  for (int i= 0; i + 1 < N (pl); i++)
-    m= min (m, distance (p, pl[i], pl[i + 1]));
-  return m;
+distance (point p, const poly_line& pl) {
+  int n= N (pl);
+  if (n == 1) return distance (p, pl[0]);
+  double m2= 1.0e100;
+  for (int i= 0; i + 1 < n; i++)
+    m2= min (m2, seg_dist2 (p, pl[i], pl[i + 1]));
+  return sqrt (m2);
 }
 
 bool
@@ -94,21 +109,32 @@ nearby (point p, poly_line pl) {
   return distance (p, pl) <= 5.0;
 }
 
+// inf/sup 采用原地分量更新，避免逐点两两合并时的临时 point 分配
 point
-inf (poly_line pl) {
-  ASSERT (N (pl) > 0, "non zero length expected");
-  point p= pl[0];
-  for (int i= 1; i < N (pl); i++)
-    p= inf (p, pl[i]);
+inf (const poly_line& pl) {
+  int n= N (pl);
+  ASSERT (n > 0, "non zero length expected");
+  point p= copy (pl[0]);
+  int    m= N (p);
+  for (int i= 1; i < n; i++) {
+    const point& q= pl[i];
+    for (int j= 0; j < m; j++)
+      p[j]= min (p[j], q[j]);
+  }
   return p;
 }
 
 point
-sup (poly_line pl) {
-  ASSERT (N (pl) > 0, "non zero length expected");
-  point p= pl[0];
-  for (int i= 1; i < N (pl); i++)
-    p= sup (p, pl[i]);
+sup (const poly_line& pl) {
+  int n= N (pl);
+  ASSERT (n > 0, "non zero length expected");
+  point p= copy (pl[0]);
+  int    m= N (p);
+  for (int i= 1; i < n; i++) {
+    const point& q= pl[i];
+    for (int j= 0; j < m; j++)
+      p[j]= max (p[j], q[j]);
+  }
   return p;
 }
 
@@ -151,22 +177,24 @@ normalize (poly_line pl) {
 
 double
 length (poly_line pl) {
+  int    n  = N (pl);
   double len= 0.0;
-  for (int i= 1; i < N (pl); i++)
+  for (int i= 1; i < n; i++)
     len+= distance (pl[i], pl[i - 1]);
   return len;
 }
 
 point
 access (poly_line pl, double t) {
+  int n= N (pl);
   if (t < 0) return pl[0];
-  for (int i= 1; i < N (pl); i++) {
+  for (int i= 1; i < n; i++) {
     point  dp = pl[i] - pl[i - 1];
     double len= l2_norm (dp);
     if (t < len) return pl[i - 1] + (t / len) * dp;
     t-= len;
   }
-  return pl[N (pl) - 1];
+  return pl[n - 1];
 }
 
 /******************************************************************************

--- a/moebius/Kernel/Types/poly_line.cpp
+++ b/moebius/Kernel/Types/poly_line.cpp
@@ -9,14 +9,14 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
-#include "math_util.hpp"
 #include "poly_line.hpp"
+#include "math_util.hpp"
 
 // 点到线段距离的平方：内联投影参数并夹断到 [0,1]；
 // t == 0 时 a 取 0，末循环退化为到端点 q1 的距离平方
 inline double
 seg_dist2 (const point& p, const point& q1, const point& q2) {
-  int    n= N (p);
+  int n= N (p);
   ASSERT (n == N (q1) && n == N (q2), "unequal lengths");
   double s= 0.0, t= 0.0;
   for (int i= 0; i < n; i++) {
@@ -115,7 +115,7 @@ inf (const poly_line& pl) {
   int n= N (pl);
   ASSERT (n > 0, "non zero length expected");
   point p= copy (pl[0]);
-  int    m= N (p);
+  int   m= N (p);
   for (int i= 1; i < n; i++) {
     const point& q= pl[i];
     for (int j= 0; j < m; j++)
@@ -129,7 +129,7 @@ sup (const poly_line& pl) {
   int n= N (pl);
   ASSERT (n > 0, "non zero length expected");
   point p= copy (pl[0]);
-  int    m= N (p);
+  int   m= N (p);
   for (int i= 1; i < n; i++) {
     const point& q= pl[i];
     for (int j= 0; j < m; j++)

--- a/moebius/Kernel/Types/poly_line.hpp
+++ b/moebius/Kernel/Types/poly_line.hpp
@@ -9,37 +9,231 @@
  * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
  ******************************************************************************/
 
+//! @file poly_line.hpp
+//! @brief 折线（poly_line）与轮廓集合（contours）的基础几何例程。
+//!
+//! 折线由有序点列构成，轮廓是若干条折线的集合。本模块提供点级工具
+//! （范数、距离、投影、上下界）、折线/轮廓的仿射变换、归一化、
+//! 弧长参数化访问、顶点检测以及手写识别用的不变量提取。
+
 #include "point.hpp"
 
 typedef array<point>     poly_line;
 typedef array<poly_line> contours;
 
-double l2_norm (point p);
-double distance (point p, point q);
-point  project (point p, point q1, point q2);
-double distance (point p, point q1, point q2);
-point  inf (point p, point q);
-point  sup (point p, point q);
+/** @name 点级工具例程 */
+/**@{*/
 
-double        distance (point p, poly_line pl);
-bool          nearby (point p, poly_line pl);
-point         inf (poly_line pl);
-point         sup (poly_line pl);
-poly_line     operator+ (poly_line pl, point p);
-poly_line     operator- (poly_line pl, point p);
-poly_line     operator* (double x, poly_line pl);
-poly_line     normalize (poly_line pl);
-double        length (poly_line pl);
-point         access (poly_line pl, double t);
+/**
+ * @brief 计算 point 的 L2 范数（欧氏长度）。
+ * @param p 输入点
+ * @return sqrt(sum(p[i]^2))
+ */
+double l2_norm (point p);
+
+/**
+ * @brief 计算两点间的欧氏距离。
+ * @param p 第一个点
+ * @param q 第二个点
+ * @return 两点距离；要求两点半维数相同
+ */
+double distance (point p, point q);
+
+/**
+ * @brief 将点 p 投影到线段 q1q2 上（含端点截断）。
+ * @param p 被投影的点
+ * @param q1 线段起点
+ * @param q2 线段终点
+ * @return 线段上离 p 最近的点
+ */
+point project (point p, point q1, point q2);
+
+/**
+ * @brief 计算点 p 到线段 q1q2 的距离。
+ * @param p 被测点
+ * @param q1 线段起点
+ * @param q2 线段终点
+ * @return 点到线段的最短距离
+ */
+double distance (point p, point q1, point q2);
+
+/**
+ * @brief 分量式下界：r[i] = min(p[i], q[i])。
+ * @param p 第一个点
+ * @param q 第二个点
+ * @return 各分量取 min 后的新点
+ */
+point inf (point p, point q);
+
+/**
+ * @brief 分量式上界：r[i] = max(p[i], q[i])。
+ * @param p 第一个点
+ * @param q 第二个点
+ * @return 各分量取 max 后的新点
+ */
+point sup (point p, point q);
+
+/**@}*/
+
+/** @name 折线例程 */
+/**@{*/
+
+/**
+ * @brief 计算点到折线的最短距离（逐段取最小）。
+ * @param p 被测点
+ * @param pl 折线
+ * @return 点 p 到所有线段距离的最小值
+ */
+double distance (point p, const poly_line& pl);
+
+/**
+ * @brief 判断点是否在折线附近（距离 <= 5.0）。
+ * @param p 被测点
+ * @param pl 折线
+ * @return 距离不超过 5.0 时返回 true
+ */
+bool nearby (point p, poly_line pl);
+
+/**
+ * @brief 折线包围盒的下角点（各分量最小值）。
+ * @param pl 非空折线
+ * @return 所有顶点分量式 min 构成的点
+ */
+point inf (const poly_line& pl);
+
+/**
+ * @brief 折线包围盒的上角点（各分量最大值）。
+ * @param pl 非空折线
+ * @return 所有顶点分量式 max 构成的点
+ */
+point sup (const poly_line& pl);
+
+/**
+ * @brief 折线平移：每个顶点加 p。
+ * @param pl 折线
+ * @param p 平移向量
+ * @return 平移后的新折线
+ */
+poly_line operator+ (poly_line pl, point p);
+
+/**
+ * @brief 折线反向平移：每个顶点减 p。
+ * @param pl 折线
+ * @param p 平移向量
+ * @return 平移后的新折线
+ */
+poly_line operator- (poly_line pl, point p);
+
+/**
+ * @brief 折线缩放：每个顶点乘标量 x。
+ * @param x 缩放系数
+ * @param pl 折线
+ * @return 缩放后的新折线
+ */
+poly_line operator* (double x, poly_line pl);
+
+/**
+ * @brief 折线归一化：先平移使下角点为原点，再缩放使最大分量为 1。
+ * @param pl 折线
+ * @return 归一化后的折线；空折线或退化（缩放因子为 0）时原样返回
+ */
+poly_line normalize (poly_line pl);
+
+/**
+ * @brief 计算折线总弧长（逐段长度求和）。
+ * @param pl 折线
+ * @return 各段欧氏长度之和
+ */
+double length (poly_line pl);
+
+/**
+ * @brief 按弧长参数 t 取折线上的点。
+ * @param pl 折线
+ * @param t 弧长参数；t <= 0 返回首点，t 超过总长返回末点
+ * @return 折线上距起点弧长为 t 处的点（含段内线性插值）
+ */
+point access (poly_line pl, double t);
+
+/**
+ * @brief 顶点检测：返回折线中"转折处"的归一化弧长参数。
+ * @param pl 折线
+ * @return 递增的参数数组，首元素 0.0、末元素 1.0，中间为检测到的顶点位置
+ */
 array<double> vertices (poly_line pl);
 
-double   distance (point p, contours pl);
-bool     nearby (point p, contours pl);
-point    inf (contours pl);
-point    sup (contours pl);
-contours operator+ (contours pl, point p);
-contours operator- (contours pl, point p);
-contours operator* (double x, contours pl);
-contours normalize (contours pl);
-void     invariants (contours gl, int level, array<tree>& disc,
-                     array<double>& cont);
+/**@}*/
+
+/** @name 轮廓（折线集合）例程 */
+/**@{*/
+
+/**
+ * @brief 计算点到轮廓集合的最短距离（逐条折线取最小）。
+ * @param p 被测点
+ * @param gl 轮廓集合
+ * @return 点到所有折线距离的最小值
+ */
+double distance (point p, contours gl);
+
+/**
+ * @brief 判断点是否在轮廓附近（距离 <= 5.0）。
+ * @param p 被测点
+ * @param gl 轮廓集合
+ * @return 距离不超过 5.0 时返回 true
+ */
+bool nearby (point p, contours gl);
+
+/**
+ * @brief 轮廓整体包围盒的下角点。
+ * @param gl 非空轮廓集合
+ * @return 所有折线顶点分量式 min 构成的点
+ */
+point inf (contours gl);
+
+/**
+ * @brief 轮廓整体包围盒的上角点。
+ * @param gl 非空轮廓集合
+ * @return 所有折线顶点分量式 max 构成的点
+ */
+point sup (contours gl);
+
+/**
+ * @brief 轮廓平移：每条折线的每个顶点加 p。
+ * @param gl 轮廓集合
+ * @param p 平移向量
+ * @return 平移后的新轮廓
+ */
+contours operator+ (contours gl, point p);
+
+/**
+ * @brief 轮廓反向平移：每条折线的每个顶点减 p。
+ * @param gl 轮廓集合
+ * @param p 平移向量
+ * @return 平移后的新轮廓
+ */
+contours operator- (contours gl, point p);
+
+/**
+ * @brief 轮廓缩放：每条折线的每个顶点乘标量 x。
+ * @param x 缩放系数
+ * @param gl 轮廓集合
+ * @return 缩放后的新轮廓
+ */
+contours operator* (double x, contours gl);
+
+/**
+ * @brief 轮廓归一化：整体平移使下角点为原点，再缩放使最大分量为 1。
+ * @param gl 轮廓集合
+ * @return 归一化后的轮廓；空轮廓或退化时原样返回
+ */
+contours normalize (contours gl);
+
+/**
+ * @brief 提取轮廓的不变量特征（手写识别用）。
+ * @param gl 轮廓集合
+ * @param level 不变量级别；level <= 1 时额外附上顶点信息
+ * @param disc [out] 离散特征（轮廓条数、每条折线的顶点数）
+ * @param cont [out] 连续特征（沿每条折线均匀采样的坐标，以及顶点参数）
+ * @note 输入 gl 会先做归一化再采样。
+ */
+void invariants (contours gl, int level, array<tree>& disc,
+                 array<double>& cont);

--- a/moebius/bench/Kernel/Types/poly_line_bench.cpp
+++ b/moebius/bench/Kernel/Types/poly_line_bench.cpp
@@ -1,0 +1,90 @@
+/** \file poly_line_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for poly_line / contours operations
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "poly_line.hpp"
+
+/** \brief 生成 n 个顶点的锯齿形折线，模拟手写笔画采样 */
+static poly_line
+mk_zigzag (int n, double w, double h) {
+  poly_line pl;
+  for (int i= 0; i < n; i++)
+    pl << point (w * i / (n - 1), (i % 2 == 0) ? 0.0 : h);
+  return pl;
+}
+
+/* ---------- 优化前实现（对照组），用于量化本次优化收益 ---------- */
+
+/// 旧版：逐段经 project（临时分配）+ 每段一次 sqrt
+static double
+legacy_distance_pl (point p, poly_line pl) {
+  double m= 1.0e10;
+  if (N (pl) == 1) return distance (p, pl[0]);
+  for (int i= 0; i + 1 < N (pl); i++) {
+    point proj= project (p, pl[i], pl[i + 1]);
+    m         = min (m, distance (p, proj));
+  }
+  return m;
+}
+
+/// 旧版：逐点两两合并，每次迭代分配临时 point
+static point
+legacy_inf_pl (poly_line pl) {
+  point p= pl[0];
+  for (int i= 1; i < N (pl); i++)
+    p= inf (p, pl[i]);
+  return p;
+}
+
+static point
+legacy_sup_pl (poly_line pl) {
+  point p= pl[0];
+  for (int i= 1; i < N (pl); i++)
+    p= sup (p, pl[i]);
+  return p;
+}
+
+int
+main () {
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (100).unit ("op");
+
+  // 50 顶点折线接近真实手写笔画的采样规模
+  poly_line pl= mk_zigzag (50, 100.0, 10.0);
+  point     p = point (50.0, 5.0);
+  point     q1= pl[10], q2= pl[11];
+
+  bench.run ("distance(point,point)", [&] { distance (p, q1); });
+  bench.run ("distance(point,segment)", [&] { distance (p, q1, q2); });
+  bench.run ("distance(point,poly_line)", [&] { distance (p, pl); });
+  bench.run ("nearby(point,poly_line)", [&] { nearby (p, pl); });
+  bench.run ("inf(poly_line)", [&] { inf (pl); });
+  bench.run ("sup(poly_line)", [&] { sup (pl); });
+  bench.run ("legacy distance(point,poly_line)",
+             [&] { legacy_distance_pl (p, pl); });
+  bench.run ("legacy inf(poly_line)", [&] { legacy_inf_pl (pl); });
+  bench.run ("legacy sup(poly_line)", [&] { legacy_sup_pl (pl); });
+  bench.run ("length(poly_line)", [&] { length (pl); });
+  bench.run ("access(poly_line)", [&] { access (pl, 60.0); });
+  bench.run ("normalize(poly_line)", [&] { normalize (pl); });
+  bench.run ("vertices(poly_line)", [&] { vertices (pl); });
+
+  contours gl;
+  gl << mk_zigzag (50, 100.0, 10.0);
+  gl << mk_zigzag (30, 80.0, 8.0);
+  bench.run ("distance(point,contours)", [&] { distance (p, gl); });
+  bench.run ("inf(contours)", [&] { inf (gl); });
+  bench.run ("normalize(contours)", [&] { normalize (gl); });
+  bench.run ("invariants(level=1)", [&] {
+    array<tree>   disc;
+    array<double> cont;
+    invariants (gl, 1, disc, cont);
+    ankerl::nanobench::doNotOptimizeAway (cont);
+  });
+
+  ankerl::nanobench::doNotOptimizeAway (pl);
+  return 0;
+}

--- a/moebius/tests/Kernel/Types/poly_line_test.cpp
+++ b/moebius/tests/Kernel/Types/poly_line_test.cpp
@@ -128,9 +128,12 @@ TEST_CASE ("test vertices") {
   // 直线段：只有首尾
   poly_line     line= mk_pl (0.0, 0.0, 0.5, 0.0, 1.0, 0.0);
   array<double> ts  = vertices (line);
-  REQUIRE (N (ts) == 2);
-  CHECK_EQ (ts[0], 0.0);
-  CHECK_EQ (ts[1], 1.0);
+  // REQUIRE 依赖异常，MSVC 关异常下不可用；CHECK 后需自行防止越界访问
+  CHECK (N (ts) == 2);
+  if (N (ts) == 2) {
+    CHECK_EQ (ts[0], 0.0);
+    CHECK_EQ (ts[1], 1.0);
+  }
   // 直角折线：中间顶点应被检出
   poly_line     bend= mk_pl (0.0, 0.0, 1.0, 0.0, 1.0, 1.0);
   array<double> vs  = vertices (bend);
@@ -172,9 +175,11 @@ TEST_CASE ("test invariants") {
   array<double> cont;
   invariants (gl, 1, disc, cont);
   // 离散特征：轮廓条数 + 每条折线顶点数
-  REQUIRE (N (disc) == 2);
-  CHECK (disc[0] == tree ("1"));
-  CHECK (disc[1] == tree ("2"));
+  CHECK (N (disc) == 2);
+  if (N (disc) == 2) {
+    CHECK (disc[0] == tree ("1"));
+    CHECK (disc[1] == tree ("2"));
+  }
   // 连续特征：21 个采样点坐标 + 顶点参数（缩放 2.5 倍）
   CHECK (N (cont) == 21 * 2 + 2);
   CHECK_EQ (cont[0], 0.0);

--- a/moebius/tests/Kernel/Types/poly_line_test.cpp
+++ b/moebius/tests/Kernel/Types/poly_line_test.cpp
@@ -1,0 +1,183 @@
+/******************************************************************************
+ * MODULE     : poly_line_test.cpp
+ * DESCRIPTION: Unit tests for poly line routines
+ * COPYRIGHT  : (C) 2026  Da Shen
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "moe_doctests.hpp"
+#include "poly_line.hpp"
+
+static poly_line
+mk_pl (double x0, double y0, double x1, double y1) {
+  poly_line pl;
+  pl << point (x0, y0) << point (x1, y1);
+  return pl;
+}
+
+static poly_line
+mk_pl (double x0, double y0, double x1, double y1, double x2, double y2) {
+  poly_line pl;
+  pl << point (x0, y0) << point (x1, y1) << point (x2, y2);
+  return pl;
+}
+
+static bool
+almost_eq (point p, point q, double eps= 1e-9) {
+  int n= N (p);
+  if (n != N (q)) return false;
+  for (int i= 0; i < n; i++)
+    if (fabs (p[i] - q[i]) > eps) return false;
+  return true;
+}
+
+TEST_CASE ("test l2_norm and point distance") {
+  CHECK_EQ (l2_norm (point (3.0, 4.0)), 5.0);
+  CHECK_EQ (distance (point (0.0, 0.0), point (3.0, 4.0)), 5.0);
+  CHECK_EQ (distance (point (1.0, 1.0), point (1.0, 1.0)), 0.0);
+}
+
+TEST_CASE ("test project onto segment") {
+  CHECK (project (point (0.5, 1.0), point (0.0, 0.0), point (1.0, 0.0)) ==
+         point (0.5, 0.0));
+  // 端点截断
+  CHECK (project (point (2.0, 1.0), point (0.0, 0.0), point (1.0, 0.0)) ==
+         point (1.0, 0.0));
+  CHECK (project (point (-1.0, 1.0), point (0.0, 0.0), point (1.0, 0.0)) ==
+         point (0.0, 0.0));
+}
+
+TEST_CASE ("test point to segment distance") {
+  CHECK_EQ (distance (point (0.5, 1.0), point (0.0, 0.0), point (1.0, 0.0)),
+            1.0);
+  CHECK_EQ (distance (point (2.0, 0.0), point (0.0, 0.0), point (1.0, 0.0)),
+            1.0);
+  // 退化线段：端点重合
+  CHECK_EQ (distance (point (0.0, 3.0), point (0.0, 0.0), point (0.0, 0.0)),
+            3.0);
+}
+
+TEST_CASE ("test inf and sup on points") {
+  CHECK (inf (point (1.0, 5.0), point (3.0, 2.0)) == point (1.0, 2.0));
+  CHECK (sup (point (1.0, 5.0), point (3.0, 2.0)) == point (3.0, 5.0));
+}
+
+TEST_CASE ("test distance to poly_line") {
+  poly_line pl= mk_pl (0.0, 0.0, 1.0, 1.0, 2.0, 0.0);
+  CHECK_EQ (distance (point (0.5, 1.0), pl), sqrt (0.125));
+  CHECK (distance (point (1.0, 1.0), pl) < 1e-9);
+  // 单点折线
+  poly_line one;
+  one << point (1.0, 2.0);
+  CHECK_EQ (distance (point (4.0, 6.0), one), 5.0);
+}
+
+TEST_CASE ("test nearby") {
+  poly_line pl= mk_pl (0.0, 0.0, 10.0, 0.0);
+  CHECK (nearby (point (5.0, 3.0), pl));
+  CHECK (!nearby (point (5.0, 6.0), pl));
+}
+
+TEST_CASE ("test inf and sup on poly_line") {
+  poly_line pl= mk_pl (1.0, 4.0, -2.0, 0.0, 3.0, -5.0);
+  CHECK (inf (pl) == point (-2.0, -5.0));
+  CHECK (sup (pl) == point (3.0, 4.0));
+}
+
+TEST_CASE ("test poly_line arithmetic operators") {
+  poly_line pl= mk_pl (1.0, 1.0, 2.0, 2.0);
+  poly_line sh= pl + point (1.0, -1.0);
+  CHECK (sh[0] == point (2.0, 0.0));
+  CHECK (sh[1] == point (3.0, 1.0));
+  poly_line bk= sh - point (1.0, -1.0);
+  CHECK (bk[0] == pl[0]);
+  CHECK (bk[1] == pl[1]);
+  poly_line sc= 2.0 * pl;
+  CHECK (sc[0] == point (2.0, 2.0));
+  CHECK (sc[1] == point (4.0, 4.0));
+}
+
+TEST_CASE ("test normalize poly_line") {
+  poly_line pl= mk_pl (2.0, 2.0, 4.0, 4.0);
+  poly_line nr= normalize (pl);
+  CHECK (almost_eq (nr[0], point (0.0, 0.0)));
+  CHECK (almost_eq (nr[1], point (1.0, 1.0)));
+  // 退化：所有点相同，缩放因子为 0
+  poly_line deg= mk_pl (1.0, 1.0, 1.0, 1.0);
+  poly_line dr = normalize (deg);
+  CHECK (dr[0] == point (0.0, 0.0));
+  // 空折线
+  poly_line empty;
+  CHECK (N (normalize (empty)) == 0);
+}
+
+TEST_CASE ("test length and access") {
+  poly_line pl= mk_pl (0.0, 0.0, 3.0, 0.0, 3.0, 4.0);
+  CHECK_EQ (length (pl), 7.0);
+  CHECK (access (pl, 0.0) == point (0.0, 0.0));
+  CHECK (almost_eq (access (pl, 1.5), point (1.5, 0.0)));
+  CHECK (almost_eq (access (pl, 5.0), point (3.0, 2.0)));
+  CHECK (almost_eq (access (pl, -1.0), point (0.0, 0.0)));
+  CHECK (almost_eq (access (pl, 100.0), point (3.0, 4.0)));
+}
+
+TEST_CASE ("test vertices") {
+  // 直线段：只有首尾
+  poly_line     line= mk_pl (0.0, 0.0, 0.5, 0.0, 1.0, 0.0);
+  array<double> ts  = vertices (line);
+  REQUIRE (N (ts) == 2);
+  CHECK_EQ (ts[0], 0.0);
+  CHECK_EQ (ts[1], 1.0);
+  // 直角折线：中间顶点应被检出
+  poly_line     bend= mk_pl (0.0, 0.0, 1.0, 0.0, 1.0, 1.0);
+  array<double> vs  = vertices (bend);
+  CHECK (N (vs) == 3);
+  CHECK (vs[1] > 0.0);
+  CHECK (vs[1] < 1.0);
+  CHECK_EQ (vs[0], 0.0);
+  CHECK_EQ (vs[2], 1.0);
+}
+
+TEST_CASE ("test contours operations") {
+  contours gl;
+  gl << mk_pl (0.0, 0.0, 2.0, 2.0);
+  gl << mk_pl (10.0, 0.0, 12.0, 2.0);
+
+  CHECK (almost_eq (inf (gl), point (0.0, 0.0)));
+  CHECK (almost_eq (sup (gl), point (12.0, 2.0)));
+  CHECK_EQ (distance (point (6.0, 0.0), gl), 4.0);
+  CHECK (nearby (point (6.0, 3.0), gl));
+  CHECK (!nearby (point (6.0, 6.0), gl));
+
+  contours sh= gl + point (1.0, 1.0);
+  CHECK (sh[0][0] == point (1.0, 1.0));
+  contours bk= sh - point (1.0, 1.0);
+  CHECK (bk[0][0] == gl[0][0]);
+  CHECK (bk[1][1] == gl[1][1]);
+  contours sc= 0.5 * gl;
+  CHECK (sc[1][1] == point (6.0, 1.0));
+
+  contours nr= normalize (gl);
+  CHECK (almost_eq (inf (nr), point (0.0, 0.0), 1e-9));
+  CHECK (max (sup (nr)) <= 1.0 + 1e-9);
+}
+
+TEST_CASE ("test invariants") {
+  contours gl;
+  gl << mk_pl (0.0, 0.0, 2.0, 2.0);
+  array<tree>   disc;
+  array<double> cont;
+  invariants (gl, 1, disc, cont);
+  // 离散特征：轮廓条数 + 每条折线顶点数
+  REQUIRE (N (disc) == 2);
+  CHECK (disc[0] == tree ("1"));
+  CHECK (disc[1] == tree ("2"));
+  // 连续特征：21 个采样点坐标 + 顶点参数（缩放 2.5 倍）
+  CHECK (N (cont) == 21 * 2 + 2);
+  CHECK_EQ (cont[0], 0.0);
+  CHECK_EQ (cont[1], 0.0);
+  CHECK (cont[N (cont) - 1] <= 2.5 + 1e-9);
+}

--- a/moebius/xmake.lua
+++ b/moebius/xmake.lua
@@ -80,7 +80,9 @@ target("libmoebius") do
 end
 
 target("moebius_tests") do
-    set_kind ("binary")
+    -- 仅作为 add_tests 子测试的容器；phony 使其不链接成单一二进制
+    -- （原先 binary 会因无 main 而在 `xmake b moebius_tests` 时链接失败）
+    set_kind ("phony")
     set_languages("c++17")
     set_default (false)
 


### PR DESCRIPTION
## 概要

- 为 \`moebius/Kernel/Types/poly_line.hpp\` 全部导出函数补充中文 Doxygen 文档（按点级工具/折线/轮廓分组），文档按项目约定放在头文件
- 新增 \`moebius/tests/Kernel/Types/poly_line_test.cpp\`（doctest，13 个 TEST_CASE / 60 断言），覆盖所有导出函数
- \`poly_line.cpp\` 性能优化：
  - \`distance(point, poly_line)\` 用平方距离比较，整条折线只开一次 \`sqrt\`，消除 \`project\` 临时分配
  - 公有 \`distance(p,q1,q2)\` 收敛为 \`sqrt(seg_dist2(...))\`，单一实现
  - \`inf/sup\` 改原地分量更新（O(n) 次分配降为 1 次）
  - 热点函数签名改 \`const point&\` / \`const poly_line&\`，消除引用计数原子加减
  - \`l2_norm\` 委托 \`point.hpp\` 的内联 \`norm()\`；删除本地 \`square\`，复用 \`math_util.hpp\`

## 测试

- \`xmake test "moebius_tests/*"\`：17/17 通过
- \`xmake b stem\`：编译干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)