### PR TITLE
[0925] 修复帮助->版本弹窗无法通过 ESC 关闭

### DIFF
--- a/devel/0925.md
+++ b/devel/0925.md
@@ -1,0 +1,61 @@
+# 0925 帮助->版本弹窗无法通过 ESC 关闭
+
+## 2026/08/20 修复「帮助 -> 版本弹窗无法通过按下 ESC 的方式关闭」
+
+### What
+
+「帮助 -> 版本」QML 弹窗在某些环境下按 ESC 无法关闭。修复后 ESC 总能关闭
+该弹窗（取消语义不变）。
+
+### Why
+
+ESC 的正常链路：`DialogShell`（`focus: true`）→ `Keys.onEscapePressed` →
+`closeBridge.cancel()` → 宿主 `done(Rejected)`。该链路依赖 QML 场景存在
+`activeFocusItem`：Qt 6.8.3 的 `QQuickDeliveryAgentPrivate::deliverKeyEvent`
+只在有 `activeFocusItem` 时才投递按键；场景无焦点项时按键事件不被投递、
+保持 accepted，也不再沿 QWidget 链传播给宿主 `QDialog::reject()`——ESC 被
+`QQuickWidget` 静默吞掉。真实运行环境（无边框 `Qt::Tool` 宿主 + exec 模态）
+中若焦点没有落到 QML 场景（平台/窗口管理器焦点差异等），即触发此缺陷。
+单元测试 `test_version_escape_cancels` 用普通 QDialog 且焦点就位，覆盖不到
+该路径。
+
+### How
+
+1. 新增 `QmlDialogEscFilter`（放在 `QTMQmlDialogBridge.hpp`，ESC 兜底属弹窗
+   通用宿主行为，与桥同文件）：装在 `QQuickWidget` 上的事件过滤器，仅在
+   「ESC 到达视图且 QML 场景无 `activeFocusItem`」时 `reject()` 宿主——此刻
+   QML 链路必然不会处理，兜底不抢占任何弹窗自身的取消语义；其余情况一律
+   放行。仅挂 `run_qml_dialog`（exec 引擎）：其弹窗（ConfirmClose /
+   ConfirmRestart / FormDialog / Statistics / Version / Preferences）的取消
+   语义即 Rejected，与 QML `cancel()` 完全等价。live 写回弹窗
+   （`run_modal_qml_dialog`，FontSelector / ParagraphFormat）不挂——它们的
+   取消须走 scheme 快照撤销，且 `done()` 不触发 `WA_DeleteOnClose`。
+2. `run_qml_dialog` 在 exec 前 `qw->setFocus()`：让弹窗激活时焦点落在 QML
+   视图，离屏 QML 场景随之激活，`DialogShell` 的 `focus: true` 生效，
+   ESC/Enter 尽量走 QML 正常链路（保持各弹窗 `onCancel` 自定义语义）。
+3. 回归测试 `test_version_escape_fallback_without_focus`：加载真实
+   `Version.qml`，强制 QML 场景无焦点项（模拟 ESC 被吞的缺陷态），断言
+   ESC 触发宿主 `rejected` 信号、弹窗隐藏、且未经 QML cancel。
+
+### 涉及文件
+
+- `src/Plugins/Qt/QTMQmlDialogBridge.hpp`（新增 `QmlDialogEscFilter`）
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+
+### Tests
+
+```bash
+gf fmt --changed-since=main                        # 无格式改动
+xmake b qml_load_test && xmake r qml_load_test     # 13 passed, 0 failed
+# GUI 实测（帮助 -> 版本 -> ESC 关闭）未执行：用户指示跳过复现、直接修复，
+# 需人工验证 ESC 可关闭弹窗
+```
+
+### 备注（构建环境）
+
+mogan2 工作区须用 `~/.local/bin/xmake`（v3.1.0+HEAD）构建；homebrew xmake
+2.9.9 无 `$(builddir)` 内置变量，`set_configdir("$(builddir)")` 展开为空导致
+配置报 `cannot copy file ... to /config.h`。另外 mogan2 是从 mogan 构建后整目录
+拷贝的，`3rdparty/*/build` 内 CMakeCache 指向 mogan 路径，配置前需删除
+`3rdparty/*/build`、`3rdparty/*/.xmake`、`build/`、`.xmake/`。

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -205,6 +205,13 @@ run_qml_dialog (const string& qml_url, const char* debug_tag,
   if (autofit_height) lock_autofit_height (qw, vl, d, logic_w, logic_h);
   else lock_fixed_size (qw, vl, d, logic_w, logic_h);
 
+  // 焦点落在 QML 视图：弹窗激活时离屏 QML 场景随之激活，DialogShell 的
+  // focus:true 生效，ESC/Enter 走 QML 正常链路
+  qw->setFocus ();
+  // QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉（不投递、
+  // 不传播给 QDialog::reject），装兜底过滤器保证 ESC 总能关闭弹窗（0925）
+  qw->installEventFilter (new QmlDialogEscFilter (&d, qw, &d));
+
   return d.exec ();
 }
 

