### PR TITLE
[1227] 表格不超过10行默认不分页，超过时自动开启分页

### DIFF
--- a/devel/1227.md
+++ b/devel/1227.md
@@ -1,0 +1,44 @@
+# 1227 表格分页默认策略
+
+## 任务
+
+表格不超过 10 行时默认不分页；在已有 10 行的基础上新增一行（第 11 行）时，
+自动触发表格分页（`table-hyphen` 置为 `y`）。
+
+## 背景
+
+[0150]（PR #3438）插入表格时一律默认开启 `table-hyphen`，导致小表格也被
+放入独立的 DOCUMENT 块并启用分页排版。本任务按行数细化默认策略。
+
+## 改动
+
+### What
+
+1. 新表格默认值按行数决定：仅当行数 > 10（且非 math 模式）时，默认写入
+   `table-hyphen "y"`；
+2. 对已有表格插入行时，若插入后总行数超过 10 且当前未开启分页，自动把
+   `table-hyphen` 置为 `y`。
+
+### Why
+
+小表格不需要分页，默认分页会引入多余的文档包裹与分页排版行为；长表格
+（> 10 行）则需要分页避免溢出页面。
+
+### How
+
+- `src/Edit/Modify/edit_table.cpp`：
+  - 新增 `TABLE_HYPHEN_ROW_THRESHOLD`（= 10）与
+    `table_default_hyphen (mode, nr_rows)` 辅助函数；
+  - `make_table` / `make_subtable` 的 `default_table_tree` 调用改为
+    传入行数感知的开关；
+  - `table_insert_row` 在行数越过阈值时调用
+    `table_set_format (fp, TABLE_HYPHEN, "y")`。
+
+### 涉及文件
+
+- `src/Edit/Modify/edit_table.cpp`
+
+## 测试
+
+- `xmake b stem` 构建通过；
+- 手工验证：插入 10 行以内表格默认无 `table-hyphen`；增长到 11 行时自动开启。

--- a/src/Edit/Modify/edit_table.cpp
+++ b/src/Edit/Modify/edit_table.cpp
@@ -66,6 +66,21 @@ table_default_hyphen_enabled (string mode) {
   return mode != "math";
 }
 
