### PR TITLE
[0935] 删除 url_numbered 遗留测试用例,修复 tests 组 CI 编译失败

### DIFF
--- a/devel/0935.md
+++ b/devel/0935.md
@@ -1,0 +1,39 @@
+# 0935 修复 CI 编译失败：删除 url_numbered 遗留测试用例
+
+## What
+
+删除 `tests/System/Files/tm_file_test.cpp` 中陈旧的 `test_url_numbered_make_dir`
+用例，修复 `xmake b --group=tests` 编译失败（Debian/Linux 与 macOS CI 的
+build 步骤均因此失败）。
+
+## Why
+
+上游 #4419（commit 2f744e4cf，[1240] 新文档 no_name 机制改为 draft_ 时间戳
+命名）从 `src/System/Files/tm_file.cpp` / `tm_file.hpp` 删除了 `url_numbered`
+和 `url_scratch` 两个函数，但遗留了 `tm_file_test.cpp` 中的
+`test_url_numbered_make_dir` 仍在调用 `url_numbered`，导致：
+
+```
+tests/System/Files/tm_file_test.cpp:37:13: error: 'url_numbered' was not declared in this scope
+```
+
+main 上该 CI 自 8 月 4 日起未跑过，所以未被发现；PR #4422 的两个 CI
+（macosbuild 与 Linux）先后触发暴露了该问题。非本 PR 引入。
+
+## How
+
+最小修复：删除 `test_url_numbered_make_dir` 的声明（原第 24 行）与整个
+函数定义（原第 27–44 行）。替代方案是给 1240 的新机制补测试，不在本任务
+范围内。
+
+## 涉及文件
+
+- `tests/System/Files/tm_file_test.cpp`
+- `devel/0935.md`
+
+## 测试
+
+```bash
+~/.local/bin/xmake b --yes --group=tests   # build ok（修复前报 url_numbered 未声明）
+~/.local/bin/xmake r tm_file_test          # 4 passed, 0 failed
+```

--- a/tests/System/Files/tm_file_test.cpp
+++ b/tests/System/Files/tm_file_test.cpp
@@ -21,27 +21,7 @@ private slots:
   void init () { init_lolly (); }
   void test_load_ramdisc ();
   void test_search_sub_dirs ();
-  void test_url_numbered_make_dir ();
 };
-
-void
-TestTMFile::test_url_numbered_make_dir () {
-  url base= url_temp_dir () * url ("tm_file_test_0741");
-  url dir = base * url ("a") * url ("b");
-  // 确保 base 目录不存在（因为涉及 rmdir 清理）防止出现意外
-  // 当测试因为 base 目录存在而不通过时，打印并手动删除
-  // cout << "base dir: " << base << LF;
-  QVERIFY (!is_directory (base));
-  QVERIFY (!is_directory (dir));
-
-  url name= url_numbered (dir, "test_", ".tmu", 1);
-  QVERIFY (is_directory (dir));
-  QVERIFY (as_string (tail (name)) == "test_1.tmu");
-
-  // 清理
-  rmdir (base);
-  QVERIFY (!is_directory (base));
-}
 
 void
 TestTMFile::test_load_ramdisc () {


### PR DESCRIPTION
## 问题

main 分支上 `xmake b --group=tests` 编译失败，导致 CI（Linux/Debian 与 macOS）build 步骤失败：

```
tests/System/Files/tm_file_test.cpp:37:13: error: 'url_numbered' was not declared in this scope
```

## 根因

上游 #4419（commit 2f744e4cf，[1240] 新文档 no_name 机制改为 draft_ 时间戳命名）从 `src/System/Files/tm_file.cpp` / `tm_file.hpp` 删除了 `url_numbered` 与 `url_scratch`，但遗留 `tm_file_test.cpp` 中的 `test_url_numbered_make_dir` 用例仍在调用 `url_numbered`。main 上该 CI 自 8 月 4 日起未跑过，未被及时发现（PR #4422 的 CI 触发后暴露）。

日志中的 `collect2: error: ld returned 1 exit status`、`ld: unknown options: -rpath=...` 为 xmake 包/flag 探测 fallback，不是失败原因。

## 修复

删除陈旧的 `test_url_numbered_make_dir` 用例（声明 + 函数体，共 20 行）。

## 验证

```bash
~/.local/bin/xmake b --yes --group=tests   # build ok（修复前报 url_numbered 未声明）
~/.local/bin/xmake r tm_file_test          # 4 passed, 0 failed
```
