### PR TITLE
[0922] 优化 curvet_closest_points 性能并补文档与单元测试

### DIFF
--- a/devel/0922.md
+++ b/devel/0922.md
@@ -1,0 +1,83 @@
+# 0922 优化 curvet_closest_points 的性能，并撰写其 Doxygen 文档和单元测试
+
+> 基于 0920（优化 curve_rep::bound）之后的 main 开发。
+
+## 任务
+
+`curvet_closest_points`（`moebius/Kernel/Types/curve.cpp`）是
+`curve_rep::find_closest_points` / `find_closest_point` 的核心扫描例程，
+按自适应步长遍历参数区间，收集曲线上到目标点距离局部极小的参数。
+它被 `closest`、曲线求交、图形编辑拾取等路径大量调用。本任务：
+
+1. 优化 `curvet_closest_points` 的性能（消除临时 `point` 与重复
+   `norm` 求值）；
+2. 为 `curvet_closest_points` 撰写中文 Doxygen 文档；
+3. 补充单元测试。
+
+## What
+
+- 扫描循环内 `norm (pt - p)` 改为 `norm2_diff (pt, p)` + 一次开方：
+  每次迭代少构造一个差向量临时 `point`（堆分配 + 引用计数原子操作）；
+- 极小距离同时维护平方值 `n02` 用于比较，开方只在需要真实距离
+  （步长估计、单调性判断）时做一次；
+- 存储候选点时 `ct.dist` 直接复用已算得的极小距离 `n0`，删除原实现
+  两次 `norm (pclosest - p)` 的重复求值，并随之删除不再使用的
+  `pclosest` 变量（每次改进极小时省一次 `point` 拷贝赋值）；
+- `curve.cpp` 中 `curvet_closest_points` 补中文 Doxygen 文档。
+
+## Why
+
+原实现每次迭代 `norm (pt - p)` 先构造差向量临时 `point`，且每存储一个
+候选点都对 `pclosest` 再算一次 `norm`——该距离即循环中已记录的极小
+距离 `n0`，纯属重复。`pclosest` 本身除用于这两次 `norm` 外无其它用途，
+可整体删除。
+
+## How
+
+1. `n2 = norm2_diff (pt, p)`，`n = sqrt (n2)`：`n2 < n02` 平方比较
+   与原 `n < n0` 真值表一致（非负距离的平方保序）；
+2. 极小更新时同时记录 `n0`（距离）与 `n02`（平方），重置时同步重置
+   两者为 `tm_infinity`；
+3. 候选点 `ct.dist= n0`；单调性判断与步长估计仍用真实距离 `n`，
+   与原实现逐值等价。
+
+## 涉及文件
+
+- `moebius/Kernel/Types/curve.cpp`：`curvet_closest_points` 优化与
+  Doxygen 文档
+- `moebius/tests/Kernel/Types/curve_test.cpp`：新增 4 个
+  find_closest_points/find_closest_point 用例
+
+## 测试
+
+```bash
+# moebius 作为子工程包含于主工程，在仓库根目录运行
+xmake test moebius_tests/curve_test  # find_closest_points 专项
+xmake test "moebius_tests/*"         # 全量 18 个测试
+```
+
+覆盖用例：
+
+- 直线段内部最近点（t≈0.5，容差为自适应步长分辨率）；
+- 最近点被钳制到端点（t=0）；
+- V 形 poly_segment 两个局部极小均被收集，且按距离升序、对称距离
+  为 sqrt(20)；
+- 两焦点重合的椭圆（单位圆）上最近点坐标为 (1,0)，`found` 置位。
+
+结果：curve_test 9/9 用例通过；全量 moebius_tests 18/18 通过。
+另有主工程 Qt curve_test（graphics 二次曲线用例）25/25 通过，确认
+libmoebius 变更未破坏图形侧行为。
+
+### 为什么测试入口是 find_closest_points 而非 curvet_closest_points 本身
+
+`curvet_closest_points` 是 `curve.cpp` 内的 `static` 函数，文件外
+不可见；其返回类型 `array<curvet>` 中的 `curvet` 也是文件内私有结构，
+外部测试无法直接调用或构造。它唯一的调用方是
+`curve_rep::find_closest_points`（`curve.cpp:152`），后者仅做一步
+排序并取出 `t` 字段。
+
+因此单元测试通过 `find_closest_points` 黑盒直达被优化函数：V 形
+折线的两个局部极小、端点钳制、圆上最近点等用例，验证的正是
+`curvet_closest_points` 扫描循环的核心行为（局部极小收集、单调
+翻转检测、自适应步长不跳过极小区段），外层的排序只是薄包装。
+不为测试放大 static 函数的可见性。

