### PR TITLE
[0828] cpp-tree->utf8raw 还原 <less>/<gtr> 为字面 < >

### DIFF
--- a/TeXmacs/tests/0828.scm
+++ b/TeXmacs/tests/0828.scm
@@ -10,32 +10,43 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(import (scheme base)
-        (liii check)
-        (liii string))
+(import (scheme base) (liii check) (liii string))
 
 (check-set-mode! 'report-failed)
 
 ;;; ========== 辅助函数 ==========
 
 ;; 由含 UTF-8 字符串标签的 stree 直接构造 UTF-8 tree
+
 (define (utf8-tree label)
-  (stree->tree `(document ,label)))
+  (stree->tree `(document ,label))
+) ;define
 
 ;; 加载插件 init 脚本（注册其自定义 serializer）
+
 (define (load-plugin-init name)
   (load (string-append (url->system (get-texmacs-path))
-                       "/plugins/" name "/progs/init-" name ".scm")))
+          "/plugins/"
+          name
+          "/progs/init-"
+          name
+          ".scm"
+        ) ;string-append
+  ) ;load
+) ;define
 
 ;; 用 UTF-8 stree 调 plugin-serialize（plugin-serialize 约定接收 stree）
+
 (define (plugin-serialize-utf8 lan label)
-  (plugin-serialize lan `(document ,label)))
+  (plugin-serialize lan `(document ,label))
+) ;define
 
 ;;; ========== texmacs->utf8raw / utf8raw->texmacs 往返 ==========
 
 (define (test-utf8raw-roundtrip)
   (define (roundtrip s)
-    (texmacs->utf8raw (utf8raw->texmacs s)))
+    (texmacs->utf8raw (utf8raw->texmacs s))
+  ) ;define
   (check (roundtrip "中文测试") => "中文测试")
   (check (roundtrip "αβγδ") => "αβγδ")
   (check (roundtrip "Hello 世界") => "Hello 世界")
@@ -44,7 +55,8 @@
   (check (roundtrip "line1\nline2") => "line1\nline2")
   (check (roundtrip "a\n\nb") => "a\n\nb")
   (check (roundtrip "") => "")
-  (check (roundtrip "  ") => "  "))
+  (check (roundtrip "  ") => "  ")
+) ;define
 
 ;;; ========== 由 UTF-8 tree 序列化 ==========
 
@@ -53,7 +65,45 @@
   (check (texmacs->utf8raw (utf8-tree "αβγδ")) => "αβγδ")
   (check (texmacs->utf8raw (utf8-tree "Hello 世界")) => "Hello 世界")
   (check (texmacs->utf8raw (utf8-tree "∑∏∫√")) => "∑∏∫√")
