### PR TITLE
[0928] 用 QML 重构调色板

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -259,6 +259,7 @@
 ("add style package" "增加宏包")
 ("add switch after" "")
 ("add switch before" "")
+("add to custom colors" "添加到自定义颜色")
 ("add" "新增")
 ("address block" "地址栏")
 ("address" "地址")
@@ -389,6 +390,7 @@
 ("base" "基线")
 ("baseline" "基线")
 ("bashkirian" "巴什基尔语")
+("basic colors" "基本颜色")
 ("basic communication using pipes" "基本管道通信")
 ("basic data types" "基本数据类型")
 ("basic types" "基本型态")
@@ -648,6 +650,10 @@
 ("curve points" "曲线点")
 ("curve" "曲线")
 ("custom" "自定义")
+("custom colors" "自定义颜色")
+("custom colors are full, delete one first"
+  "自定义颜色已满，请先删除一个颜色"
+) ;
 ("custom tab" "自定义制表符")
 ("custom tab" "自定义制表符")
 ("customizations" "定制")
@@ -698,6 +704,7 @@
 ("definition" "定义")
 ("delete column" "删除此行")
 ("delete documentation cache" "删除文档缓存")
+("delete custom color" "删除自定义颜色")
 ("delete row" "删除此列")
 ("delete" "删除")
 ("deleted" "删除")
@@ -1963,6 +1970,7 @@
 ("philosophy" "哲学")
 ("phoenician" "")
 ("phonetic" "")
+("pick screen color" "拾取屏幕颜色")
 ("picture" "图片")
 ("pictures" "图片")
 ("pink" "粉红")

--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -995,6 +995,7 @@
       <button class="nav-btn" data-target="version">Version.qml</button>
       <button class="nav-btn" data-target="preferences">Preferences.qml</button>
       <button class="nav-btn" data-target="confirmRestart">ConfirmRestart.qml</button>
+      <button class="nav-btn" data-target="colorPicker">ColorPicker.qml</button>
       <div class="sidebar-foot">模拟目标: DialogShell / DialogButtons / EnumCombo / SelectableList / PreviewPane 组合逻辑。</div>
     </aside>
 
@@ -1624,6 +1625,58 @@
         </p>
       </section>
 
+      <section class="panel" id="panel-colorpicker">
+        <div class="cards">
+          <article class="confirm-shell" style="width:520px; text-align:left;">
+            <h3 style="margin-top:0;">Choose color</h3>
+            <div style="display:flex; gap:14px;">
+              <div style="flex:1;">
+                <div style="height:170px; border-radius:6px; background:linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, #f0f);"></div>
+                <div style="height:16px; margin-top:10px; border-radius:4px; background:linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);"></div>
+              </div>
+              <div style="width:120px; display:flex; flex-direction:column; gap:6px; font-size:11px; color:#666;">
+                <div style="height:32px; border-radius:6px; background:#b420b4;"></div>
+                HEX <input value="#b420b4" style="width:100%; box-sizing:border-box;">
+                R <input value="180" style="width:100%; box-sizing:border-box;">
+                G <input value="32" style="width:100%; box-sizing:border-box;">
+                B <input value="180" style="width:100%; box-sizing:border-box;">
+                H <input value="299" style="width:100%; box-sizing:border-box;">
+                S <input value="82" style="width:100%; box-sizing:border-box;">
+                V <input value="71" style="width:100%; box-sizing:border-box;">
+              </div>
+            </div>
+            <p style="font-size:11px; color:#666; margin:12px 0 4px;">基本颜色</p>
+            <div style="display:grid; grid-template-columns:repeat(10, 1fr); gap:5px;">
+              <div style="aspect-ratio:1; border-radius:3px; background:#000;"></div><div style="aspect-ratio:1; border-radius:3px; background:#434343;"></div><div style="aspect-ratio:1; border-radius:3px; background:#666;"></div><div style="aspect-ratio:1; border-radius:3px; background:#999;"></div><div style="aspect-ratio:1; border-radius:3px; background:#b7b7b7;"></div><div style="aspect-ratio:1; border-radius:3px; background:#980000;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f00;"></div><div style="aspect-ratio:1; border-radius:3px; background:#ff9900;"></div><div style="aspect-ratio:1; border-radius:3px; background:#ff0;"></div><div style="aspect-ratio:1; border-radius:3px; background:#0f0;"></div>
+              <div style="aspect-ratio:1; border-radius:3px; background:#0ff;"></div><div style="aspect-ratio:1; border-radius:3px; background:#4a86e8;"></div><div style="aspect-ratio:1; border-radius:3px; background:#00f;"></div><div style="aspect-ratio:1; border-radius:3px; background:#9900ff;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f0f;"></div><div style="aspect-ratio:1; border-radius:3px; background:#e6b8af;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f4cccc;"></div><div style="aspect-ratio:1; border-radius:3px; background:#fce5cd;"></div><div style="aspect-ratio:1; border-radius:3px; background:#fff2cc;"></div><div style="aspect-ratio:1; border-radius:3px; background:#d9ead3;"></div>
+            </div>
+            <p style="font-size:11px; color:#666; margin:12px 0 4px;">自定义颜色</p>
+            <div style="display:flex; gap:10px; align-items:center;">
+              <div style="flex:1; display:grid; grid-template-columns:repeat(8, 1fr); gap:5px;">
+                <div style="aspect-ratio:1; border-radius:3px; background:#b420b4;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div><div style="aspect-ratio:1; border-radius:3px; background:#f1f3f4; border:1px solid #d0d4da;"></div>
+              </div>
+              <div style="display:flex; flex-direction:column; gap:6px;">
+                <button class="btn" data-log="ColorPicker: 添加到自定义颜色（满 16 格拒绝并提示）">添加到自定义颜色</button>
+                <button class="btn" data-log="ColorPicker: 删除选中的自定义颜色">删除自定义颜色</button>
+              </div>
+            </div>
+            <div style="margin-top:10px;">
+              <button class="btn" data-log="ColorPicker: 屏幕取色（colorBridge.pickScreenColor）">拾取屏幕颜色</button>
+            </div>
+            <div class="btn-row" style="margin-top:14px;">
+              <button class="btn primary" data-log="ColorPicker: OK -> submit({color, customColors})">确定</button>
+              <button class="btn" data-log="ColorPicker: Cancel -> closeBridge.cancel()">取消</button>
+            </div>
+          </article>
+        </div>
+        <p class="legend">
+          对应 QML: <code>pickerTitleProp + proposalsProp + customColorsProp + labelsProp</code>
+          <code>OK -> closeBridge.submit({color: "#rrggbb", customColors})</code>
+          <code>屏幕取色走 ColorPickerBridge（抓屏 overlay 点选，Esc 取消）</code>
+          自定义颜色 16 格，OK 时经 preference 持久化；满格拒绝添加并显示提示行。
+        </p>
+      </section>
+
 
     </main>
   </div>
