### PR TITLE
[0927] 修复帮助-版本弹窗打开后未聚焦导致 ESC 无法关闭

### DIFF
--- a/devel/0927.md
+++ b/devel/0927.md
@@ -1,0 +1,52 @@
+# 0927 帮助->版本弹窗打开后未聚焦导致 ESC 无法关闭
+
+## 2026/08/21 修复「帮助 -> 版本弹窗打开后未自动聚焦，按 ESC 无法关闭」
+
+### What
+
+「帮助 -> 版本」QML 弹窗打开后，焦点没有落到弹窗内的 QML 场景上，导致用户
+直接按 ESC 无法关闭弹窗，必须先用鼠标点一下弹窗才能正常 ESC 关闭。
+
+修复后弹窗打开即自动聚焦到 QML 视图，ESC/Enter 走 QML 正常链路关闭弹窗。
+
+### Why
+
+ESC 正常链路：`DialogShell`（`focus: true`）→ `Keys.onEscapePressed` →
+`closeBridge.cancel()` → 宿主 `done(Rejected)`。该链路生效的前提是 QML 场景
+存在 `activeFocusItem`。
+
+`run_qml_dialog` 在 `exec()` 前调用 `qw->setFocus()`，但此时无边框 `Qt::Tool`
+宿主尚未真正显示/激活，焦点设置不生效；Windows 等环境下 ESC 按键常先到达宿主
+`QDialog` 而非 `QQuickWidget`，QML 正常链路无法触发。0925 的兜底过滤器装在
+`QQuickWidget` 上，覆盖不到 ESC 先到达宿主的场景。
+
+### How
+
+1. **延迟聚焦**：`run_qml_dialog` 中将 `qw->setFocus()` 延迟到 `QTimer::singleShot(0,
+   ...)`，在 `exec()` 进入事件循环、窗口真正显示后再把焦点设到 `QQuickWidget`，
+   确保 QML 场景获得 `activeFocusItem`；同时显式设置 `qw->setFocusPolicy
+   (Qt::StrongFocus)`。
+2. **宿主级 ESC 兜底**：将 `QmlDialogEscFilter` 装在宿主 `QDialog` 上（而非
+   `QQuickWidget`）。这样无论 Windows 下 ESC 先到达宿主还是视图，只要 QML 场景
+   没有 `activeFocusItem` 就能兜底 `reject()` 宿主，且不影响正常 QML 取消语义。
+3. **回归测试**：
+   - 新增 `test_version_dialog_focuses_on_open`：用与实际一致的无边框 `Qt::Tool`
+     宿主，验证 show 后 QML 根对象获得 `activeFocus`。
+   - 更新 `test_version_escape_fallback_without_focus`：过滤器装在宿主上，并向
+     宿主发送 ESC，覆盖 Windows 焦点落在宿主的场景。
+
+### 涉及文件
+
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+- `devel/0927.md`
+
+### Tests
+
+```bash
+gf fmt --changed-since=main                        # 格式化变更
+xmake b qml_load_test && xmake r qml_load_test     # 15 passed, 0 failed
+xmake b stem                                       # 主应用编译通过
+# GUI 实测（帮助 -> 版本 -> ESC 关闭）已人工验证：弹窗打开后无需点击，直接
+# 按 ESC 即可关闭
+```