--- a/src/Plugins/Qt/QTMQmlDialogBridge.hpp
+++ b/src/Plugins/Qt/QTMQmlDialogBridge.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * MODULE      : QTMQmlDialogBridge.hpp
- * DESCRIPTION : 暴露给 QML 的桥对象，承担两类弹窗的交互回流：
- *               确认型 choose(index) / 表单型 submit({key:value})。
+ * DESCRIPTION : QML 弹窗的宿主侧辅助：暴露给 QML 的桥对象（choose/submit/
+ *               cancel 交互回流）与 ESC 兜底事件过滤器（QmlDialogEscFilter）。
  * COPYRIGHT   : (C) 2026 Mogan STEM
  *
  * This software falls under the GNU general public license version 3 or later.
@@ -14,7 +14,10 @@
 #include "boot.hpp"
 
 #include <QDialog>
+#include <QKeyEvent>
 #include <QObject>
+#include <QQuickWidget>
+#include <QQuickWindow>
 #include <QString>
 #include <QVariantMap>
 #include <QWindow>
@@ -87,6 +90,53 @@ signals:
 private:
   QDialog*    m_host;
   QVariantMap m_results;
+};
+
+/*! @class QmlDialogEscFilter
+ *  @brief ESC 被 QQuickWidget 静默吞掉时的兜底关闭过滤器（任务 0925）。
+ *
+ * @par 背景
+ * QML 弹窗的 ESC 正常链路：DialogShell（focus:true）→ Keys.onEscapePressed →
+ * closeBridge.cancel() → 宿主 done(Rejected)。该链路依赖 QML 场景存在
+ * activeFocusItem：QQuickDeliveryAgent 只向 activeFocusItem 投递按键；场景无
+ * 焦点项时按键事件不被投递、保持 accepted，也不再沿 QWidget 链传播给宿主
+ * QDialog::reject()——ESC 被静默吞掉，弹窗无法关闭。
+ *
+ * @par 语义
+ * 仅在「ESC 到达 QQuickWidget 且 QML 场景无 activeFocusItem」时 reject() 宿主
+ * ——此刻 QML 链路必然不会处理，兜底不抢占任何弹窗自身的取消语义；其余情况
+ * 一律放行。仅用于 run_qml_dialog（exec 引擎）：其弹窗的取消语义即 Rejected。
+ * live 写回弹窗（run_modal_qml_dialog）的取消须走 scheme 快照撤销，不得用
+ * 本过滤器兜底（done() 不触发 WA_DeleteOnClose，且会跳过快照恢复）。
+ */
+class QmlDialogEscFilter : public QObject {
+public:
+  /**
+   * @brief 构造 ESC 兜底过滤器。
+   * @param host 宿主 QDialog（兜底时 reject），生命期须覆盖过滤器。
+   * @param view 内嵌的 QQuickWidget（读取其 QML 场景焦点态）。
+   * @param parent QObject 父对象，过滤器随其析构。
+   */
+  QmlDialogEscFilter (QDialog* host, QQuickWidget* view, QObject* parent)
+      : QObject (parent), m_host (host), m_view (view) {}
+
+protected:
+  bool eventFilter (QObject* obj, QEvent* ev) override {
+    if (ev->type () == QEvent::KeyPress) {
+      QKeyEvent* ke= static_cast<QKeyEvent*> (ev);
+      if (ke->key () == Qt::Key_Escape && ke->modifiers () == Qt::NoModifier &&
+          m_view->quickWindow () &&
+          !m_view->quickWindow ()->activeFocusItem ()) {
+        m_host->reject ();
+        return true;
+      }
+    }
+    return QObject::eventFilter (obj, ev);
+  }
+
+private:
+  QDialog*      m_host;
+  QQuickWidget* m_view;
 };
 
 #endif // defined QTM_QML_DIALOG_BRIDGE_H

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -15,6 +15,8 @@
 
 #include "base.hpp"
 
+#include "Qt/QTMQmlDialogBridge.hpp" // QmlDialogEscFilter
+
 #include <QDialog>
 #include <QObject>
 #include <QQmlContext>
@@ -207,6 +209,7 @@ private slots:
   void test_preferences_loads ();
   void test_version_loads ();
   void test_version_escape_cancels ();
+  void test_version_escape_fallback_without_focus ();
   void test_version_long_line_wraps ();
   void test_statistics_loads ();
 };
