### PR TITLE
[0921] 优化 spline_rep::interval_no 为二分查找并补文档与测试

### DIFF
--- a/devel/0921.md
+++ b/devel/0921.md
@@ -1,0 +1,56 @@
+# [0921] 优化 spline_rep::interval_no
+
+## 1 相关文档
+- [0919.md](0919.md) - curve 迁移至 moebius（本任务基于该分支）
+
+## 2 任务相关的代码文件
+- `moebius/Kernel/Types/curve.hpp`
+- `moebius/Kernel/Types/curve.cpp`
+- `moebius/tests/Kernel/Types/spline_test.cpp`（新增）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake test "moebius_tests/spline_test"   # 新增：节点区间定位
+xmake b curve_test && xmake r curve_test
+xmake r curve_midpoint_test
+```
+
+### 3.2 非确定性测试（文档验证）
+无需手工验证（纯算法等价替换，无行为变化）。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+
+1. 将 `spline_rep::interval_no` 的线性扫描（O(n)）重构为二分查找自由函数
+   `spline_interval_no (array<double> U, double u)`（O(log n)），成员函数委托调用
+2. 为新函数及委托的成员函数补写中文 Doxygen 注释（@brief/@param/@return）
+3. 新增 `moebius/tests/Kernel/Types/spline_test.cpp` 覆盖：常规区间定位、
+   节点边界（左闭右开）、越界返回 -1、退化节点向量（空/单元素/两元素）、
+   闭合样条均匀节点
+
+## 6 Why
+
+- `interval_no` 在 `evaluate`/`bound`/`grad`/`curvature` 等热路径中被高频调用，
+  每次求值都要定位参数所在节点区间；节点向量单调不减，线性扫描可安全替换为
+  二分查找，复杂度从 O(n) 降至 O(log n)
+- 原实现越界访问风险：`i` 循环到 `N(U)-1` 时读取 `U[N(U)]`（越下标）；新实现
+  显式以 `u >= U[n-1]` 提前返回，消除该隐患
+- `spline_rep` 是 curve.cpp 的文件内私有类型，无法直接单测；将纯逻辑抽取为
+  `curve.hpp` 导出的自由函数，既可复用又可测试
+
+## 7 How
+
+- 二分查找保持与原线性扫描完全一致的语义：返回满足 `U[i] <= u < U[i+1]`
+  的 i，`u` 越出 `[U[0], U[N(U)-1])` 时返回 -1
+- 循环不变式 `U[lo] <= u < U[hi]`，区间收缩到相邻时 `lo` 即为所求
+- 成员 `spline_rep::interval_no` 改为一行委托，调用方（`evaluate`/`bound` 等）
+  无需改动
+- 测试按 moebius doctest 规范（`moe_doctests.hpp`）编写，xmake 自动发现
+  （`moebius/xmake.lua` glob `tests/**_test.cpp`）

--- a/moebius/Kernel/Types/curve.cpp
+++ b/moebius/Kernel/Types/curve.cpp
@@ -541,12 +541,37 @@ spline_rep::spline (int i, double u, int o) {
   return res;
 }
 
+/**
+ * @brief 给定曲线上的参数 u，查出 u 落在哪一段样条区间（详见 curve.hpp）
+ *
+ * 语义与原先的线性扫描完全一致：返回满足 U[i] <= u < U[i+1] 的 i，
+ * u 在 [U[0], U[N(U)-1]) 之外时返回 -1。
+ * @param U 从小到大排列的节点向量（N(U) >= 2）
+ * @param u 曲线参数值
+ * @return u 所在段的编号 i；越界返回 -1
+ */
+int
+spline_interval_no (array<double> U, double u) {
+  int n= N (U);
+  if (n < 2 || u < U[0] || u >= U[n - 1]) return -1;
+  int lo= 0, hi= n - 1;
+  // 循环不变式：U[lo] <= u < U[hi]，区间收缩到相邻时 lo 即为所求
+  while (hi - lo > 1) {
+    int mid= (lo + hi) / 2;
+    if (U[mid] <= u) lo= mid;
+    else hi= mid;
+  }
+  return lo;
+}
+
+/**
+ * @brief 定位参数 u 所在的样条节点区间编号（委托 spline_interval_no）
+ * @param u 样条参数
+ * @return 区间编号，越界返回 -1
+ */
 int
 spline_rep::interval_no (double u) {
-  int i;
-  for (i= 0; i < N (U); i++)
-    if (u >= U[i] && u < U[i + 1]) return i;
-  return -1;
+  return spline_interval_no (U, u);
 }
 
 static double

