### PR TITLE
[0926] PDF 导出完成弹窗 QML 重构

### DIFF
--- a/ai-docs/qml/README.md
+++ b/ai-docs/qml/README.md
@@ -96,6 +96,7 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
 | 对话框 | 模态引擎 | 模型 |
 |--------|---------|------|
 | `ConfirmClose` | `run_qml_dialog`（exec） | 点按钮返回结果 |
+| `ConfirmQuestion` | `run_qml_dialog`（exec） | 默认按钮居右的确认弹窗（替换 question-no-cancel 的 QMessageBox），返回语义按钮下标 |
 | `ConfirmRestart` | `run_qml_dialog`（exec） | 三按钮（立即重启/稍后/取消），返回 `"restart"/"later"/"cancel"` |
 | `FormDialog` | `run_qml_dialog`（exec） | 本地暂存 `values`，OK 一次性 submit |
 | `FontSelector` | `run_modal_qml_dialog`（setModal+show） | live 写回文档，OK 落定 / Cancel 快照撤销 / Reset 按 global? 分流（文档级系统默认、段落级回快照） |

--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -987,6 +987,7 @@
         <p>左侧切换组件，右侧查看 HTML 还原效果。</p>
       </div>
       <button class="nav-btn active" data-target="confirm">ConfirmClose.qml</button>
+      <button class="nav-btn" data-target="confirmQuestion">ConfirmQuestion.qml</button>
       <button class="nav-btn" data-target="form">FormDialog.qml</button>
       <button class="nav-btn" data-target="font">FontSelector.qml</button>
       <button class="nav-btn" data-target="paragraph">ParagraphFormat.qml</button>
@@ -1027,6 +1028,32 @@
           对应 QML: <code>message: dialogMessage</code>
           <code>buttonLabels: dialogButtons</code>
           <code>onClicked -> closeBridge.choose(index + 1)</code>
+        </p>
+      </section>
+
+      <section class="panel" id="panel-confirmQuestion">
+        <div class="cards">
+          <article class="dialog">
+            <h3>PDF导出完成，是否要打开文件？</h3>
+            <div class="btn-row">
+              <button class="btn" data-log="ConfirmQuestion Light: 选择 否 (index=0)">否</button>
+              <button class="btn primary" data-log="ConfirmQuestion Light: 选择 是 (index=1)">是</button>
+            </div>
+          </article>
+
+          <article class="dialog dark">
+            <h3>PDF导出完成，是否要打开文件？</h3>
+            <div class="btn-row">
+              <button class="btn" data-log="ConfirmQuestion Dark: 选择 否 (index=0)">否</button>
+              <button class="btn primary" data-log="ConfirmQuestion Dark: 选择 是 (index=1)">是</button>
+            </div>
+          </article>
+        </div>
+        <p class="legend">
+          对应 QML: <code>message: dialogMessage</code>
+          <code>buttonLabels: dialogButtons</code>（显示序与语义序相反，默认按钮居右）
+          <code>dialogPrimary</code> 指向默认按钮
+          <code>onActivate -> choose(primaryIndex + 1)</code>（Enter = 是）
         </p>
       </section>
 

