### PR TITLE
[0937] 修复全屏模式下光标移入特殊格式导致退出全屏

### DIFF
--- a/devel/0937.md
+++ b/devel/0937.md
@@ -1,0 +1,38 @@
+# 0937 修复全屏模式下光标移入特殊格式导致退出全屏
+
+## 问题
+
+打开全屏模式（View → Full screen mode，即全屏编辑模式）后，光标移动到有特殊格式
+的地方（如数学公式、表格、会话）时会自动退出全屏。
+
+## 原因（Why）
+
+- `qt_tm_widget_rep::set_full_screen(true)` 进入全屏时会隐藏 `menuToolBar` 和
+  QWK 标题栏（`windowAgent->titleBar()`），并将窗口置为原生全屏
+  （`Qt::WindowFullScreen`）。
+- 光标移入特殊格式时，编辑器侧 `update_menus` 会重建 focus 工具栏图标：
+  `menu_icons(2) → SLOT_FOCUS_ICONS → update_visibility()`。
+- `update_visibility()` 从未检查 `full_screen` 状态，会按 `visibility[0]`
+  重新显示 `menuToolBar` 和标题栏；在 macOS 上这会触发 QWK 重建原生窗口样式
+  （styleMask/标题栏属性变更），AppKit 随即退出原生全屏。
+
+## 修改（How）
+
+`src/Plugins/Qt/qt_tm_widget.cpp` 的 `update_visibility()`：在应用可见性之前，
+若处于全屏（`full_screen == true`），强制 `new_menuVisibility` 和
+`new_titleVisibility` 为 `false`，保持 `set_full_screen` 所做的隐藏不被翻转；
+退出全屏时 `set_full_screen(false)` 本身以 `visibility[0]=false` 调用本函数并
+随后恢复缓存状态，不受影响。
+
+其余工具栏（mode/focus 等）在全屏编辑模式下本就保持可见，其正常的可见性更新
+（含 `replaceButtons` 的防闪烁隐藏/显示）不触碰原生窗口样式，予以保留。
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_tm_widget.cpp`：`update_visibility()` 增加全屏守卫。
+
+## 测试
+
+- 构建：`xmake b stem`
+- 手动验证（需 GUI）：进入全屏编辑模式，光标在普通文本与数学公式/表格间来回移动，
+  窗口应保持全屏，不发生退出。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1606,6 +1606,13 @@ qt_tm_widget_rep::update_visibility () {
     new_pdfOutlineVisibility=
         outlineEnabled && pdfOutlineDock && pdfOutlineDock->hasContent ();
   }
+  // 全屏时菜单栏/标题栏已由 set_full_screen 隐藏，这里不得重新显示：
+  // 光标移入特殊格式会触发本函数，重新显示会重建原生窗口样式并退出全屏
+  if (full_screen) {
+    new_menuVisibility = false;
+    new_titleVisibility= false;
+  }
+
   if (XOR (old_mainVisibility, new_mainVisibility)) {
     mainToolBar->setVisible (new_mainVisibility);
   }


### PR DESCRIPTION
## 问题

打开全屏模式（View → Full screen mode，全屏编辑模式）后，光标移动到有特殊格式的地方（数学公式、表格、会话等）时会自动退出全屏。

## 原因

- `qt_tm_widget_rep::set_full_screen(true)` 进入全屏时隐藏 `menuToolBar` 和 QWK 标题栏，并将窗口置为原生全屏。
- 光标移入特殊格式时，`update_menus → menu_icons(2) → SLOT_FOCUS_ICONS → update_visibility()` 被触发。
- `update_visibility()` 从未检查 `full_screen` 状态，会按 `visibility[0]` 重新显示菜单栏和标题栏；在 macOS 上这会触发 QWK 重建原生窗口样式（styleMask 变更），AppKit 随即退出原生全屏。

## 修改

`src/Plugins/Qt/qt_tm_widget.cpp` 的 `update_visibility()`：全屏时强制 `new_menuVisibility` / `new_titleVisibility` 为 `false`，保持 `set_full_screen` 所做的隐藏不被翻转。退出全屏路径以 `visibility[0]=false` 两段式调用本函数并随后恢复缓存状态，不受影响；其余工具栏（mode/focus 等）在全屏编辑模式下的正常可见性更新保留。

## 验证

- `xmake b stem` 构建通过
- 手动 GUI 验证（用户确认已通过）：进入全屏编辑模式，光标在普通文本与数学公式/表格间来回移动，窗口保持全屏，不再退出
