### PR TITLE
[1220] 手写模式跳过 update-menus 工具栏重建

### DIFF
--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -1096,6 +1096,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
+(tm-define (graphics-handwriting?)
+  (:synopsis "Are we in the hand-drawn (handwriting) graphics mode?")
+  (== (car (graphics-mode)) 'hand-edit)
+) ;tm-define
+
 (tm-define (graphics-mode)
   (with m
     (tree->stree (get-env-tree "gr-mode"))

--- a/devel/1220.md
+++ b/devel/1220.md
@@ -1,0 +1,31 @@
+# 1220 手写模式跳过 update-menus 工具栏重建
+
+## What
+
+绘图模式的手写功能（`hand-edit`）在书写过程中反复触发
+`update_menus (ICONS_MODE | ICONS_FOCUS)`，重建 mode/focus 工具栏，
+导致手写性能差（卡顿）。手写过程中工具栏内容不会变化，这些重建纯属浪费。
+本次改动在手写模式下跳过这两处菜单刷新。
+
+## Why
+
+手写拖拽路径 `edit_drag → object-set! → graphics-assign → tree-assign + go-to`
+每个鼠标事件都会置 `THE_CURSOR`，焦点路径变化即触发工具栏重建；笔画松开时
+`edit_mouse` 又会再刷一次。工具栏重建走 scheme 懒加载工具链，开销大，
+连续书写时每笔都付一次，造成明显卡顿。
+
+## How
+
+- scheme 侧新增查询函数 `graphics-handwriting?`（`graphics-main.scm`）：
+  `(== (car (graphics-mode)) 'hand-edit)`，供 C++ 调用。
+- `edit_interface.cpp` `apply_changes` 的 `THE_CURSOR` 分支：手写模式下
+  跳过焦点变化触发的 `update_menus (ICONS_MODE | ICONS_FOCUS)`。
+- `edit_mouse.cpp` 绘图手势结束的轻量刷新：手写模式下跳过。
+
+门控遵循最小改动原则，只放开手写命中的类别，其他绘图手势行为不变。
+
+## 涉及文件
+
+- `TeXmacs/progs/graphics/graphics-main.scm`
+- `src/Edit/Interface/edit_interface.cpp`
+- `src/Edit/Interface/edit_mouse.cpp`

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -1371,9 +1371,12 @@ edit_interface_rep::apply_changes () {
     update_menus (MENU_ALL);
   }
   else if (env_change & THE_CURSOR) {
-    // 光标移动仅当焦点树身份变化时，轻量刷新 mode/focus 栏
+    // 光标移动仅当焦点树身份变化时，轻量刷新 mode/focus 栏；
+    // 手写模式拖拽过程中工具栏内容不变，跳过重建
+    bool handwriting=
+        inside_active_graphics () && as_bool (call ("graphics-handwriting?"));
     path fp= focus_get ();
-    if (fp != menu_focus_path) {
+    if (!handwriting && fp != menu_focus_path) {
       menu_focus_path= fp;
       update_menus (ICONS_MODE | ICONS_FOCUS);
     }

--- a/src/Edit/Interface/edit_mouse.cpp
+++ b/src/Edit/Interface/edit_mouse.cpp
@@ -1019,10 +1019,12 @@ edit_interface_rep::mouse_any (string type, SI x, SI y, int mods, time_t t,
   if (inside_graphics (type != "release-left") &&
       !(is_graphics_drag && !is_in_graphics_mode)) {
     if (mouse_graphics (type, x, y, mods, t, data)) {
-      // 绘图手势结束时，选中对象会变，轻量刷新 mode/focus 栏
+      // 绘图手势结束时，选中对象会变，轻量刷新 mode/focus 栏；
+      // 手写模式下菜单不变，跳过重建
       if (type == "release-left" || type == "end-drag-left" ||
           type == "release-right" || type == "end-drag-right")
-        update_menus (ICONS_MODE | ICONS_FOCUS);
+        if (!as_bool (call ("graphics-handwriting?")))
+          update_menus (ICONS_MODE | ICONS_FOCUS);
       if (is_in_graphics_mode) return;
       else {
         if (type == "press-left") {

--- a/xmake/targets/libmogan.lua
+++ b/xmake/targets/libmogan.lua
@@ -274,7 +274,6 @@ target("libmogan") do
             "$(projectdir)/src/Data/**.cpp",
             "$(projectdir)/src/Edit/**.cpp",
             "$(projectdir)/src/Graphics/**.cpp",
-            "$(projectdir)/src/Kernel/**.cpp",
             "$(projectdir)/src/Scheme/Scheme/**.cpp",
             "$(projectdir)/src/Scheme/S7/**.cpp",
             "$(projectdir)/src/Scheme/L2/**.cpp",

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -122,7 +122,6 @@ libstem_srcs = {
     "$(projectdir)/src/Data/**.cpp",
     "$(projectdir)/src/Edit/**.cpp",
     "$(projectdir)/src/Graphics/**.cpp",
-    "$(projectdir)/src/Kernel/**.cpp",
     "$(projectdir)/src/Mogan/**.cpp",
     "$(projectdir)/src/Scheme/Scheme/**.cpp",
     "$(projectdir)/src/Scheme/S7/**.cpp",


### PR DESCRIPTION
## 概要

- 修复绘图模式手写功能性能差的问题：手写（`hand-edit`）拖拽过程中每个鼠标事件都会触发 `update_menus (ICONS_MODE | ICONS_FOCUS)` 重建工具栏，而手写过程中菜单内容不会变化。现在手写模式下跳过这两处刷新（`edit_interface.cpp` 焦点变化分支、`edit_mouse.cpp` 手势结束分支），并新增 scheme 查询函数 `graphics-handwriting?`。
- 顺手清理 xmake 中已不存在的 `src/Kernel/**.cpp` glob（`libmogan.lua`、`vars.lua`），消除构建 warning。

## 测试

- 本地构建 + GUI 手写验证流畅（用户手动验证通过）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)