--- a/moebius/Kernel/Types/curve.cpp
+++ b/moebius/Kernel/Types/curve.cpp
@@ -72,6 +72,25 @@ struct less_eq_curvet {
   static inline bool leq (curvet& a, curvet& b) { return a.dist <= b.dist; }
 };
 
+/**
+ * @brief 遍历参数区间 [t1,t2]，收集曲线上到点 p 距离局部极小的参数
+ *
+ * 以自适应步长扫描曲线：每次前进的步长由 c->bound 保证不超过使曲线位移
+ * 超过 eps 的参数偏移（且上限为 max_step），从而不会跳过任何宽度超过
+ * eps 的距离极小区段。扫描中记录当前距离下降段的极小值，距离由降转升
+ * （或到达区间末尾且仍在下降）时，将该极小值作为一个候选点输出。
+ *
+ * 距离比较使用 norm2_diff 的平方距离，避免每次迭代构造差向量临时
+ * point；候选点的 dist 直接复用已算得的极小距离，不再重算 norm。
+ *
+ * @param c   被考察的曲线
+ * @param t1,t2 参数区间端点；t1 > t2 时按曲线自身环绕方向拆成
+ *              [0,t2] 与 [t1,1] 两段分别处理（闭曲线情形）
+ * @param p   目标点
+ * @param eps 距离精度，决定扫描步长的自适应收缩
+ * @return    候选点列表（未排序），按 find_closest_points 的距离序
+ *            调用方负责排序
+ */
 static array<curvet>
 curvet_closest_points (curve c, double t1, double t2, point p, double eps) {
   array<curvet> res;
@@ -83,38 +102,42 @@ curvet_closest_points (curve c, double t1, double t2, point p, double eps) {
   }
   else {
     double t;
-    double closest= -1;
-    point  pclosest;
-    double n0        = tm_infinity;
+    double closest   = -1;
+    double n0        = tm_infinity; // 当前下降段的极小距离
+    double n02       = tm_infinity; // n0 的平方，用于免开方比较
     bool   stored    = true;
     double nprec     = n0;
     bool   decreasing= false;
     double max_step  = 0.5 / max (c->nr_components (), 1);
     for (t= t1; t <= t2;) {
       point  pt= c->evaluate (t);
-      double n = norm (pt - p);
-      if (n < n0) {
-        n0      = n;
-        closest = t;
-        pclosest= pt;
-        stored  = false;
+      double n2= norm2_diff (pt, p);
+      double n = sqrt (n2);
+      if (n2 < n02) {
+        n0     = n;
+        n02    = n2;
+        closest= t;
+        stored = false;
       }
       decreasing= n < nprec;
       if (!stored && !decreasing) {
         curvet ct;
-        ct.dist= norm (pclosest - p);
+        ct.dist= n0;
         ct.t   = closest;
         res << ct;
         stored= true;
       }
-      if (stored && decreasing) n0= tm_infinity;
+      if (stored && decreasing) {
+        n0 = tm_infinity;
+        n02= tm_infinity;
+      }
       double delta= (n - eps) / 2;
       t+= min (max_step, max (0.00001, c->bound (t, max (eps, delta))));
       nprec= n;
     }
     if (!stored && decreasing) {
       curvet ct;
-      ct.dist= norm (pclosest - p);
+      ct.dist= n0;
       ct.t   = closest;
       res << ct;
     }

--- a/moebius/tests/Kernel/Types/curve_test.cpp
+++ b/moebius/tests/Kernel/Types/curve_test.cpp
@@ -77,3 +77,50 @@ TEST_CASE ("bound 契约: |t'-t|<=delta 时 |c(t')-c(t)|<=eps") {
     }
   }
 }
+
+TEST_CASE ("find_closest_points: 直线段内部最近点") {
+  // (0,0)-(10,0)，p 在正上方，最近点为 (5,0)，即 t=0.5；
+  // 容差取自适应步长的分辨率（eps/段长量级）
+  curve         c  = segment (mkp (0, 0), mkp (10, 0));
+  array<double> res= c->find_closest_points (0.0, 1.0, mkp (5, 3), 0.01);
+  CHECK (N (res) == 1);
+  CHECK (fabs (res[0] - 0.5) < 0.05);
+}
+
+TEST_CASE ("find_closest_points: 最近点被钳制到端点") {
+  // p 在线段延长线之外，最近点为端点 t=0
+  curve         c  = segment (mkp (0, 0), mkp (10, 0));
+  array<double> res= c->find_closest_points (0.0, 1.0, mkp (-3, 0), 0.01);
+  CHECK (N (res) == 1);
+  CHECK (fabs (res[0] - 0.0) < 1e-6);
+}
+
+TEST_CASE ("find_closest_points: V 形折线返回两个局部极小") {
+  // 两条腿关于 x=5 对称，p=(5,10) 到两条腿各有局部最近点
+  array<point> a;
+  a << mkp (0, 10) << mkp (5, 0) << mkp (10, 10);
+  curve         c  = poly_segment (a, array<path> ());
+  point         p  = mkp (5, 10);
+  array<double> res= c->find_closest_points (0.0, 1.0, p, 0.01);
+  CHECK (N (res) == 2);
+  // 结果按距离升序，且两个候选点到 p 的距离相等（对称）
+  double d0= norm (c->evaluate (res[0]) - p);
+  double d1= norm (c->evaluate (res[1]) - p);
+  CHECK (d0 <= d1);
+  CHECK (fabs (d0 - d1) < 0.1);
+  CHECK (fabs (d0 - sqrt (20.0)) < 0.1); // 最近点 (1,8)，距 p 为 sqrt(20)
+}
+
+TEST_CASE ("find_closest_points: 圆上最近点") {
+  // 两焦点重合于原点、过 (1,0) 的单位圆，p=(3,0)，最近点为 (1,0)
+  array<point> a;
+  a << mkp (0, 0) << mkp (0, 0) << mkp (1, 0);
+  curve  c    = ellipse (a, array<path> (), true);
+  point  p    = mkp (3, 0);
+  bool   found= false;
+  double t    = c->find_closest_point (0.0, 1.0, p, 0.01, found);
+  CHECK (found);
+  point q= c->evaluate (t);
+  CHECK (fabs (q[0] - 1.0) < 1e-2);
+  CHECK (fabs (q[1] - 0.0) < 1e-2);
+}


### PR DESCRIPTION
# [0922] 优化 curvet_closest_points 性能并补文档与单元测试

## 任务

`curvet_closest_points`（`moebius/Kernel/Types/curve.cpp`）是
`curve_rep::find_closest_points` / `find_closest_point` 的核心扫描例程，
按自适应步长遍历参数区间，收集曲线上到目标点距离局部极小的参数，被
`closest`、曲线求交、图形编辑拾取等路径大量调用。本任务优化其性能，
补充中文 Doxygen 文档与单元测试。

## 改动内容

- 扫描循环内 `norm (pt - p)` 改为 `norm2_diff (pt, p)` + 一次开方：
  每次迭代免构造一个差向量临时 `point`（堆分配 + 引用计数原子操作）；
- 极小距离同时维护平方值 `n02` 用于免开方比较（非负距离平方保序，
  与原 `n < n0` 真值表一致）；
- 存候选点时 `ct.dist` 直接复用已算得的极小距离 `n0`，消除原实现
  两处 `norm (pclosest - p)` 重复求值；随之删除不再使用的
  `pclosest` 变量（每次改进极小时省一次 `point` 拷贝赋值）；
- `curvet_closest_points` 补中文 Doxygen 文档；
- `moebius/tests/Kernel/Types/curve_test.cpp` 新增 4 个用例。

## 为什么单元测试的入口是 find_closest_points

`curvet_closest_points` 是 `curve.cpp` 内的 `static` 函数，文件外
不可见；其返回类型 `array<curvet>` 中的 `curvet` 也是文件内私有
结构，外部测试无法直接调用或构造。它唯一的调用方是
`curve_rep::find_closest_points`，后者仅做一步排序并取出 `t` 字段。

因此单元测试通过 `find_closest_points` 黑盒直达被优化函数：V 形
折线的两个局部极小、端点钳制、圆上最近点等用例，验证的正是
`curvet_closest_points` 扫描循环的核心行为（局部极小收集、单调
翻转检测、自适应步长不跳过极小区段），外层排序只是薄包装。
不为测试放大 static 函数的可见性。

## 测试

- `xmake test moebius_tests/curve_test` — 9/9 通过（含 4 个新增用例）
- `xmake test "moebius_tests/*"` — 全量 18/18 通过
- 主工程 Qt `curve_test`（graphics 二次曲线用例）— 25/25 通过，
  确认 libmoebius 变更未破坏图形侧行为

新增用例覆盖：

- 直线段内部最近点（t≈0.5，容差为自适应步长分辨率）；
- 最近点被钳制到端点（t=0）；
- V 形 poly_segment 两个局部极小均被收集，且按距离升序、对称距离
  为 sqrt(20)；
- 两焦点重合的椭圆（单位圆）上最近点坐标为 (1,0)，`found` 置位。
