### PR TITLE
[01228] moebius Data/Tree 性能优化（6 项）

### DIFF
--- a/devel/01228.md
+++ b/devel/01228.md
@@ -177,3 +177,42 @@ TUPLE，`is_concat` 比较标签是否为 CONCAT，恒为假。该判断每次�
 - `moebius/Data/Tree/tree_traverse.cpp`
 - `moebius/bench/Data/Tree/tree_traverse_bench.cpp`（新增）
 - `tests/Data/tree_cursor_test.cpp`（新增 `test_next_word` 回归）
+
+## 2026-08-19 第六项：raw_insert/raw_remove 块移动
+
+### What
+
+`tree_observer.cpp` 的 `raw_insert` / `raw_remove`（每次编辑最终落到的原语，
+apply 调度链的终点）原先用逐元素赋值搬移孩子，每个被移动孩子一次
+引用计数加+减。改为 memmove 块移动：
+
+- 插入：resize 腾位后 memmove 尾部上移；洞内 stale 位用 placement-new
+  默认句柄覆盖（不动计数），再由赋值语句正常接管。
+- 删除：先把被删孩子拷入临时数组（+1 接管所有权），memmove 尾部下移，
+  resize 收缩，临时数组析构时统一释放被删孩子的所有权。
+
+### Why
+
+在宽容器（大文档/表格/长 concat）前部插入或删除时，原实现是
+O(n) 次引用计数操作，memmove 后为纯内存搬运。表格编辑、文档开头输入
+等场景直接受益。
+
+### 记账分析（关键正确性依据）
+
+数组对每个槽位恰好持有一份所有权；memmove 位级搬移使所有权随位移动
+转移，计数不变；插入洞与被删元素按上述方式显式补齐加减，账目平衡。
+`tm_delete_array` 逐槽析构、`tm_resize_array` 增长时构造新槽，均与该账目
+兼容（容量桶内增删不触发 realloc，槽内容始终为有效句柄或 stale 位）。
+
+### 测量（1000 段文档头部插入+删除 ×1000）
+
+12.03 ms → 0.56 ms（约 21×）。
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_observer.cpp`、`tree_observer.hpp`
+  （补 raw_insert/raw_remove 声明与 Doxygen 注释）
+- `moebius/bench/Data/Tree/tree_observer_bench.cpp`（新增）
+- `tests/Data/tree_observer_test.cpp`（新增：位置正确性、
+  共享子树引用计数、跨容量桶插删）
+- 回归：tree-* 单测全绿，stem 构建 + 集成测试 2044 通过

--- a/devel/01228.md
+++ b/devel/01228.md
@@ -44,3 +44,36 @@
   is_accessible_cursor / next_valid / correct_cursor 基准
 - `tests/Data/tree_cursor_test.cpp`（新增）：合法光标基础断言、
   input+math 特判回归、next_valid/previous_valid 往返
+
+## 2026-08-19 第二项：is_empty / is_snippet 标签缓存
+
+### What
+
+`tree_helper.cpp` 中：
+- `is_empty` 对每个非 document/concat 复合节点做 `is_compound (t, "suppressed")`
+  字符串比较；排版期间逐节点调用。
+- `is_snippet` 对文档每个顶层孩子做 `is_compound (doc[i], "TeXmacs", 1)`。
+
+改为缓存 `tree_label`（`label_suppressed` / `label_texmacs_marker`）后按整数比较。
+
+### Why
+
+`is_empty` 在排版/环境长度计算（`env_length.cpp` 等 109 处调用点）高频执行，
+每个叶子与 `with` 类节点都付出一次 `as_string` 哈希查找 + 字符串比较。
+
+### How
+
+- `suppressed` 可带任意 arity（含零参），而 `is_func (t, l)` 在零参时恒为假，
+  故该处用 `L (t) == label_suppressed ()` 直接比较；
+- `TeXmacs` 标记固定一参，用 `is_func (doc[i], l, 1)`。
+
+### 测量（同机交错运行）
+
+- `is_empty` 全文档（100 段）：43.0 µs → 32–34 µs（约 -25%）
+- `is_snippet`：2510 ns → ~100 ns（约 27×）
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_helper.cpp`
+- `moebius/bench/Data/Tree/tree_helper_bench.cpp`（新增）
+- `tests/Data/tree_helper_test.cpp`（新增）

--- a/devel/01228.md
+++ b/devel/01228.md
@@ -152,3 +152,28 @@ TUPLE，`is_concat` 比较标签是否为 CONCAT，恒为假。该判断每次�
 - `moebius/bench/Data/Tree/tree_modify_bench.cpp`（新增，
   含 the_et/obtain_ip 等主程序侧符号的独立桩实现）
 - `tests/Data/tree_modify_test.cpp`（新增：双射不变量 + correct_node 行为）
+
+## 2026-08-19 第五项：tm_codepoint_at 去子串分配
+
+### What
+
+`tree_traverse.cpp` 词级光标移动（`move_word`，即 Ctrl+Left/Right）每步
+调用 `tm_codepoint_at` 两次（光标左右各一字符），原实现用 `s (pos, i)`
+切子串再 `starts`/`ends` 判断 `<#XXXX>` 十六进制形式——每次一个堆分配。
+
+改为直接在原串上按字节扫描，语义完全一致（同样的前 4 位十六进制解析）。
+
+### Why
+
+中文等非 ASCII 文本每个字符都是 `<#XXXX>` 形式（6 字节），词级移动的
+每一步都要付出两次子串分配，长文本连续跳词时累积明显。
+
+### 测量（200 组中文+ASCII 混合文本，next_word ×1000）
+
+267 ns/步 → 248 ns/步（约 -7%，其余开销在 move_accessible/drd 查询）。
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_traverse.cpp`
+- `moebius/bench/Data/Tree/tree_traverse_bench.cpp`（新增）
+- `tests/Data/tree_cursor_test.cpp`（新增 `test_next_word` 回归）

--- a/devel/01228.md
+++ b/devel/01228.md
@@ -77,3 +77,41 @@
 - `moebius/Data/Tree/tree_helper.cpp`
 - `moebius/bench/Data/Tree/tree_helper_bench.cpp`（新增）
 - `tests/Data/tree_helper_test.cpp`（新增）
+
+## 2026-08-19 第三项：left_most/right_most 死分支消除
+
+### What
+
+`tree_cursor.cpp` 的 `left_most` / `right_most`（`correct_cursor` →
+`left_correct`/`right_correct` 每层递归调用）中存在
+`is_concat (as_tree (p))` 判断：`as_tree (list<int>)` 模板构造的树标签恒为
+TUPLE，`is_concat` 比较标签是否为 CONCAT，恒为假。该判断每次递归都要把
+整个 path 转成一棵临时 TUPLE 树（O(深度) 次分配）。
+
+### Why
+
+`correct_cursor` 是 start/end/super_correct 等光标校正的必经之路，
+每次调用对路径每层付出一次临时树构造，纯属浪费。
+
+### How
+
+- 溯源确认：上游 TeXmacs 同位置写的是 `is_concat (p)`（对 int 路径同样
+  不可能为真），mogan 迁移时补了 `as_tree` 使其可编译，行为等价于死分支。
+- 直接删除判断，保留参数 `t` 上的越界自检不变。
+
+### 测量
+
+正确性由既有 `tree_cursor_test`（correct_cursor 间接覆盖 + next_valid
+往返）回归；收益为每层递归省一次 O(路径长度) 的树分配，基准噪声内
+（correct_cursor ~300 ns 量级，深路径收益更大）。
+
+### 附加负结果
+
+实验对比过把 `is_compound (tree, string)` 的实现从
+`as_string (L (t)) == s` 改为 `L (t) == as_tree_label (s)`：字符串哈希
+查找（10–15 ns）反而慢于整数键查找 + 短串比较（6–9 ns），不采纳，
+`is_compound` 保持原实现。
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_cursor.cpp`

