### PR TITLE
[0934] 修复 Windows 上翻译字典跨行条目因 CRLF 解析失败而丢失

### DIFF
--- a/devel/0934.md
+++ b/devel/0934.md
@@ -1,0 +1,53 @@
+# 0934 修复 Windows 上翻译字典跨行条目因 CRLF 解析失败而丢失
+
+## What
+
+Windows 上 AI 对话框底部免责声明（"Liii STEM can make mistakes. Check
+important info."）以及大量其它界面文案不翻译；macOS 正常。修复
+`block_to_scheme_tree` 对 CR（`\r`）的处理，使 CRLF 行尾的 scheme 块
+（翻译字典等）解析结果与 LF 完全一致。
+
+## Why
+
+- 仓库无 `.gitattributes`，Windows 版 Git 默认 `core.autocrlf=true`，
+  checkout 后 `TeXmacs/plugins/lang/dic/en_US/*.scm` 为 CRLF；macOS 为 LF。
+- `moebius/data/scheme_der.cpp` 中 `init_char_type` 只把空格/`\t`/`\n`
+  标为空白，`\r` 不是空白；`string_to_scheme_tree`（整串入口）会先剥离
+  CR，但 `block_to_scheme_tree` 没有这一步。
+- 字典加载走 `dictionary_rep::load`（`src/System/Language/dictionary.cpp`），
+  用的是 `block_to_scheme_tree`。CRLF 文件中，凡 key 与 value 分行书写的
+  条目，key 后的 `\r` 被当作普通 token 塞进 tuple，条目变成 3 元素，
+  被 `is_func (t[i], TUPLE, 2)` 判非法而整条丢弃。
+- 单行条目的 `\r` 落在括号外，不受影响——这解释了「联网搜索」已翻译、
+  跨行条目（免责声明等）不翻译的现象。
+
+实测（旧二进制 + `TEXMACS_HOME_PATH` 指向 CRLF 临时字典）：
+
+| 条目 | CRLF 格式 | 结果 |
+|---|---|---|
+| 单行 | `("zz single line probe" "单行探针OK")` | 翻译成功 |
+| 跨行 | `("zz multi line probe part one"`⏎`"多行探针OK")` | 原文返回（条目被丢弃） |
+
+各语言字典均有跨行条目（zh_CN 33+、zh_TW 22、ja_JP 26、sk_SK 118 等）。
+
+## How
+
+在 `block_to_scheme_tree` 入口增加与 `string_to_scheme_tree` 相同的
+「含 CR 才整串剥离」预处理。解析层一次修复，所有调用方（翻译字典、
+`init_texmacs`、字体数据库、converter 等）一致受益。
+
+同时在 `moebius/tests/moebius/data/scheme_der_test.cpp` 增加 CRLF 跨行
+条目的回归用例。
+
+## 涉及文件
+
+- `moebius/moebius/data/scheme_der.cpp`
+- `moebius/tests/moebius/data/scheme_der_test.cpp`
+- `devel/0934.md`
+
+## 测试
+
+1. `xmake -P moebius` 侧单测（scheme_der_test）验证 CRLF 跨行条目解析。
+2. 商业版编译（`--is_community=n`）后，用 `TEXMACS_HOME_PATH` 指向
+   CRLF 字典目录，headless 验证跨行条目（免责声明）翻译成功。
+3. Windows 端 GUI 手动验证（用户执行）。