@@ -399,6 +402,34 @@ TestQmlLoad::test_version_escape_cancels () {
   QTRY_VERIFY (qw->rootObject ()->hasActiveFocus ());
   QTest::keyClick (qw, Qt::Key_Escape);
   QCOMPARE (close->cancelCount, 1);
+}
+
+void
+TestQmlLoad::test_version_escape_fallback_without_focus () {
+  // 0925：QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉
+  // （不投递、不传播给 QDialog::reject），引擎侧的 QmlDialogEscFilter 须兜底
+  // reject 宿主弹窗，且不走 QML cancel
+  QDialog            host;
+  QQuickWidget*      qw    = new QQuickWidget (&host);
+  StubBridge*        close = new StubBridge (qw);
+  VersionStubBridge* bridge= new VersionStubBridge (qw);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  qw->rootContext ()->setContextProperty ("closeBridge", close);
+  qw->rootContext ()->setContextProperty ("versionBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->setSource (QUrl ("qrc:/qml/Version.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  qw->installEventFilter (new QmlDialogEscFilter (&host, qw, &host));
+  host.show ();
+  // 强制 QML 场景无焦点项，模拟 ESC 被吞的真实缺陷态
+  qw->rootObject ()->setFocus (false);
+  QTRY_VERIFY (!qw->rootObject ()->hasActiveFocus ());
+  QSignalSpy rejectedSpy (&host, &QDialog::rejected);
+  QTest::keyClick (qw, Qt::Key_Escape);
+  QTRY_COMPARE (rejectedSpy.count (), 1);
+  QVERIFY (!host.isVisible ());
+  QCOMPARE (close->cancelCount, 0);
 }
 
 void


### PR DESCRIPTION
## What

修复「帮助 -> 版本」弹窗在部分环境下按下 ESC 无法关闭的问题。修复后 ESC 总能
关闭该弹窗（取消语义不变），同引擎的其它 exec 型 QML 弹窗（确认关闭 / 确认
重启 / 表单 / 统计 / 首选项）一并受益。

## Why

ESC 的正常链路：`DialogShell`（`focus: true`）→ `Keys.onEscapePressed` →
`closeBridge.cancel()` → 宿主 `done(Rejected)`。该链路依赖 QML 场景存在
`activeFocusItem`：Qt 6.8.3 的 `QQuickDeliveryAgentPrivate::deliverKeyEvent`
只在有 `activeFocusItem` 时才投递按键；场景无焦点项时按键事件不被投递、
保持 accepted，也不再沿 QWidget 链传播给宿主 `QDialog::reject()`——ESC 被
`QQuickWidget` 静默吞掉。真实运行环境（无边框 `Qt::Tool` 宿主 + exec 模态）
中若焦点没有落到 QML 场景（平台/窗口管理器焦点差异等），即触发此缺陷。
既有单测 `test_version_escape_cancels` 焦点就位，覆盖不到该路径。

## How

1. 新增 `QmlDialogEscFilter`（放在 `QTMQmlDialogBridge.hpp`，ESC 兜底属弹窗
   通用宿主行为，与桥同文件）：装在
   `QQuickWidget` 上的事件过滤器，仅在「ESC 到达视图且 QML 场景无
   `activeFocusItem`」时 `reject()` 宿主——此刻 QML 链路必然不会处理，兜底
   不抢占任何弹窗自身的取消语义；其余情况一律放行。仅挂 `run_qml_dialog`
   （exec 引擎）：其弹窗的取消语义即 Rejected，与 QML `cancel()` 完全等价。
   live 写回弹窗（`run_modal_qml_dialog`，FontSelector / ParagraphFormat）
   不挂——它们的取消须走 scheme 快照撤销，且 `done()` 不触发
   `WA_DeleteOnClose`。
2. `run_qml_dialog` 在 exec 前 `qw->setFocus()`：弹窗激活时焦点落在 QML
   视图，离屏 QML 场景随之激活，`DialogShell` 的 `focus: true` 生效，
   ESC/Enter 尽量走 QML 正常链路（保持各弹窗 `onCancel` 自定义语义）。
3. 回归测试 `test_version_escape_fallback_without_focus`：加载真实
   `Version.qml`，强制 QML 场景无焦点项（模拟 ESC 被吞的缺陷态），断言
   ESC 触发宿主 `rejected` 信号、弹窗隐藏、且未经 QML cancel。

## 涉及文件

- `src/Plugins/Qt/QTMQmlDialogBridge.hpp`（新增 `QmlDialogEscFilter`）
- `src/Plugins/Qt/QTMQmlDialog.cpp`
- `tests/Plugins/Qt/qml_load_test.cpp`
- `devel/0925.md`（任务文档）

## 验证

```bash
gf fmt --changed-since=main                        # 无格式改动
xmake b qml_load_test && xmake r qml_load_test     # 13 passed, 0 failed
```

- GUI 实测：人工验证通过——打开 帮助 -> 版本 弹窗，按下 ESC 可正常关闭
  （2026-08-20，macOS，由 pigmagicfly 实测）。
