### PR TITLE
[1228] is_empty/is_snippet 缓存标签编号，消除热路径字符串比较

### DIFF
--- a/devel/1228.md
+++ b/devel/1228.md
@@ -1,0 +1,57 @@
+# 1228: is_empty / is_snippet 性能优化（moebius）
+
+## 任务
+
+优化 `moebius/Data/Tree/tree_helper.cpp` 中的 `is_empty` 与 `is_snippet`，
+消除热路径上的 `as_string (L (t))` 哈希查找与字符串比较。
+参考分支 `da/1228/moebius` 第二项优化，编译、测试与 bench 均在
+`moebius/` 子工程内完成，不编译整个项目。
+
+## What
+
+- `is_empty`：非 document/concat 复合节点原来做
+  `is_compound (t, "suppressed")`（`as_string (L (t))` 哈希查找 +
+  字符串构造 + 逐字节比较），改为函数局部静态缓存标签编号
+  `label_suppressed ()` 后做整数比较。
+- `is_snippet`：文档每个顶层孩子原来做
+  `is_compound (doc[i], "TeXmacs", 1)` 字符串比较，改为缓存
+  `label_texmacs_marker ()` 后用 `is_func (doc[i], l, 1)`。
+
+## Why
+
+- `is_empty` 在排版/环境长度计算（`env_length.cpp` 等上百处调用点）
+  高频执行，每个叶子与 `with` 类节点都付出一次字符串比较。
+- `is_snippet` 在文档根判断（保存、buffer 管理等）对每个顶层孩子扫描。
+
+## How
+
+- `make_tree_label` 幂等：同名重复调用返回已注册标签，函数局部静态
+  只在首次调用时查表一次，之后仅静态读取。
+- `suppressed` 可带任意 arity（含零参），而 `is_func (t, l)` 在零参时
+  恒为假，故用 `L (t) == label_suppressed ()` 直接比较；
+  `TeXmacs` 标记固定一参，用 `is_func (doc[i], l, 1)`。
+
+## 测量
+
+参考分支（i7, 交错 A/B 运行）：
+
+- `is_empty` 全文档（100 段）：43.0 µs → 32–34 µs（约 -25%）
+- `is_snippet`：2510 ns → ~100 ns（约 27×）
+
+本机 A/B 对比（Windows, releasedbg, `tree_helper_bench`，还原 main 版本与优化版各跑一轮）：
+
+| 基准 | 优化前 | 优化后 | 提升 |
+|------|--------|--------|------|
+| `is_empty whole doc` | 21,473 ns | 19,856 ns | 约 -8% |
+| `is_snippet` | 2,136 ns | 175 ns | 约 12× |
+| `is_multi_paragraph` | 3.43 ns | 3.44 ns | 无变化（未改动） |
+
+`xmake test "moebius_tests/*"` 18/18 通过。
+
+## 涉及文件
+
+- `moebius/Data/Tree/tree_helper.cpp`：标签缓存与调用点替换
+- `moebius/bench/Data/Tree/tree_helper_bench.cpp`（新增）：
+  is_empty 全文档 / is_snippet / is_multi_paragraph 基准
+- `tests/Data/tree_helper_test.cpp`（新增）：is_empty 各形态、
+  is_snippet 含/不含 TeXmacs 根标记的回归断言