@@ -1639,7 +1692,8 @@
         statistics: document.getElementById('panel-statistics'),
         version: document.getElementById('panel-version'),
         preferences: document.getElementById('panel-preferences'),
-        confirmRestart: document.getElementById('panel-confirm-restart')
+        confirmRestart: document.getElementById('panel-confirm-restart'),
+        colorPicker: document.getElementById('panel-colorpicker')
       };
 
       const titleMap = {
@@ -1650,7 +1704,8 @@
         paragraph: 'ParagraphFormat.qml 模拟',
         statistics: 'Statistics.qml 模拟',
         preferences: 'Preferences.qml 模拟',
-        confirmRestart: 'ConfirmRestart.qml 模拟'
+        confirmRestart: 'ConfirmRestart.qml 模拟',
+        colorPicker: 'ColorPicker.qml 模拟'
       };
 
       const codeMap = {
@@ -1661,7 +1716,8 @@
         paragraph: 'EnumCombo x N + tabs(基础/高级) + make-multi-line-with 写回',
         statistics: 'statsModel: [{label, value}, ...] + closeBridge.choose(0) 关闭',
         preferences: 'prefTabs(5) + subTabs(6) + EnumCombo + Toggle + 纯 OK 提交',
-        confirmRestart: 'message + buttonLabels + closeBridge.choose(index)'
+        confirmRestart: 'message + buttonLabels + closeBridge.choose(index)',
+        colorPicker: 'pickerTitleProp + proposals + customColors + submit({color, customColors})'
       };
 
       const viewTitle = document.getElementById('view-title');

--- a/devel/0928.md
+++ b/devel/0928.md
@@ -1,0 +1,47 @@
+# 0928: 用 QML 重构调色板
+
+## What
+将 Qt 原生 `QColorDialog` 实现的调色板替换为项目统一 QML 弹窗体系下的 `ColorPicker.qml`，保持功能不缺失，视觉风格与现有 QML 对话框一致并更具现代感。
+
+## Why
+- 当前 `qt_color_picker_widget_rep::showDialog()` 直接调用 `QColorDialog::getColor`，风格与 Mogan 正在迁移的 QML 模态对话框体系不一致。
+- QML 版本可复用 `DialogShell`、`DialogButtons`、`Theme` 等原子组件，统一暗色/亮色、DPI 缩放、圆角、按钮交互。
+- 自定义调色板可在不增加依赖的情况下加入色板预设、HEX/RGB 输入、实时预览，提升可用性。
+
+## How
+1. 新增 `src/Plugins/Qt/qml/ColorPicker.qml`：基于 `DialogShell` 组装现代感调色板，含色相条、饱和度/明度面板、RGB/HEX 输入、预设色块、颜色预览与 OK/Cancel 按钮。
+2. 在 `src/Plugins/Qt/QTMQmlDialog.hpp/cpp` 新增阻塞式 glue 入口 `cpp_color_picker_dialog(...)`，使用 `run_qml_dialog` exec 引擎一次性提交，返回选中的颜色 tree。
+3. 修改 `src/Plugins/Qt/qt_color_picker_widget.cpp` 的 `showDialog()`，改为调用 `cpp_color_picker_dialog()`，保持 `widget-color-picker` / `interactive-color` 调用链不变。
+4. 在 `src/Plugins/Qt/qml/qmldir` 与 `src/Plugins/Qt/moganqml.qrc` 登记新 QML 文件。
+5. 在 `tests/Plugins/Qt/qml_load_test.cpp` 增加 `ColorPicker.qml` 加载用例。
+
+## 测试
+- `xmake b qml_load_test && xmake r qml_load_test`
+- 数据契约自检：`MOGAN_TEST_COLOR_PICKER=#rrggbb|cancel`（返回形状与真实路径一致，均为 `(tuple "#rrggbb")` / 空 tuple）
+- 手动 GUI 验证：菜单 Format / Color -> Palette、Document -> Color / Background color 等入口。
+
+## 修复记录
+- **点击确认后不生效（人工验证反馈）**：根因是返回值形状不匹配。旧实现回调给 scheme 的是原子颜色 tree（`"#rrggbb"`），新实现 `cpp_color_picker_dialog` 按 form 弹窗惯例返回 `(tuple "#rrggbb")`，`showDialog()` 最初把整棵 tuple 直接回调，scheme 侧 `tm->stree` 拿到的不是颜色字符串，setter 静默不生效。修复：`showDialog()` 解包 `sel[0]` 再回调；同时把 `MOGAN_TEST_COLOR_PICKER` 测试钩子的返回形状改为与真实路径一致的 `(tuple "#rrggbb")`，避免钩子与真实路径分叉。
+- **底部按钮被裁剪（人工验证反馈）**：内容总高度超出窗口，QML `implicitHeight` 与 C++ `run_qml_dialog` 逻辑高度同步调高。
+- **功能缺失补齐（人工验证反馈，对照旧 QColorDialog）**：
+  - 补 HSV 数值输入（H 0–359，S/V 0–100），与 RGB/HEX 并列；
+  - 补 Custom colors（16 格）+ Add to custom colors，OK 时经 preference `color picker custom colors`（空格分隔 hex）跨会话持久化，Cancel 不保存；
+  - 补 Pick screen color：新增 `ColorPickerBridge`（抓屏快照 + 全屏十字光标 overlay 点击取色，Esc 取消；macOS 需屏幕录制权限，未授权返回空串，与 Qt 自带行为一致）。
+  - 段标题/按钮文案（basic colors / custom colors / add to custom colors / pick screen color）在 cpp 侧 `qt_translate` 注入 `labelsProp`，并在 zh_CN 字典按字母序补四条中文翻译。
+- **右栏输入框被截断（人工验证反馈）**：主编辑区高度 220 不足以容纳右栏（预览 + HEX + RGB 三行 + HSV 三行 ≈ 267），主编辑区调高到 280，弹窗高度同步调到 720。
+- **自定义颜色增删语义（人工验证反馈）**：补删除功能——点击自定义色格即选中（选中态高亮边框），「删除自定义颜色」按钮清空该格（未选中时按钮半透明、点击无效）；添加按顺序填第一个空位，16 格全满时拒绝添加，并在色格下方显示小字提示「自定义颜色已满，请先删除一个颜色」。新增文案 delete custom color / custom colors are full, delete one first 已补 zh_CN 字典。
+
+## 涉及文件
+- `src/Plugins/Qt/qml/ColorPicker.qml`（新增）
+- `src/Plugins/Qt/ColorPickerBridge.hpp`（新增）
+- `src/Plugins/Qt/ColorPickerBridge.cpp`（新增）
+- `src/Plugins/Qt/QTMQmlDialog.hpp`
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `src/Plugins/Qt/qt_color_picker_widget.cpp`
+- `src/Plugins/Qt/qt_color_picker_widget.hpp`
+- `src/Plugins/Qt/qml/qmldir`
+- `src/Plugins/Qt/moganqml.qrc`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+- `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm`
+- `ai-docs/qml/qml-dialog.html`（设计稿新增 ColorPicker 面板）
+- `devel/0928.md`