--- a/devel/01228.md
+++ b/devel/01228.md
@@ -1,0 +1,46 @@
+# 01228: moebius Data/Tree 性能优化
+
+## 任务
+
+在 `moebius/Data/Tree` 中持续挑选对产品体验影响最大的函数做性能优化，
+每项优化配套 nanobench 基准、Qt 单元测试与 Doxygen 文档。全自主迭代。
+
+## 2026-08-19 第一项：光标校验热路径标签缓存
+
+### What
+
+`tree_cursor.cpp` 中 `valid_cursor` / `pre_correct` 在每个复合节点层用
+`is_compound (t, "input", 2)`、`is_compound (t[1], "math", 1)` 做名字匹配，
+每次都要 `as_string (L (t))`（哈希查找 + 字符串构造 + 逐字节比较）。
+改为函数局部静态缓存 `tree_label`（`cursor_label_input` / `cursor_label_math`），
+用 `is_func` 整数比较替代字符串比较。
+
+### Why
+
+`valid_cursor` 是光标移动（`next_valid`/`previous_valid`）、光标校正
+（`correct_cursor`/`super_correct`）、选区判断等编辑器高频操作的核心谓词，
+每次按键/移动会在文档每层复合节点上反复求值。
+
+### How
+
+- `make_tree_label` 幂等：同名重复调用返回已注册的标签，函数局部静态
+  只在首次调用时查表一次。
+- 标签名与标签编号一一对应（`CONSTRUCTOR_NAME`/`CONSTRUCTOR_CODE` 互为逆映射），
+  `is_func (t, l, n)` 与 `is_compound (t, s, n)` 语义等价。
+
+### 测量（i7, powersave governor, 交错 A/B 各 3 轮）
+
+- `valid_cursor`（with 内路径, 深度 4）：~250 ns → ~180 ns（约 -25%）
+- `valid_cursor`（普通原子路径, 深度 3）：~130 ns → ~112 ns
+- `next_valid` 单步：~190 ns → ~178 ns（约 -5%）
+
+备注：实验过把 `move_any` 的两次 `subtree` 下降合并为一次下降（同时取父节点），
+实测反而慢 ~15%（引用计数拷贝与分支预测劣化），已回退。
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_cursor.cpp`：标签缓存与调用点替换
+- `moebius/bench/Data/Tree/tree_cursor_bench.cpp`（新增）：valid_cursor /
+  is_accessible_cursor / next_valid / correct_cursor 基准
+- `tests/Data/tree_cursor_test.cpp`（新增）：合法光标基础断言、
+  input+math 特判回归、next_valid/previous_valid 往返

--- a/devel/01228.md
+++ b/devel/01228.md
@@ -115,3 +115,40 @@ TUPLE，`is_concat` 比较标签是否为 CONCAT，恒为假。该判断每次�
 ### 涉及文件
 
 - `moebius/Data/Tree/tree_cursor.cpp`
+
+## 2026-08-19 第四项：correct_node 消除 as_string 往返
+
+### What
+
+`tree_modify.cpp` 的 `correct_node`（编辑校正与 `correct_downwards` 的核心）
+原先执行 `the_drd->contains (as_string (L (t)))`：先把标签编号转成字符串，
+`contains` 内部再做 `existing_tree_label`（哈希查名字）+ `as_tree_label`
+（又一次哈希查名字转回编号）+ `info->contains`，三次映射两次字符串哈希。
+
+新增 `drd_info_rep::contains (tree_label l)` 直接查 `info`，
+`correct_node` 改用标签编号查询。
+
+### Why
+
+`correct_node` 在每次编辑校正、样式切换后的 `correct_downwards` 全树
+遍历中对每个节点执行一次，字符串往返是纯开销。
+
+### How
+
+- 等价性依据：`contains(as_string(L(t)))` 中的 `existing_tree_label` 恒真
+  （L(t) 本身就是已注册标签的名字），故等价于 `info->contains(L(t))`；
+  名字↔编号双射由 `make_tree_label` 的幂等性保证（两参重载无外部调用点），
+  单元测试 `test_label_name_bijection` 做运行时校验。
+
+### 测量（100 段文档，交错 A/B）
+
+- `correct_node`（document + 100 段）：4.09 µs → 3.2–3.4 µs（约 -20%）
+- `correct_downwards` 全树：13.8 µs → 6.4–8.5 µs（约 -45%）
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_modify.cpp`
+- `moebius/moebius/drd/drd_info.{hpp,cpp}`（新增标签版 `contains`）
+- `moebius/bench/Data/Tree/tree_modify_bench.cpp`（新增，
+  含 the_et/obtain_ip 等主程序侧符号的独立桩实现）
+- `tests/Data/tree_modify_test.cpp`（新增：双射不变量 + correct_node 行为）

--- a/moebius/Data/Tree/tree_cursor.cpp
+++ b/moebius/Data/Tree/tree_cursor.cpp
@@ -29,6 +29,22 @@ using moebius::drd::with_drd;
  * Finding a closest cursor inside a tree
  ******************************************************************************/
 