--- a/moebius/Kernel/Types/curve.hpp
+++ b/moebius/Kernel/Types/curve.hpp
@@ -194,6 +194,22 @@ curve segment (point p1, point p2);
  * @return 折线曲线对象
  */
 curve poly_segment (array<point> a, array<path> cip);
+/**
+ * @brief 给定曲线上的参数 u，查出 u 落在哪一段样条区间
+ *
+ * 样条曲线由若干段曲线拼接而成：曲线参数（0 到 1 归一化后映射为 U 的取值
+ * 范围）取不同的值时，点落在不同的段上。每个段的范围由相邻两个节点
+ * U[i]、U[i+1] 界定。想在参数 u 处求值（求曲线上的点、切向等），就要先
+ * 用本函数确定 u 属于哪一段，再用该段对应的多项式计算。
+ *
+ * 返回满足 U[i] <= u < U[i+1] 的编号 i；若 u 比 U 的最小值还小，或不小于
+ * 最大值（曲线之外），返回 -1。用二分查找实现，复杂度 O(log n)。
+ * @param U 节点向量，从小到大排列（至少 2 个元素）
+ * @param u 曲线参数值
+ * @return u 所在段的编号 i；u 在取值范围外时返回 -1
+ */
+int spline_interval_no (array<double> U, double u);
+
 curve spline (array<point> a, array<path> cip, bool close= false,
               bool interpol= true);
 curve bezier (array<point> a);

--- a/moebius/tests/Kernel/Types/spline_test.cpp
+++ b/moebius/tests/Kernel/Types/spline_test.cpp
@@ -1,0 +1,99 @@
+/******************************************************************************
+ * MODULE     : spline_test.cpp
+ * DESCRIPTION: Unit tests for spline_interval_no (knot interval location)
+ * COPYRIGHT  : (C) 2026  Da Shen
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "curve.hpp"
+#include "moe_doctests.hpp"
+
+/**
+ * 构造与 spline_rep（非闭合、n=5）构造函数同型的节点向量：
+ * 两端各 3 个 epsilon 间隔的小节点，中间按 1 递增。
+ */
+static array<double>
+open_knots () {
+  const double  eps= 0.01;
+  array<double> U;
+  double        x= 0.0;
+  for (int i= 0; i < 3; i++) {
+    U << x;
+    x+= eps;
+  }
+  x+= 1.0 - eps;
+  for (int i= 3; i <= 5; i++) {
+    U << x;
+    x+= 1.0;
+  }
+  for (int i= 0; i < 3; i++) {
+    U << x;
+    x+= eps;
+  }
+  return U;
+}
+
+TEST_CASE ("test basic intervals") {
+  array<double> U= open_knots ();
+  int           n= N (U);
+  // 任意 u 落在 [U[0], U[n-1]) 内时，返回的 i 必须满足 U[i] <= u < U[i+1]
+  for (int i= 0; i + 1 < n; i++) {
+    double mid= (U[i] + U[i + 1]) / 2;
+    int    no = spline_interval_no (U, mid);
+    CHECK (no == i);
+    CHECK (U[no] <= mid);
+    CHECK (mid < U[no + 1]);
+  }
+}
+
+TEST_CASE ("test knot boundaries") {
+  array<double> U= open_knots ();
+  // 恰好落在节点上：左闭右开，u == U[i] 应归入区间 i
+  CHECK (spline_interval_no (U, U[0]) == 0);
+  for (int i= 1; i + 1 < N (U); i++) {
+    int no= spline_interval_no (U, U[i]);
+    CHECK (no == i);
+    CHECK (U[no] <= U[i]);
+    CHECK (U[i] < U[no + 1]);
+  }
+}
+
+TEST_CASE ("test out of range") {
+  array<double> U= open_knots ();
+  int           n= N (U);
+  CHECK (spline_interval_no (U, U[0] - 1.0) == -1);
+  CHECK (spline_interval_no (U, U[n - 1]) == -1);
+  CHECK (spline_interval_no (U, U[n - 1] + 1.0) == -1);
+}
+
+TEST_CASE ("test degenerate knot vectors") {
+  // 节点向量太短：无法构成任何区间
+  array<double> empty;
+  CHECK (spline_interval_no (empty, 0.0) == -1);
+  array<double> single (1);
+  single[0]= 1.0;
+  CHECK (spline_interval_no (single, 1.0) == -1);
+  // 两元素节点向量的唯一区间 [0, 1)
+  array<double> two (2);
+  two[0]= 0.0;
+  two[1]= 1.0;
+  CHECK (spline_interval_no (two, 0.0) == 0);
+  CHECK (spline_interval_no (two, 0.5) == 0);
+  CHECK (spline_interval_no (two, 1.0) == -1);
+}
+
+TEST_CASE ("test closed spline uniform knots") {
+  // 闭合样条的节点向量：0,1,2,... 严格递增步长 1
+  array<double> U (10);
+  for (int i= 0; i < 10; i++)
+    U[i]= (double) i;
+  for (int i= 0; i + 1 < 10; i++) {
+    CHECK (spline_interval_no (U, i + 0.5) == i);
+    CHECK (spline_interval_no (U, (double) i) == i);
+  }
+  CHECK (spline_interval_no (U, 9.5) == -1); // 9.5 >= U[9]
+  CHECK (spline_interval_no (U, -0.5) == -1);
+}