--- a/src/Plugins/Qt/ColorPickerBridge.cpp
+++ b/src/Plugins/Qt/ColorPickerBridge.cpp
@@ -1,0 +1,84 @@
+/******************************************************************************
+ * MODULE      : ColorPickerBridge.cpp
+ * DESCRIPTION : QML 调色板的屏幕取色 bridge（Pick Screen Color）。
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+#include "ColorPickerBridge.hpp"
+
+#include <QColor>
+#include <QCursor>
+#include <QDialog>
+#include <QGuiApplication>
+#include <QImage>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPixmap>
+#include <QScreen>
+
+namespace {
+
+/**
+ * @brief 全屏取色浮层：铺满屏幕显示快照，十字光标点击取色，Esc 取消。
+ *
+ * 快照 QPixmap 带 devicePixelRatio，绘制时铺满逻辑坐标窗口即可；取色时把
+ * 点击逻辑坐标乘 DPR 换算回图像像素。
+ */
+class ScreenPickOverlay : public QDialog {
+public:
+  explicit ScreenPickOverlay (const QPixmap& snapshot, QWidget* parent= nullptr)
+      : QDialog (parent,
+                 Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool),
+        m_snapshot (snapshot) {
+    setCursor (Qt::CrossCursor);
+  }
+
+  QColor pickedColor () const { return m_picked; }
+
+protected:
+  void paintEvent (QPaintEvent*) override {
+    QPainter p (this);
+    p.drawPixmap (rect (), m_snapshot);
+  }
+
+  void mousePressEvent (QMouseEvent* ev) override {
+    const qreal dpr= m_snapshot.devicePixelRatio ();
+    const QImage img  = m_snapshot.toImage ();
+    const int    px   = qRound (ev->position ().x () * dpr);
+    const int    py   = qRound (ev->position ().y () * dpr);
+    if (px >= 0 && py >= 0 && px < img.width () && py < img.height ())
+      m_picked= img.pixelColor (px, py);
+    accept ();
+  }
+
+  void keyPressEvent (QKeyEvent* ev) override {
+    if (ev->key () == Qt::Key_Escape) reject ();
+    else QDialog::keyPressEvent (ev);
+  }
+
+private:
+  QPixmap m_snapshot;
+  QColor  m_picked;
+};
+
+} // namespace
+
+QString
+ColorPickerBridge::pickScreenColor () {
+  QScreen* screen= QGuiApplication::screenAt (QCursor::pos ());
+  if (screen == nullptr) screen= QGuiApplication::primaryScreen ();
+  if (screen == nullptr) return QString ();
+  const QPixmap snapshot= screen->grabWindow (0);
+  // macOS 未授「屏幕录制」权限时快照为空，取色不可用。
+  if (snapshot.isNull ()) return QString ();
+
+  ScreenPickOverlay overlay (snapshot);
+  overlay.setGeometry (screen->geometry ());
+  if (overlay.exec () != QDialog::Accepted) return QString ();
+  const QColor c= overlay.pickedColor ();
+  return c.isValid () ? c.name () : QString ();
+}

--- a/src/Plugins/Qt/ColorPickerBridge.hpp
+++ b/src/Plugins/Qt/ColorPickerBridge.hpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ * MODULE      : ColorPickerBridge.hpp
+ * DESCRIPTION : QML 调色板的屏幕取色 bridge（Pick Screen Color）。
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+#ifndef COLOR_PICKER_BRIDGE_H
+#define COLOR_PICKER_BRIDGE_H
+
+#include <QObject>
+#include <QString>
+
+/*! @class ColorPickerBridge
+ *  @brief 承载 QML 调色板需要 native 能力的交互：屏幕取色。
+ *
+ * @par 实现要点
+ * QML 无法直接抓屏与拦截全屏鼠标点击，故屏幕取色走本 bridge：grabWindow
+ * 抓全屏快照，铺满全屏的 frameless overlay 显示快照 + 十字光标，点击处按
+ * devicePixelRatio 换算回图像像素取色，Esc 取消。
+ *
+ * @note macOS 下抓屏需要「屏幕录制」权限，未授权时 grabWindow 返回空图，
+ * 本方法返回空串（取色不可用），与 Qt 自带 QColorDialog 行为一致。
+ */
+class ColorPickerBridge : public QObject {
+  Q_OBJECT
+
+public:
+  explicit ColorPickerBridge (QObject* parent= nullptr) : QObject (parent) {}
+
+  /**
+   * @brief 进入屏幕取色模式：全屏快照 overlay，点击取色。
+   * @return 命中的颜色 "#rrggbb"；取消（Esc）或取色不可用返回空串。
+   */
+  Q_INVOKABLE QString pickScreenColor ();
+};
+
+#endif // defined COLOR_PICKER_BRIDGE_H

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -8,6 +8,7 @@
  ******************************************************************************/
 
 #include "QTMQmlDialog.hpp"
+#include "ColorPickerBridge.hpp"
 #include "FontSelectorBridge.hpp"
 #include "ParagraphFormatBridge.hpp"
 #include "PreferencesBridge.hpp"
@@ -15,8 +16,9 @@
 #include "QTMQmlDialogInternal.hpp"
 #include "VersionDialogBridge.hpp"
 
-#include "analyze.hpp" // occurs
-#include "gui.hpp"     // tm_style_sheet
+#include "analyze.hpp"     // occurs
+#include "gui.hpp"         // tm_style_sheet
+#include "preferences.hpp" // get_preference / set_preference
 #include "qt_utilities.hpp"
 #include "s7_tm.hpp"     // eval_scheme
 #include "sys_utils.hpp" // lolly: get_env
@@ -689,4 +691,90 @@ cpp_preferences_dialog () {
       620, 600);
   delete bridge;
   return tree (TUPLE);
