### PR TITLE
[1221] PDF 阅读器重新打开时跳转到上次阅读页码

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tests/pdf-last-page-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tests/pdf-last-page-test.scm
@@ -22,11 +22,13 @@
 ;; 避免污染测试环境的用户偏好。
 
 (define saved-last-pages (get-preference "pdf:last-pages"))
+
 (define saved-restore-switch (get-preference "pdf:restore-last-page"))
 
 (define (restore-preferences!)
   (set-preference "pdf:last-pages" saved-last-pages)
-  (set-preference "pdf:restore-last-page" saved-restore-switch))
+  (set-preference "pdf:restore-last-page" saved-restore-switch)
+) ;define
 
 ;; 基本 roundtrip：写入后读回；未记录的路径返回 #f。
 
@@ -34,7 +36,8 @@
   (set-preference "pdf:last-pages" "default")
   (pdf-last-page-set "/tmp/a.pdf" 3)
   (check (pdf-last-page-get "/tmp/a.pdf") => 3)
-  (check (pdf-last-page-get "/tmp/never-seen.pdf") => #f))
+  (check (pdf-last-page-get "/tmp/never-seen.pdf") => #f)
+) ;define
 
 ;; 路径含分号/引号/反斜杠等特殊字符、或超过 s7 print-length 的长路径，
 ;; 序列化均不丢数据。
@@ -42,13 +45,16 @@
 (define (test-special-chars-roundtrip)
   (set-preference "pdf:last-pages" "default")
   (let ((weird "/tmp/a;b\"c\\d e.pdf")
-        (long (string-append "/" (make-string 100 #\x) ".pdf")))
+        (long (string-append "/" (make-string 100 #\x) ".pdf"))
+       ) ;
     (pdf-last-page-set weird 42)
     (pdf-last-page-set long 8)
     (pdf-last-page-set "/tmp/other.pdf" 7)
     (check (pdf-last-page-get weird) => 42)
     (check (pdf-last-page-get long) => 8)
-    (check (pdf-last-page-get "/tmp/other.pdf") => 7)))
+    (check (pdf-last-page-get "/tmp/other.pdf") => 7)
+  ) ;let
+) ;define
 
 ;; 同一路径重复记录：去重且新值置于表头（MRU）。
 
@@ -59,22 +65,28 @@
   (pdf-last-page-set "/tmp/a.pdf" 9)
   (check (pdf-last-page-get "/tmp/a.pdf") => 9)
   (check (car (car (pdf-last-pages-read))) => "/tmp/a.pdf")
-  (check (length (pdf-last-pages-read)) => 2))
+  (check (length (pdf-last-pages-read)) => 2)
+) ;define
 
 ;; LRU 上限：写入超过 100 条后截断表尾（最旧条目被淘汰）。
 
 (define (test-lru-cap)
   (set-preference "pdf:last-pages" "default")
-  (let loop ((i 1))
+  (let loop
+    ((i 1))
     (when (<= i 105)
       (pdf-last-page-set (string-append "/tmp/f" (number->string i) ".pdf") i)
-      (loop (+ i 1))))
+      (loop (+ i 1))
+    ) ;when
+  ) ;let
   (let ((lst (pdf-last-pages-read)))
     (check (length lst) => 100)
     ;; 最新写入的在表头，最旧的 5 条被淘汰
     (check (pdf-last-page-get "/tmp/f105.pdf") => 105)
     (check (pdf-last-page-get "/tmp/f1.pdf") => #f)
-    (check (pdf-last-page-get "/tmp/f6.pdf") => 6)))
+    (check (pdf-last-page-get "/tmp/f6.pdf") => 6)
+  ) ;let
+) ;define
 
 ;; 非法输入不落盘：page<=0、非整数、非字符串路径。
 
@@ -84,17 +96,20 @@
   (pdf-last-page-set "/tmp/a.pdf" -1)
   (pdf-last-page-set "/tmp/a.pdf" "3")
   (pdf-last-page-set 123 3)
-  (check (pdf-last-pages-read) => '()))
+  (check (pdf-last-pages-read) => '())
+) ;define
 
 ;; 损坏行（无法反序列化/形状非法）被跳过，不拖垮其余记录。
 
 (define (test-corrupt-preference-tolerated)
   (set-preference "pdf:last-pages"
-    "(\"good.pdf\" . 4)\n((broken\n(\"also.pdf\" . 2)")
+    "(\"good.pdf\" . 4)\n((broken\n(\"also.pdf\" . 2)"
+  ) ;set-preference
   (check (pdf-last-pages-read) => '(("good.pdf" . 4) ("also.pdf" . 2)))
   ;; 哨兵 "default"（未设置）同样按无记录处理
   (set-preference "pdf:last-pages" "default")
-  (check (pdf-last-pages-read) => '()))
+  (check (pdf-last-pages-read) => '())
+) ;define
 
 ;; 开关：缺省（哨兵 "default"）恢复，显式 "off" 时不恢复。
 
@@ -106,7 +121,8 @@
   (set-preference "pdf:restore-last-page" "on")
   (check (pdf-last-page-to-restore "/tmp/a.pdf") => 5)
   (set-preference "pdf:restore-last-page" "off")
-  (check (pdf-last-page-to-restore "/tmp/a.pdf") => #f))
+  (check (pdf-last-page-to-restore "/tmp/a.pdf") => #f)
+) ;define
 
 (tm-define (regtest-pdf-last-page)
   (test-set-get-roundtrip)

--- a/TeXmacs/progs/texmacs/texmacs/tests/pdf-last-page-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tests/pdf-last-page-test.scm
@@ -1,0 +1,121 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : pdf-last-page-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：PDF 阅读位置记忆（pdf-last-page-get/set/
+;;               to-restore）的存取、去重、LRU 上限、序列化 roundtrip 与
+;;               "pdf:restore-last-page" 开关。不弹任何 GUI，headless 可跑。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r pdf-last-page-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/texmacs/texmacs/tm-files.scm")
+
+;; 测试直接读写真实 preference key，先快照原值，结束后恢复，
+;; 避免污染测试环境的用户偏好。
+
+(define saved-last-pages (get-preference "pdf:last-pages"))
+(define saved-restore-switch (get-preference "pdf:restore-last-page"))
+
+(define (restore-preferences!)
+  (set-preference "pdf:last-pages" saved-last-pages)
+  (set-preference "pdf:restore-last-page" saved-restore-switch))
+
+;; 基本 roundtrip：写入后读回；未记录的路径返回 #f。
+
+(define (test-set-get-roundtrip)
+  (set-preference "pdf:last-pages" "default")
+  (pdf-last-page-set "/tmp/a.pdf" 3)
+  (check (pdf-last-page-get "/tmp/a.pdf") => 3)
+  (check (pdf-last-page-get "/tmp/never-seen.pdf") => #f))
+
+;; 路径含分号/引号/反斜杠等特殊字符、或超过 s7 print-length 的长路径，
+;; 序列化均不丢数据。
+
+(define (test-special-chars-roundtrip)
+  (set-preference "pdf:last-pages" "default")
+  (let ((weird "/tmp/a;b\"c\\d e.pdf")
+        (long (string-append "/" (make-string 100 #\x) ".pdf")))
+    (pdf-last-page-set weird 42)
+    (pdf-last-page-set long 8)
+    (pdf-last-page-set "/tmp/other.pdf" 7)
+    (check (pdf-last-page-get weird) => 42)
+    (check (pdf-last-page-get long) => 8)
+    (check (pdf-last-page-get "/tmp/other.pdf") => 7)))
+
+;; 同一路径重复记录：去重且新值置于表头（MRU）。
+
+(define (test-overwrite-moves-to-front)
+  (set-preference "pdf:last-pages" "default")
+  (pdf-last-page-set "/tmp/a.pdf" 1)
+  (pdf-last-page-set "/tmp/b.pdf" 2)
+  (pdf-last-page-set "/tmp/a.pdf" 9)
+  (check (pdf-last-page-get "/tmp/a.pdf") => 9)
+  (check (car (car (pdf-last-pages-read))) => "/tmp/a.pdf")
+  (check (length (pdf-last-pages-read)) => 2))
+
+;; LRU 上限：写入超过 100 条后截断表尾（最旧条目被淘汰）。
+
+(define (test-lru-cap)
+  (set-preference "pdf:last-pages" "default")
+  (let loop ((i 1))
+    (when (<= i 105)
+      (pdf-last-page-set (string-append "/tmp/f" (number->string i) ".pdf") i)
+      (loop (+ i 1))))
+  (let ((lst (pdf-last-pages-read)))
+    (check (length lst) => 100)
+    ;; 最新写入的在表头，最旧的 5 条被淘汰
+    (check (pdf-last-page-get "/tmp/f105.pdf") => 105)
+    (check (pdf-last-page-get "/tmp/f1.pdf") => #f)
+    (check (pdf-last-page-get "/tmp/f6.pdf") => 6)))
+
+;; 非法输入不落盘：page<=0、非整数、非字符串路径。
+
+(define (test-invalid-input-ignored)
+  (set-preference "pdf:last-pages" "default")
+  (pdf-last-page-set "/tmp/a.pdf" 0)
+  (pdf-last-page-set "/tmp/a.pdf" -1)
+  (pdf-last-page-set "/tmp/a.pdf" "3")
+  (pdf-last-page-set 123 3)
+  (check (pdf-last-pages-read) => '()))
+
+;; 损坏行（无法反序列化/形状非法）被跳过，不拖垮其余记录。
+
+(define (test-corrupt-preference-tolerated)
+  (set-preference "pdf:last-pages"
+    "(\"good.pdf\" . 4)\n((broken\n(\"also.pdf\" . 2)")
+  (check (pdf-last-pages-read) => '(("good.pdf" . 4) ("also.pdf" . 2)))
+  ;; 哨兵 "default"（未设置）同样按无记录处理
+  (set-preference "pdf:last-pages" "default")
+  (check (pdf-last-pages-read) => '()))
+
+;; 开关：缺省（哨兵 "default"）恢复，显式 "off" 时不恢复。
+
+(define (test-restore-switch)
+  (set-preference "pdf:last-pages" "default")
+  (pdf-last-page-set "/tmp/a.pdf" 5)
+  (set-preference "pdf:restore-last-page" "default")
+  (check (pdf-last-page-to-restore "/tmp/a.pdf") => 5)
+  (set-preference "pdf:restore-last-page" "on")
+  (check (pdf-last-page-to-restore "/tmp/a.pdf") => 5)
+  (set-preference "pdf:restore-last-page" "off")
+  (check (pdf-last-page-to-restore "/tmp/a.pdf") => #f))
+
+(tm-define (regtest-pdf-last-page)
+  (test-set-get-roundtrip)
+  (test-special-chars-roundtrip)
+  (test-overwrite-moves-to-front)
+  (test-lru-cap)
+  (test-invalid-input-ignored)
+  (test-corrupt-preference-tolerated)
+  (test-restore-switch)
+  (restore-preferences!)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -21,9 +21,9 @@
   ) ;:use
 ) ;texmacs-module
 
-(import (only (liii string) string-contains))
+(import (only (liii string) string-contains string-split string-join))
 (import (only (srfi srfi-1) find))
-(import (only (srfi srfi-1) remove))
+(import (only (srfi srfi-1) remove take))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Remember last save/open directory
@@ -63,6 +63,68 @@
       (set-last-file-dialog-directory dir)
     ) ;let
   ) ;when
+) ;tm-define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; PDF reader: remember last reading position
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define pdf-last-pages-limit 100)
+
+(define (pdf-last-page-entry? x)
+  (and (pair? x) (string? (car x)) (integer? (cdr x)) (> (cdr x) 0))
+) ;define
+
+;; 序列化逐条一行：规避 s7 print-length（默认 40）把整个列表截断成 "..."；
+;; 单条 (path . page) 仅 2 元素、长字符串不受 print-length 影响
+
+(define (pdf-last-pages-write lst)
+  (string-join (map object->string lst) "\n")
+) ;define
+
+(define (pdf-last-pages-parse-line line)
+  (catch #t (lambda () (read (open-input-string line))) (lambda args #f))
+) ;define
+
+(define (pdf-last-pages-read)
+  ;; 偏好未设置时 get-preference 返回哨兵 "default"；坏行跳过，不拖垮整表
+  (let ((s (get-preference "pdf:last-pages")))
+    (if (or (== s "default") (== s ""))
+      '()
+      (remove (lambda (x) (not (pdf-last-page-entry? x)))
+        (map pdf-last-pages-parse-line (string-split s #\newline))
+      ) ;remove
+    ) ;if
+  ) ;let
+) ;define
+
+(tm-define (pdf-last-page-get path)
+  "Get the last reading page (1-based) of a PDF file, or #f if unknown"
+  (let ((hit (assoc path (pdf-last-pages-read))))
+    (and hit (cdr hit))
+  ) ;let
+) ;tm-define
+
+(tm-define (pdf-last-page-set path page)
+  "Record the last reading page (1-based) of a PDF file"
+  (when (and (string? path) (integer? page) (> page 0))
+    ;; 同路径去重后置于表头（MRU），超上限截断表尾
+    (let* ((lst (pdf-last-pages-read))
+           (new (cons (cons path page) (remove (lambda (p) (== (car p) path)) lst)))
+          ) ;
+      (set-preference "pdf:last-pages"
+        (pdf-last-pages-write (take new (min (length new) pdf-last-pages-limit)))
+      ) ;set-preference
+    ) ;let*
+  ) ;when
+) ;tm-define
+
+(tm-define (pdf-last-page-to-restore path)
+  "Page to jump to when opening a PDF file, or #f"
+  ;; 开关缺省视为开（哨兵 "default"），仅显式 "off" 关闭
+  (and (!= (get-preference "pdf:restore-last-page") "off")
+    (pdf-last-page-get path)
+  ) ;and
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -71,19 +71,22 @@
 
 (define pdf-last-pages-limit 100)
 
+(define-preferences ("pdf:restore-last-page" "on" (lambda args (noop))))
+
 (define (pdf-last-page-entry? x)
   (and (pair? x) (string? (car x)) (integer? (cdr x)) (> (cdr x) 0))
 ) ;define
 
 ;; 序列化逐条一行：规避 s7 print-length（默认 40）把整个列表截断成 "..."；
-;; 单条 (path . page) 仅 2 元素、长字符串不受 print-length 影响
+;; 单条 (path . page) 仅 2 元素、长字符串不受 print-length 影响。
+;; 不用 object->tmstring：其 unescape-guile 会把含反斜杠的路径序列化成有损形式
 
 (define (pdf-last-pages-write lst)
   (string-join (map object->string lst) "\n")
 ) ;define
 
 (define (pdf-last-pages-parse-line line)
-  (catch #t (lambda () (read (open-input-string line))) (lambda args #f))
+  (catch #t (lambda () (string->object line)) (lambda args #f))
 ) ;define
 
 (define (pdf-last-pages-read)
@@ -121,10 +124,7 @@
 
 (tm-define (pdf-last-page-to-restore path)
   "Page to jump to when opening a PDF file, or #f"
-  ;; 开关缺省视为开（哨兵 "default"），仅显式 "off" 关闭
-  (and (!= (get-preference "pdf:restore-last-page") "off")
-    (pdf-last-page-get path)
-  ) ;and
+  (and (preference-on? "pdf:restore-last-page") (pdf-last-page-get path))
 ) ;tm-define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/tests/1221.scm
+++ b/TeXmacs/tests/1221.scm
@@ -1,0 +1,79 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1221.scm
+;; DESCRIPTION : GUI 集成测试：PDF 阅读位置记忆的 C++ 链路回归。
+;;               覆盖两个曾导致「重新打开不跳页」的缺陷：
+;;               1. loadFromFile 末尾 updatePageNavigation 发 pageChanged(1)
+;;                  把已存页码覆盖成第 1 页（恢复页码须在加载前查询）；
+;;               2. 程序退出时 ~qt_tm_widget_rep 不执行，退出前无保存时机
+;;                  （改为 pageChanged 即存 preference）。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 1221
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(load "./TeXmacs/progs/texmacs/texmacs/tm-files.scm")
+
+(define test-pdf
+  (url->system "$TEXMACS_PATH/tests/PDF/quartus_manual_with_outline.pdf"))
+
+(define other-buf
+  (url->system "$TEXMACS_PATH/tests/64_1.tm"))
+
+(define step-delay-ms 500)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1221-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1221)
+  (run-chain (list
+    ;; 预置阅读记录：第 5 页
+    (cons "seed last page 5"
+      (lambda ()
+        (pdf-last-page-set test-pdf 5)
+        (check (pdf-last-page-get test-pdf) => 5)))
+    ;; 打开 PDF。注意：加载触发的 pageChanged(1) 与恢复跳页的回写
+    ;; （singleShot(0)，滚动 valueChanged → pageChanged）是异步的，
+    ;; 检查须等一拍再做
+    (cons "open pdf"
+      (lambda ()
+        (load-buffer test-pdf)))
+    ;; 恢复完成后记录须仍是 5（不得停留在加载时的第 1 页）
+    (cons "restore keeps record"
+      (lambda ()
+        (check (pdf-last-page-get test-pdf) => 5)))
+    ;; 切走再切回：记录仍不得被第 1 页覆盖
+    (cons "switch away"
+      (lambda ()
+        (load-buffer other-buf)
+        (check (pdf-last-page-get test-pdf) => 5)))
+    (cons "switch back keeps record"
+      (lambda ()
+        (load-buffer test-pdf)
+        (check (pdf-last-page-get test-pdf) => 5)))
+    (cons "report + quit"
+      (lambda ()
+        (check-report)
+        (quit-TeXmacs)))
+  ))
+) ;tm-define

--- a/devel/1221.md
+++ b/devel/1221.md
@@ -1,0 +1,64 @@
+# 1221 PDF 阅读器记住上次阅读位置
+
+## What
+
+PDF 阅读器第二次打开同一个文件时，自动跳转到上次阅读的页码。
+
+## Why
+
+阅读长 PDF 时每次重新打开都回到第 1 页，体验差。参考 Okular 的 docdata
+机制（`core/document.cpp` 的 `DocumentViewport` 持久化），实现最小闭环：
+关闭时存、打开时恢复、无记录默认第 1 页、显式跳转优先。
+
+## How
+
+三层改动：
+
+1. **存储层（preference）**：`pdf:last-pages` 存「文件绝对路径 → 页码（1-based）」
+   的 alist，MRU 在表头，上限 100 条（LRU 截断）。开关
+   `pdf:restore-last-page`，缺省（哨兵 `"default"`）视为开，仅显式 `"off"` 关闭。
+   - 序列化逐条一行（`(path . page)\n...`）：规避 s7 `print-length`（默认 40）
+     把整个列表截断成 `...`；单条仅 2 元素、长字符串不受 `print-length` 影响。
+     坏行反序列化失败时跳过该行，不拖垮整表。
+2. **Scheme 层**（`TeXmacs/progs/texmacs/texmacs/tm-files.scm`）：
+   - `pdf-last-page-get/set`：读写 alist（set 时同路径去重置表头 + LRU 截断）；
+   - `pdf-last-page-to-restore`：开关门控后的查询，C++ 打开 PDF 时调用。
+3. **C++ 层**（`src/Plugins/Qt/qt_tm_widget.{hpp,cpp}`）：
+   - `save_pdf_last_page()`：读 `PDFReaderWidget::currentPage()`，
+     `eval_scheme` 调 `pdf-last-page-set`。触发点：SLOT_FILE 离开 PDF
+     标签页前（切走或换另一个 PDF）、`~qt_tm_widget_rep`（窗口关闭）；
+   - `schedule_restore_pdf_last_page()`：`sync_startup_tab_mode` 的 pdf
+     分支每次进入时调用，`QTimer::singleShot(0)` 延迟到布局/滚动范围就绪后
+     `eval_scheme` 查 `pdf-last-page-to-restore`，有记录则 `goToPage`
+     （内部已 clamp 到 `[1, pageCount]`）；无记录不动作（停在第 1 页）。
+   - 路径经 `scm_quote` 转义拼 scheme 串；`use-modules` 一次性确保
+     `(texmacs texmacs tm-files)` 已加载（参照 QTMHomePage 先例）。
+
+显式跳转（大纲/链接 `goToPage`）发生在进入 PDF 标签页之后，不受恢复影响；
+恢复只在进入标签页时发生一次，且跳转目标就是离开时的页码，tab 往返一致。
+
+## 涉及文件
+
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm`：存取函数 + import
+  `string-split`/`string-join`/`take`
+- `TeXmacs/progs/texmacs/texmacs/tests/pdf-last-page-test.scm`：纯逻辑测试
+  （roundtrip/特殊字符/长路径/MRU/LRU/非法输入/坏行/开关），新增
+- `src/Plugins/Qt/qt_tm_widget.hpp`：`save_pdf_last_page` /
+  `schedule_restore_pdf_last_page` 声明
+- `src/Plugins/Qt/qt_tm_widget.cpp`：实现 + 三个挂点（SLOT_FILE 离开前、
+  析构、pdf 分支恢复）
+
+## 测试
+
+```bash
+xmake b stem && xmake r pdf-last-page-test
+```
+
+## 已知问题（预先存在，与本任务无关）
+
+当前 HEAD（115b207e8，= origin/main）在本机 boot 阶段崩溃：
+`init_app` → 加载插件 scheme 文件 → `tmg_url_concretize`（生成的
+`glue_url.cpp`）中 `string` 析构 double free。干净 HOME、全量重建均复现，
+stash 本任务改动后同样复现，疑与 #4377（基础类型迁移 moebius）有关。
+该问题阻塞 `xmake r *-test` 的 runtime 验证；scheme 逻辑已用 Goldfish
+解释器 + preference stub 独立验证（16/16 通过）。

--- a/devel/1221.md
+++ b/devel/1221.md
@@ -58,3 +58,36 @@ xmake b stem && xmake r pdf-last-page-test
 
 注：本机 releasedbg 模式存在预存 boot 崩溃（`tmg_url_concretize` 的
 double free，与 #4377 后的 main 同样出现），用 release 模式验证。
+
+## 2026-08-19 修复：重新打开实际不跳页
+
+### 根因（两个，均已用真实 GUI 复现确认）
+
+1. **退出时保存钩子是死代码**：带 PDF 标签页退出程序，`~qt_tm_widget_rep`
+   根本不执行（加打印验证过），SLOT_FILE 保存也只在切走标签页时触发——
+   直接退出什么都不存，重开自然回第 1 页。用户实测的 PDF 在 preference
+   里只留下 `. 1` 记录，与症状吻合。
+2. **加载时的 pageChanged(1) 覆盖旧记录**：`loadFromFile` 末尾
+   `updatePageNavigation` 发 `pageChanged(1)`，若恢复查询发生在加载之后，
+   读到的已是第 1 页。
+
+### How（修订）
+
+- **翻页即存**：`sync_startup_tab_mode` 创建 viewer 时连接
+  `pageChanged` → `call("pdf-last-page-set", path, page)`。preference 是
+  内存 hashmap 写入，落盘由退出时 save-preferences 统一完成，对任何退出
+  路径（关窗/退出/切页）都健壮。
+- **恢复页码在 loadFromFile 之前查询**，把页码直接传给
+  `schedule_restore_pdf_last_page(int)`，singleShot(0) 只做 goToPage；
+  跳页后滚动 valueChanged → pageChanged(5) 回写，记录恢复为真实页码。
+- 删除失效的析构保存与冗余的 SLOT_FILE 保存（`save_pdf_last_page` 移除）。
+
+### 新增自动化测试
+
+- `TeXmacs/tests/1221.scm`（GUI 集成，`MOGAN_TEST_GUI=1 xmake r 1221`）：
+  预置第 5 页 → 打开 → 切走 → 切回，四点断言记录始终为 5。同时回归
+  上述两个缺陷（覆盖成 1 或退出丢记录都会挂）。
+- `tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp` 增加
+  `test_restoreLastPage_deferredJump`：多页 PDF 上复现生产恢复路径
+  （loadFromFile 后 singleShot(0) goToPage），等布局稳定后断言
+  currentPage()==5。

--- a/devel/1221.md
+++ b/devel/1221.md
@@ -22,17 +22,19 @@ PDF 阅读器第二次打开同一个文件时，自动跳转到上次阅读的�
      坏行反序列化失败时跳过该行，不拖垮整表。
 2. **Scheme 层**（`TeXmacs/progs/texmacs/texmacs/tm-files.scm`）：
    - `pdf-last-page-get/set`：读写 alist（set 时同路径去重置表头 + LRU 截断）；
-   - `pdf-last-page-to-restore`：开关门控后的查询，C++ 打开 PDF 时调用。
+   - `pdf-last-page-to-restore`：开关门控后的查询（`define-preferences`
+     声明默认值 "on"，`preference-on?` 判定），C++ 打开 PDF 时调用。
 3. **C++ 层**（`src/Plugins/Qt/qt_tm_widget.{hpp,cpp}`）：
    - `save_pdf_last_page()`：读 `PDFReaderWidget::currentPage()`，
-     `eval_scheme` 调 `pdf-last-page-set`。触发点：SLOT_FILE 离开 PDF
-     标签页前（切走或换另一个 PDF）、`~qt_tm_widget_rep`（窗口关闭）；
+     `call("pdf-last-page-set", path, page)`（call facade 自动 marshal）。
+     触发点：SLOT_FILE（离开 PDF 标签页或换 PDF，幂等）、`~qt_tm_widget_rep`
+     （窗口关闭）；
    - `schedule_restore_pdf_last_page()`：`sync_startup_tab_mode` 的 pdf
      分支每次进入时调用，`QTimer::singleShot(0)` 延迟到布局/滚动范围就绪后
-     `eval_scheme` 查 `pdf-last-page-to-restore`，有记录则 `goToPage`
+     `call("pdf-last-page-to-restore", path)`，有记录则 `goToPage`
      （内部已 clamp 到 `[1, pageCount]`）；无记录不动作（停在第 1 页）。
-   - 路径经 `scm_quote` 转义拼 scheme 串；`use-modules` 一次性确保
-     `(texmacs texmacs tm-files)` 已加载（参照 QTMHomePage 先例）。
+   - `(texmacs texmacs tm-files)` 模块在 init-research.scm 启动期已加载，
+     无需 ensure。
 
 显式跳转（大纲/链接 `goToPage`）发生在进入 PDF 标签页之后，不受恢复影响；
 恢复只在进入标签页时发生一次，且跳转目标就是离开时的页码，tab 往返一致。
@@ -54,11 +56,5 @@ PDF 阅读器第二次打开同一个文件时，自动跳转到上次阅读的�
 xmake b stem && xmake r pdf-last-page-test
 ```
 
-## 已知问题（预先存在，与本任务无关）
-
-当前 HEAD（115b207e8，= origin/main）在本机 boot 阶段崩溃：
-`init_app` → 加载插件 scheme 文件 → `tmg_url_concretize`（生成的
-`glue_url.cpp`）中 `string` 析构 double free。干净 HOME、全量重建均复现，
-stash 本任务改动后同样复现，疑与 #4377（基础类型迁移 moebius）有关。
-该问题阻塞 `xmake r *-test` 的 runtime 验证；scheme 逻辑已用 Goldfish
-解释器 + preference stub 独立验证（16/16 通过）。
+注：本机 releasedbg 模式存在预存 boot 崩溃（`tmg_url_concretize` 的
+double free，与 #4377 后的 main 同样出现），用 release 模式验证。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1005,9 +1005,6 @@ qt_tm_widget_rep::~qt_tm_widget_rep () {
     debug_widgets << "qt_tm_widget_rep::~qt_tm_widget_rep of widget "
                   << type_as_string () << LF;
 
-  // 窗口关闭时保存 PDF 阅读页码（须在 delete pdfViewerWidget 之前）
-  save_pdf_last_page ();
-
   // clear any residual waiting menu installation
   waiting_widgets= remove (waiting_widgets, this);
 
@@ -1156,23 +1153,12 @@ qt_tm_widget_rep::poll_central_unfreeze (int generation, qint64 start_ms) {
  ******************************************************************************/
 
 void
-qt_tm_widget_rep::save_pdf_last_page () {
-  if (!pdfTabMode || !pdfViewerWidget) return;
-  int page= pdfViewerWidget->currentPage ();
-  if (page <= 0) return;
-  call ("pdf-last-page-set", from_qstring_utf8 (currentPdfPath), page);
-}
-
-void
-qt_tm_widget_rep::schedule_restore_pdf_last_page () {
-  if (!pdfViewerWidget) return;
+qt_tm_widget_rep::schedule_restore_pdf_last_page (int page) {
+  if (!pdfViewerWidget || page <= 0) return;
   // 延迟到事件循环下一轮再跳页：布局与滚动范围需在 show 后才就绪
   PDFReaderWidget* viewer= pdfViewerWidget;
-  string           path  = from_qstring_utf8 (currentPdfPath);
-  QTimer::singleShot (0, viewer, [viewer, path] () {
-    object r= call ("pdf-last-page-to-restore", path);
-    if (is_int (r)) viewer->goToPage (as_int (r));
-  });
+  QTimer::singleShot (0, viewer,
+                      [viewer, page] () { viewer->goToPage (page); });
 }
 
 void
@@ -1222,6 +1208,16 @@ qt_tm_widget_rep::sync_startup_tab_mode () {
 
     if (!pdfViewerWidget) {
       pdfViewerWidget= new PDFReaderWidget (centralwidget ());
+      // 翻页即存：窗口关闭/程序退出时 ~qt_tm_widget_rep 并不执行，
+      // 退出前没有可靠的保存时机，改为页码变化时立刻写入 preference
+      // （内存 hashmap，落盘由退出时的 save-preferences 统一完成）
+      PDFReaderWidget* viewer= pdfViewerWidget;
+      QObject::connect (pdfViewerWidget, &PDFReaderWidget::pageChanged, viewer,
+                        [this] (int page, int) {
+                          if (pdfTabMode && page > 0)
+                            call ("pdf-last-page-set",
+                                  from_qstring_utf8 (currentPdfPath), page);
+                        });
       // 连接大纲提取 → dock 填充，dock 点击 → 阅读器跳页（仅连一次）
       if (pdfOutlineDock) {
         QObject::connect (
@@ -1243,12 +1239,17 @@ qt_tm_widget_rep::sync_startup_tab_mode () {
     // Connect toolbar to the PDF reader
     pdfToolBar->connectTo (pdfViewerWidget);
 
+    // 恢复页码须在 loadFromFile 之前查询：load 完成时的
+    // updatePageNavigation 会发 pageChanged(1)，把旧记录覆盖成第 1 页
+    object restorePage=
+        call ("pdf-last-page-to-restore", from_qstring_utf8 (currentPdfPath));
+    int pageToRestore= is_int (restorePage) ? as_int (restorePage) : 0;
     // Load PDF if path changed
     if (!currentPdfPath.isEmpty () && currentPdfPath != lastLoadedPdfPath) {
       pdfViewerWidget->loadFromFile (currentPdfPath);
       lastLoadedPdfPath= currentPdfPath;
     }
-    schedule_restore_pdf_last_page ();
+    schedule_restore_pdf_last_page (pageToRestore);
   }
   else {
     // Show normal editor view (unless chat tab mode is active)
@@ -1908,10 +1909,8 @@ qt_tm_widget_rep::send (slot s, blackbox val) {
     if (DEBUG_QT_WIDGETS) debug_widgets << "\tFile: " << file << LF;
     mainwindow ()->setWindowFilePath (utf8_to_qstring (file));
     currentEditorFile= file;
-    // 离开 PDF 标签页（切走或换另一个 PDF）前记下阅读页码（幂等，值未变不落盘）
-    save_pdf_last_page ();
-    startupTabMode= is_startup_tab_file (file);
-    pdfTabMode    = is_pdf_tab_file (file);
+    startupTabMode   = is_startup_tab_file (file);
+    pdfTabMode       = is_pdf_tab_file (file);
     if (pdfTabMode) {
       currentPdfPath= utf8_to_qstring (file);
     }

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1151,44 +1151,27 @@ qt_tm_widget_rep::poll_central_unfreeze (int generation, qint64 start_ms) {
 }
 
 /******************************************************************************
- * PDF 阅读位置记忆（存取由 scheme 侧 pdf-last-page-get/set 负责）
+ * PDF 阅读位置记忆（存取由 scheme 侧 pdf-last-page-get/set 负责；
+ * (texmacs texmacs tm-files) 模块在 init-research.scm 启动期已加载）
  ******************************************************************************/
-
-static void
-pdf_last_pages_ensure_module () {
-  static bool loaded= false;
-  if (!loaded) {
-    eval_scheme ("(use-modules (texmacs texmacs tm-files))");
-    loaded= true;
-  }
-}
 
 void
 qt_tm_widget_rep::save_pdf_last_page () {
-  if (!pdfTabMode || !pdfViewerWidget || currentPdfPath.isEmpty ()) return;
+  if (!pdfTabMode || !pdfViewerWidget) return;
   int page= pdfViewerWidget->currentPage ();
   if (page <= 0) return;
-  pdf_last_pages_ensure_module ();
-  eval_scheme ("(pdf-last-page-set " *
-               scm_quote (from_qstring_utf8 (currentPdfPath)) * " " *
-               as_string (page) * ")");
+  call ("pdf-last-page-set", from_qstring_utf8 (currentPdfPath), page);
 }
 
 void
 qt_tm_widget_rep::schedule_restore_pdf_last_page () {
-  if (!pdfViewerWidget || currentPdfPath.isEmpty ()) return;
-  pdf_last_pages_ensure_module ();
+  if (!pdfViewerWidget) return;
   // 延迟到事件循环下一轮再跳页：布局与滚动范围需在 show 后才就绪
-  QPointer<PDFReaderWidget> viewer (pdfViewerWidget);
-  string                    path= from_qstring_utf8 (currentPdfPath);
-  QTimer::singleShot (0, pdfViewerWidget, [viewer, path] () {
-    if (!viewer) return;
-    tmscm r=
-        eval_scheme ("(pdf-last-page-to-restore " * scm_quote (path) * ")");
-    if (tmscm_is_int (r)) {
-      int page= tmscm_to_int (r);
-      if (page > 0) viewer->goToPage (page);
-    }
+  PDFReaderWidget* viewer= pdfViewerWidget;
+  string           path  = from_qstring_utf8 (currentPdfPath);
+  QTimer::singleShot (0, viewer, [viewer, path] () {
+    object r= call ("pdf-last-page-to-restore", path);
+    if (is_int (r)) viewer->goToPage (as_int (r));
   });
 }
 
@@ -1925,9 +1908,8 @@ qt_tm_widget_rep::send (slot s, blackbox val) {
     if (DEBUG_QT_WIDGETS) debug_widgets << "\tFile: " << file << LF;
     mainwindow ()->setWindowFilePath (utf8_to_qstring (file));
     currentEditorFile= file;
-    // 离开 PDF 标签页（切走或换另一个 PDF）前记下阅读页码
-    if (pdfTabMode && file != from_qstring_utf8 (currentPdfPath))
-      save_pdf_last_page ();
+    // 离开 PDF 标签页（切走或换另一个 PDF）前记下阅读页码（幂等，值未变不落盘）
+    save_pdf_last_page ();
     startupTabMode= is_startup_tab_file (file);
     pdfTabMode    = is_pdf_tab_file (file);
     if (pdfTabMode) {

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1005,6 +1005,9 @@ qt_tm_widget_rep::~qt_tm_widget_rep () {
     debug_widgets << "qt_tm_widget_rep::~qt_tm_widget_rep of widget "
                   << type_as_string () << LF;
 
+  // 窗口关闭时保存 PDF 阅读页码（须在 delete pdfViewerWidget 之前）
+  save_pdf_last_page ();
+
   // clear any residual waiting menu installation
   waiting_widgets= remove (waiting_widgets, this);
 
@@ -1147,6 +1150,48 @@ qt_tm_widget_rep::poll_central_unfreeze (int generation, qint64 start_ms) {
   });
 }
 
+/******************************************************************************
+ * PDF 阅读位置记忆（存取由 scheme 侧 pdf-last-page-get/set 负责）
+ ******************************************************************************/
+
+static void
+pdf_last_pages_ensure_module () {
+  static bool loaded= false;
+  if (!loaded) {
+    eval_scheme ("(use-modules (texmacs texmacs tm-files))");
+    loaded= true;
+  }
+}
+
+void
+qt_tm_widget_rep::save_pdf_last_page () {
+  if (!pdfTabMode || !pdfViewerWidget || currentPdfPath.isEmpty ()) return;
+  int page= pdfViewerWidget->currentPage ();
+  if (page <= 0) return;
+  pdf_last_pages_ensure_module ();
+  eval_scheme ("(pdf-last-page-set " *
+               scm_quote (from_qstring_utf8 (currentPdfPath)) * " " *
+               as_string (page) * ")");
+}
+
+void
+qt_tm_widget_rep::schedule_restore_pdf_last_page () {
+  if (!pdfViewerWidget || currentPdfPath.isEmpty ()) return;
+  pdf_last_pages_ensure_module ();
+  // 延迟到事件循环下一轮再跳页：布局与滚动范围需在 show 后才就绪
+  QPointer<PDFReaderWidget> viewer (pdfViewerWidget);
+  string                    path= from_qstring_utf8 (currentPdfPath);
+  QTimer::singleShot (0, pdfViewerWidget, [viewer, path] () {
+    if (!viewer) return;
+    tmscm r=
+        eval_scheme ("(pdf-last-page-to-restore " * scm_quote (path) * ")");
+    if (tmscm_is_int (r)) {
+      int page= tmscm_to_int (r);
+      if (page > 0) viewer->goToPage (page);
+    }
+  });
+}
+
 void
 qt_tm_widget_rep::sync_startup_tab_mode () {
   QWidget* editorWidget= main_widget->qwid;
@@ -1220,6 +1265,7 @@ qt_tm_widget_rep::sync_startup_tab_mode () {
       pdfViewerWidget->loadFromFile (currentPdfPath);
       lastLoadedPdfPath= currentPdfPath;
     }
+    schedule_restore_pdf_last_page ();
   }
   else {
     // Show normal editor view (unless chat tab mode is active)
@@ -1879,8 +1925,11 @@ qt_tm_widget_rep::send (slot s, blackbox val) {
     if (DEBUG_QT_WIDGETS) debug_widgets << "\tFile: " << file << LF;
     mainwindow ()->setWindowFilePath (utf8_to_qstring (file));
     currentEditorFile= file;
-    startupTabMode   = is_startup_tab_file (file);
-    pdfTabMode       = is_pdf_tab_file (file);
+    // 离开 PDF 标签页（切走或换另一个 PDF）前记下阅读页码
+    if (pdfTabMode && file != from_qstring_utf8 (currentPdfPath))
+      save_pdf_last_page ();
+    startupTabMode= is_startup_tab_file (file);
+    pdfTabMode    = is_pdf_tab_file (file);
     if (pdfTabMode) {
       currentPdfPath= utf8_to_qstring (file);
     }

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -188,6 +188,10 @@ private:
   /// 新编辑器首帧就绪前保持中央区冻结，就绪后解冻（轮询，带超时兜底）。
   void schedule_central_unfreeze ();
   void poll_central_unfreeze (int generation, qint64 start_ms);
+  /// 记录当前 PDF 的阅读页码（切走标签页/关窗时）。
+  void save_pdf_last_page ();
+  /// 延迟恢复 PDF 上次阅读页码（等布局与滚动范围就绪）。
+  void schedule_restore_pdf_last_page ();
 
   // Version update notification
   void    checkVersionUpdate ();
@@ -214,14 +218,12 @@ private:
        chatContentWidget; ///\< 聊天标签页模式下显示的控件（QTChatTabWidget）。
   bool startupTabMode;    ///\< 启动标签页视图是否激活。
   bool startupChromePending_; ///\< 启动页期间是否有被推迟的 chrome 待补装。
-  PDFReaderWidget* pdfViewerWidget;         ///\< PDF 标签页模式下的阅读器控件。
-  bool             pdfTabMode;              ///\< PDF 阅读器标签页是否激活。
-  QString          currentPdfPath;          ///\< 当前显示的 PDF 路径。
-  QString          lastLoadedPdfPath;       ///\< 上次加载的 PDF 路径。
-  void             save_pdf_last_page ();   ///\< 记录当前 PDF 的阅读页码。
-  void   schedule_restore_pdf_last_page (); ///\< 延迟恢复 PDF 上次阅读页码。
-  bool   chatTabMode;                       ///\< 聊天标签页视图是否激活。
-  bool   chatSidebarMode;                   ///\< AI 聊天侧边栏模式是否激活。
+  PDFReaderWidget* pdfViewerWidget;   ///\< PDF 标签页模式下的阅读器控件。
+  bool             pdfTabMode;        ///\< PDF 阅读器标签页是否激活。
+  QString          currentPdfPath;    ///\< 当前显示的 PDF 路径。
+  QString          lastLoadedPdfPath; ///\< 上次加载的 PDF 路径。
+  bool             chatTabMode;       ///\< 聊天标签页视图是否激活。
+  bool             chatSidebarMode;   ///\< AI 聊天侧边栏模式是否激活。
   bool   chatSidebarModeMemory_;      ///\< 记忆用户主动设置的侧边栏模式状态。
   bool   centralWidgetUpdatesFrozen_; ///\< 标签切换期间冻结编辑区更新。
   int    centralUnfreezeGeneration_;  ///\< 延迟解冻的代际号，防止旧轮询误解冻。

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -214,12 +214,14 @@ private:
        chatContentWidget; ///\< 聊天标签页模式下显示的控件（QTChatTabWidget）。
   bool startupTabMode;    ///\< 启动标签页视图是否激活。
   bool startupChromePending_; ///\< 启动页期间是否有被推迟的 chrome 待补装。
-  PDFReaderWidget* pdfViewerWidget;   ///\< PDF 标签页模式下的阅读器控件。
-  bool             pdfTabMode;        ///\< PDF 阅读器标签页是否激活。
-  QString          currentPdfPath;    ///\< 当前显示的 PDF 路径。
-  QString          lastLoadedPdfPath; ///\< 上次加载的 PDF 路径。
-  bool             chatTabMode;       ///\< 聊天标签页视图是否激活。
-  bool             chatSidebarMode;   ///\< AI 聊天侧边栏模式是否激活。
+  PDFReaderWidget* pdfViewerWidget;         ///\< PDF 标签页模式下的阅读器控件。
+  bool             pdfTabMode;              ///\< PDF 阅读器标签页是否激活。
+  QString          currentPdfPath;          ///\< 当前显示的 PDF 路径。
+  QString          lastLoadedPdfPath;       ///\< 上次加载的 PDF 路径。
+  void             save_pdf_last_page ();   ///\< 记录当前 PDF 的阅读页码。
+  void   schedule_restore_pdf_last_page (); ///\< 延迟恢复 PDF 上次阅读页码。
+  bool   chatTabMode;                       ///\< 聊天标签页视图是否激活。
+  bool   chatSidebarMode;                   ///\< AI 聊天侧边栏模式是否激活。
   bool   chatSidebarModeMemory_;      ///\< 记忆用户主动设置的侧边栏模式状态。
   bool   centralWidgetUpdatesFrozen_; ///\< 标签切换期间冻结编辑区更新。
   int    centralUnfreezeGeneration_;  ///\< 延迟解冻的代际号，防止旧轮询误解冻。

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -188,10 +188,9 @@ private:
   /// 新编辑器首帧就绪前保持中央区冻结，就绪后解冻（轮询，带超时兜底）。
   void schedule_central_unfreeze ();
   void poll_central_unfreeze (int generation, qint64 start_ms);
-  /// 记录当前 PDF 的阅读页码（切走标签页/关窗时）。
-  void save_pdf_last_page ();
   /// 延迟恢复 PDF 上次阅读页码（等布局与滚动范围就绪）。
-  void schedule_restore_pdf_last_page ();
+  /// page 为预先查得的页码（须在 loadFromFile 前查询，见实现处说明）。
+  void schedule_restore_pdf_last_page (int page);
 
   // Version update notification
   void    checkVersionUpdate ();

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -17,6 +17,7 @@
 #include <QPinchGesture>
 #include <QRubberBand>
 #include <QScrollBar>
+#include <QTimer>
 #include <QWheelEvent>
 #include <QtTest/QtTest>
 
@@ -213,6 +214,29 @@ private slots:
     QApplication::processEvents ();
 
     QCOMPARE (widget->currentPage (), 1);
+    delete widget;
+  }
+
+  // 1221：复现生产代码 schedule_restore_pdf_last_page 的恢复路径——
+  // loadFromFile 后立即 singleShot(0) 跳页。页面懒渲染，布局未就绪时
+  // w->y() 全为 0，goToPage 实际滚回第 1 页。
+  void test_restoreLastPage_deferredJump () {
+    PDFReaderWidget* widget= new PDFReaderWidget ();
+    widget->resize (400, 300);
+    widget->show ();
+
+    url pdfUrl=
+        url_system ("$TEXMACS_PATH/tests/PDF/quartus_manual_with_outline.pdf");
+    if (is_regular (pdfUrl)) {
+      widget->loadFromFile (to_qstring (as_string (pdfUrl)));
+    }
+    QVERIFY (widget->pageCount () > 5);
+
+    QTimer::singleShot (0, widget, [widget] () { widget->goToPage (5); });
+    // 等渲染与布局稳定（懒渲染完成后页高才正确）
+    QTest::qWaitFor ([widget] () { return widget->currentPage () > 1; }, 5000);
+
+    QCOMPARE (widget->currentPage (), 5);
     delete widget;
   }
 


### PR DESCRIPTION
## 概要

PDF 阅读器记住每个文件的上次阅读页码，重新打开时自动跳转回去。

- 存储层：`pdf:last-pages` preference 存「路径 → 页码」alist（MRU 上限 100，逐行序列化规避 s7 print-length 截断），开关 `pdf:restore-last-page` 默认开
- 保存：`pageChanged` 信号即写 preference（窗口关闭/程序退出时 `~qt_tm_widget_rep` 不执行，析构与 SLOT_FILE 保存点不可靠，已实测确认）
- 恢复：进入 PDF 标签页时在 `loadFromFile` **之前**查询页码（加载末尾的 `pageChanged(1)` 会覆盖旧记录），`singleShot(0)` 延迟跳页

## 测试

- `TeXmacs/progs/texmacs/texmacs/tests/pdf-last-page-test.scm`：纯逻辑（roundtrip/特殊字符/MRU/LRU/坏行/开关），18 checks
- `TeXmacs/tests/1221.scm`（GUI 集成，`MOGAN_TEST_GUI=1 xmake r 1221`）：预置第 5 页 → 打开 → 切走 → 切回，覆盖两个曾导致失效的缺陷
- `tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp`：控件级恢复路径 `test_restoreLastPage_deferredJump`
- 跨进程手工回归：seed 第 5 页 → 重开退出 → preference 保持 5

任务文档：`devel/1221.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)