### PR TITLE
[1238] PDF 截图矩形选区改为两次点击确定,不再按住拖拽

### DIFF
--- a/devel/1238.md
+++ b/devel/1238.md
@@ -1,0 +1,41 @@
+# 1238 PDF 截图矩形选区改为两次点击确定
+
+## 任务
+
+PDF 阅读器截图(矩形选区)由「按住左键拖拽」改为「两次点击」:
+第一次左键点击确定第一个点,松开鼠标后移动鼠标即出现矩形选框,
+第二次左键点击确定第二个点并完成截图。Esc 取消行为不变。
+
+## What
+
+- `PDFReaderWidget::eventFilter` 矩形选区分支:
+  - 第一次 `MouseButtonPress` 记录起点并显示选框;
+  - 无按键的 `MouseMove`(mouse tracking 已开启)实时更新选框;
+  - 第二次 `MouseButtonPress` 完成截图;同点重复点击(宽高 <= 1,
+    含双击)不结束选区;
+  - 删除原先 `MouseButtonRelease` 结束选区的分支。
+- `finishRectSelect` 中 `exec_delayed`(OCR)增加 `the_gui != NULL`
+  守卫:单元测试环境未启动完整 GUI,`the_gui` 为 NULL 时原先直接
+  崩溃(此为既有崩溃,拖拽模式在测试中完成选区同样触发)。
+- 提示文案由 "Draw a rectangle ..." 改为 "Click two corners to
+  select, ...".
+- 测试更新为点击-移动-点击语义;无按键的 mouseMove 用
+  `QApplication::sendEvent` 显式投递(`QTest::mouseMove` 不投递
+  无按键移动事件)。
+
+## Why
+
+按住左键拖拽在触控板/长文档滚动场景下易与滚动手势冲突,两次点击
+更易操作。
+
+## How
+
+见 What;涉及文件:
+
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp`
+- `tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp`
+
+## 验证
+
+`xmake b qt_pdf_reader_widget_test && xmake r qt_pdf_reader_widget_test`
+47 passed, 0 failed。

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -36,6 +36,7 @@
 #include "MuPDF/mupdf_renderer.hpp"
 #include "qt_chat_tab_widget.hpp"
 #include "qt_dpi_utils.hpp"
+#include "qt_gui.hpp"
 #include "qt_utilities.hpp"
 #include "scheme.hpp"
 #include "tm_sys_utils.hpp"
@@ -482,8 +483,9 @@ PDFReaderWidget::setRectSelectMode (bool checked) {
 #else
     QString shortcut= "Ctrl+Shift+v";
 #endif
-    hintLabel_->setText (
-        QString ("Draw a rectangle and use %1 to magic paste!").arg (shortcut));
+    hintLabel_->setText (QString ("Click two corners to select, then use %1 to "
+                                  "magic paste!")
+                             .arg (shortcut));
     hintLabel_->adjustSize ();
     hintLabel_->move (PAGE_MARGIN, PAGE_MARGIN);
     hintLabel_->show ();
@@ -519,7 +521,8 @@ PDFReaderWidget::finishRectSelect (const QPoint& viewportPos) {
   if (clipboard) {
     clipboard->setPixmap (selected);
     // Trigger silent OCR to populate cache; the result is not inserted here.
-    if (!is_community_stem ()) {
+    // the_gui 在单元测试等未启动完整 GUI 的场景下为 NULL
+    if (!is_community_stem () && the_gui != NULL) {
       exec_delayed (scheme_cmd (
           "(when (defined? 'ocr-recognize-silent) (ocr-recognize-silent))"));
     }
@@ -1647,13 +1650,27 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
               event->type () == QEvent::MouseButtonDblClick)) {
       QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
       if (mouseEvent->button () == Qt::LeftButton) {
-        rectSelectDragging_= true;
-        rectSelectStart_   = contentPos;
-        if (!rubberBand_) {
-          rubberBand_= new QRubberBand (QRubberBand::Rectangle, contentWidget_);
+        if (rectSelectDragging_) {
+          // 第二次点击:确定第二个点,完成截图;同点重复点击(如双击,QRect
+          // 两点构造宽高至少为 1)不结束选区
+          QRect rect (rectSelectStart_, contentPos);
+          rect= rect.normalized ();
+          if (rect.width () > 1 && rect.height () > 1) {
+            rectSelectDragging_= false;
+            finishRectSelect (mouseEvent->pos ());
+          }
         }
-        rubberBand_->setGeometry (QRect (rectSelectStart_, QSize ()));
-        rubberBand_->show ();
+        else {
+          // 第一次点击:确定第一个点,移动鼠标即可出现选框
+          rectSelectDragging_= true;
+          rectSelectStart_   = contentPos;
+          if (!rubberBand_) {
+            rubberBand_=
+                new QRubberBand (QRubberBand::Rectangle, contentWidget_);
+          }
+          rubberBand_->setGeometry (QRect (rectSelectStart_, QSize ()));
+          rubberBand_->show ();
+        }
         mouseEvent->accept ();
         return true;
       }
@@ -1665,16 +1682,6 @@ PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
       rubberBand_->setGeometry (rect);
       static_cast<QMouseEvent*> (event)->accept ();
       return true;
-    }
-    else if (rectSelectMode_ && rectSelectDragging_ &&
-             event->type () == QEvent::MouseButtonRelease) {
-      QMouseEvent* mouseEvent= static_cast<QMouseEvent*> (event);
-      if (mouseEvent->button () == Qt::LeftButton) {
-        rectSelectDragging_= false;
-        finishRectSelect (mouseEvent->pos ());
-        mouseEvent->accept ();
-        return true;
-      }
     }
   }
   return QWidget::eventFilter (watched, event);

--- a/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
+++ b/tests/Plugins/Qt/qt_pdf_reader_widget_test.cpp
@@ -300,16 +300,19 @@ private slots:
     QLabel* hint= widget->findChild<QLabel*> ("rectSelectHint");
     QVERIFY (hint != nullptr);
     QVERIFY (hint->isVisible ());
-    QVERIFY (hint->text ().contains ("Draw a rectangle"));
+    QVERIFY (hint->text ().contains ("Click two corners"));
 
-    // 模拟拖拽选择
+    // 模拟点击-移动-点击选择
     QWidget* vp= widget->viewport ();
     QVERIFY (vp != nullptr);
     QPoint start (50, 50);
     QPoint end (150, 150);
-    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, start);
-    QTest::mouseMove (vp, end);
-    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, end);
+    QTest::mouseClick (vp, Qt::LeftButton, Qt::NoModifier, start);
+    // 无按键的 mouseMove 需显式投递(QTest::mouseMove 不会送达)
+    QMouseEvent moveEvent (QEvent::MouseMove, end, vp->mapToGlobal (end),
+                           Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent (vp, &moveEvent);
+    QTest::mouseClick (vp, Qt::LeftButton, Qt::NoModifier, end);
     QApplication::processEvents ();
 
     // 选择完成后提示变为 Copied to Clipboard!
@@ -347,12 +350,14 @@ private slots:
     QWidget* vp= widget->viewport ();
     QVERIFY (vp != nullptr);
 
-    // 模拟拖拽选择
+    // 模拟点击-移动-点击选择
     QPoint start (50, 50);
     QPoint end (150, 150);
-    QTest::mousePress (vp, Qt::LeftButton, Qt::NoModifier, start);
-    QTest::mouseMove (vp, end);
-    QTest::mouseRelease (vp, Qt::LeftButton, Qt::NoModifier, end);
+    QTest::mouseClick (vp, Qt::LeftButton, Qt::NoModifier, start);
+    QMouseEvent moveEvent (QEvent::MouseMove, end, vp->mapToGlobal (end),
+                           Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent (vp, &moveEvent);
+    QTest::mouseClick (vp, Qt::LeftButton, Qt::NoModifier, end);
     QApplication::processEvents ();
 
     // 验证剪贴板有图片


### PR DESCRIPTION
## 概述

PDF 截图的矩形选区交互从「按住拖拽」改为「两次点击确定」：第一次点击定起点，第二次点击定终点并完成选区。

## 关联

- 任务文档:`devel/1238.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)