+}
+
+/**
+ * @brief QML 调色板弹窗的 glue 入口（声明/语义见 QTMQmlDialog.hpp）。
+ *
+ * @details 走 run_qml_dialog（exec 阻塞模态，无需 live 写回）。ColorPicker.qml
+ * 提供色相/饱和度/明度面板、HSV/RGB/HEX 数值输入、基础色块、自定义颜色
+ * （跨会话持久化）与屏幕取色。自定义颜色经 preference "color picker custom
+ * colors"（空格分隔 hex 列表）读写。测试钩子 MOGAN_TEST_COLOR_PICKER=
+ * <hex>|cancel 命中时不弹窗。
+ */
+tree
+cpp_color_picker_dialog (string title, array<tree> proposals,
+                         bool pickPattern) {
+  string preset= get_env ("MOGAN_TEST_COLOR_PICKER");
+  if (preset == "cancel") return tree (TUPLE);
+  if (preset != "") {
+    // 测试钩子：与真实路径同构，返回 (tuple "#rrggbb")；支持无 # 前缀的 hex。
+    string hex= preset;
+    if (hex[0] != '#') hex= string ("#") * hex;
+    tree r (TUPLE);
+    r << tree (hex);
+    return r;
+  }
+
+  QStringList qmlProposals;
+  QString     initColor ("#ffffff");
+  for (int i= 0; i < N (proposals); i++) {
+    if (is_atomic (proposals[i])) {
+      QString col= to_qstring (get_label (proposals[i]));
+      qmlProposals << col;
+      if (i == 0) initColor= col;
+    }
+  }
+
+  // 自定义颜色跨会话持久化：空格分隔 hex 列表存于 preference。
+  const string CUSTOM_PREF = "color picker custom colors";
+  QStringList  customColors= to_qstring (get_preference (CUSTOM_PREF, ""))
+                                .split (' ', Qt::SkipEmptyParts);
+
+  // 段标题与按钮文案在 cpp 侧 qt_translate（同 translate_buttons 惯例）。
+  QVariantMap labels;
+  labels["basicColors"] = qt_translate ("Basic colors");
+  labels["customColors"]= qt_translate ("Custom colors");
+  labels["addToCustom"] = qt_translate ("Add to custom colors");
+  labels["deleteCustom"]= qt_translate ("Delete custom color");
+  labels["customFull"]=
+      qt_translate ("Custom colors are full, delete one first");
+  labels["pickScreenColor"]= qt_translate ("Pick screen color");
+
+  array<string>    buttons= {string ("OK"), string ("Cancel")};
+  QmlDialogBridge* bridge = nullptr;
+  run_qml_dialog (
+      "qrc:/qml/ColorPicker.qml", "ColorPicker.qml",
+      [&] (QQuickWidget* qw, QDialog& host) {
+        bridge                     = inject_common_context (qw, host);
+        ColorPickerBridge* cpBridge= new ColorPickerBridge ();
+        qw->rootContext ()->setContextProperty ("colorBridge", cpBridge);
+        QObject::connect (&host, &QDialog::destroyed, cpBridge,
+                          &QObject::deleteLater);
+        qw->rootContext ()->setContextProperty ("pickerTitleProp",
+                                                to_qstring (title));
+        qw->rootContext ()->setContextProperty ("proposalsProp", qmlProposals);
+        qw->rootContext ()->setContextProperty ("pickPatternProp", pickPattern);
+        qw->rootContext ()->setContextProperty ("initialColorProp", initColor);
+        qw->rootContext ()->setContextProperty ("customColorsProp",
+                                                customColors);
+        qw->rootContext ()->setContextProperty ("labelsProp", labels);
+        qw->rootContext ()->setContextProperty ("dialogButtonsProp",
+                                                translate_buttons (buttons));
+      },
+      560, 720);
+
+  tree               r (TUPLE);
+  const QVariantMap& res= bridge ? bridge->results () : QVariantMap ();
+  delete bridge;
+  if (res.contains ("color")) {
+    QString col= res.value ("color").toString ();
+    if (col.length () > 0) r << tree (from_qstring (col));
+    // OK 时把自定义颜色写回 preference；Cancel 不持久化。
+    if (res.contains ("customColors")) {
+      QString joined= res.value ("customColors").toStringList ().join (' ');
+      set_preference (CUSTOM_PREF, from_qstring (joined));
+    }
+  }
+  return r;
 }

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -228,4 +228,23 @@ bool cpp_version_dialog (string title, string message);
  */
 tree cpp_preferences_dialog ();
 
+/**
+ * @brief QML 调色板弹窗的 glue 入口。
+ * @param title 弹窗标题（已翻译）。
+ * @param proposals 预设颜色列表，每项为颜色字符串 tree（如 "#ff0000"
+ * 或命名颜色）。
+ * @param pickPattern 是否用于选择图案/背景（当前保留参数，与旧 widget
+ * 语义一致）。
+ * @return 用户确认返回 `(tuple "#rrggbb")`；取消 / 关闭 / 加载失败返回空
+ * tuple。
+ * @details 走 run_qml_dialog（exec 阻塞模态，无需 live 写回）。ColorPicker.qml
+ * 提供 色相/饱和度/明度面板、HSV/RGB/HEX 数值输入、基础色块、自定义颜色
+ * （16 格增删，OK 时经 preference 跨会话持久化）与屏幕取色，对齐原生
+ * QColorDialog 的功能集。调用方（qt_color_picker_widget）取 sel[0] 作颜色
+ * 字符串回调 scheme。
+ * @note 测试钩子 MOGAN_TEST_COLOR_PICKER=<hex>|cancel 命中时不弹窗。
+ */
+tree cpp_color_picker_dialog (string title, array<tree> proposals,
+                              bool pickPattern);
+
 #endif // defined QTM_QML_DIALOG_H

--- a/src/Plugins/Qt/moganqml.qrc
+++ b/src/Plugins/Qt/moganqml.qrc
@@ -15,6 +15,7 @@
         <file>qml/atoms/Toggle.qml</file>
         <file>qml/atoms/GroupHeader.qml</file>
         <file>qml/FontSelector.qml</file>
+        <file>qml/ColorPicker.qml</file>
         <file>qml/ConfirmClose.qml</file>
         <file>qml/ConfirmQuestion.qml</file>
         <file>qml/ConfirmRestart.qml</file>