--- a/moebius/Data/Tree/tree_helper.cpp
+++ b/moebius/Data/Tree/tree_helper.cpp
@@ -25,6 +25,26 @@ L (modification mod) {
  * Compound trees
  ******************************************************************************/
 
+/**
+ * @brief "suppressed" 标签的缓存编号，避免 is_empty 每次做字符串比较
+ * @note make_tree_label 幂等，函数局部静态首次调用后仅做静态读取
+ */
+static tree_label
+label_suppressed () {
+  static tree_label l= make_tree_label ("suppressed");
+  return l;
+}
+
+/**
+ * @brief "TeXmacs" 文档根标记标签的缓存编号，供 is_snippet 快速比较
+ * @note make_tree_label 幂等，函数局部静态首次调用后仅做静态读取
+ */
+static tree_label
+label_texmacs_marker () {
+  static tree_label l= make_tree_label ("TeXmacs");
+  return l;
+}
+
 tree
 compound (string s) {
   return tree (make_tree_label (s));
@@ -89,7 +109,7 @@ is_snippet (tree doc) {
   if (!is_document (doc)) return true;
   int i, n= N (doc);
   for (i= 0; i < n; i++)
-    if (is_compound (doc[i], "TeXmacs", 1)) return false;
+    if (is_func (doc[i], label_texmacs_marker (), 1)) return false;
   return true;
 }
 
@@ -234,7 +254,8 @@ is_empty (tree t) {
       if (!is_empty (t[i])) return false;
     return is_concat (t) || (n <= 1);
   }
-  return is_compound (t, "suppressed");
+  // suppressed 可带任意 arity，不能用在零参时为假的 is_func
+  return L (t) == label_suppressed ();
 }
 
 bool

--- a/moebius/bench/Data/Tree/tree_helper_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_helper_bench.cpp
@@ -1,0 +1,51 @@
+/** \file tree_helper_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for tree_helper predicates on the typesetting path
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "tree_helper.hpp"
+
+using namespace moebius;
+
+/** 构造典型文档：100 段，每段 concat 由原子与少量复合节点组成 */
+static tree
+mk_document () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 100; i++) {
+    tree par (CONCAT);
+    for (int j= 0; j < 10; j++) {
+      par << tree ("word" * as_string (j));
+      if (j == 4)
+        par << tree (make_tree_label ("with"), tree ("color"), tree ("red"),
+                     tree ("inner" * as_string (j)));
+    }
+    doc << par;
+  }
+  return doc;
+}
+
+/** 递归统计 is_empty 为真的节点数，模拟排版期的逐节点调用 */
+static int
+count_empty (tree t) {
+  int r= is_empty (t) ? 1 : 0;
+  if (is_compound (t))
+    for (int i= 0; i < N (t); i++)
+      r+= count_empty (t[i]);
+  return r;
+}
+
+int
+main () {
+  tree                     doc= mk_document ();
+  int                      n  = 0;
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (100).unit ("op");
+  bench.run ("is_empty whole doc", [&] { n+= count_empty (doc); });
+  bench.run ("is_snippet", [&] { n+= is_snippet (doc) ? 1 : 0; });
+  bench.run ("is_multi_paragraph",
+             [&] { n+= is_multi_paragraph (doc) ? 1 : 0; });
+  ankerl::nanobench::doNotOptimizeAway (n);
+  return 0;
+}

--- a/tests/Data/tree_helper_test.cpp
+++ b/tests/Data/tree_helper_test.cpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * MODULE     : tree_helper_test.cpp
+ * DESCRIPTION: Tests for tree_helper predicates
+ * COPYRIGHT  : (C) 2026 Mogan developers
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "tree_helper.hpp"
+
+using namespace moebius;
+
+class TestTreeHelper : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_is_empty ();
+  void test_is_snippet ();
+};
+
+void
+TestTreeHelper::test_is_empty () {
+  QVERIFY (is_empty (tree ("")));
+  QVERIFY (!is_empty (tree ("a")));
+  // 空段落/空 concat 视为空
+  QVERIFY (is_empty (tree (DOCUMENT)));
+  QVERIFY (is_empty (tree (DOCUMENT, tree (""))));
+  QVERIFY (!is_empty (tree (DOCUMENT, tree ("a"))));
+  QVERIFY (is_empty (tree (CONCAT)));
+  // concat 只要有一个非空孩子即非空
+  QVERIFY (!is_empty (tree (CONCAT, tree (""), tree ("b"))));
+  // suppressed 标签视为空
+  QVERIFY (is_empty (tree (make_tree_label ("suppressed"))));
+  QVERIFY (!is_empty (tree (make_tree_label ("kept"), tree ("x"))));
+}
+
+void
+TestTreeHelper::test_is_snippet () {
+  // 非文档一律是 snippet
+  QVERIFY (is_snippet (tree ("x")));
+  QVERIFY (is_snippet (tree (CONCAT, tree ("x"))));
+  // 不含 TeXmacs 根标记的文档也是 snippet
+  tree doc (DOCUMENT, tree ("body"));
+  QVERIFY (is_snippet (doc));
+  // 首层含 (TeXmacs ...) 的文档不是 snippet
+  tree full (DOCUMENT, tree (make_tree_label ("TeXmacs"), tree ("1.0.2")),
+             tree ("body"));
+  QVERIFY (!is_snippet (full));
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestTreeHelper)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "tree_helper_test.moc"


### PR DESCRIPTION
## 概述

优化 `moebius/Data/Tree/tree_helper.cpp` 中 `is_empty` 与 `is_snippet` 的热路径：用函数局部静态缓存的 `tree_label` 编号（`label_suppressed` / `label_texmacs_marker`）替代 `as_string (L (t))` 哈希查找 + 字符串比较。

## 本机 A/B 测量（Windows, releasedbg, tree_helper_bench）

| 基准 | 优化前 | 优化后 | 提升 |
|------|--------|--------|------|
| is_snippet | 2,136 ns | 175 ns | ~12× |
| is_empty whole doc | 21,473 ns | 19,856 ns | ~-8% |

## 测试

- `xmake test "moebius_tests/*"`：18/18 通过
- 新增 `tests/Data/tree_helper_test.cpp`、`moebius/bench/Data/Tree/tree_helper_bench.cpp`

任务文档：`devel/1228.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)