### PR TITLE
[1237] 鼠标拖选期间光标保持在按下位置

### DIFF
--- a/devel/1237.md
+++ b/devel/1237.md
@@ -1,0 +1,27 @@
+# 1237 鼠标拖选期间光标位置被改变
+
+## 问题
+
+按住鼠标左键进入选择模式后,移动鼠标的过程中光标位置会跟随鼠标改变;
+松开左键时光标又被移动到松开位置。预期:光标应保持在按下左键时的位置。
+
+## 原因分析
+
+鼠标拖选关键路径(`src/Edit/Interface/edit_mouse.cpp`):
+
+- `press-left` → `mouse_click()`:记录锚点 `start_x/start_y`
+- `dragging-left` → `mouse_drag()`:`go_to(x, y)` 把光标 `tp` 移到鼠标位置
+- `release-left` → `mouse_select(x, y, mods, drag=true)`:再次 `go_to(x, y)`
+
+通过 `[1237]` 调试日志确认:`set_selection`/`select()` 只更新选区,不动 `tp`;
+拖动及松开过程中光标移动完全来自两处 `go_to(x, y)`。
+
+## 修复
+
+- `mouse_drag`:`go_to` 前保存 `tp`,计算完选区后恢复,拖动期间光标固定在按下位置
+- `mouse_select`:`drag=true`(拖选结束)时恢复到进入函数前的 `tp`;单纯点击
+  (`drag=false`)行为不变,仍跳到点击处
+
+## 涉及文件
+
+- `src/Edit/Interface/edit_mouse.cpp`

--- a/devel/1237.md
+++ b/devel/1237.md
@@ -1,27 +1,64 @@
-# 1237 鼠标拖选期间光标位置被改变
+# [1237] 鼠标拖选期间光标位置被改变
 
-## 问题
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
 
-按住鼠标左键进入选择模式后,移动鼠标的过程中光标位置会跟随鼠标改变;
-松开左键时光标又被移动到松开位置。预期:光标应保持在按下左键时的位置。
+## 2 任务相关的代码文件
+- src/Edit/Interface/edit_mouse.cpp
 
-## 原因分析
+## 3 如何测试
 
-鼠标拖选关键路径(`src/Edit/Interface/edit_mouse.cpp`):
+### 3.1 确定性测试（单元测试）
 
-- `press-left` → `mouse_click()`:记录锚点 `start_x/start_y`
-- `dragging-left` → `mouse_drag()`:`go_to(x, y)` 把光标 `tp` 移到鼠标位置
-- `release-left` → `mouse_select(x, y, mods, drag=true)`:再次 `go_to(x, y)`
+本任务为鼠标交互时序行为，现有测试框架无法模拟真实鼠标拖选事件序列，
+无对应的自动化单元测试。
 
-通过 `[1237]` 调试日志确认:`set_selection`/`select()` 只更新选区,不动 `tp`;
+### 3.2 非确定性测试（文档验证）
+
+手动 GUI 验证（`xmake b stem && xmake r stem` 启动后）：
+
+1. **拖选期间光标不动**：按住左键从某位置开始拖动，选区随鼠标扩展，
+   但闪烁光标始终停留在按下左键的位置，不跟随鼠标移动
+2. **松开后光标仍回按下位置**：拖到别处松开左键，选区保留，光标仍在按下位置
+3. **普通点击行为不变**：单击某处（无拖动），光标仍跳到点击处
+4. **双击/三击选词选段**：双击选中单词、三击选中整段，光标位置不受影响
+5. **Shift+点击扩展选区**：已有选区时 Shift+点击，选区扩展，行为正常
+6. **图文混合场景**：在含图片/公式附近拖选，跨越图形边界时选区正常，
+   不因 `inside_graphics` 状态切换出现光标跳变
+7. **拖选后编辑**：拖选一段文字后直接输入字符，选中文本被替换，
+   替换发生在按下位置一侧的选区（与修改前替换结果一致）
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+
+修复鼠标拖选期间光标位置被改变的问题：
+
+1. `mouse_drag`：`go_to` 前保存 `tp`，计算完选区后恢复，拖动期间光标固定在按下位置
+2. `mouse_select`：`drag=true`（拖选结束）时恢复到进入函数前的 `tp`；
+   单纯点击（`drag=false`）行为不变，仍跳到点击处
+
+## 6 Why
+
+按住鼠标左键进入选择模式后，移动鼠标的过程中光标位置会跟随鼠标改变；
+松开左键时光标又被移动到松开位置。预期：光标应保持在按下左键时的位置。
+
+## 7 How
+
+鼠标拖选关键路径（`src/Edit/Interface/edit_mouse.cpp`）：
+
+- `press-left` → `mouse_click()`：记录锚点 `start_x/start_y`
+- `dragging-left` → `mouse_drag()`：`go_to(x, y)` 把光标 `tp` 移到鼠标位置
+- `release-left` → `mouse_select(x, y, mods, drag=true)`：再次 `go_to(x, y)`
+
+通过调试日志确认：`set_selection`/`select()` 只更新选区，不动 `tp`；
 拖动及松开过程中光标移动完全来自两处 `go_to(x, y)`。
 
