### PR TITLE
[0930] 魔法粘贴支持 ChatGPT 新版前端公式结构

### DIFF
--- a/TeXmacs/plugins/html/progs/html/htmltm.scm
+++ b/TeXmacs/plugins/html/progs/html/htmltm.scm
@@ -637,6 +637,23 @@
   ) ;let*
 ) ;define
 
+;; ChatGPT 行间公式判定：style 含 display:block，或首个子节点为 katex-display
+;;
+;; ChatGPT 新版前端（KaTeX 客户端布局）不再输出 katex-mathml / MathML，
+;; LaTeX 源码改放在 role="math" 节点的 data-math-source 属性（aria-label 兜底）；
+;; 源码不含定界符，htmltm-span 按行内/行间包上 \( \) 或 \[ \] 后走标准 LaTeX 导入
+
+(define (htmltm-chatgpt-display? a c)
+  (let ((style (string-replace (or (shtml-attr-non-null a 'style) "") " " "")))
+    (or (string-contains? style "display:block")
+      (and (pair? c)
+        (func? (car c) 'h:span)
+        (== (shtml-attr-non-null (sxml-attr-list (car c)) 'class) "katex-display")
+      ) ;and
+    ) ;or
+  ) ;let
+) ;define
+
 (define (htmltm-span env a c)
   (with class-value
     (shtml-attr-non-null a 'class)
@@ -657,6 +674,25 @@
            (begin
              (htmltm env (first c))
            ) ;begin
+          ) ;
+
+          ((and (== (shtml-attr-non-null a 'role) "math")
+             (or (shtml-attr-non-null a 'data-math-source)
+               (shtml-attr-non-null a 'aria-label)
+             ) ;or
+           ) ;and
+           (let* ((latex-src (or (shtml-attr-non-null a 'data-math-source)
+                               (shtml-attr-non-null a 'aria-label)
+                             ) ;or
+                  ) ;latex-src
+                  (wrapped (if (htmltm-chatgpt-display? a c)
+                             (string-append "\\[ " latex-src " \\]")
+                             (string-append "\\( " latex-src " \\)")
+                           ) ;if
+                  ) ;wrapped
+                 ) ;
+             (list (tm->stree (latex->texmacs (parse-latex wrapped))))
+           ) ;let*
           ) ;
 
           ((and (== class-value "ztext-math"))

--- a/TeXmacs/tests/0930.scm
+++ b/TeXmacs/tests/0930.scm
@@ -45,37 +45,39 @@
 
 (define (test-chatgpt-inline-math)
   (check (convert gpt-inline "html-snippet" "texmacs-stree")
-    => '(concat "inline "
-          (math (concat "f" (rprime "'") (around "(" "x" ")")))
-          " end"
-        ) ;concat
+    =>
+    '(concat "inline "
+       (math (concat "f" (rprime "'") (around "(" "x" ")")))
+       " end")
   ) ;check
 ) ;define
 
 (define (test-chatgpt-display-math)
   (check (convert gpt-display "html-snippet" "texmacs-stree")
-    => '(document "before"
-          (equation*
-           (concat (big "int") (rsub "0") (rsup "1") "x" (rsup "2") "*"
-             (space "0.17em") "d*x"
-           ) ;concat
-          ) ;equation*
-          "after"
-        ) ;document
+    =>
+    '(document "before"
+       (equation* (concat (big "int")
+                    (rsub "0")
+                    (rsup "1")
+                    "x"
+                    (rsup "2")
+                    "*"
+                    (space "0.17em")
+                    "d*x"))
+       "after")
   ) ;check
 ) ;define
 
 (define (test-chatgpt-display-multiline)
   (check (convert gpt-display-multiline "html-snippet" "texmacs-stree")
-    => '(equation* (concat "a=b" (next-line) "c=d"))
+    =>
+    '(equation* (concat "a=b" (next-line) "c=d"))
   ) ;check
 ) ;define
 
 (define (test-chatgpt-aria-label-fallback)
   ;; 缺 data-math-source 时用 aria-label 兜底
-  (check (convert gpt-aria-only "html-snippet" "texmacs-stree")
-    => '(math "y=x")
-  ) ;check
+  (check (convert gpt-aria-only "html-snippet" "texmacs-stree") => '(math "y=x"))
 ) ;define
 
 (define (test-legacy-katex-unchanged)
@@ -85,7 +87,10 @@
 
 (define (test-role-math-without-source-unchanged)
   ;; role="math" 但无源码属性时仍走通用 MathML 路径
-  (check (convert gpt-no-source-mathml "html-snippet" "texmacs-stree") => '(math "z"))
+  (check (convert gpt-no-source-mathml "html-snippet" "texmacs-stree")
+    =>
+    '(math "z")
+  ) ;check
 ) ;define
 
 (tm-define (test_0930)

--- a/TeXmacs/tests/0930.scm
+++ b/TeXmacs/tests/0930.scm
@@ -1,0 +1,99 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0930.scm
+;; DESCRIPTION : Tests for magic paste of ChatGPT's new-frontend HTML
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;; ChatGPT 新版前端（2026-08 起，KaTeX 客户端布局）的公式标记：
+;; 不再输出 katex-mathml / MathML annotation，LaTeX 源码保存在
+;; role="math" 节点的 data-math-source 属性（aria-label 兜底），
+;; 行间公式带 style="display: block;" 且首个子节点为 katex-display。
+
+(define gpt-inline
+  "<p>inline <span data-start=\"119\" data-end=\"128\" role=\"math\" aria-label=\"f'(x)\" data-math-source=\"f'(x)\" data-client-katex-layout=\"\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\">f'(x)</span></span></span></span> end</p>"
+) ;define
+
+(define gpt-display
+  "<p>before</p><span data-start=\"479\" data-end=\"507\" role=\"math\" aria-label=\"\\int_0^1 x^2\\,dx\" data-math-source=\"\\int_0^1 x^2\\,dx\" data-client-katex-layout=\"\" style=\"display: block;\"><span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\">int01x2dx</span></span></span></span></span><p>after</p>"
+) ;define
+
+(define gpt-display-multiline
+  "<span role=\"math\" data-math-source=\"a=b \\\\ c=d\" data-client-katex-layout=\"\" style=\"display: block;\"><span class=\"katex-display\"><span class=\"katex\"></span></span></span>"
+) ;define
+
+(define gpt-aria-only
+  "<span role=\"math\" aria-label=\"y=x\"><span class=\"katex\"></span></span>"
+) ;define
+
+(define gpt-legacy-katex
+  "<span class=\"katex\"><span class=\"katex-mathml\"><math><semantics><mrow><mi>x</mi></mrow><annotation encoding=\"application/x-tex\">x</annotation></semantics></math></span><span class=\"katex-html\" aria-hidden=\"true\"></span></span>"
+) ;define
+
+(define gpt-no-source-mathml
+  "<span role=\"math\"><span class=\"katex\"><span class=\"katex-mathml\"><math><mi>z</mi></math></span></span></span>"
+) ;define
+
+(define (test-chatgpt-inline-math)
+  (check (convert gpt-inline "html-snippet" "texmacs-stree")
+    => '(concat "inline "
+          (math (concat "f" (rprime "'") (around "(" "x" ")")))
+          " end"
+        ) ;concat
+  ) ;check
+) ;define
+
+(define (test-chatgpt-display-math)
+  (check (convert gpt-display "html-snippet" "texmacs-stree")
+    => '(document "before"
+          (equation*
+           (concat (big "int") (rsub "0") (rsup "1") "x" (rsup "2") "*"
+             (space "0.17em") "d*x"
+           ) ;concat
+          ) ;equation*
+          "after"
+        ) ;document
+  ) ;check
+) ;define
+
+(define (test-chatgpt-display-multiline)
+  (check (convert gpt-display-multiline "html-snippet" "texmacs-stree")
+    => '(equation* (concat "a=b" (next-line) "c=d"))
+  ) ;check
+) ;define
+
+(define (test-chatgpt-aria-label-fallback)
+  ;; 缺 data-math-source 时用 aria-label 兜底
+  (check (convert gpt-aria-only "html-snippet" "texmacs-stree")
+    => '(math "y=x")
+  ) ;check
+) ;define
+
+(define (test-legacy-katex-unchanged)
+  ;; 旧版 katex-mathml（MathML annotation）路径不受影响
+  (check (convert gpt-legacy-katex "html-snippet" "texmacs-stree") => '(math "x"))
+) ;define
+
+(define (test-role-math-without-source-unchanged)
+  ;; role="math" 但无源码属性时仍走通用 MathML 路径
+  (check (convert gpt-no-source-mathml "html-snippet" "texmacs-stree") => '(math "z"))
+) ;define
+
+(tm-define (test_0930)
+  (test-chatgpt-inline-math)
+  (test-chatgpt-display-math)
+  (test-chatgpt-display-multiline)
+  (test-chatgpt-aria-label-fallback)
+  (test-legacy-katex-unchanged)
+  (test-role-math-without-source-unchanged)
+  (check-report)
+) ;tm-define

--- a/devel/0930.md
+++ b/devel/0930.md
@@ -1,0 +1,85 @@
+# [0930] 修复魔法粘贴不支持 ChatGPT（新版前端 KaTeX 客户端布局）
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/html/progs/html/htmltm.scm` - HTML→TeXmacs 转换，`htmltm-span` 新增 ChatGPT 新版公式分支
+- `TeXmacs/tests/0930.scm` - 集成测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（集成测试）
+```bash
+xmake r 0930
+```
+
+回归测试：
+```bash
+xmake r 2042   # 魔法粘贴快捷键
+xmake r 0195   # Scheme 粘贴
+xmake r 0407   # LaTeX 导入
+xmake r generic-edit-test
+```
+
+### 3.2 非确定性测试（手动验证）
+1. 浏览器打开 ChatGPT，让它回答一个包含行内公式和行间公式的问题。
+2. 选中回答内容复制（或点回答下方的复制按钮后复制渲染区域）。
+3. 在 Mogan 中 `Ctrl+Shift+V`（或 编辑→魔法粘贴）。
+4. 预期：行内公式进入 `(math ...)`，行间公式成为独立 `equation*` 公式行，不再是乱码文本。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+xmake r 0930
+```
+
+## 5 What
+
+修复魔法粘贴无法正确粘贴 ChatGPT 网页内容的问题：公式全部退化成渲染后的乱码纯文本
+（如 `∫01x2dx`），行内/行间结构完全丢失。
+
+## 6 Why
+
+ChatGPT 前端升级后公式 DOM 结构变化：旧版输出 `<span class="katex"><span
+class="katex-mathml"><math>...<annotation encoding="application/x-tex">`（MathML + LaTeX
+注解），Mogan 通过 `htmltm-span` 的 katex 分支取 MathML 转换。
+
+新版（2026-08 抓取的实际剪贴板标记）改为 KaTeX 客户端布局，**不再输出任何 MathML**：
+
+```html
+<!-- 行内 -->
+<span role="math" aria-label="f'(x)" data-math-source="f'(x)" data-client-katex-layout="">
+  <span class="katex"><span class="katex-html" aria-hidden="true">...</span></span>
+</span>
+<!-- 行间：style="display: block;" 且首个子节点为 katex-display -->
+<span role="math" data-math-source="\int_0^1 x^2\,dx" data-client-katex-layout="" style="display: block;">
+  <span class="katex-display"><span class="katex">...</span></span>
+</span>
+```
+
+LaTeX 源码只保留在 `role="math"` 节点的 `data-math-source` 属性（`aria-label` 内容相同，
+可作兜底），子树里只剩 `katex-html` 视觉渲染文本。旧代码既不匹配 katex 分支（没有
+`katex-mathml` 子节点），也不匹配知乎/豆包分支，落入通用 `htmltm-pass`，把视觉渲染文本
+当正文粘贴，公式丢失。
+
+## 7 How
+
+`htmltm-span` 新增分支（放在旧 katex 分支之后、知乎分支之前）：
+
+1. 命中条件：`role="math"` 且带非空 `data-math-source`（缺省时用 `aria-label` 兜底）。
+2. 取出 LaTeX 源码后按行内/行间包定界符：行间（`htmltm-chatgpt-display?`：`style` 含
+   `display:block` 或首个子节点 class 为 `katex-display`）包 `\[ \]`，否则包 `\( \)`，
+   再走标准 `parse-latex` → `latex->texmacs` 导入，产出与原 MathML 路径一致的
+   `(math ...)` / `(equation* ...)` 形状。
+3. 不带源码属性的 `role="math"` 节点（子树含真实 MathML 的情况）不命中该分支，仍走
+   通用 MathML 路径，行为不变。
+
+## 8 涉及文件
+
+- `TeXmacs/plugins/html/progs/html/htmltm.scm`：
+  - 新增 `htmltm-chatgpt-display?`：判定 ChatGPT 行间公式。
+  - `htmltm-span`：新增 `role="math"` + `data-math-source`/`aria-label` 分支。
+- `TeXmacs/tests/0930.scm`：新增集成测试，覆盖行内、行间、多行行间、aria-label 兜底、
+  旧版 katex-mathml 回归、无源码属性的 role=math 回归共 6 项断言。

--- a/devel/0930.md
+++ b/devel/0930.md
@@ -83,3 +83,18 @@ LaTeX 源码只保留在 `role="math"` 节点的 `data-math-source` 属性（`ar
   - `htmltm-span`：新增 `role="math"` + `data-math-source`/`aria-label` 分支。
 - `TeXmacs/tests/0930.scm`：新增集成测试，覆盖行内、行间、多行行间、aria-label 兜底、
   旧版 katex-mathml 回归、无源码属性的 role=math 回归共 6 项断言。
+
+## 9 已知限制
+
+本修复只覆盖剪贴板 HTML 中**包含** `role="math"` 包裹节点的情况（如整段/整条消息复制，
+或复制回答的渲染区域）。若用户只选中公式本身复制，浏览器选区序列化只取公共祖先
+（内层 `.katex`/`.katex-html`）以下的子树，`role="math"` 包裹节点整个不进剪贴板，
+`data-math-source` 无从读取，公式仍退化为渲染文本。
+
+该场景需要从 `katex-html` 视觉 DOM（`.mord`/`.msupsub`/`.vlist` 等结构）反推 LaTeX，
+涉及对 KaTeX 输出格式的逆向解析，作为后续独立任务处理；本任务不展开。
+
+## 10 手动验证状态
+
+尚未完成真实 GUI 手动验证（需要从 chatgpt.com 实际复制内容并用 `Ctrl+Shift+V` 粘贴）。
+自动化测试（`xmake r 0930`，6 项断言）基于 2026-08 实际抓取的 ChatGPT 标记样本。


### PR DESCRIPTION
# [0930] 魔法粘贴支持 ChatGPT 新版前端公式结构

## 问题现象

从 ChatGPT 网页复制包含公式的内容，用魔法粘贴（`Ctrl+Shift+V`）粘贴进 Mogan 时，公式全部退化为渲染后的乱码纯文本（如 `\int_0^1 x^2\,dx` 变成 `int01x2dx`），行内/行间公式结构完全丢失。

## 根因

ChatGPT 前端已升级为 KaTeX 客户端布局（2026-08 实抓的剪贴板标记），公式 DOM 不再输出任何 MathML：

**旧版**（Mogan 现有 `htmltm-span` katex 分支支持的）：

```html
<span class="katex">
  <span class="katex-mathml"><math>...<annotation encoding="application/x-tex">...</annotation></math></span>
  <span class="katex-html" aria-hidden="true">...</span>
</span>
```

**新版**：

```html
<!-- 行内 -->
<span role="math" aria-label="f'(x)" data-math-source="f'(x)" data-client-katex-layout="">
  <span class="katex"><span class="katex-html" aria-hidden="true">...</span></span>
</span>
<!-- 行间：style="display: block;" 且首个子节点为 katex-display -->
<span role="math" data-math-source="\int_0^1 x^2\,dx" style="display: block;">
  <span class="katex-display"><span class="katex">...</span></span>
</span>
```

LaTeX 源码只保留在 `role="math"` 节点的 `data-math-source` 属性中。旧代码的 katex 分支要求存在 `katex-mathml` 子节点，新版标记匹配不上，落入通用路径把视觉渲染文本当正文粘贴。

## 修复方式

`htmltm-span` 新增分支（`TeXmacs/plugins/html/progs/html/htmltm.scm`）：

1. 命中条件：`role="math"` 且带非空 `data-math-source`（缺失时用 `aria-label` 兜底）。
2. 取出 LaTeX 源码后按行内/行间包定界符：行间（新增 `htmltm-chatgpt-display?` 判定：`style` 含 `display:block` 或首个子节点 class 为 `katex-display`）包 `\[ \]`，否则包 `\( \)`，再走标准 `parse-latex` → `latex->texmacs` 导入，产出与原 MathML 路径一致的 `(math ...)` / `(equation* ...)`。
3. 不带源码属性的 `role="math"` 节点不命中该分支，仍走通用 MathML 路径，行为不变。

## 测试

新增集成测试 `TeXmacs/tests/0930.scm`（`xmake r 0930`，6 项断言全过）：行内公式、行间公式、多行行间公式、aria-label 兜底、旧版 katex-mathml 回归、无源码属性 `role="math"` 回归。测试样本取自 2026-08 实际抓取的 ChatGPT 标记。

回归测试通过：`2042`（魔法粘贴快捷键）、`0195`、`0407`、`generic-edit-test`。
注：本地 `0622`、`0339` 在未打本补丁的主干上同样失败，属主干既有问题，与本改动无关。

## 已知限制

本修复覆盖剪贴板 HTML 中包含 `role="math"` 包裹节点的场景（整段/整条消息复制、复制回答渲染区域）。若只选中公式本身复制，浏览器选区序列化只取内层 `.katex`/`.katex-html` 子树，`role="math"` 节点不进剪贴板，`data-math-source` 无从读取。该场景需从 `katex-html` 视觉 DOM 反推 LaTeX，作为后续独立任务处理（详见 `devel/0930.md` 第 9 节）。

## 手动验证步骤

1. 浏览器打开 chatgpt.com，提问一个包含行内公式和行间公式的问题。
2. 选中整段回答复制（或使用回答下方的复制按钮区域）。
3. 在 Mogan 中 `Ctrl+Shift+V`（编辑→魔法粘贴）。
4. 预期：行内公式进入行内数学模式，行间公式成为独立公式行。