### PR DESCRIPTION
## What

1. 将 `spline_rep::interval_no` 的线性扫描（O(n)）重构为二分查找自由函数 `spline_interval_no (array<double> U, double u)`（O(log n)），成员函数一行委托，调用方（`evaluate`/`bound`/`grad`/`curvature` 等）无需改动
2. 为新函数及成员函数补写中文 Doxygen 注释
3. 新增 `moebius/tests/Kernel/Types/spline_test.cpp`（doctest，自动发现）：常规区间定位、节点边界（左闭右开）、越界返回 -1、退化节点向量（空/单/双元素）、闭合样条均匀节点

## Why

- `interval_no` 在 `evaluate`/`bound`/`grad`/`curvature` 等热路径中被高频调用，每次求值都要定位参数所在节点区间；节点向量单调不减，可安全用二分查找将复杂度从 O(n) 降至 O(log n)
- 原实现存在越下标隐患：`u >= U[N(U)-1]` 时循环会读取 `U[N(U)]`；新实现显式提前返回，消除该隐患
- `spline_rep` 是 curve.cpp 的文件内私有类型，无法直接单测；抽取为 `curve.hpp` 导出的自由函数后既可复用又可测试

## How

- 二分查找保持与原线性扫描完全一致的语义：返回满足 `U[i] <= u < U[i+1]` 的 i，`u` 越出 `[U[0], U[N(U)-1])` 时返回 -1
- 循环不变式 `U[lo] <= u < U[hi]`，区间收缩到相邻时 `lo` 即为所求
- 基于 [0919](https://github.com/MoganLab/mogan/pull/4386)（curve 迁移至 moebius，已合并）与 [0920](https://github.com/MoganLab/mogan/pull/4389) 之上的最新 `main` rebase

## 验证

```bash
xmake test "moebius_tests/spline_test"   # 5 用例 74 断言全部通过
xmake r curve_test                       # 25 过 0 败
xmake r curve_midpoint_test              # 10 过 0 败
gf fmt --changed-since=main
```

纯算法等价替换，无用户可见行为变化，无需手工 GUI 验证。