--- a/src/Plugins/Qt/qml/ColorPicker.qml
+++ b/src/Plugins/Qt/qml/ColorPicker.qml
@@ -1,0 +1,541 @@
+// ColorPicker.qml — 现代感 QML 调色板。
+// 基于 DialogShell + Theme 原子组装，替换原生 QColorDialog，保持
+// interactive-color / interactive-background 调用链不变。
+//
+// context property（C++ 注入）：pickerTitleProp、initialColorProp、
+// proposalsProp、pickPatternProp、customColorsProp、labelsProp、
+// dialogButtonsProp、colorBridge、closeBridge、dpScale、isDark。
+
+import QtQuick
+import "atoms"
+
+DialogShell {
+    id: root
+    implicitWidth: 560 * Theme.scaleFactor
+    implicitHeight: 720 * Theme.scaleFactor
+    implicitMargins: 20 * Theme.scaleFactor
+
+    // 由 C++ 注入的初始颜色（#rrggbb 字符串）与预设列表。
+    property string initialColor: typeof initialColorProp !== "undefined" ? initialColorProp : "#ffffff"
+    property var proposals: typeof proposalsProp !== "undefined" ? proposalsProp : []
+    property bool pickPattern: typeof pickPatternProp !== "undefined" ? pickPatternProp : false
+    property var labels: typeof labelsProp !== "undefined" ? labelsProp : ({})
+    property var bridge: typeof colorBridge !== "undefined" ? colorBridge : null
+
+    // 当前选中颜色（QML color 类型）。
+    property color currentColor: root.initialColor
+
+    // HSV 工作态：hue / saturation / value 均归一化到 [0,1]。
+    property real hue: 0
+    property real saturation: 0
+    property real value: 1
+
+    // 解析 initialColor 到 HSV。
+    Component.onCompleted: {
+        var c = Qt.rgba(currentColor.r, currentColor.g, currentColor.b, 1.0);
+        root.hue = c.hsvHue;
+        root.saturation = c.hsvSaturation;
+        root.value = c.hsvValue;
+    }
+
+    // HSV 变化时更新 currentColor。
+    onHueChanged: root.currentColor = Qt.hsva(root.hue, root.saturation, root.value, 1.0)
+    onSaturationChanged: root.currentColor = Qt.hsva(root.hue, root.saturation, root.value, 1.0)
+    onValueChanged: root.currentColor = Qt.hsva(root.hue, root.saturation, root.value, 1.0)
+
+    // HEX 表示（小写，不带 #）。
+    property string hexValue: {
+        var toHex = function (v) {
+            var h = Math.round(v * 255).toString(16);
+            return h.length === 1 ? "0" + h : h;
+        };
+        return toHex(root.currentColor.r) + toHex(root.currentColor.g) + toHex(root.currentColor.b);
+    }
+
+    property var rgbValue: {
+        return {
+            r: Math.round(root.currentColor.r * 255),
+            g: Math.round(root.currentColor.g * 255),
+            b: Math.round(root.currentColor.b * 255)
+        };
+    }
+
+    property var hsvValue: {
+        return {
+            h: Math.round(root.hue * 359),
+            s: Math.round(root.saturation * 100),
+            v: Math.round(root.value * 100)
+        };
+    }
+
+    // 默认预设色板（现代感常用色），仅在 proposals 为空时启用。
+    property var defaultPresets: [
+        "#000000", "#434343", "#666666", "#999999", "#b7b7b7",
+        "#980000", "#ff0000", "#ff9900", "#ffff00", "#00ff00",
+        "#00ffff", "#4a86e8", "#0000ff", "#9900ff", "#ff00ff",
+        "#e6b8af", "#f4cccc", "#fce5cd", "#fff2cc", "#d9ead3"
+    ]
+
+    property var presetColors: root.proposals.length > 0 ? root.proposals : root.defaultPresets
+
+    // 自定义颜色（16 格，OK 时由 C++ 持久化到 preference）。
+    property var customColors: {
+        var init = typeof customColorsProp !== "undefined" ? customColorsProp : [];
+        var arr = [];
+        for (var i = 0; i < 16; i++)
+            arr.push(i < init.length ? init[i] : "");
+        return arr;
+    }
+    // 当前选中的自定义色格下标（删除对象）；-1 表示未选中。
+    property int selectedCustomIndex: -1
+    // 色格已满仍点添加时显示提示行。
+    property bool customFullHint: false
+
+    function addToCustomColors() {
+        var arr = root.customColors.slice();
+        var idx = arr.indexOf("");
+        if (idx < 0) {
+            // 已满：拒绝添加，提示需先删除。
+            root.customFullHint = true;
+            return;
+        }
+        arr[idx] = "#" + root.hexValue;
+        root.customColors = arr;
+        root.customFullHint = false;
+    }
+
+    function deleteCustomColor() {
+        if (root.selectedCustomIndex < 0)
+            return;
+        var arr = root.customColors.slice();
+        arr[root.selectedCustomIndex] = "";
+        root.customColors = arr;
+        root.selectedCustomIndex = -1;
+        root.customFullHint = false;
+    }
+
+    function setColorFromHex(hex) {
+        root.currentColor = hex;
+        var c = Qt.rgba(root.currentColor.r, root.currentColor.g, root.currentColor.b, 1.0);
+        root.hue = c.hsvHue;
+        root.saturation = c.hsvSaturation;
+        root.value = c.hsvValue;
+    }
+
+    onCancel: closeBridge.cancel()
+
+    content: Column {
+        spacing: 12 * Theme.scaleFactor
+        anchors.fill: parent
+
+        // 标题
+        Text {
+            text: typeof pickerTitleProp !== "undefined" ? pickerTitleProp : qsTr("Choose color")
+            color: Theme.fg
+            font.pixelSize: Theme.fontBody
+            font.bold: true
+        }
+
+        // 主编辑区
+        Row {
+            width: parent.width
+            height: 280 * Theme.scaleFactor
+            spacing: 16 * Theme.scaleFactor
+
+            // 左侧：饱和度/明度面板 + 色相条
+            Column {
+                width: parent.width - 148 * Theme.scaleFactor
+                height: parent.height
+                spacing: 10 * Theme.scaleFactor
+
+                // 饱和度/明度面板
+                Item {
+                    id: svPanel
+                    width: parent.width
+                    height: parent.height - Theme.rowH - parent.spacing
+
+                    Canvas {
+                        id: svCanvas
+                        anchors.fill: parent
+                        onPaint: {
+                            var ctx = getContext("2d");
+                            var w = width;
+                            var h = height;
+                            for (var y = 0; y < h; y++) {
+                                var v = 1 - y / h;
+                                var grad = ctx.createLinearGradient(0, 0, w, 0);
+                                grad.addColorStop(0, Qt.hsva(root.hue, 0, v, 1).toString());
+                                grad.addColorStop(1, Qt.hsva(root.hue, 1, v, 1).toString());
+                                ctx.fillStyle = grad;
+                                ctx.fillRect(0, y, w, 1);
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        id: svKnob
+                        width: 12 * Theme.scaleFactor
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: 2 * Theme.scaleFactor
+                        border.color: root.value > 0.5 ? "#000000" : "#ffffff"
+                        x: root.saturation * svPanel.width - width / 2
+                        y: (1 - root.value) * svPanel.height - height / 2
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        function updateFromMouse(mouse) {
+                            root.saturation = Math.max(0, Math.min(1, mouse.x / svPanel.width));
+                            root.value = Math.max(0, Math.min(1, 1 - mouse.y / svPanel.height));
+                        }
+                        onPressed: updateFromMouse(mouse)
+                        onPositionChanged: if (pressed) updateFromMouse(mouse)
+                    }
+
+                    // hue 变化后重绘 SV 面板
+                    Connections {
+                        target: root
+                        function onHueChanged() { svCanvas.requestPaint(); }
+                    }
+                }
+
+                // 色相条
+                Item {
+                    id: huePanel
+                    width: parent.width
+                    height: Theme.rowH
+
+                    Canvas {
+                        id: hueCanvas
+                        anchors.fill: parent
+                        onPaint: {
+                            var ctx = getContext("2d");
+                            var grad = ctx.createLinearGradient(0, 0, width, 0);
+                            for (var i = 0; i <= 6; i++) {
+                                grad.addColorStop(i / 6, Qt.hsva(i / 6, 1, 1, 1).toString());
+                            }
+                            ctx.fillStyle = grad;
+                            ctx.fillRect(0, 0, width, height);
+                        }
+                    }
+
+                    Rectangle {
+                        id: hueKnob
+                        width: 8 * Theme.scaleFactor
+                        height: parent.height + 4 * Theme.scaleFactor
+                        radius: 2 * Theme.scaleFactor
+                        color: "#ffffff"
+                        border.width: 1 * Theme.scaleFactor
+                        border.color: "#000000"
+                        x: root.hue * huePanel.width - width / 2
+                        y: -2 * Theme.scaleFactor
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        function updateFromMouse(mouse) {
+                            root.hue = Math.max(0, Math.min(1, mouse.x / huePanel.width));
+                        }
+                        onPressed: updateFromMouse(mouse)
+                        onPositionChanged: if (pressed) updateFromMouse(mouse)
+                    }
+                }
+            }
+
+            // 右侧：预览 + HEX + RGB + HSV
+            Column {
+                width: 132 * Theme.scaleFactor
+                height: parent.height
+                spacing: 8 * Theme.scaleFactor
+
+                // 颜色预览
+                Rectangle {
+                    width: parent.width
+                    height: 36 * Theme.scaleFactor
+                    radius: Theme.radius
+                    color: root.currentColor
+                    border.width: Theme.borderW
+                    border.color: Theme.borderClr
+                }
+
+                // HEX 输入
+                Column {
+                    width: parent.width
+                    spacing: 3 * Theme.scaleFactor
+
+                    Text {
+                        text: "HEX"
+                        color: Theme.muted
+                        font.pixelSize: Theme.fontTiny
+                    }
+
+                    Rectangle {
+                        width: parent.width
+                        height: 30 * Theme.scaleFactor
+                        radius: Theme.radius
+                        color: Theme.fieldBg
+                        border.width: Theme.borderW
+                        border.color: Theme.borderClr
+
+                        TextInput {
+                            id: hexInput
+                            anchors.fill: parent
+                            anchors.margins: Theme.padS
+                            verticalAlignment: TextInput.AlignVCenter
+                            horizontalAlignment: TextInput.AlignHCenter
+                            color: Theme.fg
+                            font.pixelSize: Theme.fontBody
+                            text: "#" + root.hexValue
+                            selectByMouse: true
+                            validator: RegularExpressionValidator { regularExpression: /^#[0-9A-Fa-f]{6}$/ }
+                            onEditingFinished: root.setColorFromHex(text)
+                        }
+                    }
+                }
+
+                // RGB 输入
+                Column {
+                    width: parent.width
+                    spacing: 4 * Theme.scaleFactor
+
+                    Repeater {
+                        model: ["R", "G", "B"]
+                        delegate: Row {
+                            width: parent.width
+                            spacing: 5 * Theme.scaleFactor
+
+                            Text {
+                                width: 14 * Theme.scaleFactor
+                                text: modelData
+                                color: Theme.muted
+                                font.pixelSize: Theme.fontTiny
+                                verticalAlignment: Text.AlignVCenter
+                                height: 26 * Theme.scaleFactor
+                            }
+
+                            Rectangle {
+                                width: parent.width - 19 * Theme.scaleFactor
+                                height: 26 * Theme.scaleFactor
+                                radius: Theme.radius
+                                color: Theme.fieldBg
+                                border.width: Theme.borderW
+                                border.color: Theme.borderClr
+
+                                TextInput {
+                                    anchors.fill: parent
+                                    anchors.margins: Theme.padS
+                                    verticalAlignment: TextInput.AlignVCenter
+                                    horizontalAlignment: TextInput.AlignRight
+                                    color: Theme.fg
+                                    font.pixelSize: Theme.fontBody
+                                    text: modelData === "R" ? root.rgbValue.r : (modelData === "G" ? root.rgbValue.g : root.rgbValue.b)
+                                    selectByMouse: true
+                                    validator: IntValidator { bottom: 0; top: 255 }
+                                    onEditingFinished: {
+                                        var v = parseInt(text, 10);
+                                        var r = root.rgbValue.r;
+                                        var g = root.rgbValue.g;
+                                        var b = root.rgbValue.b;
+                                        if (modelData === "R") r = v;
+                                        else if (modelData === "G") g = v;
+                                        else b = v;
+                                        var c = Qt.rgba(r / 255, g / 255, b / 255, 1.0);
+                                        root.hue = c.hsvHue;
+                                        root.saturation = c.hsvSaturation;
+                                        root.value = c.hsvValue;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // HSV 输入
+                Column {
+                    width: parent.width
+                    spacing: 4 * Theme.scaleFactor
+
+                    Repeater {
+                        model: ["H", "S", "V"]
+                        delegate: Row {
+                            width: parent.width
+                            spacing: 5 * Theme.scaleFactor
+
+                            Text {
+                                width: 14 * Theme.scaleFactor
+                                text: modelData
+                                color: Theme.muted
+                                font.pixelSize: Theme.fontTiny
+                                verticalAlignment: Text.AlignVCenter
+                                height: 26 * Theme.scaleFactor
+                            }
+
+                            Rectangle {
+                                width: parent.width - 19 * Theme.scaleFactor
+                                height: 26 * Theme.scaleFactor
+                                radius: Theme.radius
+                                color: Theme.fieldBg
+                                border.width: Theme.borderW
+                                border.color: Theme.borderClr
+
+                                TextInput {
+                                    anchors.fill: parent
+                                    anchors.margins: Theme.padS
+                                    verticalAlignment: TextInput.AlignVCenter
+                                    horizontalAlignment: TextInput.AlignRight
+                                    color: Theme.fg
+                                    font.pixelSize: Theme.fontBody
+                                    text: modelData === "H" ? root.hsvValue.h : (modelData === "S" ? root.hsvValue.s : root.hsvValue.v)
+                                    selectByMouse: true
+                                    validator: IntValidator { bottom: 0; top: modelData === "H" ? 359 : 100 }
+                                    onEditingFinished: {
+                                        var v = parseInt(text, 10);
+                                        if (modelData === "H") root.hue = Math.max(0, Math.min(359, v)) / 359;
+                                        else if (modelData === "S") root.saturation = Math.max(0, Math.min(100, v)) / 100;
+                                        else root.value = Math.max(0, Math.min(100, v)) / 100;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 基础颜色
+        Text {
+            text: root.labels.basicColors !== undefined ? root.labels.basicColors : "Basic colors"
+            color: Theme.muted
+            font.pixelSize: Theme.fontTiny
+        }
+
+        Grid {
+            width: parent.width
+            columns: 10
+            spacing: 5 * Theme.scaleFactor
+
+            Repeater {
+                model: root.presetColors
+                delegate: Rectangle {
+                    width: (parent.width - (parent.columns - 1) * parent.spacing) / parent.columns
+                    height: width
+                    radius: 3 * Theme.scaleFactor
+                    color: modelData
+                    border.width: Theme.borderW
+                    border.color: root.hexValue === String(modelData).replace("#", "") ? Theme.selectBorder : Theme.borderClr
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.setColorFromHex(modelData)
+                    }
+                }
+            }
+        }
+
+        // 自定义颜色
+        Row {
+            width: parent.width
+            spacing: Theme.gapM
+
+            Text {
+                text: root.labels.customColors !== undefined ? root.labels.customColors : "Custom colors"
+                color: Theme.muted
+                font.pixelSize: Theme.fontTiny
+                verticalAlignment: Text.AlignVCenter
+                height: parent.height
+                width: 92 * Theme.scaleFactor
+            }
+
+            Column {
+                width: parent.width - 92 * Theme.scaleFactor - customBtns.width - 2 * Theme.gapM
+                spacing: 4 * Theme.scaleFactor
+
+                Grid {
+                    width: parent.width
+                    columns: 8
+                    spacing: 5 * Theme.scaleFactor
+
+                    Repeater {
+                        model: root.customColors
+                        delegate: Rectangle {
+                            width: (parent.width - (parent.columns - 1) * parent.spacing) / parent.columns
+                            height: width
+                            radius: 3 * Theme.scaleFactor
+                            color: modelData !== "" ? modelData : Theme.fieldBg
+                            border.width: index === root.selectedCustomIndex ? 2 * Theme.scaleFactor : Theme.borderW
+                            border.color: index === root.selectedCustomIndex ? Theme.selectBorder : (root.hexValue === String(modelData).replace("#", "") ? Theme.selectBorder : Theme.borderClr)
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: modelData !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                onClicked: {
+                                    if (modelData !== "") {
+                                        root.setColorFromHex(modelData);
+                                        root.selectedCustomIndex = index;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 满员拒绝提示
+                Text {
+                    visible: root.customFullHint
+                    text: root.labels.customFull !== undefined ? root.labels.customFull : "Custom colors are full, delete one first"
+                    color: Theme.muted
+                    font.pixelSize: Theme.fontTiny
+                }
+            }
+
+            Column {
+                id: customBtns
+                spacing: 8 * Theme.scaleFactor
+                anchors.verticalCenter: parent.verticalCenter
+
+                MiniButton {
+                    size: "normal"
+                    text: root.labels.addToCustom !== undefined ? root.labels.addToCustom : "Add to custom colors"
+                    onClicked: root.addToCustomColors()
+                }
+
+                MiniButton {
+                    size: "normal"
+                    text: root.labels.deleteCustom !== undefined ? root.labels.deleteCustom : "Delete custom color"
+                    opacity: root.selectedCustomIndex >= 0 ? 1.0 : 0.5
+                    onClicked: root.deleteCustomColor()
+                }
+            }
+        }
+
+        // 屏幕取色
+        MiniButton {
+            size: "normal"
+            text: root.labels.pickScreenColor !== undefined ? root.labels.pickScreenColor : "Pick screen color"
+            visible: root.bridge !== null
+            onClicked: {
+                var hex = root.bridge.pickScreenColor();
+                if (hex !== "") root.setColorFromHex(hex);
+            }
+        }
+
+        // 按钮
+        DialogButtons {
+            anchors.horizontalCenter: parent.horizontalCenter
+            buttonLabels: typeof dialogButtonsProp !== "undefined" ? dialogButtonsProp : [qsTr("OK"), qsTr("Cancel")]
+            onClicked: function (index) {
+                if (index === 0) {
+                    var customs = [];
+                    for (var i = 0; i < root.customColors.length; i++)
+                        if (root.customColors[i] !== "") customs.push(root.customColors[i]);
+                    closeBridge.submit({ color: "#" + root.hexValue, customColors: customs });
+                } else {
+                    closeBridge.cancel();
+                }
+            }
+        }
+    }
+}

--- a/src/Plugins/Qt/qml/qmldir
+++ b/src/Plugins/Qt/qml/qmldir
@@ -1,6 +1,7 @@
 ConfirmClose 1.0 ConfirmClose.qml
 ConfirmQuestion 1.0 ConfirmQuestion.qml
 ConfirmRestart 1.0 ConfirmRestart.qml
+ColorPicker 1.0 ColorPicker.qml
 FormDialog 1.0 FormDialog.qml
 FontSelector 1.0 FontSelector.qml
 ParagraphFormat 1.0 ParagraphFormat.qml

--- a/src/Plugins/Qt/qt_color_picker_widget.cpp
+++ b/src/Plugins/Qt/qt_color_picker_widget.cpp
@@ -10,12 +10,13 @@
  ******************************************************************************/
 
 #include "qt_color_picker_widget.hpp"
+#include "QTMQmlDialog.hpp"
 #include "qt_utilities.hpp"
 
 #include "message.hpp"
 #include "scheme.hpp"
 
-#include <QColorDialog>
+#include <QColor>
 
 /**
  * Needed for whitebox_rep::display
@@ -28,9 +29,8 @@ operator<< (tm_ostream& out, const QColor& col) {
 qt_color_picker_widget_rep::qt_color_picker_widget_rep (command     call_back,
                                                         bool        pickPattern,
                                                         array<tree> proposals)
-    : _commandAfterExecution (call_back), _pickPattern (pickPattern) {
-  (void) proposals;
-}
+    : _commandAfterExecution (call_back), _pickPattern (pickPattern),
+      _proposals (proposals) {}
 
 qt_color_picker_widget_rep::~qt_color_picker_widget_rep () {}
 
@@ -65,16 +65,12 @@ qt_color_picker_widget_rep::plain_window_widget (string name, command q,
 void
 qt_color_picker_widget_rep::showDialog () {
   if (_pickPattern) {
-    // do stuff
+    // TODO: pattern picking is currently unsupported.
   }
   else {
-#if 0 //(QT_VERSION >= 0x040500)
-    QColor _sel = QColorDialog::getColor(Qt::white, 0, to_qstring(_windowTitle));
-#else
-    QColor _sel= QColorDialog::getColor (Qt::white);
-#endif
-    if (_sel.isValid ()) {
-      _commandAfterExecution (list_object (object (tree (from_qcolor (_sel)))));
+    tree sel= cpp_color_picker_dialog (_windowTitle, _proposals, _pickPattern);
+    if (is_compound (sel) && N (sel) > 0) {
+      _commandAfterExecution (list_object (object (sel[0])));
     }
   }
 }

--- a/src/Plugins/Qt/qt_color_picker_widget.hpp
+++ b/src/Plugins/Qt/qt_color_picker_widget.hpp
@@ -36,9 +36,10 @@ public:
   void showDialog ();
 
 protected:
-  string  _windowTitle;
-  command _commandAfterExecution;
-  bool    _pickPattern;
+  string      _windowTitle;
+  command     _commandAfterExecution;
+  bool        _pickPattern;
+  array<tree> _proposals;
 };
 
 #endif // QT_COLOR_PICKER_WIDGET_HPP

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -40,6 +40,14 @@ public:
   Q_INVOKABLE void startMove () {}
 };
 
+// ColorPicker 的 colorBridge 占位：pickScreenColor 返回空串（不取色）。
+class ColorStubBridge : public QObject {
+  Q_OBJECT
+public:
+  explicit ColorStubBridge (QObject* p= nullptr) : QObject (p) {}
+  Q_INVOKABLE QString pickScreenColor () { return QString (); }
+};
+
 class VersionStubBridge : public QObject {
   Q_OBJECT
   Q_PROPERTY (QString title READ title CONSTANT)
@@ -213,6 +221,7 @@ private slots:
   void test_version_escape_fallback_without_focus ();
   void test_version_long_line_wraps ();
   void test_statistics_loads ();
+  void test_color_picker_loads ();
 };
 
 // 共用：构造带 closeBridge/dpScale/isDark 的 QQuickWidget，加载给定 qrc url。
@@ -486,6 +495,41 @@ TestQmlLoad::test_version_long_line_wraps () {
     }
   QVERIFY (line);
   QTRY_VERIFY (line->height () > 40.0); // 单行 14*1.35≈19，换行后显著更高
+}
+
+void
+TestQmlLoad::test_color_picker_loads () {
+  // ColorPicker 顶层读取 pickerTitleProp / proposalsProp / pickPatternProp /
+  // initialColorProp / customColorsProp / labelsProp / dialogButtonsProp /
+  // colorBridge，注入最小占位保证文档实例化。
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge*      bridge  = new StubBridge (qw);
+  ColorStubBridge* cpBridge= new ColorStubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("colorBridge", cpBridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->rootContext ()->setContextProperty ("pickerTitleProp",
+                                          QString ("Choose color"));
+  qw->rootContext ()->setContextProperty (
+      "proposalsProp", QStringList ({"#ff0000", "#00ff00", "#0000ff"}));
+  qw->rootContext ()->setContextProperty ("pickPatternProp", false);
+  qw->rootContext ()->setContextProperty ("initialColorProp",
+                                          QString ("#ff0000"));
+  qw->rootContext ()->setContextProperty ("customColorsProp",
+                                          QStringList ({"#123456"}));
+  QVariantMap labels;
+  labels["basicColors"]    = QString ("Basic colors");
+  labels["customColors"]   = QString ("Custom colors");
+  labels["addToCustom"]    = QString ("Add to custom colors");
+  labels["pickScreenColor"]= QString ("Pick screen color");
+  qw->rootContext ()->setContextProperty ("labelsProp", labels);
+  qw->rootContext ()->setContextProperty ("dialogButtonsProp",
+                                          QStringList ({"OK", "Cancel"}));
+  qw->setSource (QUrl ("qrc:/qml/ColorPicker.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
 }
 
 QTEST_MAIN (TestQmlLoad)


### PR DESCRIPTION
## 任务
0928：用 QML 重构调色板，功能不能缺失，样式参考现有 QML 弹窗体系并更具现代感。

## What
将 Qt 原生 `QColorDialog` 实现的调色板替换为项目统一 QML 弹窗体系下的 `ColorPicker.qml`，保持 `widget-color-picker` / `interactive-color` / `interactive-background` 调用链不变。

## Why
- 旧实现直接调用 `QColorDialog::getColor`，风格与 Mogan 正在迁移的 QML 模态对话框体系不一致；
- QML 版本复用 `DialogShell` / `DialogButtons` / `Theme` 等原子组件，统一暗色/亮色、DPI 缩放、圆角与按钮交互。

## How
1. 新增 `src/Plugins/Qt/qml/ColorPicker.qml`：HSV 取色面板 + 色相条、HSV/RGB/HEX 数值输入、基础色块、实时预览、OK/Cancel；
2. 新增 `src/Plugins/Qt/ColorPickerBridge.*`：屏幕取色（抓屏快照 + 全屏十字光标 overlay 点选，Esc 取消；macOS 需屏幕录制权限，未授权返回空串，与 Qt 自带行为一致）；
3. `QTMQmlDialog.cpp/hpp` 新增阻塞式 glue 入口 `cpp_color_picker_dialog(title, proposals, pickPattern)`，走 `run_qml_dialog` exec 引擎，OK 返回 `(tuple "#rrggbb")`、Cancel 返回空 tuple；
4. `qt_color_picker_widget.cpp/hpp`：`showDialog()` 改调 `cpp_color_picker_dialog()`，解包 `sel[0]` 回调 scheme；
5. 自定义颜色 16 格增删：按序填空位、满格拒绝并显示提示行；OK 时经 preference `color picker custom colors` 跨会话持久化，Cancel 不保存；
6. 文案走 `qt_translate` 注入，zh_CN 字典按字母序新增 6 条；
7. `ai-docs/qml/qml-dialog.html` 新增 ColorPicker 设计稿面板；`qml_load_test.cpp` 新增 `test_color_picker_loads`。

## 功能对照（旧 QColorDialog → 新 QML）
- Basic colors 色块 ✅（预设 20 色）
- HSV / RGB / HTML(HEX) 数值输入 ✅
- Custom colors + Add to Custom Colors ✅（16 格，跨会话持久化；新增删除功能与满员提示）
- Pick Screen Color ✅（ColorPickerBridge 抓屏取色）

## 验证
- `xmake b stem` 构建通过 ✅
- `xmake b qml_load_test && xmake r qml_load_test`：15 passed, 0 failed ✅
- `gf fmt --changed-since=main` 无增量改动 ✅
- 测试钩子：`MOGAN_TEST_COLOR_PICKER=<hex>|cancel`，返回形状与真实路径一致
- 手动 GUI 验证（由用户完成）✅：确认按钮应用颜色、弹窗尺寸、右栏 HSV/RGB/HEX 输入完整显示、自定义颜色添加/删除/满员提示均通过

## 测试入口
- 菜单 Format → Color → Palette、Document → Color / Background color 等入口打开调色板
- `MOGAN_TEST_COLOR_PICKER=ff0000` / `cancel` 可绕过弹窗做契约测试