-## 修复
-
-- `mouse_drag`:`go_to` 前保存 `tp`,计算完选区后恢复,拖动期间光标固定在按下位置
-- `mouse_select`:`drag=true`(拖选结束)时恢复到进入函数前的 `tp`;单纯点击
-  (`drag=false`)行为不变,仍跳到点击处
-
-## 涉及文件
-
-- `src/Edit/Interface/edit_mouse.cpp`
+因此在这两处 `go_to(x, y)` 前后保存/恢复 `tp`：拖动期间与拖选结束时
+光标都保持在按下位置，而点击（`drag=false`）路径不受影响。

--- a/src/Edit/Interface/edit_mouse.cpp
+++ b/src/Edit/Interface/edit_mouse.cpp
@@ -175,6 +175,7 @@ void
 edit_interface_rep::mouse_drag (SI x, SI y) {
   if (inside_graphics () && is_in_graphics_mode) return;
   if (mouse_message ("drag", x, y)) return;
+  path last_tp= tp; // 拖选期间光标应保持在按下左键时的位置
   go_to (x, y);
   end_x= x;
   end_y= y;
@@ -188,6 +189,7 @@ edit_interface_rep::mouse_drag (SI x, SI y) {
     p2       = temp;
   }
   set_selection (p1, p2);
+  go_to (last_tp);
   notify_change (THE_SELECTION);
 }
 
@@ -211,6 +213,7 @@ edit_interface_rep::mouse_select (SI x, SI y, int mods, bool drag) {
   bool b0= inside_graphics (false);
   bool b = inside_graphics ();
   if (b) g= get_graphics ();
+  path last_tp= tp; // 拖选结束时, 光标保持在按下左键时的位置
   go_to (x, y);
   if ((!b0 && inside_graphics (false)) || (b0 && !inside_graphics (false)))
     drag= false;
@@ -226,6 +229,7 @@ edit_interface_rep::mouse_select (SI x, SI y, int mods, bool drag) {
     set_selection (p0, p0);
     notify_change (THE_SELECTION);
   }
+  else go_to (last_tp);
   if (selection_active_any ()) selection_set ("mouse", selection_get (), true);
 }
 


### PR DESCRIPTION
## 问题

按住鼠标左键进入选择模式后，移动鼠标的过程中光标位置跟随鼠标改变；松开左键时光标又被移到松开位置。预期光标应保持在按下左键时的位置。

## 原因

`mouse_drag` 与 `mouse_select`（拖选结束）中的 `go_to(x, y)` 会移动光标；`set_selection` 本身不动光标。已通过调试日志确认。

## 修复

- `mouse_drag`：`go_to` 前保存 `tp`，计算完选区后恢复
- `mouse_select`：`drag=true` 时恢复进入前的 `tp`；单纯点击行为不变

任务文档：`devel/1237.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)