+//! 行数超过该阈值时,默认开启表格分页
+static const int TABLE_HYPHEN_ROW_THRESHOLD= 10;
+
+/**
+ * @brief 行数超过阈值时默认开启表格分页
+ * @param mode 编辑模式
+ * @param nr_rows 表格总行数
+ * @return 是否默认开启 table-hyphen
+ */
+static bool
+table_default_hyphen (string mode, int nr_rows) {
+  return table_default_hyphen_enabled (mode) &&
+         nr_rows > TABLE_HYPHEN_ROW_THRESHOLD;
+}
+
 tree
 default_table_tree (int nr_rows, int nr_cols, bool enable_table_hyphen) {
   tree T= empty_table (nr_rows, nr_cols);
@@ -1072,7 +1087,7 @@ void
 edit_table_rep::make_table (int nr_rows, int nr_cols) {
   // cout << "make_table " << nr_rows << ", " << nr_cols << "\n";
   string mode               = get_env_string (MODE);
-  bool   enable_table_hyphen= table_default_hyphen_enabled (mode);
+  bool   enable_table_hyphen= table_default_hyphen (mode, nr_rows);
   tree   format_T= default_table_tree (nr_rows, nr_cols, enable_table_hyphen);
   path   p (0, 0, 0, 0);
   insert_tree (format_T, path (N (format_T) - 1, p));
@@ -1083,8 +1098,9 @@ edit_table_rep::make_table (int nr_rows, int nr_cols) {
   typeset_invalidate_env (); // FIXME: dirty hack for getting correct limits
   table_get_limits (fp, i1, j1, i2, j2);
   if ((nr_rows < i1) || (nr_cols < j1)) {
-    format_T= default_table_tree (max (nr_rows, i1), max (nr_cols, j1),
-                                  enable_table_hyphen);
+    format_T=
+        default_table_tree (max (nr_rows, i1), max (nr_cols, j1),
+                            table_default_hyphen (mode, max (nr_rows, i1)));
     assign (fp, format_T);
     go_to (fp * path (N (format_T) - 1, p));
   }
@@ -1123,7 +1139,7 @@ edit_table_rep::make_subtable (int nr_rows, int nr_cols) {
   path cp= search_upwards (CELL);
   if (is_nil (cp)) return;
   tree T= default_table_tree (
-      nr_rows, nr_cols, table_default_hyphen_enabled (get_env_string (MODE)));
+      nr_rows, nr_cols, table_default_hyphen (get_env_string (MODE), nr_rows));
   path p (0, 0, 0, 0);
   p= path (N (T) - 1, p);
   T= tree (SUBTABLE, T);
@@ -1187,6 +1203,11 @@ edit_table_rep::table_insert_row (bool forward) {
   table_get_extents (fp, nr_rows, nr_cols);
   table_get_limits (fp, i1, j1, i2, j2);
   if (nr_rows + 1 > i2) return;
+  // 行数超过阈值时自动开启表格分页
+  if (nr_rows + 1 > TABLE_HYPHEN_ROW_THRESHOLD &&
+      as_string (table_get_format (fp, TABLE_HYPHEN)) != "y" &&
+      get_env_string (MODE) != "math")
+    table_set_format (fp, TABLE_HYPHEN, string ("y"));
   table_insert (fp, row + (forward ? 1 : 0), col, 1, 0);
   table_go_to (fp, row + (forward ? 1 : 0), col);
   table_correct_block_content ();

--- a/src/Edit/Modify/edit_table.cpp
+++ b/src/Edit/Modify/edit_table.cpp
@@ -61,24 +61,18 @@ table_needs_document_wrap (string hyphen, string block, string mode) {
   return (hyphen == "y" || block == "yes") && mode != "math";
 }
 
-bool
-table_default_hyphen_enabled (string mode) {
-  return mode != "math";
-}
-
 //! 行数超过该阈值时,默认开启表格分页
 static const int TABLE_HYPHEN_ROW_THRESHOLD= 10;
 
 /**
- * @brief 行数超过阈值时默认开启表格分页
+ * @brief 非 math 模式且行数超过阈值时,默认开启表格分页
  * @param mode 编辑模式
  * @param nr_rows 表格总行数
  * @return 是否默认开启 table-hyphen
  */
 static bool
 table_default_hyphen (string mode, int nr_rows) {
-  return table_default_hyphen_enabled (mode) &&
-         nr_rows > TABLE_HYPHEN_ROW_THRESHOLD;
+  return mode != "math" && nr_rows > TABLE_HYPHEN_ROW_THRESHOLD;
 }
 
 tree
@@ -1086,9 +1080,9 @@ edit_table_rep::table_ver_decorate (path fp, int row, int rbef, int raft) {
 void
 edit_table_rep::make_table (int nr_rows, int nr_cols) {
   // cout << "make_table " << nr_rows << ", " << nr_cols << "\n";
-  string mode               = get_env_string (MODE);
-  bool   enable_table_hyphen= table_default_hyphen (mode, nr_rows);
-  tree   format_T= default_table_tree (nr_rows, nr_cols, enable_table_hyphen);
+  string mode    = get_env_string (MODE);
+  tree   format_T= default_table_tree (nr_rows, nr_cols,
+                                       table_default_hyphen (mode, nr_rows));
   path   p (0, 0, 0, 0);
   insert_tree (format_T, path (N (format_T) - 1, p));
 
@@ -1204,9 +1198,8 @@ edit_table_rep::table_insert_row (bool forward) {
   table_get_limits (fp, i1, j1, i2, j2);
   if (nr_rows + 1 > i2) return;
   // 行数超过阈值时自动开启表格分页
-  if (nr_rows + 1 > TABLE_HYPHEN_ROW_THRESHOLD &&
-      as_string (table_get_format (fp, TABLE_HYPHEN)) != "y" &&
-      get_env_string (MODE) != "math")
+  if (table_default_hyphen (get_env_string (MODE), nr_rows + 1) &&
+      as_string (table_get_format (fp, TABLE_HYPHEN)) != "y")
     table_set_format (fp, TABLE_HYPHEN, string ("y"));
   table_insert (fp, row + (forward ? 1 : 0), col, 1, 0);
   table_go_to (fp, row + (forward ? 1 : 0), col);

--- a/src/Edit/Modify/edit_table.cpp
+++ b/src/Edit/Modify/edit_table.cpp
@@ -70,7 +70,7 @@ static const int TABLE_HYPHEN_ROW_THRESHOLD= 10;
  * @param nr_rows 表格总行数
  * @return 是否默认开启 table-hyphen
  */
-static bool
+bool
 table_default_hyphen (string mode, int nr_rows) {
   return mode != "math" && nr_rows > TABLE_HYPHEN_ROW_THRESHOLD;
 }

--- a/tests/Edit/Modify/edit_table_test.cpp
+++ b/tests/Edit/Modify/edit_table_test.cpp
@@ -16,7 +16,7 @@ using namespace moebius;
 extern tree empty_table (int nr_rows, int nr_cols);
 extern tree default_table_tree (int nr_rows, int nr_cols,
                                 bool enable_table_hyphen);
-extern bool table_default_hyphen_enabled (string mode);
+extern bool table_default_hyphen (string mode, int nr_rows);
 extern bool table_needs_document_wrap (string hyphen, string block,
                                        string mode);
 
@@ -170,17 +170,18 @@ TestEditTable::test_default_table_tree_twith_value () {
 
 void
 TestEditTable::test_default_hyphen_enabled_in_text_mode () {
-  QVERIFY (table_default_hyphen_enabled ("text"));
+  QVERIFY (table_default_hyphen ("text", 11));
+  QVERIFY (!table_default_hyphen ("text", 10));
 }
 
 void
 TestEditTable::test_default_hyphen_disabled_in_math_mode () {
-  QVERIFY (!table_default_hyphen_enabled ("math"));
+  QVERIFY (!table_default_hyphen ("math", 11));
 }
 
 void
 TestEditTable::test_default_table_tree_skips_table_hyphen_in_math_mode () {
-  tree T= default_table_tree (2, 3, table_default_hyphen_enabled ("math"));
+  tree T= default_table_tree (2, 3, table_default_hyphen ("math", 11));
   QVERIFY (is_func (T, TFORMAT));
 
   for (int i= 0; i < N (T); i++) {


### PR DESCRIPTION
## 概述

细化表格分页默认策略([0150] 引入的默认分页行为按行数区分):

- 新建表格行数 ≤ 10 时,默认不开启 `table-hyphen`(不分页)
- 已有 10 行的表格再插入一行(第 11 行)时,自动开启 `table-hyphen`(分页)
- math 模式(子表格/矩阵)不受影响,仍默认不分页

## 改动

均在 `src/Edit/Modify/edit_table.cpp`:

- 新增 `TABLE_HYPHEN_ROW_THRESHOLD`(= 10)与 `table_default_hyphen (mode, nr_rows)`
- `make_table` / `make_subtable` 按行数决定默认值
- `table_insert_row` 在行数越过阈值时自动设置 `table-hyphen "y"`

任务文档:`devel/1227.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)