-  (check (texmacs->utf8raw (stree->tree '(document "line1" "line2"))) => "line1\nline2"))
+  (check (texmacs->utf8raw (stree->tree '(document "line1" "line2")))
+    =>
+    "line1\nline2"
+  ) ;check
+) ;define
+
+;; stree（s-exp）中文本用字面 < >，stree->tree 成 tree 后 cpp-tree->utf8raw 须原样输出，
+;; 不得引入 <less>/<gtr> 转义
+
+(define (test-cpp-tree-to-utf8raw-angle-brackets)
+  (check (cpp-tree->utf8raw (stree->tree '(document "a<b>c"))) => "a<b>c")
+  (check (cpp-tree->utf8raw (stree->tree '(document "<"))) => "<")
+  (check (cpp-tree->utf8raw (stree->tree '(document ">"))) => ">")
+  (check (cpp-tree->utf8raw (stree->tree '(document "<x>" "y<z"))) => "<x>\ny<z")
+  ;; 与 CJK 混合
+  (check (cpp-tree->utf8raw (stree->tree '(document "中文<文>")))
+    =>
+    "中文<文>"
+  ) ;check
+  ;; 完整链路：stem->tree（stree->tree + herk 化）后再 herk->utf8 还原，< > 仍是字面
+  (define stem->tree (lambda (s) (utf8-tree->herk-tree (stree->tree s))))
+  (check (cpp-tree->utf8raw (herk-tree->utf8-tree (stem->tree '(document "中文<文>a<b>")))
+         ) ;cpp-tree->utf8raw
+    =>
+    "中文<文>a<b>"
+  ) ;check
+
+  ;; 编辑器内部 tree 里 > 存成 <gtr>（TeXmacs 树字符串转义）。真实输入路径（如在插件中
+  ;; 键入 1>2）产生的就是这种形式，cpp-tree->utf8raw 须把 <gtr>/<less> 还原成字面 > <。
+  ;; herk_to_utf8 只识别 <#XXXX>，命名转义在 tree_to_utf8raw 的 un_escape_angle 中解码。
+  (check (cpp-tree->utf8raw (herk-tree->utf8-tree (stree->tree '(document "1<gtr>2"))))
+    =>
+    "1>2"
+  ) ;check
+  (check (cpp-tree->utf8raw (herk-tree->utf8-tree (stree->tree '(document "a<less>b"))))
+    =>
+    "a<b"
+  ) ;check
+) ;define
 
 ;;; ========== utf8raw->texmacs 保留原始字节 ==========
 
@@ -63,14 +113,16 @@
   (check (texmacs->utf8raw t) => "<#5206><#5B50>")
   ;; CR/LF 归一化
   (check (texmacs->utf8raw (utf8raw->texmacs "a\r\nb")) => "a\nb")
-  (check (texmacs->utf8raw (utf8raw->texmacs "a\rb")) => "a\nb"))
+  (check (texmacs->utf8raw (utf8raw->texmacs "a\rb")) => "a\nb")
+) ;define
 
 ;;; ========== 默认 serializer 输出 UTF-8 raw ==========
 
 (define (test-utf8raw-serialize-utf8)
   (define s (utf8raw-serialize "python" (utf8-tree "print('中文')")))
   (check (string-contains? s "中文") => #t)
-  (check (string-contains? s "<#4E2D>") => #f))
+  (check (string-contains? s "<#4E2D>") => #f)
+) ;define
 
 (define (test-generic-serialize-utf8)
   (define s (generic-serialize "python" (utf8-tree "print('中文')")))
@@ -78,109 +130,158 @@
   (check (string-contains? s "utf8:") => #t)
   (check (string-contains? s "中文") => #t)
   (check (string-contains? s "<#4E2D>") => #f)
-  (check (string-ends? s (char->string #\x05)) => #t))
+  (check (string-ends? s (char->string #\x05)) => #t)
+) ;define
 
 ;;; ========== 各插件自定义 serializer 输出 UTF-8 ==========
 
 (define (test-python-serialize-utf8)
   (load-plugin-init "python")
-  (with s (plugin-serialize-utf8 "python" "print('中文')")
+  (with s
+    (plugin-serialize-utf8 "python" "print('中文')")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 (define (test-julia-serialize-utf8)
   (load-plugin-init "julia")
-  (with s (plugin-serialize-utf8 "julia" "println(\"中文\")")
+  (with s
+    (plugin-serialize-utf8 "julia" "println(\"中文\")")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 (define (test-goldfish-serialize-utf8)
   (load-plugin-init "goldfish")
-  (with s (plugin-serialize-utf8 "goldfish" "(display \"中文\")")
+  (with s
+    (plugin-serialize-utf8 "goldfish" "(display \"中文\")")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 (define (test-gnuplot-serialize-utf8)
   (load-plugin-init "gnuplot")
-  (with s (plugin-serialize-utf8 "gnuplot" "set title \"中文\"")
+  (with s
+    (plugin-serialize-utf8 "gnuplot" "set title \"中文\"")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 (define (test-autosave-serialize-utf8)
   (load-plugin-init "autosave")
-  (with s (plugin-serialize-utf8 "autosave" "(display \"中文\")")
+  (with s
+    (plugin-serialize-utf8 "autosave" "(display \"中文\")")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 (define (test-tikz-serialize-utf8)
   (load-plugin-init "tikz")
-  (with s (plugin-serialize-utf8 "tikz" "\\node {中文};")
+  (with s
+    (plugin-serialize-utf8 "tikz" "\\node {中文};")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 (define (test-quiver-serialize-utf8)
   (load-plugin-init "quiver")
-  (with s (plugin-serialize-utf8 "quiver" "\\node {中文};")
+  (with s
+    (plugin-serialize-utf8 "quiver" "\\node {中文};")
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
     (when (string-contains? s "<EOF>")
-      (check (string-ends? s "\n<EOF>\n") => #t))))
+      (check (string-ends? s "\n<EOF>\n") => #t)
+    ) ;when
+  ) ;with
+) ;define
 
 ;; Maxima 经 (plugin-configure :serializer ...) 注册，依赖二进制存在；测试环境无二进制，
 ;; plugin-serialize 会落回默认 utf8raw-serialize 而测不到 maxima-serialize，故直接调用。
+
 (define (test-maxima-serialize-utf8)
   (load-plugin-init "maxima")
-  (with s (maxima-serialize "maxima" '(document "x:中文"))
+  (with s
+    (maxima-serialize "maxima" '(document "x:中文"))
     (check (string-contains? s "中文") => #t)
     (check (string-contains? s "<#4E2D>") => #f)
-    (check (string-ends? s ";\n") => #t))
+    (check (string-ends? s ";\n") => #t)
+  ) ;with
   (check (maxima-serialize "maxima" '(document "")) => "0;\n")
-  (with s (maxima-serialize "maxima" '(document "中文$"))
-    (check (string-ends? s "中文$\n") => #t)))
+  (with s
+    (maxima-serialize "maxima" '(document "中文$"))
+    (check (string-ends? s "中文$\n") => #t)
+  ) ;with
+) ;define
 
 ;;; ========== 输入端：utf8raw->texmacs 后转 Herk ==========
 
 ;; 模拟 input.cpp：把 utf8: 负载解析成 UTF-8 tree，再转成内部 Herk tree。
+
 (define (test-input-utf8-to-herk)
-  (define herk-str (texmacs->stm (utf8-tree->herk-tree (utf8raw->texmacs "print('中文')"))))
+  (define herk-str
+    (texmacs->stm (utf8-tree->herk-tree (utf8raw->texmacs "print('中文')")))
+  ) ;define
   (check (string-contains? herk-str "<#4E2D>") => #t)
   (check (string-contains? herk-str "<#6587>") => #t)
-  (check (string-contains? herk-str "中文") => #f))
+  (check (string-contains? herk-str "中文") => #f)
+) ;define
 
 ;; emoji（BMP 外）在 utf8_to_herk 映射表里没有对应项，tree_utf8_to_herk 须以 <#XXXX>
 ;; 保留而非丢弃——这是 0828 相对 0827（走 utf8_to_cork 会静默丢失此类字符）的关键修正。
+
 (define (test-input-emoji-to-herk)
-  (define herk-str (texmacs->stm (utf8-tree->herk-tree (utf8raw->texmacs "x:🎉"))))
+  (define herk-str
+    (texmacs->stm (utf8-tree->herk-tree (utf8raw->texmacs "x:🎉")))
+  ) ;define
   (check (string-contains? herk-str "<#1F389>") => #t)
-  (check (string-contains? herk-str "🎉") => #f))
+  (check (string-contains? herk-str "🎉") => #f)
+) ;define
 
 ;; 普通文本与 <#XXXX> 字面混合：<#XXXX> 原样存活（不被当作 UTF-8 字节再解码），CJK 正常往返。
+
 (define (test-utf8raw-mixed-hex-literal)
   (define t (utf8raw->texmacs "代码<#5206>"))
-  (check (texmacs->utf8raw t) => "代码<#5206>"))
+  (check (texmacs->utf8raw t) => "代码<#5206>")
+) ;define
 
 ;;; ========== 写出端：Herk tree -> UTF-8 tree -> raw 串 ==========
 
 ;; 模拟主进程到插件的路径：内部 Herk tree 先转 UTF-8 tree，再由 texmacs->utf8raw 序列化。
+
 (define (test-write-path-herk-to-utf8raw)
-  (define s (texmacs->utf8raw
-              (herk-tree->utf8-tree
-                (stm-snippet->texmacs "(frac \"<#5206><#5B50>\" \"<#5206><#6BCD>\")"))))
+  (define s
+    (texmacs->utf8raw (herk-tree->utf8-tree (stm-snippet->texmacs "(frac \"<#5206><#5B50>\" \"<#5206><#6BCD>\")")
+                      ) ;herk-tree->utf8-tree
+    ) ;texmacs->utf8raw
+  ) ;define
   (check (string-contains? s "分子") => #t)
   (check (string-contains? s "分母") => #t)
-  (check (string-contains? s "<#5206>") => #f))
+  (check (string-contains? s "<#5206>") => #f)
+) ;define
 
 ;;; ========== input-done? 旁路：序列化前 Herk stree 转 UTF-8 ==========
 
@@ -188,6 +289,7 @@
 ;; UTF-8 stree 再 plugin-serialize。下方正向断言验证转换后输出 UTF-8；反向断言证明不转换
 ;; 则 Herk 的 <#XXXX> 字面会原样漏给插件（插件收到 8 个 ASCII 字符 "<#4E2D>" 而非"中"），
 ;; 即该转换是必需的、不可省略。
+
 (define (test-input-done-herk-to-utf8)
   (load-plugin-init "python")
   (define herk-stree '(document "print('<#4E2D><#6587>')"))
@@ -196,7 +298,8 @@
   (check (string-contains? (plugin-serialize "python" pre-u8) "<#4E2D>") => #f)
   (define bad (plugin-serialize "python" herk-stree))
   (check (string-contains? bad "<#4E2D>") => #t)
-  (check (string-contains? bad "中文") => #f))
+  (check (string-contains? bad "中文") => #f)
+) ;define
 
 ;;; ========== 测试入口 ==========
 
@@ -204,6 +307,7 @@
   (test-utf8raw-roundtrip)
   (test-utf8raw-from-tree)
   (test-utf8raw-to-tree)
+  (test-cpp-tree-to-utf8raw-angle-brackets)
   (test-utf8raw-serialize-utf8)
   (test-generic-serialize-utf8)
   (test-python-serialize-utf8)
@@ -219,4 +323,5 @@
   (test-utf8raw-mixed-hex-literal)
   (test-write-path-herk-to-utf8raw)
   (test-input-done-herk-to-utf8)
-  (check-report))
+  (check-report)
+) ;tm-define

--- a/devel/0828.md
+++ b/devel/0828.md
@@ -60,3 +60,22 @@ xmake r 0828
 
 ## PS
 - `TeXmacs/plugins/*/progs/data/*.scm` 中出现的 `(texmacs->verbatim x (acons "texmacs->verbatim:encoding" "SourceCode" '()))` 用于文件格式导入/导出（如 `.py`、`.cpp`、`.scm`），不属于插件 I/O 路径；SourceCode 编码用于文件持久化与往返，0828 不涉及这些路径，保持原样不改。
+
+## 6 补充：cpp-tree->utf8raw 的 <less>/<gtr> 解码（da/0828/unit_test 分支）
+
+### What
+在插件（如 python）中键入 `1>2`，插件实际收到的是 `1<gtr>2`——编辑器内部 tree 把 `>` 存成 `<gtr>`（TeXmacs 树字符串转义），而 `herk_to_utf8` 只识别 `<#XXXX>`，命名转义原样漏给插件。
+
+### Why
+- herk 编码本身的转义只有 `<#XXXX>`；`<gtr>`/`<less>` 是 tm/cork 树字符串的转义，混进 herk 层会破坏 tmu 格式的序列化行为，故 `tree_herk_to_utf8` 不能改。
+- `cork_to_utf8` / `tm_decode` 也不能直接用：前者会解 `<#XXXX>` 并按 Cork 字节表映射（会破坏已是 UTF-8 的多字节）；后者会丢弃裸 `>` 与未知 `<...>` 实体、未闭合 `<` 时截断。
+- `tree_to_utf8raw` 只服务插件 I/O 序列化（0828 引入），是放这个解码的正确出口。
+
+### How
+1. `src/Data/Convert/Verbatim/verbatim.cpp`：新增静态 `un_escape_angle`，只精确匹配 `<less>`→`<`、`<gtr>`→`>`，其余字节一律不动（`<#XXXX>` 字面保留）；快路径先扫描 `<`，无命中零拷贝返回原串，有转义才从首个 `<` 起重建。`tree_to_utf8raw` 在 `as_verbatim` 之后过一遍。
+2. `TeXmacs/tests/0828.scm`：新增 `test-cpp-tree-to-utf8raw-angle-brackets`，覆盖字面 `<`/`>`（stree 直构）、单字符、多行、CJK 混合、完整 stem->tree（`stree->tree` + `utf8-tree->herk-tree`）→ `herk-tree->utf8-tree` → utf8raw 链路，以及编辑器转义形式 `"1<gtr>2"`/`"a<less>b"` 的还原。
+3. 期间在 `init-python.scm` 的 `python-serialize` 加过 `display*` 调试打印（before/after），确认修复后已删除。
+
+### 涉及文件
+- `src/Data/Convert/Verbatim/verbatim.cpp`
+- `TeXmacs/tests/0828.scm`

--- a/src/Data/Convert/Verbatim/verbatim.cpp
+++ b/src/Data/Convert/Verbatim/verbatim.cpp
@@ -271,9 +271,38 @@ tree_to_verbatim (tree t, bool wrap, string enc) {
 #endif
 }
 
+// 插件 I/O 输入树来自编辑器，< > 以 <less>/<gtr>
+// 转义存储；序列化须还原为字面字符。 仅处理这两个命名转义：<#XXXX>
+// 字面须原样保留，不能用 tm_decode。
+static string
+un_escape_angle (string s) {
+  int i, n= N (s);
+  for (i= 0; i < n; i++)
+    if (s[i] == '<') {
+      // 慢路径：遇到 '<' 才开始逐字重建，无转义的常见情形零拷贝
+      string r= s (0, i);
+      while (i < n) {
+        if (s[i] == '<' && i + 5 < n && s (i, i + 6) == "<less>") {
+          r << '<';
+          i+= 6;
+        }
+        else if (s[i] == '<' && i + 4 < n && s (i, i + 5) == "<gtr>") {
+          r << '>';
+          i+= 5;
+        }
+        else {
+          r << s[i];
+          i++;
+        }
+      }
+      return r;
+    }
+  return s;
+}
+
 string
 tree_to_utf8raw (tree t) {
-  string buf= as_verbatim (t, false);
+  string buf= un_escape_angle (as_verbatim (t, false));
 #ifdef OS_WIN
   return unix_to_dos (buf);
 #else


### PR DESCRIPTION
## 问题
在插件（如 python）中键入 `1>2`，插件实际收到 `1<gtr>2`：编辑器内部 tree 把 `>` 存成 `<gtr>`（TeXmacs 树字符串转义），而 `herk_to_utf8` 只识别 `<#XXXX>`，命名转义原样漏给插件。

## 方案
在 `tree_to_utf8raw`（插件 I/O 序列化专用出口）新增 `un_escape_angle`：
- 只精确匹配 `<less>`→`<`、`<gtr>`→`>`，`<#XXXX>` 字面保留
- 无 `<` 时零拷贝快路径返回原串

不 `herk_to_utf8` / `cork_to_utf8` / `tm_decode` 改动的原因见 devel/0828.md 第 6 节（tmu 格式依赖、hex 转义需保留、裸 > 丢弃等副作用）。

## 测试
`TeXmacs/tests/0828.scm` 新增 `test-cpp-tree-to-utf8raw-angle-brackets`：字面 `<`/`>`、单字符、多行、CJK 混合、stem->tree 完整链路、编辑器转义形式还原。`xmake r 0828` 71 correct, 0 failed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)