--- a/devel/0927.md
+++ b/devel/0927.md
@@ -88,3 +88,39 @@ xmake build --yes qml_load_test
 xmake build --yes stem && xmake install --yes stem
 # 真实 MoganSTEM 执行 (mogan-version)，对话框出现后 ESC 关闭并正常退出
 ```
+
+## 2026/08/21 修复「首次打开版本弹窗有概率按 ESC 无反应」
+
+### What
+
+macOS 上完全退出 Mogan 后重新启动，第一次打开「帮助 -> 版本」弹窗时，
+有概率按 ESC 无反应；点一次确定后，后续打开恢复正常。
+
+### Why
+
+上一版修复只有两次聚焦时机：`QTimer::singleShot(0)` 一次、`WindowActivate`
+事件一次。macOS 首次弹无边框 `Qt::Tool` 窗口时 key window 切换可能晚于这两
+个时机（首次还要初始化 QML 引擎，更慢），单次 `setFocus` 落空后焦点留在主
+窗口，ESC 事件根本没进弹窗，宿主上的兜底过滤器也收不到。
+
+### How
+
+把一次性聚焦改成带成功条件的重试循环：`QTimer` 每 50ms 执行
+`activateWindow()` + 两层焦点同步（QWidget `setFocus` + QML 根项
+`forceActiveFocus`），QML 根项 `hasActiveFocus()` 即停，上限 20 次（1s）防
+极端环境空转。定时器挂在宿主 `QDialog` 上随弹窗析构自清。保留
+`WindowActivate` 过滤器与宿主级 ESC 兜底作为补充防线。
+
+### 涉及文件
+
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `devel/0927.md`
+
+### Tests
+
+```bash
+gf fmt --changed-since=origin/main                 # 无格式改动
+xmake b qml_load_test && xmake r qml_load_test     # 15 passed, 0 failed
+xmake b stem && xmake install --yes stem           # build ok / install ok
+# GUI 实测已人工验证：重启后第一次打开版本弹窗直接按 ESC 可关闭
+```

--- a/devel/0927.md
+++ b/devel/0927.md
@@ -50,3 +50,41 @@ xmake b stem                                       # 主应用编译通过
 # GUI 实测（帮助 -> 版本 -> ESC 关闭）已人工验证：弹窗打开后无需点击，直接
 # 按 ESC 即可关闭
 ```
