### PR TITLE
[0933] 修复 macOS 上 as_string(time_t) 重载二义导致的编译错误

### DIFF
--- a/devel/0933.md
+++ b/devel/0933.md
@@ -1,0 +1,39 @@
+# 0933 修复 macOS 编译错误：as_string(time_t) 重载二义
+
+## What
+
+修复 macOS（arm64 + Apple clang）上 `xmake b stem` 编译失败的问题。
+
+## Why
+
+`texmacs_time ()` 返回 `time_t`。lolly 的 `as_string` 整数重载集为
+`int16_t / int32_t / int64_t / unsigned int / unsigned long int`：
+
+- Linux LP64 上 `int64_t` 即 `long`，与 `time_t`（`long`）精确匹配，编译通过；
+- macOS 上 `int64_t` 是 `long long`，`long` 实参到 `int64_t` 与
+  `unsigned long int` 均需整数转换，clang 报 `call to 'as_string' is ambiguous`。
+
+报错位置共两处：
+
+- `src/Texmacs/Data/new_buffer.cpp:222`（无标题新文档 draft_ 时间戳命名）
+- `src/Texmacs/Server/tm_debug.cpp:195`（crash report 文件名）
+
+## How
+
+在两处调用点显式转换为 `int64_t`：
+`as_string ((int64_t) texmacs_time ())`，并加一行注释说明原因。
+不改动 lolly 的重载集（改动面最小，且其它调用点无此问题）。
+
+## 涉及文件
+
+- `src/Texmacs/Data/new_buffer.cpp`
+- `src/Texmacs/Server/tm_debug.cpp`
+- `devel/0933.md`
+
+## 测试
+
+```bash
+~/.local/bin/xmake b --yes stem   # build ok
+```
+
+修复前在 58%/59% 处分别报 `call to 'as_string' is ambiguous`；修复后完整构建通过。

--- a/src/Texmacs/Data/new_buffer.cpp
+++ b/src/Texmacs/Data/new_buffer.cpp
@@ -219,7 +219,8 @@ make_new_buffer () {
   if (is_none (name) || !is_nil (concrete_buffer (name))) {
     // scheme 未就绪或返回名字已被占用时的兜底:毫秒时间戳保证唯一
     url dir= get_documents_path () * "LiiiSTEM/no_name";
-    name   = dir * ("draft_" * as_string (texmacs_time ()) * ".tmu");
+    // time_t 在 macOS 上是 long,int64_t 是 long long,不显式转换会重载二义
+    name= dir * ("draft_" * as_string ((int64_t) texmacs_time ()) * ".tmu");
   }
   set_buffer_tree (name, tree (DOCUMENT));
   return name;

--- a/src/Texmacs/Server/tm_debug.cpp
+++ b/src/Texmacs/Server/tm_debug.cpp
@@ -192,7 +192,8 @@ tm_failure (const char* msg) {
   cerr << "TeXmacs] Dumping report below\n\n" << report << "\n";
 #else
   url dir ("$TEXMACS_HOME_PATH/system/crash");
-  url err= dir * ("crash_report_" * as_string (texmacs_time ()));
+  // time_t 在 macOS 上是 long,int64_t 是 long long,不显式转换会重载二义
+  url err= dir * ("crash_report_" * as_string ((int64_t) texmacs_time ()));
   if (!save_string (err, report))
     cerr << "TeXmacs] Crash report saved in " << err << "\n";
   else


### PR DESCRIPTION
## 问题

macOS（arm64 + Apple clang）上 `xmake b stem` 编译失败：

```
src/Texmacs/Data/new_buffer.cpp:222:32: error: call to 'as_string' is ambiguous
```

## 根因

`texmacs_time ()` 返回 `time_t`。lolly 的 `as_string` 整数重载集为
`int16_t / int32_t / int64_t / unsigned int / unsigned long int`：

- Linux LP64 上 `int64_t` 即 `long`，与 `time_t`（`long`）精确匹配，编译通过；
- macOS 上 `int64_t` 是 `long long`，`long` 实参到 `int64_t` 与 `unsigned long int`
  均需整数转换，clang 报重载二义。

报错共两处：`new_buffer.cpp`（#4419 引入的 draft_ 时间戳命名）与 `tm_debug.cpp`（crash report 文件名）。

## 修复

在两处调用点显式转换为 `int64_t`：`as_string ((int64_t) texmacs_time ())`，
并加一行注释说明原因。不改动 lolly 的重载集（改动面最小，其它调用点无此问题）。

## 验证

- [x] 修复前 macOS 上复现 `call to 'as_string' is ambiguous`
- [x] 修复后 `xmake b --yes stem` 完整构建通过（build ok）
- [x] `gf fmt --changed-since=main` 已通过
- [x] 改动对 Linux 无影响（LP64 上 `(int64_t)` 为恒等转换）
