### PR TITLE
[1235] 注册 markdown lazy-format（仅非社区版）

### DIFF
--- a/TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm
+++ b/TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm
@@ -1,0 +1,22 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : markdown-format.scm
+;; DESCRIPTION : Markdown 格式定义（仅非社区版生效）
+;; COPYRIGHT   : (C) 2026  MoganLab
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (markdown markdown-format))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Markdown
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-format markdown
+  (:name "Markdown")
+  (:suffix "md" "markdown")
+) ;define-format

--- a/TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm
+++ b/TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm
@@ -16,7 +16,4 @@
 ;; Markdown
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-format markdown
-  (:name "Markdown")
-  (:suffix "md" "markdown")
-) ;define-format
+(define-format markdown (:name "Markdown") (:suffix "md" "markdown"))

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -523,7 +523,9 @@
 (lazy-format (docx docx-format) docx)
 (lazy-format (html html-format) html)
 ;; markdown 转换仅在非社区版提供
-(when (not (community-stem?)) (lazy-format (markdown markdown-format) markdown))
+(when (not (community-stem?))
+  (lazy-format (markdown markdown-format) markdown)
+) ;when
 (lazy-define (convert images tmimage)
   export-selection-as-graphics
   clipboard-copy-image

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -522,6 +522,8 @@
 (lazy-format (tmu tmu-format) tmu)
 (lazy-format (docx docx-format) docx)
 (lazy-format (html html-format) html)
+;; markdown 转换仅在非社区版提供
+(when (not (community-stem?)) (lazy-format (markdown markdown-format) markdown))
 (lazy-define (convert images tmimage)
   export-selection-as-graphics
   clipboard-copy-image

--- a/devel/1235.md
+++ b/devel/1235.md
@@ -1,0 +1,37 @@
+# 1235 Markdown lazy-format 注册
+
+## What
+
+为 markdown 格式补上 scheme 侧的格式声明与 lazy-format 注册：
+
+- 新增 `TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm`，
+  模块 `(markdown markdown-format)`，`define-format markdown`
+  （`:name "Markdown"`，`:suffix "md" "markdown"`）。
+- `TeXmacs/progs/init-research.scm` 在 html 之后追加
+  `(when (not (community-stem?)) (lazy-format (markdown markdown-format) markdown))`。
+
+## Why
+
+非社区版的 `paste-as-markdown` 走 `clipboard-paste-import "markdown"`，
+要求 scheme 侧存在 `markdown` 格式；此前从未注册，格式链路不完整。
+社区版保留原有 verbatim + OCR（md.tex）回退路径，不注册该格式。
+
+## How
+
+- 插件的 `progs` 目录由 `init_texmacs.cpp` 的 `plugin_path` 自动加入
+  模块搜索路径（`$TEXMACS_PATH/plugins/*/progs`），无需额外接线，
+  参照 csv 插件（`(csv csv-format)`）的结构。
+- 版本门槛用 glue 函数 `community-stem?`（`is_community_stem`，
+  `src/Scheme/L3/glue_misc.lua`）在 boot 期判断，glue 在 progs 加载前
+  已注册，可直接调用。
+
+## 后续
+
+- `markdown-format.scm` 目前只声明格式，尚未提供
+  `converter markdown-snippet/document <-> texmacs-tree`，
+  具体转换器待后续 commit 补充。
+
+## 涉及文件
+
+- `TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm`（新增）
+- `TeXmacs/progs/init-research.scm`


### PR DESCRIPTION
- 新增 \`TeXmacs/plugins/markdown/progs/markdown/markdown-format.scm\`：\`(markdown markdown-format)\` 模块，声明 markdown 格式（suffix \`md\`/\`markdown\`）
- \`init-research.scm\` 注册 \`(when (not (community-stem?)) (lazy-format (markdown markdown-format) markdown))\`，社区版不注册，保留原 verbatim + OCR 回退
- 转换器实现（markdown-snippet/document ↔ texmacs-tree）后续另行提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)