### PR TITLE
[1231] 非社区版增加 Ghost text 实验选项（默认关闭）

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -1072,6 +1072,7 @@
 ("graphical effects" "图形效果")
 ("graphical interface" "图形界面")
 ("ghost lines" "智能标尺")
+("Ghost text" "幽灵文本补全")
 ("graphics geometry" "画布设置")
 ("graphics grids" "网格设置")
 ("graphics overlay" "图形图层")

--- a/TeXmacs/progs/generic/ghost-text.scm
+++ b/TeXmacs/progs/generic/ghost-text.scm
@@ -40,7 +40,10 @@
 
 (tm-define (is-ghost-active?) ghost-active?)
 
-(tm-define (ghost-enable?) (defined? 'ghost-cloud-predict))
+;; 实验选项「Ghost text」（仅非社区版展示，默认关闭）
+(tm-define (ghost-enable?)
+  (and (defined? 'ghost-cloud-predict) (get-boolean-preference "ghost text"))
+) ;tm-define
 
 ;; =============================================================================
 ;; Context collection

--- a/TeXmacs/progs/kernel/texmacs/pref-keys.scm
+++ b/TeXmacs/progs/kernel/texmacs/pref-keys.scm
@@ -227,6 +227,7 @@
 (define-public (pref-experimental-encryption) "experimental encryption")
 (define-public (pref-experimental-use-native-menubar) "use native menubar")
 (define-public (pref-experimental-use-unified-toolbar) "use unified toolbar")
+(define-public (pref-experimental-ghost-text) "ghost text")
 (define-public (pref-prog-highlight-brackets) "prog:highlight brackets")
 (define-public (pref-prog-automatic-brackets) "prog:automatic brackets")
 (define-public (pref-prog-select-brackets) "prog:select brackets")

--- a/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-widgets.scm
@@ -920,146 +920,164 @@
 ;; ---- Other / Experimental fields（双栏 toggles，带平台条件过滤） ----
 
 (define preferences-qml-other-experimental-fields
-  (list
-    ;; 双栏布局（layout 'two-col）：左栏 column 0、右栏 column 1。
-    (list (pref-experimental-fast-environments)
-      "Fast environments"
+  (append (list
+            ;; 双栏布局（layout 'two-col）：左栏 column 0、右栏 column 1。
+            (list (pref-experimental-fast-environments)
+              "Fast environments"
+              '()
+              '()
+              #f
+              'group
+              "Experimental features (to be used with care)"
+              'group-span
+              #t
+              'layout
+              'two-col
+              'column
+              0
+            ) ;list
+            (list (pref-experimental-alpha)
+              "Alpha transparency"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              0
+            ) ;list
+            (list (pref-experimental-new-style-page-breaking)
+              "New style page breaking"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              0
+            ) ;list
+            (list (pref-experimental-encryption)
+              "Encryption"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              0
+            ) ;list
+            (list (pref-experimental-use-native-menubar)
+              "Use native menubar"
+              '()
+              '()
+              #f
+              'hint
+              (hint-macos-only)
+              'layout
+              'two-col
+              'column
+              0
+              'platform-filter
+              'macos-only
+            ) ;list
+            ;; 右栏（column 1）—— Experimental 程序员 / 搜索 / 打印 等。
+            (list (pref-prog-highlight-brackets)
+              "Program bracket matching"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              1
+            ) ;list
+            (list (pref-prog-automatic-brackets)
+              "Automatic program brackets"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              1
+            ) ;list
+            (list (pref-prog-select-brackets)
+              "Program bracket selections"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              1
+            ) ;list
+            (list (pref-case-insensitive-match)
+              "Case-insensitive search"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              1
+            ) ;list
+            (list (pref-gui-print-dialogue)
+              "Use print dialogue"
+              '()
+              '()
+              #f
+              'hint
+              (hint-qt-only)
+              'layout
+              'two-col
+              'column
+              1
+              'platform-filter
+              'qt-only
+            ) ;list
+            (list (pref-texlive-fonts)
+              "Use fonts in texlive"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              1
+            ) ;list
+            (list (pref-experimental-use-unified-toolbar)
+              "Use unified toolbars"
+              '()
+              '()
+              #f
+              'hint
+              (hint-macos-only)
+              'layout
+              'two-col
+              'column
+              1
+              'platform-filter
+              'macos-only
+            ) ;list
+          ) ;list
+    ;; ghost text 触发开关仅非社区版展示（社区版无 ghost-cloud-predict，本来就不触发）。
+    ;; 不能作为 (list ...) 的条件元素——社区版下求值成 '()，build-tab 逐字段
+    ;; field->descriptor 会对 '() 做 list-ref 越界崩溃。
+    (if (community-stem?)
       '()
-      '()
-      #f
-      'group
-      "Experimental features (to be used with care)"
-      'group-span
-      #t
-      'layout
-      'two-col
-      'column
-      0
-    ) ;list
-    (list (pref-experimental-alpha)
-      "Alpha transparency"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      0
-    ) ;list
-    (list (pref-experimental-new-style-page-breaking)
-      "New style page breaking"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      0
-    ) ;list
-    (list (pref-experimental-encryption)
-      "Encryption"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      0
-    ) ;list
-    (list (pref-experimental-use-native-menubar)
-      "Use native menubar"
-      '()
-      '()
-      #f
-      'hint
-      (hint-macos-only)
-      'layout
-      'two-col
-      'column
-      0
-      'platform-filter
-      'macos-only
-    ) ;list
-    ;; 右栏（column 1）—— Experimental 程序员 / 搜索 / 打印 等。
-    (list (pref-prog-highlight-brackets)
-      "Program bracket matching"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      1
-    ) ;list
-    (list (pref-prog-automatic-brackets)
-      "Automatic program brackets"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      1
-    ) ;list
-    (list (pref-prog-select-brackets)
-      "Program bracket selections"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      1
-    ) ;list
-    (list (pref-case-insensitive-match)
-      "Case-insensitive search"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      1
-    ) ;list
-    (list (pref-gui-print-dialogue)
-      "Use print dialogue"
-      '()
-      '()
-      #f
-      'hint
-      (hint-qt-only)
-      'layout
-      'two-col
-      'column
-      1
-      'platform-filter
-      'qt-only
-    ) ;list
-    (list (pref-texlive-fonts)
-      "Use fonts in texlive"
-      '()
-      '()
-      #f
-      'layout
-      'two-col
-      'column
-      1
-    ) ;list
-    (list (pref-experimental-use-unified-toolbar)
-      "Use unified toolbars"
-      '()
-      '()
-      #f
-      'hint
-      (hint-macos-only)
-      'layout
-      'two-col
-      'column
-      1
-      'platform-filter
-      'macos-only
-    ) ;list
-  ) ;list
+      (list (list (pref-experimental-ghost-text)
+              "Ghost text"
+              '()
+              '()
+              #f
+              'layout
+              'two-col
+              'column
+              0
+            ) ;list
+      ) ;list
+    ) ;if
+  ) ;append
 ) ;define
 
 ;; 字段格式解析 / flag->assoc / 平台过滤 / current-value / resolve-options /

--- a/TeXmacs/progs/texmacs/texmacs/tm-server.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-server.scm
@@ -148,6 +148,7 @@
  ("gui:line-input:autocommit" "on" noop)
  ("use native menubar" (get-default-native-menubar) noop)
  ("use unified toolbar" (get-default-unified-toolbar) noop)
+ ("ghost text" "off" noop)
  ("texmacs->image:format" "png" noop)
  ("autobackup" "on" noop)
 ) ;define-preferences

--- a/devel/1231.md
+++ b/devel/1231.md
@@ -1,0 +1,41 @@
+# 1231 非社区版增加关闭 ghost text 触发的实验选项
+
+## What
+
+在 编辑 → 首选项 → 其他 → 实验特性 中新增「Ghost text」开关（仅非社区版
+`is_community=false` 构建显示），关闭后 ghost text 补全不再触发。
+
+## Why
+
+非社区版默认启用 ghost text 云端补全，但部分用户不需要/不想产生云端请求，
+需要一个可关闭的入口。社区版本就无 `ghost-cloud-predict`（`ghost-enable?`
+第一重判断），功能天然关闭，无需展示该选项。
+
+## How
+
+- 偏好键 `ghost text` 默认 `"off"`（`tm-server.scm` 的 `define-preferences`
+  默认值表），非社区版默认不触发补全，需在实验特性中手动开启。
+- `ghost-text.scm` 的 `ghost-enable?` 增加 `(get-boolean-preference "ghost text")`
+  判断，`trigger-ghost-text` 入口统一生效。
+- `preferences-widgets.scm` 的 `preferences-qml-other-experimental-fields`
+  改为 `(append (list ...) (if (community-stem?) '() (list ghost-field)))`，
+  社区版不拼入该字段（`build-tab` 逐字段求值，不能留 `'()` 元素）。
+- `pref-keys.scm` 增加 `pref-experimental-ghost-text`。
+- zh_CN 词典补 `("Ghost text" "幽灵文本补全")`。
+
+## 踩坑记录
+
+第一版把 `(if (community-stem?) '() (list ghost字段))` 直接作为
+`preferences-qml-other-experimental-fields` 外层 `(list ...)` 的元素：社区版
+构建下该元素求值成 `'()`，`build-tab`（preferences-tools.scm:411）逐字段调
+`field->descriptor` 时 `(list-ref '() 1)` 越界，打开首选项面板即崩
+（`list-ref second argument, 1, is out of range`）。修复：改为
+`(append (list ...) (if ...))`，条件分支永远不进入字段列表本身。
+
+## 涉及文件
+
+- `TeXmacs/progs/texmacs/texmacs/tm-server.scm`
+- `TeXmacs/progs/generic/ghost-text.scm`
+- `TeXmacs/progs/texmacs/menus/preferences-widgets.scm`
+- `TeXmacs/progs/kernel/texmacs/pref-keys.scm`
+- `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm`


### PR DESCRIPTION
## 摘要

在 编辑 → 首选项 → 其他 → 实验特性 中新增「Ghost text」开关（仅非社区版显示），控制 ghost text 云端补全是否触发。默认关闭。

## 改动

- 偏好键 `ghost text` 默认 `"off"`（`tm-server.scm` 默认值表）
- `ghost-enable?` 增加 `(get-boolean-preference "ghost text")` 判断，`trigger-ghost-text` 入口统一生效，实时读取无需重启
- `preferences-qml-other-experimental-fields` 用 `(append (list ...) (if (community-stem?) '() ...))` 拼入字段，社区版不展示（社区版无 `ghost-cloud-predict`，功能本就关闭）
- zh_CN 词典补翻译「幽灵文本补全」

## 踩坑

条件字段不能作为 `(list ...)` 的元素——社区版下求值成 `'()`，`build-tab` 逐字段 `field->descriptor` 时 `list-ref` 越界崩溃。

🤖 Generated with [Claude Code](https://claude.com/claude-code)