### PR TITLE
[1228] raw_insert/raw_remove 逐元素搬移改为 memmove 块移动

### DIFF
--- a/devel/1228.md
+++ b/devel/1228.md
@@ -106,3 +106,48 @@ xmake b --yes tree_helper_bench && xmake r tree_helper_bench
 - `moebius/Data/Tree/tree_cursor.cpp`：新增 `label_input`/`label_math`
   缓存，valid_cursor/pre_correct 调用点替换
 - `devel/1228.md`：本节记录
+
+## 第八项：raw_insert/raw_remove 块移动
+
+### What
+
+`tree_observer.cpp` 的 `raw_insert` / `raw_remove`（每次编辑最终落到的原语，
+apply 调度链的终点）原先用逐元素赋值搬移孩子，每个被移动孩子一次
+引用计数加+减。改为 memmove 块移动：
+
+- 插入：resize 腾位后 memmove 尾部上移；洞内 stale 位用 placement-new
+  默认句柄覆盖（不动计数），再由赋值语句正常接管。
+- 删除：先把被删孩子拷入临时数组（+1 接管所有权），memmove 尾部下移，
+  resize 收缩，临时数组析构时统一释放被删孩子的所有权。
+
+### Why
+
+在宽容器（大文档/表格/长 concat）前部插入或删除时，原实现是
+O(n) 次引用计数操作，memmove 后为纯内存搬运。表格编辑、文档开头输入
+等场景直接受益。
+
+### 记账分析（关键正确性依据）
+
+数组对每个槽位恰好持有一份所有权；memmove 位级搬移使所有权随位移动
+转移，计数不变；插入洞与被删元素按上述方式显式补齐加减，账目平衡。
+`tm_delete_array` 逐槽析构、`tm_resize_array` 增长时构造新槽，均与该账目
+兼容（容量桶内增删不触发 realloc，槽内容始终为有效句柄或 stale 位）。
+
+### 测量（参考分支，1000 段文档头部插入+删除 ×1000）
+
+12.03 ms → 0.56 ms（约 21×）。
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_observer.cpp`、`tree_observer.hpp`
+  （补 raw_insert/raw_remove 声明与 Doxygen 注释）
+- `moebius/bench/Data/Tree/tree_observer_bench.cpp`（新增）
+- `tests/Data/tree_observer_test.cpp`（新增：位置正确性、
+  共享子树引用计数、跨容量桶插删）
+
+### 本机构建 / 测试
+
+`xmake b --yes libmoebius` 构建通过，`xmake test "moebius_tests/*"` 17/17
+通过。`tree_observer_test` 本机因 Qt 安装缺 `Qt6Bodymovin.lib` 无法链接
+（存量问题，`tree_helper_test` 同样失败），测试与 bench 以参考分支
+CI 为准。

--- a/moebius/Data/Tree/tree_observer.cpp
+++ b/moebius/Data/Tree/tree_observer.cpp
@@ -6,6 +6,8 @@
 #include "tree_cursor.hpp"
 #include "tree_helper.hpp"
 
+#include <string.h>
+
 extern tree the_et;
 
 /******************************************************************************
@@ -248,12 +250,18 @@ raw_insert (tree& ref, int pos, tree t) {
     ref->label=
         ref->label (0, pos) * t->label * ref->label (pos, N (ref->label));
   else {
-    int i, n= N (ref), nr= N (t);
+    int n= N (ref), nr= N (t);
+    // 块移动代替逐元素赋值：每个被移动孩子的引用计数加减一次都省去。
+    // 记账：memmove 把 [pos, n) 的句柄位原样搬到 [pos+nr, n+nr)，
+    // 数组对其所有权引用随位移动转移；洞里的 stale 位用 placement-new
+    // 默认句柄覆盖（不减计数），随后被赋值语句正常接管
     AR (ref)->resize (n + nr);
-    for (i= n - 1; i >= pos; i--)
-      ref[i + nr]= ref[i];
-    for (i= 0; i < nr; i++)
-      ref[pos + i]= t[i];
+    tree* a= A (AR (ref));
+    memmove (a + pos + nr, a + pos, (size_t) (n - pos) * sizeof (tree));
+    for (int i= 0; i < nr; i++)
+      new ((void*) (a + pos + i)) tree ();
+    for (int i= 0; i < nr; i++)
+      a[pos + i]= t[i];
   }
   if (!is_nil (ref->data)) {
     ref->data->notify_insert (ref, pos, is_atomic (t) ? N (t->label) : N (t));
@@ -287,9 +295,13 @@ raw_remove (tree& ref, int pos, int nr) {
   if (is_atomic (ref))
     ref->label= ref->label (0, pos) * ref->label (pos + nr, N (ref->label));
   else {
-    int i, n= N (ref) - nr;
-    for (i= pos; i < n; i++)
-      ref[i]= ref[i + nr];
+    int n= N (ref) - nr;
+    // 先把被删孩子拷出（引用计数 +1，接管数组的所有权），memmove 尾部
+    // 下移（计数随位移动转移，超出新长度的重复位直接丢弃），
+    // 最后 tmp 析构时统一释放被删孩子的所有权
+    array<tree> tmp (A (AR (ref)) + pos, nr);
+    tree*       a= A (AR (ref));
+    memmove (a + pos, a + pos + nr, (size_t) (n - pos) * sizeof (tree));
     AR (ref)->resize (n);
   }
   if (!is_nil (ref->data)) ref->data->done (ref, mod);

--- a/moebius/Data/Tree/tree_observer.hpp
+++ b/moebius/Data/Tree/tree_observer.hpp
@@ -20,6 +20,17 @@ void remove_node (path p);
 void set_cursor (path p, tree data);
 void touch (path p);
 
+/**
+ * @brief 在 ref 的 pos 处直接插入 t 的孩子，绕过 apply 的调度与观察者协议
+ * @note 仅由 raw_apply 及测试/基准使用
+ */
+void raw_insert (tree& ref, int pos, tree t);
+/**
+ * @brief 在 ref 的 pos 处直接删除 nr 个孩子，绕过 apply 的调度与观察者协议
+ * @note 仅由 raw_apply 及测试/基准使用
+ */
+void raw_remove (tree& ref, int pos, int nr);
+
 void assign (tree& ref, tree t);
 void insert (tree& ref, int pos, tree t);
 void remove (tree& ref, int pos, int nr);

--- a/moebius/bench/Data/Tree/tree_observer_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_observer_bench.cpp
@@ -1,0 +1,58 @@
+/** \file tree_observer_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for raw tree modifications on the editing path
+ *  \date   2026
+ */
+
+#include "nanobench.h"
+#include "observers.hpp"
+#include "tree_helper.hpp"
+#include "tree_observer.hpp"
+
+#include <moebius/drd/drd_std.hpp>
+
+using namespace moebius;
+
+// 修改链引用的全局编辑树与 ip 观察者定义在 mogan 主程序侧，
+// 基准中给出未挂接的独立桩实现
+tree the_et;
+path
+obtain_ip (tree& ref) {
+  (void) ref; // 未挂接的树没有 ip
+  return path ();
+}
+bool
+ip_attached (path ip) {
+  (void) ip;
+  return false;
+}
+observer
+list_observer (observer o1, observer o2) {
+  (void) o1; (void) o2; // 基准树未挂观察者，不会被调用
+  return observer ();
+}
+
+/** 构造有 1000 个孩子的宽文档 */
+static tree
+mk_wide_doc () {
+  tree doc (DOCUMENT);
+  for (int i= 0; i < 1000; i++)
+    doc << tree ("para" * as_string (i));
+  return doc;
+}
+
+int
+main () {
+  ankerl::nanobench::Bench bench;
+  bench.minEpochIterations (10).unit ("op");
+
+  // 单个 op 内插删配平，避免 epoch 叠加导致文档规模无界增长
+  tree doc= mk_wide_doc ();
+  bench.run ("raw_insert+remove head x1000", [&] {
+    for (int i= 0; i < 1000; i++)
+      raw_insert (doc, 0, tree (DOCUMENT, tree ("x")));
+    for (int i= 0; i < 1000; i++)
+      raw_remove (doc, 0, 1);
+  });
+  return 0;
+}

--- a/moebius/bench/Data/Tree/tree_observer_bench.cpp
+++ b/moebius/bench/Data/Tree/tree_observer_bench.cpp
@@ -28,7 +28,8 @@ ip_attached (path ip) {
 }
 observer
 list_observer (observer o1, observer o2) {
-  (void) o1; (void) o2; // 基准树未挂观察者，不会被调用
+  (void) o1;
+  (void) o2; // 基准树未挂观察者，不会被调用
   return observer ();
 }
 

--- a/tests/Data/tree_observer_test.cpp
+++ b/tests/Data/tree_observer_test.cpp
@@ -1,0 +1,110 @@
+/******************************************************************************
+ * MODULE     : tree_observer_test.cpp
+ * DESCRIPTION: Tests for raw tree modifications and refcount integrity
+ * COPYRIGHT  : (C) 2026 Mogan developers
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "tree_helper.hpp"
+#include "tree_observer.hpp"
+
+using namespace moebius;
+
+class TestTreeObserver : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  void test_raw_insert ();
+  void test_raw_remove ();
+  void test_insert_remove_refcount ();
+};
+
+void
+TestTreeObserver::test_raw_insert () {
+  tree doc (DOCUMENT, tree ("a"), tree ("b"), tree ("d"));
+  // 在头部插入
+  raw_insert (doc, 0, tree (DOCUMENT, tree ("x")));
+  QVERIFY (N (doc) == 4);
+  QVERIFY (doc[0] == tree ("x"));
+  QVERIFY (doc[1] == tree ("a"));
+  // 在中部插入多个
+  raw_insert (doc, 2, tree (DOCUMENT, tree ("m"), tree ("n")));
+  QVERIFY (N (doc) == 6);
+  QVERIFY (doc[1] == tree ("a"));
+  QVERIFY (doc[2] == tree ("m"));
+  QVERIFY (doc[3] == tree ("n"));
+  QVERIFY (doc[4] == tree ("b"));
+  QVERIFY (doc[5] == tree ("d"));
+  // 在尾部插入
+  raw_insert (doc, 6, tree (DOCUMENT, tree ("z")));
+  QVERIFY (N (doc) == 7);
+  QVERIFY (doc[6] == tree ("z"));
+}
+
+void
+TestTreeObserver::test_raw_remove () {
+  tree doc (DOCUMENT, tree ("a"), tree ("b"), tree ("c"), tree ("d"),
+            tree ("e"));
+  // 头部删除
+  raw_remove (doc, 0, 1);
+  QVERIFY (N (doc) == 4);
+  QVERIFY (doc[0] == tree ("b"));
+  // 中部删除多个
+  raw_remove (doc, 1, 2);
+  QVERIFY (N (doc) == 2);
+  QVERIFY (doc[0] == tree ("b"));
+  QVERIFY (doc[1] == tree ("e"));
+  // 尾部删除
+  raw_remove (doc, 1, 1);
+  QVERIFY (N (doc) == 1);
+  QVERIFY (doc[0] == tree ("b"));
+}
+
+void
+TestTreeObserver::test_insert_remove_refcount () {
+  // 交叉插入/删除并共享子树：若数组块移动的引用计数记账有误，
+  // 后续拷贝比较或进程退出时会崩溃或得到错误内容
+  tree shared (CONCAT, tree ("s1"), tree ("s2"));
+  tree doc (DOCUMENT);
+  for (int round= 0; round < 50; round++) {
+    tree ins (DOCUMENT);
+    ins << shared << tree ("t") << shared;
+    raw_insert (doc, 0, ins);
+    QVERIFY (doc[0] == shared);
+    QVERIFY (doc[2] == shared);
+    if (round % 2 == 0) raw_remove (doc, 0, 1);
+  }
+  QVERIFY (N (doc) == 125);
+  // 大数组跨容量桶的插入/删除
+  tree big (DOCUMENT);
+  for (int i= 0; i < 1000; i++)
+    big << tree ("p" * as_string (i));
+  for (int i= 0; i < 40; i++)
+    raw_insert (big, 500, tree (DOCUMENT, tree ("q")));
+  QVERIFY (N (big) == 1040);
+  QVERIFY (big[500] == tree ("q"));
+  QVERIFY (big[499] == tree ("p499"));
+  QVERIFY (big[539] == tree ("q"));
+  QVERIFY (big[540] == tree ("p500"));
+  raw_remove (big, 500, 40);
+  QVERIFY (N (big) == 1000);
+  QVERIFY (big[500] == tree ("p500"));
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestTreeObserver)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "tree_observer_test.moc"


### PR DESCRIPTION
任务文档：devel/1228.md 第八项。

## What

- `raw_insert`：resize 腾位后 memmove 尾部上移；洞内 stale 位用 placement-new 默认句柄覆盖，再由赋值语句接管
- `raw_remove`：被删孩子先拷入临时数组接管所有权，memmove 尾部下移，resize 收缩，临时数组析构时统一释放

## Why

每次编辑最终落到 raw_insert/raw_remove（apply 调度链终点）。宽容器前部插删原先付出 O(n) 次引用计数加减，memmove 后为纯内存搬运（参考分支测量约 21×）。

## 测试

- `xmake b --yes libmoebius` 构建通过
- `xmake test "moebius_tests/*"` 17/17 通过
- 新增 `tree_observer_test`（位置正确性、共享子树引用计数、跨容量桶插删）与 `tree_observer_bench`；本机 Qt 安装缺 Qt6Bodymovin.lib 无法链接 Qt 测试（存量问题，tree_helper_test 同样失败），以 CI 为准

🤖 Generated with [Claude Code](https://claude.com/claude-code)