### PR TITLE
[1185] 修复新会话首次发送失败导致欢迎页不切换

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -408,6 +408,15 @@
             ) ;
         ;; 延迟初始化：首次发送时设置 session body 并加载样式包
         (let ((plugin-ses (string-append "chat-tab:" session-id)))
+          ;; 消息编辑器懒创建（#4258）后，新会话首次发送时 message buffer
+          ;; 既不存在也无 view：with-buffer 经 buffer-focus 切视图，任一
+          ;; 不满足都会短路返回 #f，初始化代码因此永不执行。
+          ;; 先 buffer-set-body 直接建 buffer（不得用 view-passive 单独建，
+          ;; 其内部 buffer_load 对 tmfs://chat/* 会产出 Invalid tmfs
+          ;; document 错误文档），再 view-passive 补挂 passive view。
+          (when (not (buffer-exists? msg-buf))
+            (buffer-set-body msg-buf '(document "")))
+          (view-passive msg-buf)
           (with-buffer msg-buf
             (let ((msg-body (buffer-get-body msg-buf)))
               (when (chat-tab-buffer-empty? msg-body)

--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -415,7 +415,8 @@
           ;; 其内部 buffer_load 对 tmfs://chat/* 会产出 Invalid tmfs
           ;; document 错误文档），再 view-passive 补挂 passive view。
           (when (not (buffer-exists? msg-buf))
-            (buffer-set-body msg-buf '(document "")))
+            (buffer-set-body msg-buf '(document ""))
+          ) ;when
           (view-passive msg-buf)
           (with-buffer msg-buf
             (let ((msg-body (buffer-get-body msg-buf)))

--- a/devel/1185.md
+++ b/devel/1185.md
@@ -664,3 +664,46 @@ main 一致;保留功能改动。
 
 **保留**:delayed-kbd-map(chinese-kbd.scm)、chat-style 默认包去掉
 preview-ref(chat-style.scm)。
+
+## 修复新会话首次发送失败:界面停在欢迎页(2026-08-22)
+
+**What**:新会话(欢迎页)首次按 Enter/点发送按钮,消息发送失败,
+界面不切换到对话模式。分支 `da/1230/llm_enter`。
+
+**Why**:#4258 将消息区嵌入编辑器改为懒创建后,新会话首次发送时
+message buffer(`tmfs://chat/<sid>/message`)既不存在也无 view。而
+`chat-tab-session-send` 的初始化代码与 `chat-tab-append-round!` 都包在
+`with-buffer` 里,`with-buffer` 宏(cursor.scm)展开为
+
+```scheme
+(and (or (url? new) (string? new))
+     (buffer-exists? new)
+     (buffer-focus new #f)   ;; 无 view 时返回 #f
+     body ...)
+```
+
+buffer 不存在或无 view 任一不满足,整个 with-buffer **静默短路返回
+#f,函数体一行不执行**,`chat-tab-send` 恒返回 `#f`,`enterConversationMode`
+不会执行,表现为"欢迎页无法刷新"。eager 时代 buffer 由
+`texmacs_input_widget` 的 `create_buffer` 预先建立,问题被掩盖。
+
+二分定位:rc6 good / rc10 bad,`88b6d200e`(#4258)引入。
+
+**How**:在 `chat-tab-session-send` 进入 `with-buffer msg-buf` 前确保
+buffer 与 view 就绪(chat-protocol.scm,+9 行):
+
+```scheme
+(when (not (buffer-exists? msg-buf))
+  (buffer-set-body msg-buf '(document "")))
+(view-passive msg-buf)
+```
+
+- `buffer-set-body` 对缺失 buffer 走 `insert_buffer` 直接创建,**不得**
+  单独用 `view-passive` 建 buffer:其内部 `concrete_buffer_insist` 对
+  不存在的 buffer 走 `buffer_load`,`tmfs://chat/*` 无加载器,会产出
+  "Invalid tmfs document." 错误文档,污染首条消息。
+- 随后 `view-passive` 只补挂 passive view(buffer 已存在,不再触发
+  load),使 `buffer-focus` 可成功返回。
+
+**验证**:手动 GUI 测试——新会话输入文字按 Enter,消息正常发送、欢迎页
+正常切换到对话模式;连续多轮对话、恢复历史会话均正常。


### PR DESCRIPTION
## 问题

新会话(欢迎页)首次按 Enter 或点击发送按钮,消息发送失败,界面不切换到对话模式。用户报告 v2026.3.0-rc6 good / rc10 bad,二分定位到 #4258(消息区嵌入编辑器懒创建,`88b6d200e`)。

## 根因

懒创建后,新会话首次发送时 message buffer(`tmfs://chat/<sid>/message`)既不存在也无 view。而 `chat-tab-session-send` 的初始化代码与 `chat-tab-append-round!` 都包在 `with-buffer` 里,该宏展开为:

```scheme
(and (or (url? new) (string? new))
     (buffer-exists? new)
     (buffer-focus new #f)   ;; 无 view 时返回 #f
     body ...)
```

buffer 不存在或无 view 任一不满足,整个 `with-buffer` **静默短路返回 #f,函数体一行不执行**。`chat-tab-send` 恒返回 `#f`,`enterConversationMode` 不会执行,表现为"欢迎页无法刷新"。eager 时代 buffer 由 `texmacs_input_widget` 的 `create_buffer` 预先建立,问题被掩盖。

## 修复

在 `chat-tab-session-send` 进入 `with-buffer msg-buf` 前(`chat-protocol.scm`,+9 行):

```scheme
(when (not (buffer-exists? msg-buf))
  (buffer-set-body msg-buf '(document "")))
(view-passive msg-buf)
```

- `buffer-set-body` 对缺失 buffer 走 `insert_buffer` 直接创建。**不得**单独用 `view-passive` 建 buffer:其内部 `concrete_buffer_insist` 对不存在的 buffer 走 `buffer_load`,`tmfs://chat/*` 无加载器,会产出 "Invalid tmfs document." 错误文档
- 随后 `view-passive` 只补挂 passive view(buffer 已存在,不再触发 load),使 `buffer-focus` 成功返回

## 测试

- 手动 GUI 验证:新会话输入文字按 Enter,消息正常发送、欢迎页正常切换到对话模式;连续多轮对话、恢复历史会话均正常 ✅
- `xmake b stem` 构建通过 ✅

任务文档:`devel/1185.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)