--- a/devel/0926.md
+++ b/devel/0926.md
@@ -1,0 +1,86 @@
+# [0926] PDF 导出完成弹窗 QML 重构（ConfirmQuestion.qml）
+
+## 1 相关文档
+
+- 设计稿：`ai-docs/qml/qml-dialog.html`（ConfirmQuestion 面板）
+- 规则：`ai-docs/qml/README.md`（QML 弹窗体系规矩）
+- 任务文档模板：[dddd.md](dddd.md)
+
+## 2 任务相关的代码文件
+
+### 新增
+
+- `src/Plugins/Qt/qml/ConfirmQuestion.qml` — 「问题」确认弹窗 QML 正文
+- `devel/0926.md` — 本文档
+
+### 修改
+
+- `src/Plugins/Qt/QTMQmlDialog.hpp/cpp` — 新增 glue 入口 `cpp_confirm_question`
+- `src/Plugins/Qt/qt_dialogues.cpp` — `question-no-cancel` 分支从 QMessageBox 改为 QML
+- `src/Plugins/Qt/qml/qmldir`、`src/Plugins/Qt/moganqml.qrc` — 登记 ConfirmQuestion
+- `tests/Plugins/Qt/qml_load_test.cpp` — `test_confirm_question_loads`
+- `tests/Plugins/Qt/qml_dialog_test.cpp` — `test_confirm_question_hook`
+- `ai-docs/qml/qml-dialog.html` — ConfirmQuestion 设计稿面板
+- `ai-docs/qml/README.md` — 成品弹窗表加 ConfirmQuestion
+
+## 3 如何测试
+
+```bash
+# QML 加载测试（含 test_confirm_question_loads）
+xmake b qml_load_test && xmake r qml_load_test
+
+# C++ glue 钩子测试（含 test_confirm_question_hook）
+xmake b qml_dialog_test && xmake r qml_dialog_test
+
+# 整体构建
+xmake b stem
+
+# 真实 GUI 人工验证
+xmake r stem
+# 文件 → 导出 → Pdf，导出完成后应弹出 QML 圆角弹窗：
+# 左「否」右「是」（默认高亮），Enter = 是（打开文件），Esc = 否
+```
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+xmake b qml_load_test && xmake r qml_load_test
+xmake b qml_dialog_test && xmake r qml_dialog_test
+```
+
+## 5 What
+
+把「PDF 导出完成，是否要打开文件？」确认弹窗从 QMessageBox 重构为 QML 弹窗
+`ConfirmQuestion.qml`（DialogShell + DialogButtons 体系）；「是」「否」按钮
+位置互换——「否」在左、「是」在右，默认按钮仍是「是」。
+
+## 6 Why
+
+- 该弹窗是仅剩的 QMessageBox 原生弹窗之一，外观（系统标题栏 + 蓝色问号图标）
+  与已迁移的 QML 弹窗（ConfirmClose / ConfirmRestart 等）不一致；
+- 主按钮（默认操作）居右符合平台惯例；默认保持「是」不改变键盘语义
+  （Enter 仍等于「是」）。
+
+## 7 How
+
+- `question-no-cancel` 类型只有 `user-simple-confirm` 一个来源，其唯一调用方
+  即 PDF 导出完成确认（`tm-print.scm` 的 `user-confirm-open-pdf`），故只迁移
+  该分支；带取消按钮的 `question` 类型（`user-confirm`，文件覆盖确认等）仍走
+  原 QMessageBox，不在本任务范围。
+- C++ 新增 `cpp_confirm_question (message, buttons)`：`buttons[0]` 为默认
+  （肯定）按钮；注入 QML 时把按钮文案按相反顺序传给 `dialogButtons`，并注入
+  `dialogPrimary = N-1`（默认按钮居右、primary 高亮）；`run_qml_dialog` 返回的
+  显示下标映射回 `buttons` 语义下标后返回；Esc / 加载失败返回 -1。
+- `perform_dialog` 的 `question-no-cancel` 分支改调 `cpp_confirm_question`，
+  命中时下标取 `scm_quote (proposals[picked])` 写回 `input`（与原逻辑一致）；
+  返回 -1 时写 `"#f"`，与原来点 X 的语义相同（按「否」处理）。
+- QML 侧 `onActivate`（Enter/Return）触发 `choose(primaryIndex + 1)`，即默认
+  按钮「是」。
+- 测试钩子 `MOGAN_TEST_CONFIRM_QUESTION=<下标|cancel>` 命中时不弹窗直接返回，
+  供自动化测试。
+
+### 行为变化说明
+
+- Esc：原 QMessageBox（无 Cancel 按钮）按 Esc 无响应；新 QML 弹窗 Esc 等效
+  「否」（与点 X 一致），更贴合确认弹窗惯例。

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -332,8 +332,43 @@ cpp_confirm_restart (string title, string message) {
   }
 }
 
-// ---- form 引擎 --------------------------------------------------------------
+/**
+ * @brief 「问题」确认弹窗的 glue 入口（声明/语义见 QTMQmlDialog.hpp）。
+ *
+ * @details buttons 为语义顺序（buttons[0] 默认）；注入 QML 的 dialogButtons 按
+ * 相反显示顺序（默认按钮居右），dialogPrimary 指向显示序的最后一个。QML 返回
+ * 的 choose 值为显示下标 +1，映射回语义下标为 N - choice。按钮文案已在 scm
+ * 侧翻译，此处纯透传、不再过 translate_buttons。测试钩子
+ * MOGAN_TEST_CONFIRM_QUESTION=<下标|cancel> 命中时不弹窗。
+ */
+int
+cpp_confirm_question (string message, array<string> buttons) {
+  string preset= get_env ("MOGAN_TEST_CONFIRM_QUESTION");
+  if (preset == "cancel") return -1;
+  if (is_int (preset)) return as_int (preset);
+  const int n= N (buttons);
+  if (n <= 0) return -1;
+  QStringList qmlButtons;
+  for (int i= 0; i < n; i++)
+    qmlButtons << to_qstring (buttons[n - 1 - i]);
+  QmlDialogBridge* bridge= nullptr;
+  int              choice= run_qml_dialog (
+      "qrc:/qml/ConfirmQuestion.qml", "question dialog",
+      [&] (QQuickWidget* qw, QDialog& host) {
+        bridge= inject_common_context (qw, host);
+        qw->rootContext ()->setContextProperty ("dialogMessage",
+                                                             to_qstring (message));
+        qw->rootContext ()->setContextProperty ("dialogButtons", qmlButtons);
+        qw->rootContext ()->setContextProperty ("dialogPrimary", n - 1);
+      },
+      400, 150);
+  delete bridge;
+  // choose(0) = Esc / X；加载失败为 -1；二者均按取消处理。
+  if (choice <= 0 || choice > n) return -1;
+  return n - choice;
+}
 
+// ---- form 引擎 --------------------------------------------------------------
 // 字段节点下标协议（见 QTMQmlDialog.hpp @par 数据协议）：
 // (<type> <label> <key> (<options>...) <value> <live?>)
 // label/key/value 的位置在 form 引擎多处使用，集中在此避免魔法下标散落。

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -135,6 +135,18 @@ string cpp_confirm_close (string message, bool scratch);
 string cpp_confirm_restart (string title, string message);
 
 /**
+ * @brief 「问题」确认弹窗的 glue 入口（QML 版，替换 question-no-cancel 的
+ * QMessageBox，如 PDF 导出完成询问是否打开文件）。
+ * @param message 已翻译的正文。
+ * @param buttons 已翻译的按钮文案，buttons[0] 为默认（肯定）按钮。
+ * @return 用户点选按钮在 buttons 中的下标（≥0）；Esc / QML 加载失败返回 -1。
+ * @details 注入 QML 时按钮显示顺序与 buttons 相反——默认按钮居右并 primary
+ * 高亮（与原 QMessageBox 的左右位置互换），Enter 触发默认按钮。测试钩子
+ * MOGAN_TEST_CONFIRM_QUESTION=<下标|cancel> 命中时不弹窗直接返回。
+ */
+int cpp_confirm_question (string message, array<string> buttons);
+
+/**
  * @brief 通用 form 弹窗引擎的 glue 入口。
  * @param fields scm 构造的字段表，@b 须经 stree->tree 转换（glue 不自动转
  * pair）。 结构见顶部 @par 数据协议：(form (enum <label> <key> (<opt>...)

--- a/src/Plugins/Qt/moganqml.qrc
+++ b/src/Plugins/Qt/moganqml.qrc
@@ -16,6 +16,7 @@
         <file>qml/atoms/GroupHeader.qml</file>
         <file>qml/FontSelector.qml</file>
         <file>qml/ConfirmClose.qml</file>
+        <file>qml/ConfirmQuestion.qml</file>
         <file>qml/ConfirmRestart.qml</file>
         <file>qml/FormDialog.qml</file>
         <file>qml/ParagraphFormat.qml</file>

--- a/src/Plugins/Qt/qml/ConfirmQuestion.qml
+++ b/src/Plugins/Qt/qml/ConfirmQuestion.qml
@@ -1,0 +1,62 @@
+// ConfirmQuestion.qml — 「问题」确认弹窗（如 PDF 导出完成询问是否打开文件）。
+// 替换原 QMessageBox 问题弹窗（question-no-cancel）。与 ConfirmClose 同构，
+// 差异：主按钮（默认）下标由 C++ 经 dialogPrimary 注入——按钮显示顺序与语义
+// 顺序相反（默认按钮居右），Enter 触发默认按钮。
+//
+// context property（C++ 注入）：dialogMessage、dialogButtons（显示顺序，均已
+// 翻译）、dialogPrimary（默认按钮下标）、dpScale、isDark、closeBridge。
+// 按钮下标从 1 起（0 = Esc = 取消），clicked(index) 映射 choose(index + 1)。
+
+import QtQuick
+import "atoms"
+
+DialogShell {
+    id: root
+    implicitWidth: 400
+    implicitHeight: 150
+    implicitMargins: 28 * Theme.scaleFactor
+
+    property string message: typeof dialogMessage !== "undefined" ? dialogMessage : ""
+    property var buttonLabels: typeof dialogButtons !== "undefined" ? dialogButtons : []
+    property int primaryIndex: typeof dialogPrimary !== "undefined" ? dialogPrimary : 0
+
+    // Enter/Return 触发默认按钮（primaryIndex 指向的按钮，如「是」）。
+    onActivate: () => closeBridge.choose(root.primaryIndex + 1)
+
+    // content 填满正文区（DialogShell 强制设 anchors.fill），消息+按钮用内层
+    // Column 垂直居中。外层 Item 不可省：它承接 anchors.fill，让 Column 自由用
+    // verticalCenter 居中（同一 Item 不能既 fill 又 verticalCenter）。用 root.id
+    // 引用根属性（content 被 reparent 到 contentCol，parent 链不可靠）。
+    content: Item {
+        Column {
+            id: body
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.right: parent.right
+            spacing: 28 * Theme.scaleFactor
+
+            Text {
+                width: body.width
+                text: root.message
+                color: Theme.fg
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 17 * Theme.scaleFactor
+                font.weight: Font.Bold
+                font.letterSpacing: 0.2 * Theme.scaleFactor
+                // 单行。文案过长时 ElideMiddle 中间省略（保留首尾）。
+                elide: Text.ElideMiddle
+            }
+
+            DialogButtons {
+                anchors.horizontalCenter: parent.horizontalCenter
+                buttonLabels: root.buttonLabels
+                primaryIndex: root.primaryIndex
+                buttonWidth: 108 * Theme.scaleFactor
+                letterSpacing: 0.3
+                onClicked: function (index) {
+                    closeBridge.choose(index + 1);
+                }
+            }
+        }
+    }
+}

--- a/src/Plugins/Qt/qml/qmldir
+++ b/src/Plugins/Qt/qml/qmldir
@@ -1,4 +1,5 @@
 ConfirmClose 1.0 ConfirmClose.qml
+ConfirmQuestion 1.0 ConfirmQuestion.qml
 ConfirmRestart 1.0 ConfirmRestart.qml
 FormDialog 1.0 FormDialog.qml
 FontSelector 1.0 FontSelector.qml

--- a/src/Plugins/Qt/qt_dialogues.cpp
+++ b/src/Plugins/Qt/qt_dialogues.cpp
@@ -12,6 +12,7 @@
 #include "qt_dialogues.hpp"
 #include "QTMGuiHelper.hpp"
 #include "QTMMenuHelper.hpp"
+#include "QTMQmlDialog.hpp" // cpp_confirm_question
 #include "analyze.hpp"
 #include "converter.hpp"
 #include "message.hpp"
@@ -270,8 +271,24 @@ qt_inputs_list_widget_rep::field (int i) {
 
 void
 qt_inputs_list_widget_rep::perform_dialog () {
-  if ((N (children) == 1) && (field (0)->type == "question" ||
-                              field (0)->type == "question-no-cancel")) {
+  if ((N (children) == 1) && field (0)->type == "question-no-cancel") {
+    // QML 确认弹窗（ConfirmQuestion）：按钮显示顺序与 proposals 相反，
+    // 默认按钮（proposals[0]）居右并高亮；返回值已映射回 proposals 下标。
+    int choices= N (field (0)->proposals);
+    if (choices > 0) {
+      array<string> buttons (choices);
+      for (int i= 0; i < choices; i++)
+        buttons[i]= upcase_first (field (0)->proposals[i]);
+      int picked= cpp_confirm_question (field (0)->prompt, buttons);
+      if (picked >= 0 && picked < choices)
+        field (0)->input= scm_quote (field (0)->proposals[picked]);
+      else field (0)->input= "#f"; // Esc / 加载失败，按「否」处理
+    }
+    else {
+      field (0)->input= "#f";
+    }
+  }
+  else if ((N (children) == 1) && field (0)->type == "question") {
     // then use Qt messagebox for smoother, more standard UI
     QWidget* mainwindow= QApplication::activeWindow ();
     // main texmacs window. There are probably better ways...
@@ -281,10 +298,7 @@ qt_inputs_list_widget_rep::perform_dialog () {
     QMessageBox msgBox (mainwindow);
     // sets parent widget, so that it appears at the proper location
     msgBox.setText (to_qstring (field (0)->prompt));
-    /// 对于 question-no-cancel，不添加取消按钮，避免出现三选项对话框。
-    bool add_cancel= (field (0)->type == "question");
-    if (add_cancel)
-      msgBox.addButton (qt_translate ("Cancel"), QMessageBox::RejectRole);
+    msgBox.addButton (qt_translate ("Cancel"), QMessageBox::RejectRole);
 
     // Allow any number of choices. The first one is the default.
     int                   choices= N (field (0)->proposals);
@@ -299,8 +313,7 @@ qt_inputs_list_widget_rep::perform_dialog () {
       msgBox.setDefaultButton (buttonlist[0]);
       for (int i= 0; i < choices - 1; ++i)
         QWidget::setTabOrder (buttonlist[i], buttonlist[i + 1]);
-      if (add_cancel)
-        QWidget::setTabOrder (buttonlist[choices - 1], msgBox.escapeButton ());
+      QWidget::setTabOrder (buttonlist[choices - 1], msgBox.escapeButton ());
     }
     msgBox.setWindowTitle (qt_translate ("Question"));
     msgBox.setIcon (QMessageBox::Question);

--- a/tests/Plugins/Qt/qml_dialog_test.cpp
+++ b/tests/Plugins/Qt/qml_dialog_test.cpp
@@ -71,6 +71,7 @@ private slots:
   void test_field_tree_to_qml_malformed ();
   void test_translate_buttons ();
   void test_confirm_close_hook ();
+  void test_confirm_question_hook ();
   void test_form_dialog_hook ();
 };
 
@@ -212,6 +213,26 @@ TestQmlDialog::test_confirm_close_hook () {
   {
     EnvHook hook ("MOGAN_TEST_CONFIRM_CLOSE", "Cancel");
     QCOMPARE (cpp_confirm_close ("msg", false), string ("Cancel"));
+  }
+}
+
+// MOGAN_TEST_CONFIRM_QUESTION 钩子：<下标> 命中时返回 buttons 语义下标、
+// cancel 时返回 -1（Esc / 加载失败语义），均不弹窗。
+void
+TestQmlDialog::test_confirm_question_hook () {
+  array<string> buttons;
+  buttons << string ("yes") << string ("no");
+  {
+    EnvHook hook ("MOGAN_TEST_CONFIRM_QUESTION", "0");
+    QCOMPARE (cpp_confirm_question ("msg", buttons), 0); // 默认按钮
+  }
+  {
+    EnvHook hook ("MOGAN_TEST_CONFIRM_QUESTION", "1");
+    QCOMPARE (cpp_confirm_question ("msg", buttons), 1);
+  }
+  {
+    EnvHook hook ("MOGAN_TEST_CONFIRM_QUESTION", "cancel");
+    QCOMPARE (cpp_confirm_question ("msg", buttons), -1);
   }
 }
 

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -202,6 +202,7 @@ private slots:
   void cleanup () { cleanup_qt_top_level_widgets (); }
 
   void test_confirm_close_loads ();
+  void test_confirm_question_loads ();
   void test_confirm_restart_loads ();
   void test_form_dialog_loads ();
   void test_font_selector_loads ();
@@ -232,6 +233,29 @@ load_qml (const QString& qrcUrl) {
 void
 TestQmlLoad::test_confirm_close_loads () {
   QCOMPARE (load_qml ("qrc:/qml/ConfirmClose.qml"), QQuickWidget::Ready);
+}
+
+void
+TestQmlLoad::test_confirm_question_loads () {
+  // ConfirmQuestion 复用 ConfirmClose 的 dialogMessage/dialogButtons，多一个
+  // dialogPrimary（默认按钮下标）。按钮按显示顺序注入（左「否」右「是」）。
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge* bridge= new StubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->rootContext ()->setContextProperty (
+      "dialogMessage", QString ("PDF导出完成，是否要打开文件？"));
+  QStringList buttons;
+  buttons << "否" << "是";
+  qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
+  qw->rootContext ()->setContextProperty ("dialogPrimary", 1);
+  qw->setSource (QUrl ("qrc:/qml/ConfirmQuestion.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  // dialogPrimary 透传：QML 侧 primaryIndex 应与注入一致。
+  QCOMPARE (qw->rootObject ()->property ("primaryIndex").toInt (), 1);
 }
 
 void


### PR DESCRIPTION
## What

把「PDF 导出完成，是否要打开文件？」确认弹窗从 QMessageBox 重构为 QML 弹窗
`ConfirmQuestion.qml`（DialogShell + DialogButtons 体系），并互换「是」「否」
按钮位置——「否」在左、「是」在右，默认按钮仍是「是」。

## Why

该弹窗是仅剩的 QMessageBox 原生弹窗之一，外观（系统标题栏 + 蓝色问号图标）与
已迁移的 QML 弹窗（ConfirmClose / ConfirmRestart 等）不一致。主按钮（默认操作）
居右符合平台惯例；默认保持「是」不改变键盘语义（Enter 仍等于「是」）。

## How

1. `question-no-cancel` 类型只有 `user-simple-confirm` 一个来源，其唯一调用方即
   PDF 导出完成确认（`tm-print.scm` 的 `user-confirm-open-pdf`），故只迁移该分支；
   带取消按钮的 `question` 类型（文件覆盖确认等）仍走原 QMessageBox，不在本任务范围。
2. C++ 新增 `cpp_confirm_question (message, buttons)`：`buttons[0]` 为默认（肯定）
   按钮；注入 QML 时按钮文案按相反顺序传给 `dialogButtons`、注入
   `dialogPrimary = N-1`（默认按钮居右并 primary 高亮）；QML 返回的显示下标映射回
   语义下标后返回；Esc / 加载失败返回 -1。
3. `perform_dialog` 的 `question-no-cancel` 分支改调 `cpp_confirm_question`，命中时
   取 `scm_quote (proposals[picked])` 写回 `input`（与原逻辑一致）；返回 -1 时写
   `"#f"`，与原来点 X 的语义相同（按「否」处理）。
4. QML 侧 `onActivate`（Enter/Return）触发 `choose(primaryIndex + 1)`，即默认按钮
   「是」；Esc 走 DialogShell 的 `onCancel`（exec 引擎级 Esc 兜底见 0925）。

### 行为变化说明

- Esc：原 QMessageBox（无 Cancel 按钮）按 Esc 无响应；新 QML 弹窗 Esc 等效「否」
  （与点 X 一致），更贴合确认弹窗惯例。

## 涉及文件

- `src/Plugins/Qt/qml/ConfirmQuestion.qml`（新增）
- `src/Plugins/Qt/QTMQmlDialog.hpp` / `QTMQmlDialog.cpp`
- `src/Plugins/Qt/qt_dialogues.cpp`
- `src/Plugins/Qt/qml/qmldir`、`src/Plugins/Qt/moganqml.qrc`
- `tests/Plugins/Qt/qml_load_test.cpp`、`tests/Plugins/Qt/qml_dialog_test.cpp`
- `ai-docs/qml/qml-dialog.html`、`ai-docs/qml/README.md`
- `devel/0926.md`

## 验证

```bash
gf fmt --changed-since=main                        # 无格式改动
xmake b qml_load_test && xmake r qml_load_test     # 14 passed, 0 failed
xmake b qml_dialog_test && xmake r qml_dialog_test # 14 passed, 0 failed
xmake b stem                                       # build ok
```

- GUI 实测未执行，待人工验证：文件 → 导出 → Pdf，导出完成后弹窗应左「否」右「是」、
  默认高亮「是」，Enter = 打开文件，Esc = 否。
