### PR TITLE
[1230] 修复 LLM 首次对话 %chat 回显漏出到 session 文档末尾

### DIFF
--- a/devel/1230.md
+++ b/devel/1230.md
@@ -1,0 +1,65 @@
+# [1230] LLM 首次对话 %chat 行漏出到会话文档末尾
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 现象
+
+Chat tab 新会话第一次发送时，插件回显的 `%chat {json}` 行没有被插入到
+第一个 `unfolded-io-text` 的输出域，而是落到了 session 文档的最外层末尾
+（所有 io 节点之后）。第二次发送行为正常（%chat 行在对应 io 的输出域内）。
+
+```
+<\session|llm|chat-tab:UUID>
+  <\unfolded-io-text> VLM> ... qiqiqi ... script-busy </unfolded-io-text>
+  <\unfolded-io-text> llm> ... 888 ... %chat{...888...} </unfolded-io-text>
+  %chat {"content":"qiqiqi",...}   <-- 漏出到这里
+</session>
+```
+
+## 3 任务相关的代码文件
+- TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+- TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
+- TeXmacs/progs/utils/plugins/plugin-eval.scm
+
+## 4 如何测试
+
+### 4.1 手动验证
+新建 Chat 会话，连发两条消息，保存后检查 .tm：两轮 %chat 行都应在
+各自 `unfolded-io-text` 内，session 文档顶层不应出现裸的 %chat 字符串。
+
+## 5 What
+
+在 `ChatController::onSendRequested` 中，把 `panel->ensureMessageWidget ()`
+提前到 scheme `chat-tab-send` 调用之前（原先在发送成功后的
+`panel->enterConversationMode ()` 里才懒创建）。
+
+## 6 Why
+
+首次发送的时序是：
+
+1. C++ 调 scheme `chat-tab-send`，scheme 在 message buffer 里追加
+   `unfolded-io-text` 并把输出域节点指针（`tree->tree-pointer`）存进
+   plugin pending 队列；
+2. scheme 返回 `#t`，C++ `enterConversationMode()` → `ensureMessageWidget()`
+   → `texmacs_input_widget(..., msgBufUrl)` 对已存在 buffer 执行
+   set_buffer_tree **整体覆盖**，buffer 换成内容相同的新树；
+3. 插件回显到达时 pending 队列里的 `out` 指针已指向被替换的旧树，
+   observer 退化为文档级：`%chat {json}` 回显被插到 session 文档最外层
+   末尾，`tree-set out :up 0` 的 prompt 更新也失效（首轮 prompt 停留在
+   `VLM>` 而非 `llm>`）。
+
+第二轮发送时 widget 已存在，`ensureMessageWidget` 直接返回，树不会被替换，
+故只有第一次对话泄漏。
+
+## 7 How
+
+把消息编辑器的懒创建挪到 scheme 发送之前：指针捕获发生在树被（可能的）
+set_buffer_tree 替换之后，指针全程有效。`ensureMessageWidget` 只创建
+widget、不切换欢迎页可见性，`enterConversationMode` 的欢迎页切换时序
+（[1185] 首次发送失败不切页）不受影响。
+
+## 8 涉及文件
+
+- src/Plugins/Qt/qt_chat_controller.cpp
+

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -217,6 +217,12 @@ ChatController::onSendRequested (const string& sessionId) {
     }
   }
 
+  // 必须在 scheme 发送之前创建消息编辑器：texmacs_input_widget 对已存在
+  // buffer 会 set_buffer_tree 整体覆盖，若放在 chat-tab-send 之后，scheme
+  // 侧记录的输出节点指针会指向被替换的旧树，导致首轮 %chat 回显漏出到
+  // session 文档末尾（devel/1230.md）
+  panel->ensureMessageWidget ();
+
   if (!as_bool (
           call ("chat-tab-send", sessionId, session->model,
                 session->thinking ? string ("enabled") : string ("disabled"),


### PR DESCRIPTION
## 问题

Chat tab 新会话第一次发送时，插件回显的 `%chat {json}` 行没有被插入到第一个 `unfolded-io-text` 的输出域，而是漏出到 session 文档最外层末尾；且首轮 prompt 停留在模型名（如 `VLM>`）而未更新为 `llm>`。第二次发送行为正常。

## 根因

首次发送时序：

1. C++ 调 scheme `chat-tab-send`，scheme 在 message buffer 追加 io 节点并把输出域指针（`tree->tree-pointer`）存入 plugin pending 队列；
2. scheme 返回后，C++ `enterConversationMode()` → `ensureMessageWidget()` → `texmacs_input_widget` 对已存在 buffer 执行 set_buffer_tree **整体覆盖**；
3. 回显到达时指针已指向被替换的旧树，observer 退化为文档级 → 插入落到 session 文档末尾、prompt 更新失效。

第二轮 widget 已存在，树不再被替换，故仅首次对话泄漏。

## 修复

`ChatController::onSendRequested` 中把 `panel->ensureMessageWidget()` 提前到 scheme 发送之前：指针捕获发生在树替换之后，全程有效。`ensureMessageWidget` 只创建 widget、不切欢迎页，不影响 [1185] 首次发送失败不切页的语义。

详见 `devel/1230.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)