### PR TITLE
[1223] 启动页 buffer 跳过 apply_changes 排版

### DIFF
--- a/devel/1223.md
+++ b/devel/1223.md
@@ -1,0 +1,30 @@
+# 1223 启动页跳过排版
+
+## 问题
+
+启动时 `std-bench` 日志出现:
+
+```
+apply_changes: tmfs://startup-tab took 12 ms
+```
+
+启动页 buffer(`tmfs://startup-tab`)的排版结果从不显示(UI 完全由
+QTMStartupTabWidget 承担,editor canvas 被隐藏),这次排版是纯浪费。
+
+## 原因
+
+- 启动页 buffer 在 `new_window.cpp` 中以空 `tree(DOCUMENT)` 创建并 attach view;
+- `edit_main_rep` 构造时无条件 `notify_change(THE_TREE)`,置脏标记;
+- `tm_server_rep::interpose_handler` 对所有 attached view 无差别调用
+  `ed->apply_changes()`,无 buffer 类型过滤,于是启动页被完整排版一次。
+
+`should_update_menu`(edit_interface.cpp)已为 startup-tab 建立了"跳过编辑器
+路径"的分类(1220),但排版路径没有对应特判,属于遗漏。
+
+## 改动
+
+`src/Texmacs/Server/tm_server.cpp`:`interpose_handler` 的 view 循环中,
+`is_startup_tab_buffer(vw->buf->buf->name)` 的 view 跳过 `apply_changes()`
+(与 `set_user_active`、`animate` 无关,仅跳过排版改动应用)。
+
+按门槛修改最小化原则,只处理 startup-tab,不扩展 chat-tab 等其他类别。

--- a/devel/1223.md
+++ b/devel/1223.md
@@ -23,8 +23,28 @@ QTMStartupTabWidget 承担,editor canvas 被隐藏),这次排版是纯浪费。
 
 ## 改动
 
-`src/Texmacs/Server/tm_server.cpp`:`interpose_handler` 的 view 循环中,
-`is_startup_tab_buffer(vw->buf->buf->name)` 的 view 跳过 `apply_changes()`
-(与 `set_user_active`、`animate` 无关,仅跳过排版改动应用)。
+`src/Edit/Interface/edit_interface.cpp`:`edit_interface_rep::apply_changes`
+中,窗口装饰(滚动条/工具栏)处理之后、选区处理之前,对
+`is_startup_tab_buffer(buf->buf->name)` 的 buffer 执行
+`env_change &= THE_MENUS`,屏蔽排版/环境/选区/光标/焦点等全部改动位,
+仅保留菜单位(经 `should_update_menu` 过滤后只剩 TAB_PAGES 重建)。
+
+### 为什么不是整个跳过 apply_changes
+
+`apply_changes` 不只排版:还负责 zoom 同步、滚动条/窗口装饰、选区失效、
+光标刷新、`update_menus`(1220 的 tab 页栏过滤依赖此入口)。整体跳过会丢
+掉这些副作用。
+
+### 为什么不是只跳过 typeset 调用
+
+`eb` 永远为 nil 时,后续 extents 块(`eb->x1`)与光标块(`go_to_here` 内
+`eb->find_check_cursor`)会解引用空指针。屏蔽 env_change 位让这些块的
+进入条件自然不成立,全部安全跳过。
 
 按门槛修改最小化原则,只处理 startup-tab,不扩展 chat-tab 等其他类别。
+
+## 迭代记录
+
+- 初版在 `tm_server.cpp` 的 interpose 循环整体跳过 startup-tab 的
+  `apply_changes`,审查发现会丢掉菜单/滚动条/窗口装饰等副作用,已回退,
+  改为上述 env_change 位屏蔽方案。

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -1121,6 +1121,11 @@ edit_interface_rep::apply_changes () {
     }
   }
 
+  // 启动页 UI 由 Qt widget 承担,排版结果不显示:屏蔽除菜单外的全部
+  // 改动位,跳过排版/光标/选区等编辑器路径(eb 保持 nil,相关代码均不可
+  // 触达),仅保留 tab 页栏重建
+  if (is_startup_tab_buffer (buf->buf->name)) env_change&= THE_MENUS;
+
   // cout << "Handling selection\n";
   if (env_change & (THE_TREE + THE_ENVIRONMENT + THE_SELECTION)) {
     if (!is_nil (selection_rects)) {

--- a/src/Texmacs/Server/tm_server.cpp
+++ b/src/Texmacs/Server/tm_server.cpp
@@ -22,7 +22,6 @@
 #include "goldfish.hpp"
 #include "lolly/system/subprocess.hpp"
 #include "new_style.hpp"
-#include "new_view.hpp"
 #include "s7_blackbox.hpp"
 #include "socket_notifier.hpp"
 #include "sys_utils.hpp"
@@ -224,8 +223,7 @@ tm_server_rep::interpose_handler () {
 
       for (j= 0; j < N (buf->vws); j++) {
         tm_view vw= (tm_view) buf->vws[j];
-        // 启动页 UI 由 Qt widget 承担,排版结果不显示,无需 apply_changes
-        if (vw->win != NULL && !is_startup_tab_buffer (vw->buf->buf->name)) {
+        if (vw->win != NULL) {
           string btask= "apply_changes: " * as_string (vw->buf->buf->name);
           bench_start (btask);
           vw->ed->apply_changes ();

--- a/src/Texmacs/Server/tm_server.cpp
+++ b/src/Texmacs/Server/tm_server.cpp
@@ -22,6 +22,7 @@
 #include "goldfish.hpp"
 #include "lolly/system/subprocess.hpp"
 #include "new_style.hpp"
+#include "new_view.hpp"
 #include "s7_blackbox.hpp"
 #include "socket_notifier.hpp"
 #include "sys_utils.hpp"
@@ -223,7 +224,8 @@ tm_server_rep::interpose_handler () {
 
       for (j= 0; j < N (buf->vws); j++) {
         tm_view vw= (tm_view) buf->vws[j];
-        if (vw->win != NULL) {
+        // 启动页 UI 由 Qt widget 承担,排版结果不显示,无需 apply_changes
+        if (vw->win != NULL && !is_startup_tab_buffer (vw->buf->buf->name)) {
           string btask= "apply_changes: " * as_string (vw->buf->buf->name);
           bench_start (btask);
           vw->ed->apply_changes ();


### PR DESCRIPTION
## 问题

启动时 bench 日志出现 `apply_changes: tmfs://startup-tab took 12 ms`。启动页 UI 完全由 QTMStartupTabWidget 承担(editor canvas 隐藏),排版结果从不显示,这次排版是纯浪费。

## 原因

- `edit_main_rep` 构造时无条件 `notify_change(THE_TREE)`
- `tm_server_rep::interpose_handler` 对所有 attached view 无差别调用 `apply_changes()`,无 buffer 类型过滤

`should_update_menu` 已为 startup-tab 建立"跳过编辑器路径"分类(#4381),排版路径是遗漏。

## 改动

`interpose_handler` 的 view 循环中对 `is_startup_tab_buffer` 的 view 跳过 `apply_changes()`。按最小改动原则只处理 startup-tab。

🤖 Generated with [Claude Code](https://claude.com/claude-code)