+
+## 2026/08/21 修复「帮助 -> 版本」弹窗在 Windows 打开后未自动聚焦
+
+### What
+
+修复 Windows 下通过「帮助 -> 版本」打开 QML 版本弹窗后，QML 场景没有
+`activeFocusItem` 的问题。弹窗打开后 ESC 和 Enter 重新走 DialogShell 的正常
+QML 按键链路。
+
+### Why
+
+无边框 `Qt::Tool` 宿主窗口在 Windows 上会在 `show` 后异步激活。此前仅在
+`exec()` 前或首个事件循环中调用 `QQuickWidget::setFocus()`，宿主尚未真正激活时
+QML 根项的 `Component.onCompleted` 也已执行，导致 QWidget 焦点与 QML active focus
+脱节。
+
+### How
+
+1. 给宿主 `QDialog` 设置 `QQuickWidget` 焦点代理。
+2. 监听宿主 `WindowActivate`；每次真正激活后，重新聚焦 QQuickWidget 并对 QML
+   根项调用 `forceActiveFocus()`。
+3. 新增真实 `run_qml_dialog + exec()` 回归测试：检查 QML 根项已获得 active focus，
+   自动发送 ESC 并验证正常取消关闭。
+
+### 涉及文件
+
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+- `devel/0927.md`
+
+### Tests
+
+```bash
+xmake build --yes qml_load_test
+# 在 Qt 运行时环境下执行 qml_load_test：14 passed, 0 failed
+xmake build --yes stem && xmake install --yes stem
+# 真实 MoganSTEM 执行 (mogan-version)，对话框出现后 ESC 关闭并正常退出
+```

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -244,10 +244,24 @@ run_qml_dialog (const string& qml_url, const char* debug_tag,
   qw->setFocusPolicy (Qt::StrongFocus);
   d.setFocusProxy (qw);
   d.installEventFilter (new QmlDialogFocusFilter (&d, qw, &d));
-  QTimer::singleShot (0, &d, [&d, qw] () {
-    d.activateWindow ();
-    focus_qml_dialog (d, qw);
-  });
+  // 各平台窗口激活时机不同：macOS 首次弹无边框 Qt::Tool 时 key window 切换
+  // 可能晚于事件循环首个节拍，单次 setFocus 落空后焦点留在主窗口，ESC 被
+  // 主窗口吞掉（0927）。每 50ms 重试，QML 根项拿到 activeFocus 即停，上限
+  // 20 次（1s）防极端环境下空转。
+  QTimer* focusRetry= new QTimer (&d);
+  focusRetry->setInterval (50);
+  QObject::connect (focusRetry, &QTimer::timeout, &d,
+                    [&d, qw, focusRetry, attempts= 0] () mutable {
+                      if (qw->rootObject () &&
+                          qw->rootObject ()->hasActiveFocus ()) {
+                        focusRetry->stop ();
+                        return;
+                      }
+                      d.activateWindow ();
+                      focus_qml_dialog (d, qw);
+                      if (++attempts >= 20) focusRetry->stop ();
+                    });
+  focusRetry->start ();
   // QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉（不投递、
   // 不传播给 QDialog::reject），装兜底过滤器保证 ESC 总能关闭弹窗（0925）。
   // Windows 下无边框 Qt::Tool 焦点常落到宿主 QDialog 而非 QQuickWidget，故

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -160,6 +160,37 @@ lock_autofit_height (QQuickWidget* qw, QVBoxLayout* vl, QDialog& d, int logic_w,
 }
 
 /**
+ * @brief 在宿主窗口真正激活后，把 QWidget 和 QML 两层焦点交给弹窗根项。
+ *
+ * Windows 的无边框 Qt::Tool 会在 show 后异步激活；若只在 exec 前或首个
+ * 事件循环中请求焦点，QQuickWidget 虽可获得 QWidget 焦点，QML 场景仍可能没有
+ * activeFocusItem。WindowActivate 到达时再同步一次两层焦点。
+ */
+static void
+focus_qml_dialog (QDialog& host, QQuickWidget* view) {
+  host.setFocus (Qt::OtherFocusReason);
+  view->setFocus (Qt::OtherFocusReason);
+  if (view->rootObject ()) view->rootObject ()->forceActiveFocus ();
+}
+
+class QmlDialogFocusFilter : public QObject {
+public:
+  QmlDialogFocusFilter (QDialog* host, QQuickWidget* view, QObject* parent)
+      : QObject (parent), m_host (host), m_view (view) {}
+
+protected:
+  bool eventFilter (QObject*, QEvent* ev) override {
+    if (ev->type () == QEvent::WindowActivate)
+      focus_qml_dialog (*m_host, m_view);
+    return false;
+  }
+
+private:
+  QDialog*      m_host;
+  QQuickWidget* m_view;
+};
+
+/**
  * @brief 通用 QML 模态弹窗引擎。
  *
  * 把两类弹窗（确认型 / form 型）共用的 QDialog 拼装 + setSource + 加载检查 +
@@ -208,10 +239,15 @@ run_qml_dialog (const string& qml_url, const char* debug_tag,
 
   // 焦点落在 QML 视图：弹窗激活时离屏 QML 场景随之激活，DialogShell 的
   // focus:true 生效，ESC/Enter 走 QML 正常链路。
-  // exec() 前窗口尚未真正显示，直接 setFocus() 在某些平台不生效；延迟到
-  // 进入事件循环、窗口 show 出来后再聚焦，确保 QML 场景获得 activeFocusItem。
+  // exec() 前窗口尚未真正显示，直接 setFocus() 在某些平台不生效。焦点代理让
+  // Qt 在宿主得焦点时转交给 QQuickWidget；WindowActivate 再同步 QML 根项。
   qw->setFocusPolicy (Qt::StrongFocus);
-  QTimer::singleShot (0, qw, [qw] () { qw->setFocus (); });
+  d.setFocusProxy (qw);
+  d.installEventFilter (new QmlDialogFocusFilter (&d, qw, &d));
+  QTimer::singleShot (0, &d, [&d, qw] () {
+    d.activateWindow ();
+    focus_qml_dialog (d, qw);
+  });
   // QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉（不投递、
   // 不传播给 QDialog::reject），装兜底过滤器保证 ESC 总能关闭弹窗（0925）。
   // Windows 下无边框 Qt::Tool 焦点常落到宿主 QDialog 而非 QQuickWidget，故

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -33,6 +33,7 @@ using moebius::data::tree_to_scheme_tree;
 #include <QQuickWidget>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <QVariantList>
 #include <QVariantMap>
@@ -206,11 +207,16 @@ run_qml_dialog (const string& qml_url, const char* debug_tag,
   else lock_fixed_size (qw, vl, d, logic_w, logic_h);
 
   // 焦点落在 QML 视图：弹窗激活时离屏 QML 场景随之激活，DialogShell 的
-  // focus:true 生效，ESC/Enter 走 QML 正常链路
-  qw->setFocus ();
+  // focus:true 生效，ESC/Enter 走 QML 正常链路。
+  // exec() 前窗口尚未真正显示，直接 setFocus() 在某些平台不生效；延迟到
+  // 进入事件循环、窗口 show 出来后再聚焦，确保 QML 场景获得 activeFocusItem。
+  qw->setFocusPolicy (Qt::StrongFocus);
+  QTimer::singleShot (0, qw, [qw] () { qw->setFocus (); });
   // QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉（不投递、
-  // 不传播给 QDialog::reject），装兜底过滤器保证 ESC 总能关闭弹窗（0925）
-  qw->installEventFilter (new QmlDialogEscFilter (&d, qw, &d));
+  // 不传播给 QDialog::reject），装兜底过滤器保证 ESC 总能关闭弹窗（0925）。
+  // Windows 下无边框 Qt::Tool 焦点常落到宿主 QDialog 而非 QQuickWidget，故
+  // 过滤器装在宿主上，确保无论事件先到达哪个对象都能兜底。
+  d.installEventFilter (new QmlDialogEscFilter (&d, qw, &d));
 
   return d.exec ();
 }

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -417,13 +417,13 @@ void
 TestQmlLoad::test_version_dialog_focuses_on_open () {
   // 0927：必须经真实 run_qml_dialog + exec() 路径验证。弹窗显示后检查 QML
   // 场景焦点并发 ESC，确认正常 QML 取消链路生效。
-  bool sawDialog= false;
-  bool hadFocus = false;
+  bool sawDialog = false;
+  bool hadFocus  = false;
   bool sentEscape= false;
   QTimer::singleShot (200, [&] () {
     for (QWidget* topLevel : QApplication::topLevelWidgets ())
       if (topLevel->objectName () == "QTMQmlDialog") {
-        sawDialog= true;
+        sawDialog       = true;
         QQuickWidget* qw= topLevel->findChild<QQuickWidget*> ();
         hadFocus        = qw && qw->rootObject ()->hasActiveFocus ();
         if (qw) {

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -23,6 +23,7 @@
 #include <QQuickItem>
 #include <QQuickWidget>
 #include <QStringList>
+#include <QTimer>
 #include <QUrl>
 #include <QVariantList>
 #include <QVariantMap>
@@ -209,6 +210,7 @@ private slots:
   void test_paragraph_format_loads ();
   void test_preferences_loads ();
   void test_version_loads ();
+  void test_version_dialog_focuses_on_open ();
   void test_version_escape_cancels ();
   void test_version_escape_fallback_without_focus ();
   void test_version_long_line_wraps ();
@@ -410,6 +412,29 @@ TestQmlLoad::test_version_loads () {
 }
 
 void
+TestQmlLoad::test_version_dialog_focuses_on_open () {
+  // 0927：帮助->版本弹窗打开后须自动聚焦到 QML 场景，ESC/Enter 才能走 QML
+  // 正常链路（DialogShell.focus/Keys.onEscapePressed）。这里用与实际引擎
+  // 相同的无边框 Qt::Tool 宿主，并延迟到窗口显示后再 setFocus，模拟修复后
+  // 的真实路径。
+  QDialog       host (nullptr, Qt::FramelessWindowHint | Qt::Dialog | Qt::Tool);
+  QQuickWidget* qw         = new QQuickWidget (&host);
+  StubBridge*   close      = new StubBridge (qw);
+  VersionStubBridge* bridge= new VersionStubBridge (qw);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  qw->rootContext ()->setContextProperty ("closeBridge", close);
+  qw->rootContext ()->setContextProperty ("versionBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->setSource (QUrl ("qrc:/qml/Version.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  qw->setFocusPolicy (Qt::StrongFocus);
+  QTimer::singleShot (0, qw, [qw] () { qw->setFocus (); });
+  host.show ();
+  QTRY_VERIFY (qw->rootObject ()->hasActiveFocus ());
+}
+
+void
 TestQmlLoad::test_version_escape_cancels () {
   QDialog            host;
   QQuickWidget*      qw    = new QQuickWidget (&host);
@@ -430,9 +455,10 @@ TestQmlLoad::test_version_escape_cancels () {
 
 void
 TestQmlLoad::test_version_escape_fallback_without_focus () {
-  // 0925：QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉
+  // 0925/0927：QML 场景无 activeFocusItem 时 ESC 会被 QQuickWidget 静默吞掉
   // （不投递、不传播给 QDialog::reject），引擎侧的 QmlDialogEscFilter 须兜底
-  // reject 宿主弹窗，且不走 QML cancel
+  // reject 宿主弹窗，且不走 QML cancel。Windows 下 ESC 常先到达宿主 QDialog，
+  // 故过滤器装在宿主上并向宿主发 ESC，覆盖该场景。
   QDialog            host;
   QQuickWidget*      qw    = new QQuickWidget (&host);
   StubBridge*        close = new StubBridge (qw);
@@ -444,13 +470,15 @@ TestQmlLoad::test_version_escape_fallback_without_focus () {
   qw->rootContext ()->setContextProperty ("isDark", false);
   qw->setSource (QUrl ("qrc:/qml/Version.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
-  qw->installEventFilter (new QmlDialogEscFilter (&host, qw, &host));
+  // 过滤器装在宿主 QDialog 上：Windows 下 ESC 常先到达宿主而非 QQuickWidget
+  host.installEventFilter (new QmlDialogEscFilter (&host, qw, &host));
   host.show ();
   // 强制 QML 场景无焦点项，模拟 ESC 被吞的真实缺陷态
   qw->rootObject ()->setFocus (false);
   QTRY_VERIFY (!qw->rootObject ()->hasActiveFocus ());
   QSignalSpy rejectedSpy (&host, &QDialog::rejected);
-  QTest::keyClick (qw, Qt::Key_Escape);
+  // 直接向宿主发送 ESC，覆盖 Windows 焦点落在宿主的场景
+  QTest::keyClick (&host, Qt::Key_Escape);
   QTRY_COMPARE (rejectedSpy.count (), 1);
   QVERIFY (!host.isVisible ());
   QCOMPARE (close->cancelCount, 0);

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -15,8 +15,10 @@
 
 #include "base.hpp"
 
+#include "Qt/QTMQmlDialog.hpp"       // cpp_version_dialog
 #include "Qt/QTMQmlDialogBridge.hpp" // QmlDialogEscFilter
 
+#include <QApplication>
 #include <QDialog>
 #include <QObject>
 #include <QQmlContext>
@@ -413,25 +415,34 @@ TestQmlLoad::test_version_loads () {
 
 void
 TestQmlLoad::test_version_dialog_focuses_on_open () {
-  // 0927：帮助->版本弹窗打开后须自动聚焦到 QML 场景，ESC/Enter 才能走 QML
-  // 正常链路（DialogShell.focus/Keys.onEscapePressed）。这里用与实际引擎
-  // 相同的无边框 Qt::Tool 宿主，并延迟到窗口显示后再 setFocus，模拟修复后
-  // 的真实路径。
-  QDialog       host (nullptr, Qt::FramelessWindowHint | Qt::Dialog | Qt::Tool);
-  QQuickWidget* qw         = new QQuickWidget (&host);
-  StubBridge*   close      = new StubBridge (qw);
-  VersionStubBridge* bridge= new VersionStubBridge (qw);
-  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
-  qw->rootContext ()->setContextProperty ("closeBridge", close);
-  qw->rootContext ()->setContextProperty ("versionBridge", bridge);
-  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
-  qw->rootContext ()->setContextProperty ("isDark", false);
-  qw->setSource (QUrl ("qrc:/qml/Version.qml"));
-  QCOMPARE (qw->status (), QQuickWidget::Ready);
-  qw->setFocusPolicy (Qt::StrongFocus);
-  QTimer::singleShot (0, qw, [qw] () { qw->setFocus (); });
-  host.show ();
-  QTRY_VERIFY (qw->rootObject ()->hasActiveFocus ());
+  // 0927：必须经真实 run_qml_dialog + exec() 路径验证。弹窗显示后检查 QML
+  // 场景焦点并发 ESC，确认正常 QML 取消链路生效。
+  bool sawDialog= false;
+  bool hadFocus = false;
+  bool sentEscape= false;
+  QTimer::singleShot (200, [&] () {
+    for (QWidget* topLevel : QApplication::topLevelWidgets ())
+      if (topLevel->objectName () == "QTMQmlDialog") {
+        sawDialog= true;
+        QQuickWidget* qw= topLevel->findChild<QQuickWidget*> ();
+        hadFocus        = qw && qw->rootObject ()->hasActiveFocus ();
+        if (qw) {
+          QTest::keyClick (qw, Qt::Key_Escape);
+          sentEscape= true;
+        }
+        return;
+      }
+  });
+  // 运行时加载失败等异常不能让测试遗留一个阻塞模态窗口。
+  QTimer::singleShot (2000, [] () {
+    for (QWidget* topLevel : QApplication::topLevelWidgets ())
+      if (topLevel->objectName () == "QTMQmlDialog")
+        static_cast<QDialog*> (topLevel)->reject ();
+  });
+  QVERIFY (!cpp_version_dialog ("Version", "Version information"));
+  QVERIFY (sawDialog);
+  QVERIFY (hadFocus);
+  QVERIFY (sentEscape);
 }
 
 void


### PR DESCRIPTION
## 问题

「帮助 -> 版本」QML 弹窗打开后，焦点没有自动落到弹窗内的 QML 场景上，导致用户直接按 ESC 无法关闭弹窗，必须先用鼠标点一下弹窗才能正常 ESC 关闭。macOS 上还表现为：重启后**第一次**打开版本弹窗有概率按 ESC 无反应，点过一次后恢复正常。

## 原因

ESC 正常链路：`DialogShell`（`focus: true`）→ `Keys.onEscapePressed` → `closeBridge.cancel()` → 宿主 `done(Rejected)`。该链路生效的前提是 QML 场景存在 `activeFocusItem`。

- `exec()` 前窗口尚未真正显示，直接 `setFocus()` 不生效；无边框 `Qt::Tool` 宿主在 Windows/macOS 上都是 show 后异步激活，单次聚焦容易落空。
- 首次弹窗时（QML 引擎冷启动更慢）key window 切换可能晚于所有一次性聚焦时机，焦点留在主窗口，ESC 事件根本没进弹窗，任何弹窗内过滤器都收不到。

## 修复方案

1. **两层焦点同步**：`focus_qml_dialog` 同时设置 QWidget 焦点（宿主 + `QQuickWidget`）和 QML 根项 `forceActiveFocus()`；宿主设 `setFocusProxy(qw)`，让 Qt 在宿主得焦点时自动转交视图。
2. **带成功条件的重试循环**：`QTimer` 每 50ms 执行 `activateWindow()` + 两层焦点同步，QML 根项 `hasActiveFocus()` 即停，上限 20 次（1s）防极端环境空转；定时器挂在宿主上随弹窗析构自清。
3. **WindowActivate 过滤器**：窗口每次真正激活时再同步一次两层焦点，覆盖激活时机晚于重试循环的场景。
4. **宿主级 ESC 兜底**（沿用 0925 的 `QmlDialogEscFilter`，改装在宿主 `QDialog` 上）：无论 ESC 先到达宿主还是视图，只要 QML 场景没有 `activeFocusItem` 就兜底 `reject()`，不抢占 QML 正常取消语义。
5. **回归测试**：
   - `test_version_dialog_focuses_on_open`：走真实 `run_qml_dialog + exec()` 路径，弹窗显示后断言 QML 根项获得 active focus，并自动发 ESC 验证正常取消关闭。
   - `test_version_escape_fallback_without_focus`：强制 QML 场景无焦点项，向宿主发 ESC，验证兜底 `reject()` 生效且不走 QML cancel。

## 涉及文件

- `src/Plugins/Qt/QTMQmlDialog.cpp`
- `tests/Plugins/Qt/qml_load_test.cpp`
- `devel/0927.md`

## 验证结果

```bash
gf fmt --changed-since=origin/main                 # 通过
xmake b qml_load_test && xmake r qml_load_test     # 15 passed, 0 failed
xmake b stem && xmake install --yes stem           # build ok / install ok
```

GUI 人工验证（macOS + Windows 双端）：
- 帮助 -> 版本弹窗打开后无需点击，直接按 ESC 可关闭；
- 重启后第一次打开版本弹窗直接按 ESC 可关闭（偶发失焦已消除）。