--- a/moebius/moebius/data/scheme_der.cpp
+++ b/moebius/moebius/data/scheme_der.cpp
@@ -216,6 +216,15 @@ string_to_scheme_tree (string s) {
 scheme_tree
 block_to_scheme_tree (string s) {
   if (!char_type_init) init_char_type ();
+  // 同 string_to_scheme_tree: 先剥离 CR,否则 CRLF 文件中元组内的换行
+  // 会被当作普通 token,导致跨行条目(如翻译字典)解析失败
+  bool has_cr= false;
+  for (int k= 0; k < N (s); k++)
+    if (s[k] == '\015') {
+      has_cr= true;
+      break;
+    }
+  if (has_cr) s= replace (s, "\015", "");
   scheme_tree p (TUPLE);
   int         i     = 0;
   const int   length= N (s);

--- a/moebius/tests/moebius/data/scheme_der_test.cpp
+++ b/moebius/tests/moebius/data/scheme_der_test.cpp
@@ -93,10 +93,12 @@ TEST_SUITE ("scheme_der") {
     scheme_tree t= block_to_scheme_tree (s);
     CHECK (is_tuple (t));
     CHECK_EQ (N (t), 2);
-    CHECK (is_tuple (t[0]) && N (t[0]) == 2);
+    CHECK (is_tuple (t[0]));
+    CHECK_EQ (N (t[0]), 2);
     CHECK (atom_of (t[0][0]) == "\"key one\"");
     CHECK (atom_of (t[0][1]) == "\"value one\"");
-    CHECK (is_tuple (t[1]) && N (t[1]) == 2);
+    CHECK (is_tuple (t[1]));
+    CHECK_EQ (N (t[1]), 2);
   }
 
 } // TEST_SUITE

--- a/moebius/tests/moebius/data/scheme_der_test.cpp
+++ b/moebius/tests/moebius/data/scheme_der_test.cpp
@@ -86,4 +86,17 @@ TEST_SUITE ("scheme_der") {
     CHECK (atom_of (t[1][0]) == "b");
   }
 
+  TEST_CASE ("block parse with CRLF line breaks") {
+    // Windows(CRLF)字典文件里跨行条目不应因 CR 产生多余词元
+    string s=
+        "(\"key one\"\015\n  \"value one\"\015\n) ;\015\n(\"k2\" \"v2\")\015\n";
+    scheme_tree t= block_to_scheme_tree (s);
+    CHECK (is_tuple (t));
+    CHECK_EQ (N (t), 2);
+    CHECK (is_tuple (t[0]) && N (t[0]) == 2);
+    CHECK (atom_of (t[0][0]) == "\"key one\"");
+    CHECK (atom_of (t[0][1]) == "\"value one\"");
+    CHECK (is_tuple (t[1]) && N (t[1]) == 2);
+  }
+
 } // TEST_SUITE


### PR DESCRIPTION
# [0934] 修复 Windows 上翻译字典跨行条目因 CRLF 解析失败而丢失

## 问题

Windows 上 AI 对话框底部免责声明("Liii STEM can make mistakes. Check
important info.")以及大量其它界面文案不翻译;macOS 正常。

## 根因

- 仓库无 `.gitattributes`,Windows 版 Git 默认 `core.autocrlf=true`,
  checkout 后 `TeXmacs/plugins/lang/dic/en_US/*.scm` 为 CRLF;macOS 为 LF。
- `moebius/data/scheme_der.cpp` 中 `init_char_type` 只把空格/`\t`/`\n`
  标为空白,`\r` 不是空白;`string_to_scheme_tree`(整串入口)会先剥离
  CR,但 `block_to_scheme_tree` 没有这一步。
- 字典加载(`dictionary_rep::load`)走 `block_to_scheme_tree`:CRLF 文件中
  凡 key 与 value 分行书写的条目,key 后的 `\r` 被当作普通 token 塞进
  tuple,条目变成 3 元素,被 `is_func (t[i], TUPLE, 2)` 判非法而整条丢弃。
- 单行条目的 `\r` 落在括号外不受影响——这解释了「联网搜索」已翻译、
  跨行条目(免责声明等)不翻译的现象。各语言字典均有跨行条目
  (zh_CN 33+、zh_TW 22、ja_JP 26、sk_SK 118 等)。

## 修复

在 `block_to_scheme_tree` 入口增加与 `string_to_scheme_tree` 相同的
「含 CR 才整串剥离」预处理(解析层一次修复,所有调用方一致受益),
并新增 CRLF 跨行条目的回归单测。

## 验证

- `xmake f --yes -vD -m releasedbg --is_community=n` + `xmake b stem` 编译通过。
- headless 对照实验(`TEXMACS_HOME_PATH` 指向 CRLF 临时字典):
  - 修复前:跨行条目原文返回(条目被丢弃)
  - 修复后:跨行条目恢复翻译(`R2: 多行探针OK`),单行条目不受影响
- Windows 端 GUI 手动验证:待完成(商业版重新编译后,AI 对话框底部
  免责声明及其它跨行条目文案应恢复中文)。

## 任务文档

`devel/0934.md`