+/**
+ * @brief 光标热路径上频繁按名字匹配的标签，缓存为 tree_label 后可用整数比较
+ * @note 避免每次 as_string(L(t)) 的哈希查找与字符串比较；
+ *       make_tree_label 幂等，首次调用后仅做静态读取
+ */
+static tree_label
+cursor_label_input () {
+  static tree_label l= make_tree_label ("input");
+  return l;
+}
+static tree_label
+cursor_label_math () {
+  static tree_label l= make_tree_label ("math");
+  return l;
+}
+
 bool
 is_inside (tree t, path p) {
   if (is_nil (p)) return false;
@@ -322,8 +338,8 @@ valid_cursor (tree t, path p, bool start_flag) {
   if (is_mod_active_once (t)) return is_atomic (t[0]) || (!is_atom (p->next));
   if (is_prime (t)) return false;
   // FIXME: hack for treating VAR_EXPAND "math"
-  if (is_compound (t, "input", 2) && (N (p) == 2) &&
-      is_compound (t[1], "math", 1) && (p->item == 1))
+  if (is_func (t, cursor_label_input (), 2) && (N (p) == 2) &&
+      is_func (t[1], cursor_label_math (), 1) && (p->item == 1))
     return false;
   if (is_func (t, BIG_AROUND) && p->item == 1) {
     if (p == path (1, 0) && is_right_script_prime (t[1])) return false;
@@ -385,8 +401,8 @@ pre_correct (tree t, path p) {
     else return path (1);
   }
   // FIXME: hack for treating VAR_EXPAND "math"
-  if (is_compound (t, "input", 2) && (N (p) == 2) &&
-      is_compound (t[1], "math", 1) && (p->item == 1)) {
+  if (is_func (t, cursor_label_input (), 2) && (N (p) == 2) &&
+      is_func (t[1], cursor_label_math (), 1) && (p->item == 1)) {
     int i= (p->next->item == 0 ? 0 : right_index (t[1][0]));
     return path (1, 0, pre_correct (t[1][0], path (i)));
   }

--- a/moebius/Data/Tree/tree_cursor.cpp
+++ b/moebius/Data/Tree/tree_cursor.cpp
@@ -426,7 +426,9 @@ left_most (tree t, path p) {
 
   int i= p->item;
   if (is_atom (p)) return i == 0;
-  if (is_concat (as_tree (p))) return (i == 0) && left_most (t[0], p->next);
+  // 历史遗留死分支：is_concat (as_tree (p)) 恒为假（as_tree(list<int>)
+  // 构造的树标签是 TUPLE，永不等于 CONCAT），原实现每次递归都要为
+  // 该判断分配一棵临时树，直接省去
   return false;
 }
 
@@ -461,8 +463,7 @@ right_most (tree t, path p) {
 
   int i= p->item;
   if (is_atom (p)) return i == right_index (t);
-  if (is_concat (as_tree (p)))
-    return (i == 1) && right_most (t[N (t) - 1], p->next);
+  // 同 left_most：is_concat (as_tree (p)) 恒为假，死分支省去临时树分配
   return false;
 }
 

--- a/moebius/Data/Tree/tree_helper.cpp
+++ b/moebius/Data/Tree/tree_helper.cpp
@@ -25,6 +25,26 @@ L (modification mod) {
  * Compound trees
  ******************************************************************************/
 
+/**
+ * @brief "suppressed" 标签的缓存编号，避免 is_empty 每次做字符串比较
+ * @note make_tree_label 幂等，函数局部静态首次调用后仅做静态读取
+ */
+static tree_label
+label_suppressed () {
+  static tree_label l= make_tree_label ("suppressed");
+  return l;
+}
+
+/**
+ * @brief "TeXmacs" 文档根标记标签的缓存编号，供 is_snippet 快速比较
+ * @note make_tree_label 幂等，函数局部静态首次调用后仅做静态读取
+ */
+static tree_label
+label_texmacs_marker () {
+  static tree_label l= make_tree_label ("TeXmacs");
+  return l;
+}
+
 tree
 compound (string s) {
   return tree (make_tree_label (s));
@@ -89,7 +109,7 @@ is_snippet (tree doc) {
   if (!is_document (doc)) return true;
   int i, n= N (doc);
   for (i= 0; i < n; i++)
-    if (is_compound (doc[i], "TeXmacs", 1)) return false;
+    if (is_func (doc[i], label_texmacs_marker (), 1)) return false;
   return true;
 }
 
@@ -234,7 +254,8 @@ is_empty (tree t) {
       if (!is_empty (t[i])) return false;
     return is_concat (t) || (n <= 1);
   }
-  return is_compound (t, "suppressed");
+  // suppressed 可带任意 arity，不能用在零参时为假的 is_func
+  return L (t) == label_suppressed ();
 }
 
 bool

--- a/moebius/Data/Tree/tree_modify.cpp
+++ b/moebius/Data/Tree/tree_modify.cpp
@@ -127,8 +127,7 @@ correct_node (tree& t) {
   // NOTE: this routine should only modify t and its descendants,
   // but not any ancestors
   if (is_compound (t)) {
-    if (the_drd->contains (as_string (L (t))) &&
-        !the_drd->correct_arity (L (t), N (t)))
+    if (the_drd->contains (L (t)) && !the_drd->correct_arity (L (t), N (t)))
       assign (t, "");
     if (is_concat (t)) correct_concat_node (t, 0);
   }

--- a/moebius/Data/Tree/tree_observer.cpp
+++ b/moebius/Data/Tree/tree_observer.cpp
@@ -6,6 +6,8 @@
 #include "tree_cursor.hpp"
 #include "tree_helper.hpp"
 
+#include <string.h>
+
 extern tree the_et;
 
 /******************************************************************************
@@ -248,12 +250,18 @@ raw_insert (tree& ref, int pos, tree t) {
     ref->label=
         ref->label (0, pos) * t->label * ref->label (pos, N (ref->label));
   else {
-    int i, n= N (ref), nr= N (t);
+    int n= N (ref), nr= N (t);
+    // 块移动代替逐元素赋值：每个被移动孩子的引用计数加减一次都省去。
+    // 记账：memmove 把 [pos, n) 的句柄位原样搬到 [pos+nr, n+nr)，
+    // 数组对其所有权引用随位移动转移；洞里的 stale 位用 placement-new
+    // 默认句柄覆盖（不减计数），随后被赋值语句正常接管
     AR (ref)->resize (n + nr);
-    for (i= n - 1; i >= pos; i--)
-      ref[i + nr]= ref[i];
-    for (i= 0; i < nr; i++)
-      ref[pos + i]= t[i];
+    tree* a= A (AR (ref));
+    memmove (a + pos + nr, a + pos, (size_t) (n - pos) * sizeof (tree));
+    for (int i= 0; i < nr; i++)
+      new ((void*) (a + pos + i)) tree ();
+    for (int i= 0; i < nr; i++)
+      a[pos + i]= t[i];
   }
   if (!is_nil (ref->data)) {
     ref->data->notify_insert (ref, pos, is_atomic (t) ? N (t->label) : N (t));
@@ -287,9 +295,13 @@ raw_remove (tree& ref, int pos, int nr) {
   if (is_atomic (ref))
     ref->label= ref->label (0, pos) * ref->label (pos + nr, N (ref->label));
   else {
-    int i, n= N (ref) - nr;
-    for (i= pos; i < n; i++)
-      ref[i]= ref[i + nr];
+    int n= N (ref) - nr;
+    // 先把被删孩子拷出（引用计数 +1，接管数组的所有权），memmove 尾部
+    // 下移（计数随位移动转移，超出新长度的重复位直接丢弃），
+    // 最后 tmp 析构时统一释放被删孩子的所有权
+    array<tree> tmp (A (AR (ref)) + pos, nr);
+    tree*       a= A (AR (ref));
+    memmove (a + pos, a + pos + nr, (size_t) (n - pos) * sizeof (tree));
     AR (ref)->resize (n);
   }
   if (!is_nil (ref->data)) ref->data->done (ref, mod);

--- a/moebius/Data/Tree/tree_observer.hpp
+++ b/moebius/Data/Tree/tree_observer.hpp
@@ -20,6 +20,17 @@ void remove_node (path p);
 void set_cursor (path p, tree data);
 void touch (path p);
 
+/**
+ * @brief 在 ref 的 pos 处直接插入 t 的孩子，绕过 apply 的调度与观察者协议
+ * @note 仅由 raw_apply 及测试/基准使用
+ */
+void raw_insert (tree& ref, int pos, tree t);
+/**
+ * @brief 在 ref 的 pos 处直接删除 nr 个孩子，绕过 apply 的调度与观察者协议
+ * @note 仅由 raw_apply 及测试/基准使用
+ */
+void raw_remove (tree& ref, int pos, int nr);
+
 void assign (tree& ref, tree t);
 void insert (tree& ref, int pos, tree t);
 void remove (tree& ref, int pos, int nr);

--- a/moebius/Data/Tree/tree_traverse.cpp
+++ b/moebius/Data/Tree/tree_traverse.cpp
@@ -363,28 +363,30 @@ is_iso_alphanum (char c) {
 
 // Extract a single TeXmacs character at byte position `pos`
 // and return a coarse Unicode codepoint for boundary checks.
+// 直接在原串上扫描，不构造子串：词级移动每步都会调用，
+// 子串切片的堆分配在 CJK 文本（<#XXXX> 形式）下是主要开销
 static inline bool
 tm_codepoint_at (string s, int pos, unsigned int& code) {
   if (pos < 0 || pos >= N (s)) return false;
 
   int i= pos;
   tm_char_forwards (s, i);
-  string c= s (pos, i);
-  if (c == "") return false;
+  int len= i - pos;
+  if (len < 1) return false;
 
   // Plain ASCII
-  if (N (c) == 1) {
-    code= (unsigned int) (unsigned char) c[0];
+  if (len == 1) {
+    code= (unsigned int) (unsigned char) s[pos];
     return true;
   }
 
   // TeXmacs internal hexadecimal form: <#....>
   // Only parse leading hex digits for block-level checks.
-  if (starts (c, "<#") && ends (c, ">")) {
+  if (s[pos] == '<' && s[pos + 1] == '#' && s[i - 1] == '>') {
     unsigned int v= 0;
-    int          k= 2, cnt= 0;
-    for (; k < N (c) - 1 && cnt < 4; k++, cnt++) {
-      char         ch= c[k];
+    int          k= pos + 2, cnt= 0;
+    for (; k < i - 1 && cnt < 4; k++, cnt++) {
+      char         ch= s[k];
       unsigned int d;
       if (ch >= '0' && ch <= '9') d= (unsigned int) (ch - '0');
       else if (ch >= 'a' && ch <= 'f') d= 10u + (unsigned int) (ch - 'a');

--- a/moebius/bench/Data/Tree/tree_cursor_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_cursor_bench.cpp
@@ -1,0 +1,77 @@
+/** \file tree_cursor_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for cursor validation and movement hot paths
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "tree_cursor.hpp"
+#include "tree_helper.hpp"
+#include "tree_traverse.hpp"
+
+#include <moebius/drd/drd_std.hpp>
+
+using namespace moebius;
+
+/** 构造一篇有代表性的文档：document 下 100 个段落，
+ * 每段是 concat，由 10 个原子片段和少量复合节点构成
+ */
+static tree
+mk_document () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 100; i++) {
+    tree par (CONCAT);
+    for (int j= 0; j < 10; j++) {
+      par << tree ("word" * as_string (j));
+      if (j == 4) par << tree (make_tree_label ("with"),
+                                tree ("color"), tree ("red"),
+                                tree ("inner" * as_string (j)));
+    }
+    doc << par;
+  }
+  return doc;
+}
+
+/** 收集一批典型光标路径：每段中部原子片段的起点/终点 */
+static array<path>
+mk_paths (tree& doc) {
+  array<path> ps;
+  for (int i= 0; i < N (doc); i++)
+    for (int j= 0; j < N (doc[i]); j++)
+      if (is_atomic (doc[i][j])) {
+        ps << path (i, j, 0);
+        ps << path (i, j, N (doc[i][j]->label));
+      }
+  return ps;
+}
+
+int
+main () {
+  tree       doc= mk_document ();
+  array<path> ps = mk_paths (doc);
+  path       mid= ps[N (ps) >> 1];
+
+  bool b= false;
+  path r= path ();
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (1000).unit ("op");
+  bench.run ("valid_cursor", [&] {
+    for (int i= 0; i < N (ps); i++)
+      b= b || valid_cursor (doc, ps[i]);
+  });
+  bench.run ("is_accessible_cursor", [&] {
+    for (int i= 0; i < N (ps); i++)
+      b= b || is_accessible_cursor (doc, ps[i]);
+  });
+  bench.run ("next_valid", [&] {
+    path q= mid;
+    for (int i= 0; i < 200; i++)
+      q= next_valid (doc, q);
+    r= q;
+  });
+  bench.run ("correct_cursor", [&] { r= correct_cursor (doc, mid, true); });
+
+  ankerl::nanobench::doNotOptimizeAway (b);
+  ankerl::nanobench::doNotOptimizeAway (r);
+  return 0;
+}

--- a/moebius/bench/Data/Tree/tree_cursor_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_cursor_bench.cpp
@@ -23,9 +23,9 @@ mk_document () {
     tree par (CONCAT);
     for (int j= 0; j < 10; j++) {
       par << tree ("word" * as_string (j));
-      if (j == 4) par << tree (make_tree_label ("with"),
-                                tree ("color"), tree ("red"),
-                                tree ("inner" * as_string (j)));
+      if (j == 4)
+        par << tree (make_tree_label ("with"), tree ("color"), tree ("red"),
+                     tree ("inner" * as_string (j)));
     }
     doc << par;
   }
@@ -47,12 +47,12 @@ mk_paths (tree& doc) {
 
 int
 main () {
-  tree       doc= mk_document ();
+  tree        doc= mk_document ();
   array<path> ps = mk_paths (doc);
-  path       mid= ps[N (ps) >> 1];
+  path        mid= ps[N (ps) >> 1];
 
-  bool b= false;
-  path r= path ();
+  bool                     b= false;
+  path                     r= path ();
   ankerl::nanobench::Bench bench;
   bench.minEpochIterations (1000).unit ("op");
   bench.run ("valid_cursor", [&] {

--- a/moebius/bench/Data/Tree/tree_helper_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_helper_bench.cpp
@@ -1,0 +1,50 @@
+/** \file tree_helper_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for tree_helper predicates on the typesetting path
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "tree_helper.hpp"
+
+using namespace moebius;
+
+/** 构造典型文档：100 段，每段 concat 由原子与少量复合节点组成 */
+static tree
+mk_document () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 100; i++) {
+    tree par (CONCAT);
+    for (int j= 0; j < 10; j++) {
+      par << tree ("word" * as_string (j));
+      if (j == 4) par << tree (make_tree_label ("with"),
+                                tree ("color"), tree ("red"),
+                                tree ("inner" * as_string (j)));
+    }
+    doc << par;
+  }
+  return doc;
+}
+
+/** 递归统计 is_empty 为真的节点数，模拟排版期的逐节点调用 */
+static int
+count_empty (tree t) {
+  int r= is_empty (t) ? 1 : 0;
+  if (is_compound (t))
+    for (int i= 0; i < N (t); i++)
+      r+= count_empty (t[i]);
+  return r;
+}
+
+int
+main () {
+  tree doc = mk_document ();
+  int  n   = 0;
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (100).unit ("op");
+  bench.run ("is_empty whole doc", [&] { n+= count_empty (doc); });
+  bench.run ("is_snippet", [&] { n+= is_snippet (doc) ? 1 : 0; });
+  bench.run ("is_multi_paragraph", [&] { n+= is_multi_paragraph (doc) ? 1 : 0; });
+  ankerl::nanobench::doNotOptimizeAway (n);
+  return 0;
+}

--- a/moebius/bench/Data/Tree/tree_helper_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_helper_bench.cpp
@@ -17,9 +17,9 @@ mk_document () {
     tree par (CONCAT);
     for (int j= 0; j < 10; j++) {
       par << tree ("word" * as_string (j));
-      if (j == 4) par << tree (make_tree_label ("with"),
-                                tree ("color"), tree ("red"),
-                                tree ("inner" * as_string (j)));
+      if (j == 4)
+        par << tree (make_tree_label ("with"), tree ("color"), tree ("red"),
+                     tree ("inner" * as_string (j)));
     }
     doc << par;
   }
@@ -38,13 +38,14 @@ count_empty (tree t) {
 
 int
 main () {
-  tree doc = mk_document ();
-  int  n   = 0;
+  tree                     doc= mk_document ();
+  int                      n  = 0;
   ankerl::nanobench::Bench bench;
   bench.minEpochIterations (100).unit ("op");
   bench.run ("is_empty whole doc", [&] { n+= count_empty (doc); });
   bench.run ("is_snippet", [&] { n+= is_snippet (doc) ? 1 : 0; });
-  bench.run ("is_multi_paragraph", [&] { n+= is_multi_paragraph (doc) ? 1 : 0; });
+  bench.run ("is_multi_paragraph",
+             [&] { n+= is_multi_paragraph (doc) ? 1 : 0; });
   ankerl::nanobench::doNotOptimizeAway (n);
   return 0;
 }

--- a/moebius/bench/Data/Tree/tree_modify_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_modify_bench.cpp
@@ -28,7 +28,8 @@ ip_attached (path ip) {
 }
 observer
 list_observer (observer o1, observer o2) {
-  (void) o1; (void) o2; // 基准树未挂观察者，不会被调用
+  (void) o1;
+  (void) o2; // 基准树未挂观察者，不会被调用
   return observer ();
 }
 
@@ -41,8 +42,8 @@ mk_document () {
     for (int j= 0; j < 10; j++) {
       par << tree ("word" * as_string (j));
       if (j == 4)
-        par << tree (make_tree_label ("with"), tree ("color"),
-                     tree ("red"), tree ("inner"));
+        par << tree (make_tree_label ("with"), tree ("color"), tree ("red"),
+                     tree ("inner"));
     }
     doc << par;
   }
@@ -51,8 +52,8 @@ mk_document () {
 
 int
 main () {
-  tree doc = mk_document ();
-  tree doc2= mk_document ();
+  tree                     doc = mk_document ();
+  tree                     doc2= mk_document ();
   ankerl::nanobench::Bench bench;
   bench.minEpochIterations (100).unit ("op");
   bench.run ("correct_node", [&] {

--- a/moebius/bench/Data/Tree/tree_modify_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_modify_bench.cpp
@@ -1,0 +1,65 @@
+/** \file tree_modify_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for tree correction on the editing path
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "observers.hpp"
+#include "tree_helper.hpp"
+#include "tree_modify.hpp"
+
+#include <moebius/drd/drd_std.hpp>
+
+using namespace moebius;
+
+// tree_modify 的 assign/correct 链引用全局编辑树与 ip 观察者，
+// 两者定义在 mogan 主程序侧，基准中给出未挂接的独立桩实现
+tree the_et;
+path
+obtain_ip (tree& ref) {
+  (void) ref; // 未挂接的树没有 ip
+  return path ();
+}
+bool
+ip_attached (path ip) {
+  (void) ip;
+  return false;
+}
+observer
+list_observer (observer o1, observer o2) {
+  (void) o1; (void) o2; // 基准树未挂观察者，不会被调用
+  return observer ();
+}
+
+/** 构造典型文档：100 段，每段 concat 由原子与少量复合节点组成 */
+static tree
+mk_document () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 100; i++) {
+    tree par (CONCAT);
+    for (int j= 0; j < 10; j++) {
+      par << tree ("word" * as_string (j));
+      if (j == 4)
+        par << tree (make_tree_label ("with"), tree ("color"),
+                     tree ("red"), tree ("inner"));
+    }
+    doc << par;
+  }
+  return doc;
+}
+
+int
+main () {
+  tree doc = mk_document ();
+  tree doc2= mk_document ();
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (100).unit ("op");
+  bench.run ("correct_node", [&] {
+    correct_node (doc);
+    for (int i= 0; i < N (doc); i++)
+      correct_node (doc[i]);
+  });
+  bench.run ("correct_downwards", [&] { correct_downwards (doc2); });
+  return 0;
+}

--- a/moebius/bench/Data/Tree/tree_observer_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_observer_bench.cpp
@@ -1,0 +1,58 @@
+/** \file tree_observer_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for raw tree modifications on the editing path
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "observers.hpp"
+#include "tree_helper.hpp"
+#include "tree_observer.hpp"
+
+#include <moebius/drd/drd_std.hpp>
+
+using namespace moebius;
+
+// 修改链引用的全局编辑树与 ip 观察者定义在 mogan 主程序侧，
+// 基准中给出未挂接的独立桩实现
+tree the_et;
+path
+obtain_ip (tree& ref) {
+  (void) ref; // 未挂接的树没有 ip
+  return path ();
+}
+bool
+ip_attached (path ip) {
+  (void) ip;
+  return false;
+}
+observer
+list_observer (observer o1, observer o2) {
+  (void) o1; (void) o2; // 基准树未挂观察者，不会被调用
+  return observer ();
+}
+
+/** 构造有 1000 个孩子的宽文档 */
+static tree
+mk_wide_doc () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 1000; i++)
+    doc << tree ("para" * as_string (i));
+  return doc;
+}
+
+int
+main () {
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (10).unit ("op");
+
+  // 单个 op 内插删配平，避免 epoch 叠加导致文档规模无界增长
+  tree doc= mk_wide_doc ();
+  bench.run ("raw_insert+remove head x1000", [&] {
+    for (int i= 0; i < 1000; i++)
+      raw_insert (doc, 0, tree (DOCUMENT, tree ("x")));
+    for (int i= 0; i < 1000; i++)
+      raw_remove (doc, 0, 1);
+  });
+  return 0;
+}

--- a/moebius/bench/Data/Tree/tree_traverse_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_traverse_bench.cpp
@@ -28,8 +28,8 @@ mk_cjk_doc () {
 
 int
 main () {
-  tree doc= mk_cjk_doc ();
-  path p (0, 0, 0);
+  tree                     doc= mk_cjk_doc ();
+  path                     p (0, 0, 0);
   ankerl::nanobench::Bench bench;
   bench.minEpochIterations (1).unit ("op");
   bench.run ("next_word x1000", [&] {

--- a/moebius/bench/Data/Tree/tree_traverse_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_traverse_bench.cpp
@@ -1,0 +1,42 @@
+/** \file tree_traverse_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for word-based cursor traversal
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "tree_helper.hpp"
+#include "tree_traverse.hpp"
+
+#include <moebius/drd/drd_std.hpp>
+
+using namespace moebius;
+
+/** 构造一段含 TeXmacs 十六进制中文字符的长文本 */
+static tree
+mk_cjk_doc () {
+  string s;
+  for (int i= 0; i < 200; i++) {
+    s << "<#4e2d>";
+    s << "<#6587>";
+    if (i % 5 == 0) s << " ";
+    if (i % 7 == 0) s << "abc";
+  }
+  tree doc (DOCUMENT, tree (CONCAT, tree (s)));
+  return doc;
+}
+
+int
+main () {
+  tree doc= mk_cjk_doc ();
+  path p (0, 0, 0);
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (1).unit ("op");
+  bench.run ("next_word x1000", [&] {
+    path q= p;
+    for (int i= 0; i < 1000; i++)
+      q= next_word (doc, q);
+    ankerl::nanobench::doNotOptimizeAway (q);
+  });
+  return 0;
+}

--- a/moebius/moebius/drd/drd_info.cpp
+++ b/moebius/moebius/drd/drd_info.cpp
@@ -60,6 +60,11 @@ drd_info_rep::contains (string l) {
   return existing_tree_label (l) && info->contains (as_tree_label (l));
 }
 
+bool
+drd_info_rep::contains (tree_label l) {
+  return info->contains (l);
+}
+
 tm_ostream&
 operator<< (tm_ostream& out, drd_info drd) {
   return out << "drd [" << drd->name << "]";

--- a/moebius/moebius/drd/drd_info.hpp
+++ b/moebius/moebius/drd/drd_info.hpp
@@ -36,6 +36,14 @@ public:
   tree get_locals ();
   bool set_locals (tree t);
   bool contains (string l);
+  /**
+   * @brief 按标签编号查询 DRD 是否已知该标签
+   * @param l 标签编号
+   * @return 已注册返回 true
+   * @note 与 contains (as_string (l)) 等价（标签名与编号一一对应），
+   *       供编辑校正等热路径免去字符串往返
+   */
+  bool contains (tree_label l);
 
   /* Properties of the tag itself */
   void set_type (tree_label tag, int tp);

--- a/tests/Data/tree_cursor_test.cpp
+++ b/tests/Data/tree_cursor_test.cpp
@@ -26,6 +26,7 @@ private slots:
   void test_valid_cursor_basics ();
   void test_valid_cursor_input_math ();
   void test_next_valid ();
+  void test_next_word ();
 };
 
 void
@@ -52,13 +53,12 @@ TestTreeCursor::test_valid_cursor_input_math () {
   QVERIFY (!valid_cursor (input_math, path (1, 0)));
 
   // 普通的 input（第二个孩子不是 math）不受影响
-  tree input_plain (make_tree_label ("input"), tree ("name"),
-                    tree ("plain"));
+  tree input_plain (make_tree_label ("input"), tree ("name"), tree ("plain"));
   QVERIFY (valid_cursor (input_plain, path (1, 0)));
 
   // 同名 with 结构不受 input 特判影响
-  tree with_math (make_tree_label ("with"), tree ("mode"),
-                  tree ("math"), tree ("body"));
+  tree with_math (make_tree_label ("with"), tree ("mode"), tree ("math"),
+                  tree ("body"));
   QVERIFY (valid_cursor (with_math, path (2, 0)));
 }
 
@@ -69,8 +69,8 @@ TestTreeCursor::test_next_valid () {
     tree par (CONCAT);
     par << tree ("aa") << tree ("bb");
     if (i == 2)
-      par << tree (make_tree_label ("with"), tree ("color"),
-                   tree ("red"), tree ("inner"));
+      par << tree (make_tree_label ("with"), tree ("color"), tree ("red"),
+                   tree ("inner"));
     doc << par;
   }
   // 从首个原子起点逐步前进，位置应单调不减且始终合法
@@ -84,6 +84,37 @@ TestTreeCursor::test_next_valid () {
   // 反向移动应能回到起点附近
   path back= previous_valid (doc, p);
   QVERIFY (back != p);
+}
+
+void
+TestTreeCursor::test_next_word () {
+  // 词级移动应前进到合法光标位置（到达末尾后停驻）
+  tree doc (DOCUMENT, tree (CONCAT, tree ("aaa bbb ccc ddd eee fff")));
+  path p (0, 0, 0);
+  int progressed= 0;
+  for (int i= 0; i < 10; i++) {
+    path q= next_word (doc, p);
+    QVERIFY (valid_cursor (doc, q));
+    QVERIFY (path_inf_eq (p, q));
+    if (q == p) break;
+    progressed++;
+    p= q;
+  }
+  QVERIFY (progressed >= 1);
+
+  // 含 <#XXXX> 中文字符的文本：词移动不崩溃，前进后停驻于合法位置
+  tree cjk (DOCUMENT, tree (CONCAT, tree ("<#4e2d><#6587> abc")));
+  path r (0, 0, 0);
+  int cjk_progressed= 0;
+  for (int i= 0; i < 20; i++) {
+    path s= next_word (cjk, r);
+    QVERIFY (valid_cursor (cjk, s));
+    QVERIFY (path_inf_eq (r, s));
+    if (s == r) break;
+    cjk_progressed++;
+    r= s;
+  }
+  QVERIFY (cjk_progressed >= 1);
 }
 
 #ifdef QTTEXMACS

--- a/tests/Data/tree_cursor_test.cpp
+++ b/tests/Data/tree_cursor_test.cpp
@@ -1,0 +1,97 @@
+/******************************************************************************
+ * MODULE     : tree_cursor_test.cpp
+ * DESCRIPTION: Tests for cursor validation and movement
+ * COPYRIGHT  : (C) 2026 Mogan developers
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "tree_cursor.hpp"
+#include "tree_helper.hpp"
+#include "tree_traverse.hpp"
+
+using namespace moebius;
+
+class TestTreeCursor : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_valid_cursor_basics ();
+  void test_valid_cursor_input_math ();
+  void test_next_valid ();
+};
+
+void
+TestTreeCursor::test_valid_cursor_basics () {
+  tree doc (DOCUMENT);
+  tree par (CONCAT);
+  par << tree ("hello") << tree ("world");
+  doc << par << par;
+  // 原子内部与边界均为合法光标位置
+  QVERIFY (valid_cursor (doc, path (0, 0, 0)));
+  QVERIFY (valid_cursor (doc, path (0, 0, N (doc[0][0]->label))));
+  QVERIFY (valid_cursor (doc, path (0, 1, 2)));
+  // 非法索引与空路径
+  QVERIFY (!valid_cursor (doc, path ()));
+  QVERIFY (!is_inside (doc, path (0, 5, 0)));
+}
+
+void
+TestTreeCursor::test_valid_cursor_input_math () {
+  // VAR_EXPAND "math" 的特殊情形：
+  // (input "name" (math "x")) 的 math 参数内不允许光标
+  tree input_math (make_tree_label ("input"), tree ("name"),
+                   tree (make_tree_label ("math"), tree ("x")));
+  QVERIFY (!valid_cursor (input_math, path (1, 0)));
+
+  // 普通的 input（第二个孩子不是 math）不受影响
+  tree input_plain (make_tree_label ("input"), tree ("name"),
+                    tree ("plain"));
+  QVERIFY (valid_cursor (input_plain, path (1, 0)));
+
+  // 同名 with 结构不受 input 特判影响
+  tree with_math (make_tree_label ("with"), tree ("mode"),
+                  tree ("math"), tree ("body"));
+  QVERIFY (valid_cursor (with_math, path (2, 0)));
+}
+
+void
+TestTreeCursor::test_next_valid () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 5; i++) {
+    tree par (CONCAT);
+    par << tree ("aa") << tree ("bb");
+    if (i == 2)
+      par << tree (make_tree_label ("with"), tree ("color"),
+                   tree ("red"), tree ("inner"));
+    doc << par;
+  }
+  // 从首个原子起点逐步前进，位置应单调不减且始终合法
+  path p (0, 0, 0);
+  for (int i= 0; i < 20; i++) {
+    path q= next_valid (doc, p);
+    QVERIFY (q != p);
+    QVERIFY (valid_cursor (doc, q));
+    p= q;
+  }
+  // 反向移动应能回到起点附近
+  path back= previous_valid (doc, p);
+  QVERIFY (back != p);
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestTreeCursor)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "tree_cursor_test.moc"

--- a/tests/Data/tree_cursor_test.cpp
+++ b/tests/Data/tree_cursor_test.cpp
@@ -91,7 +91,7 @@ TestTreeCursor::test_next_word () {
   // 词级移动应前进到合法光标位置（到达末尾后停驻）
   tree doc (DOCUMENT, tree (CONCAT, tree ("aaa bbb ccc ddd eee fff")));
   path p (0, 0, 0);
-  int progressed= 0;
+  int  progressed= 0;
   for (int i= 0; i < 10; i++) {
     path q= next_word (doc, p);
     QVERIFY (valid_cursor (doc, q));
@@ -105,7 +105,7 @@ TestTreeCursor::test_next_word () {
   // 含 <#XXXX> 中文字符的文本：词移动不崩溃，前进后停驻于合法位置
   tree cjk (DOCUMENT, tree (CONCAT, tree ("<#4e2d><#6587> abc")));
   path r (0, 0, 0);
-  int cjk_progressed= 0;
+  int  cjk_progressed= 0;
   for (int i= 0; i < 20; i++) {
     path s= next_word (cjk, r);
     QVERIFY (valid_cursor (cjk, s));

--- a/tests/Data/tree_helper_test.cpp
+++ b/tests/Data/tree_helper_test.cpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * MODULE     : tree_helper_test.cpp
+ * DESCRIPTION: Tests for tree_helper predicates
+ * COPYRIGHT  : (C) 2026 Mogan developers
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "tree_helper.hpp"
+
+using namespace moebius;
+
+class TestTreeHelper : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_is_empty ();
+  void test_is_snippet ();
+};
+
+void
+TestTreeHelper::test_is_empty () {
+  QVERIFY (is_empty (tree ("")));
+  QVERIFY (!is_empty (tree ("a")));
+  // 空段落/空 concat 视为空
+  QVERIFY (is_empty (tree (DOCUMENT)));
+  QVERIFY (is_empty (tree (DOCUMENT, tree (""))));
+  QVERIFY (!is_empty (tree (DOCUMENT, tree ("a"))));
+  QVERIFY (is_empty (tree (CONCAT)));
+  // concat 只要有一个非空孩子即非空
+  QVERIFY (!is_empty (tree (CONCAT, tree (""), tree ("b"))));
+  // suppressed 标签视为空
+  QVERIFY (is_empty (tree (make_tree_label ("suppressed"))));
+  QVERIFY (!is_empty (tree (make_tree_label ("kept"), tree ("x"))));
+}
+
+void
+TestTreeHelper::test_is_snippet () {
+  // 非文档一律是 snippet
+  QVERIFY (is_snippet (tree ("x")));
+  QVERIFY (is_snippet (tree (CONCAT, tree ("x"))));
+  // 不含 TeXmacs 根标记的文档也是 snippet
+  tree doc (DOCUMENT, tree ("body"));
+  QVERIFY (is_snippet (doc));
+  // 首层含 (TeXmacs ...) 的文档不是 snippet
+  tree full (DOCUMENT, tree (make_tree_label ("TeXmacs"), tree ("1.0.2")),
+             tree ("body"));
+  QVERIFY (!is_snippet (full));
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestTreeHelper)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "tree_helper_test.moc"

--- a/tests/Data/tree_modify_test.cpp
+++ b/tests/Data/tree_modify_test.cpp
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * MODULE     : tree_modify_test.cpp
+ * DESCRIPTION: Tests for tree correction routines
+ * COPYRIGHT  : (C) 2026 Mogan developers
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "tree_helper.hpp"
+#include "tree_modify.hpp"
+
+#include <moebius/drd/drd_std.hpp>
+#include <moebius/tree_label.hpp>
+
+using namespace moebius;
+
+class TestTreeModify : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_label_name_bijection ();
+  void test_correct_node ();
+};
+
+void
+TestTreeModify::test_label_name_bijection () {
+  // contains(L(t)) 与 contains(as_string(L(t))) 等价的前提：
+  // 标签名与标签编号一一对应
+  array<string> names= get_all_primitives ();
+  for (int i= 0; i < N (names); i++) {
+    string      n= names[i];
+    tree_label l= as_tree_label (n);
+    QVERIFY (existing_tree_label (n));
+    QVERIFY (l != UNKNOWN);
+    QVERIFY (to_string (l) == n);
+  }
+  // 扩展标签同样满足
+  tree_label ext= make_tree_label ("test-bijection-ext");
+  QVERIFY (as_tree_label ("test-bijection-ext") == ext);
+  QVERIFY (to_string (ext) == string ("test-bijection-ext"));
+  QVERIFY (make_tree_label ("test-bijection-ext") == ext);
+}
+
+void
+TestTreeModify::test_correct_node () {
+  // 原子节点不做校正
+  tree a ("x");
+  correct_node (a);
+  QVERIFY (is_atomic (a));
+
+  // DRD 未知的标签不校正
+  tree unknown (make_tree_label ("test-unknown-tag-zzz"), tree ("x"));
+  tree unknown2= unknown;
+  correct_node (unknown2);
+  QVERIFY (unknown2 == unknown);
+
+  // DRD 已知但 arity 错误的标签被替换为空串
+  tree_label bad_l= make_tree_label ("test-arity-tag-zzz");
+  drd::the_drd->set_arity (bad_l, 1, 0, ARITY_NORMAL, CHILD_DETAILED);
+  tree bad (bad_l, tree ("a"), tree ("b"));
+  correct_node (bad);
+  QVERIFY (bad == tree (""));
+  // arity 正确则保留
+  tree_label good_l= make_tree_label ("test-arity-tag2-zzz");
+  drd::the_drd->set_arity (good_l, 1, 0, ARITY_NORMAL, CHILD_DETAILED);
+  tree good (good_l, tree ("a"));
+  correct_node (good);
+  QVERIFY (good == tree (good_l, tree ("a")));
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestTreeModify)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "tree_modify_test.moc"

--- a/tests/Data/tree_modify_test.cpp
+++ b/tests/Data/tree_modify_test.cpp
@@ -35,7 +35,7 @@ TestTreeModify::test_label_name_bijection () {
   // 标签名与标签编号一一对应
   array<string> names= get_all_primitives ();
   for (int i= 0; i < N (names); i++) {
-    string      n= names[i];
+    string     n= names[i];
     tree_label l= as_tree_label (n);
     QVERIFY (existing_tree_label (n));
     QVERIFY (l != UNKNOWN);

--- a/tests/Data/tree_observer_test.cpp
+++ b/tests/Data/tree_observer_test.cpp
@@ -1,0 +1,110 @@
+/******************************************************************************
+ * MODULE     : tree_observer_test.cpp
+ * DESCRIPTION: Tests for raw tree modifications and refcount integrity
+ * COPYRIGHT  : (C) 2026 Mogan developers
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "tree_helper.hpp"
+#include "tree_observer.hpp"
+
+using namespace moebius;
+
+class TestTreeObserver : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_raw_insert ();
+  void test_raw_remove ();
+  void test_insert_remove_refcount ();
+};
+
+void
+TestTreeObserver::test_raw_insert () {
+  tree doc (DOCUMENT, tree ("a"), tree ("b"), tree ("d"));
+  // 在头部插入
+  raw_insert (doc, 0, tree (DOCUMENT, tree ("x")));
+  QVERIFY (N (doc) == 4);
+  QVERIFY (doc[0] == tree ("x"));
+  QVERIFY (doc[1] == tree ("a"));
+  // 在中部插入多个
+  raw_insert (doc, 2, tree (DOCUMENT, tree ("m"), tree ("n")));
+  QVERIFY (N (doc) == 6);
+  QVERIFY (doc[1] == tree ("a"));
+  QVERIFY (doc[2] == tree ("m"));
+  QVERIFY (doc[3] == tree ("n"));
+  QVERIFY (doc[4] == tree ("b"));
+  QVERIFY (doc[5] == tree ("d"));
+  // 在尾部插入
+  raw_insert (doc, 6, tree (DOCUMENT, tree ("z")));
+  QVERIFY (N (doc) == 7);
+  QVERIFY (doc[6] == tree ("z"));
+}
+
+void
+TestTreeObserver::test_raw_remove () {
+  tree doc (DOCUMENT, tree ("a"), tree ("b"), tree ("c"), tree ("d"),
+            tree ("e"));
+  // 头部删除
+  raw_remove (doc, 0, 1);
+  QVERIFY (N (doc) == 4);
+  QVERIFY (doc[0] == tree ("b"));
+  // 中部删除多个
+  raw_remove (doc, 1, 2);
+  QVERIFY (N (doc) == 2);
+  QVERIFY (doc[0] == tree ("b"));
+  QVERIFY (doc[1] == tree ("e"));
+  // 尾部删除
+  raw_remove (doc, 1, 1);
+  QVERIFY (N (doc) == 1);
+  QVERIFY (doc[0] == tree ("b"));
+}
+
+void
+TestTreeObserver::test_insert_remove_refcount () {
+  // 交叉插入/删除并共享子树：若数组块移动的引用计数记账有误，
+  // 后续拷贝比较或进程退出时会崩溃或得到错误内容
+  tree shared (CONCAT, tree ("s1"), tree ("s2"));
+  tree doc (DOCUMENT);
+  for (int round= 0; round < 50; round++) {
+    tree ins (DOCUMENT);
+    ins << shared << tree ("t") << shared;
+    raw_insert (doc, 0, ins);
+    QVERIFY (doc[0] == shared);
+    QVERIFY (doc[2] == shared);
+    if (round % 2 == 0) raw_remove (doc, 0, 1);
+  }
+  QVERIFY (N (doc) == 125);
+  // 大数组跨容量桶的插入/删除
+  tree big (DOCUMENT);
+  for (int i= 0; i < 1000; i++)
+    big << tree ("p" * as_string (i));
+  for (int i= 0; i < 40; i++)
+    raw_insert (big, 500, tree (DOCUMENT, tree ("q")));
+  QVERIFY (N (big) == 1040);
+  QVERIFY (big[500] == tree ("q"));
+  QVERIFY (big[499] == tree ("p499"));
+  QVERIFY (big[539] == tree ("q"));
+  QVERIFY (big[540] == tree ("p500"));
+  raw_remove (big, 500, 40);
+  QVERIFY (N (big) == 1000);
+  QVERIFY (big[500] == tree ("p500"));
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestTreeObserver)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "tree_observer_test.moc"


### PR DESCRIPTION
## [01228] moebius Data/Tree 性能优化（6 项）

每项均配套 nanobench 基准、Qt 单元测试与 Doxygen 注释，详见 `devel/01228.md`。

| # | 优化 | 收益 |
|---|------|------|
| 1 | `valid_cursor`/`pre_correct` 缓存 input/math 标签，整数比较替代字符串比较 | with 路径 -25% |
| 2 | `is_empty`/`is_snippet` 标签缓存 | is_snippet 27×，is_empty 全树 -25% |
| 3 | `left_most`/`right_most` 消除恒假的 `as_tree(p)` 判断（每层递归一次临时树分配） | 死代码消除 |
| 4 | `correct_node` 用标签编号查询 DRD（新增 `drd_info::contains(tree_label)`） | correct_downwards -45% |
| 5 | 词级移动 `tm_codepoint_at` 改原串字节扫描，去除子串分配 | 中文跳词 -7% |
| 6 | `raw_insert`/`raw_remove` 逐元素引用计数搬移改 memmove 块移动 | 1000 段文档头部插删 21× |

## 测试

- 新增 `tests/Data/tree_{cursor,helper,modify,observer}_test.cpp`，全部通过
- 既有 `tree-test`（20 checks）通过；stem 构建 + 集成测试 2044 通过
- 第 6 项附引用计数记账分析（memmove 位级搬移 + 洞位/被删元素显式补账）

## 负结果（记录于任务文档，未采纳）

- `is_compound(tree,string)` 改标签比较反而更慢（字符串哈希 > 整数键查找+短串比较）
- `move_any` 合并两次 subtree 下降实测回退 15%，已放弃

🤖 Generated with [Claude Code](https://claude.com/claude-code)