### PR TITLE
[1239] 商业版悬浮用户中心按钮直接显示用户中心

### DIFF
--- a/devel/1239.md
+++ b/devel/1239.md
@@ -1,0 +1,38 @@
+# 1239 用户中心悬浮直接显示
+
+## 任务
+
+商业版：鼠标悬浮在窗口栏用户中心（登录）按钮上时直接显示用户中心弹窗，
+无需点击。社区版保持原有行为（点击跳转官网）。
+
+## What
+
+- `QWK::LoginButton` 新增 `hovered()` / `unhovered()` 信号，分别在
+  `enterEvent` / `leaveEvent` 中 emit。
+- `qt_tm_widget_rep` 新增 `showUserCenterOnHover ()`：
+  - 社区版直接 return（保持点击行为）；
+  - 弹窗已可见时不做 toggle 隐藏（与点击路径的差异）；
+  - `m_userCenterHoverPending` 标志保证同一次悬浮只触发一次，避免网络
+    请求在途时重复 Enter 导致并发拉取用户信息；`unhovered` 时重置。
+- 商业版分支额外连接 `hovered` → `showUserCenterOnHover`、
+  `unhovered` → 重置标志。
+
+## Why
+
+悬浮即见降低用户中心（会员信息/登录）的触达成本；社区版无登录态，
+保持点击跳官网的既有交互不变。
+
+## How（TDD）
+
+1. 先写 `tests/Plugins/Qt/login_button_test.cpp`（QSignalSpy 断言
+   Enter/Leave 事件触发 hovered/unhovered 信号），确认编译失败（red）。
+2. 在 `loginbutton.hpp/cpp` 实现信号，测试通过（green）。
+3. 在 `qt_tm_widget.hpp/cpp` 接入悬浮显示逻辑。
+
+## 涉及文件
+
+- `src/Plugins/QWindowKit/loginbutton.hpp`
+- `src/Plugins/QWindowKit/loginbutton.cpp`
+- `src/Plugins/Qt/qt_tm_widget.hpp`
+- `src/Plugins/Qt/qt_tm_widget.cpp`
+- `tests/Plugins/Qt/login_button_test.cpp`

--- a/devel/1239.md
+++ b/devel/1239.md
@@ -36,3 +36,28 @@
 - `src/Plugins/Qt/qt_tm_widget.hpp`
 - `src/Plugins/Qt/qt_tm_widget.cpp`
 - `tests/Plugins/Qt/login_button_test.cpp`
+
+## 测试方法
+
+### 自动化（TDD 单元测试）
+
+```bash
+xmake b login_button_test && xmake r login_button_test
+```
+
+覆盖：Enter 事件触发 `hovered()`、Leave 事件触发 `unhovered()`（QSignalSpy 断言）。
+
+### GUI 手动验证（商业版构建）
+
+1. 启动 GUI：`xmake b stem && xmake r stem`
+2. **悬浮显示**：鼠标移到窗口栏最左侧用户中心按钮上，不点击，
+   用户中心弹窗应直接弹出：
+   - 已登录（本地有 token）：拉取用户信息后展示会员信息
+   - 未登录：直接显示登录对话框
+3. **防重复触发**：弹窗已显示时，鼠标在按钮上反复进出，弹窗不应闪烁
+   或重复发起网络请求（日志中 `Cached token` 每次悬浮最多一条）。
+4. **悬浮不隐藏**：弹窗可见时再次悬浮，弹窗不应被 toggle 隐藏
+   （隐藏仍只能通过点击按钮或关闭弹窗实现）。
+5. **点击行为不回归**：点击按钮仍走原逻辑（可见时隐藏，不可见时显示）。
+6. **社区版回归**：社区版构建下悬浮按钮无任何弹窗，点击仍跳转官网
+   （`account-oauth2-config` 的 `click-return-liii-url`）。

--- a/src/Plugins/QWindowKit/loginbutton.cpp
+++ b/src/Plugins/QWindowKit/loginbutton.cpp
@@ -140,6 +140,7 @@ LoginButton::enterEvent (QEnterEvent* event) {
   Q_D (LoginButton);
   d->hovered= true;
   d->reloadIcon ();
+  emit hovered ();
   QPushButton::enterEvent (event);
 }
 
@@ -148,6 +149,7 @@ LoginButton::leaveEvent (QEvent* event) {
   Q_D (LoginButton);
   d->hovered= false;
   d->reloadIcon ();
+  emit unhovered ();
   QPushButton::leaveEvent (event);
 }
 

--- a/src/Plugins/QWindowKit/loginbutton.hpp
+++ b/src/Plugins/QWindowKit/loginbutton.hpp
@@ -44,6 +44,10 @@ public:
   bool badgeVisible () const;
   void setBadgeVisible (bool visible);
 
+Q_SIGNALS:
+  void hovered ();
+  void unhovered ();
+
 protected:
   void enterEvent (QEnterEvent* event) override;
   void leaveEvent (QEvent* event) override;

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -453,6 +453,11 @@ qt_tm_widget_rep::qt_tm_widget_rep (int mask, command _quit)
     // 惰性到首次使用（ensureLoginDialog）时再创建
     QObject::connect (loginButton, &QWK::LoginButton::clicked,
                       [this] () { checkLocalTokenAndLogin (); });
+    // 悬浮直接显示用户中心；离开按钮后重置，允许下一次悬浮再次触发
+    QObject::connect (loginButton, &QWK::LoginButton::hovered,
+                      [this] () { showUserCenterOnHover (); });
+    QObject::connect (loginButton, &QWK::LoginButton::unhovered,
+                      [this] () { m_userCenterHoverPending= false; });
   }
 
   // 邀请好友按钮 - 放在登录按钮左侧（商业版已登录时显示）
@@ -3171,6 +3176,21 @@ qt_tm_widget_rep::checkLocalTokenAndLogin () {
     // 没有token，显示登录对话框（用户需要手动点击登录按钮）
     show_login_dialog_at_button (ensureLoginDialog (), loginButton);
   }
+}
+
+/**
+ * @brief 悬浮显示用户中心（商业版）
+ *
+ * 与点击路径的差异：已可见时不做 toggle 隐藏；同一次悬浮内只触发一次，
+ * 避免网络请求在途时重复 Enter 导致并发拉取用户信息。
+ */
+void
+qt_tm_widget_rep::showUserCenterOnHover () {
+  if (is_community_stem ()) return;
+  if (m_loginDialog && m_loginDialog->isVisible ()) return;
+  if (m_userCenterHoverPending) return;
+  m_userCenterHoverPending= true;
+  checkLocalTokenAndLogin ();
 }
 
 void

--- a/src/Plugins/Qt/qt_tm_widget.hpp
+++ b/src/Plugins/Qt/qt_tm_widget.hpp
@@ -133,6 +133,8 @@ private:
   void              setupLoginDialog (QWK::LoginDialog* loginDialog);
   QWK::LoginDialog* ensureLoginDialog ();
   void              checkLocalTokenAndLogin ();
+  void              showUserCenterOnHover ();
+  bool              m_userCenterHoverPending= false;
   void              fetchUserInfo (const QString& token, bool showDialog= true);
   void              refreshLoginDialogPlacement ();
   bool              shouldShowLoginDialogUpdateSection ();

--- a/tests/Plugins/Qt/login_button_test.cpp
+++ b/tests/Plugins/Qt/login_button_test.cpp
@@ -50,6 +50,9 @@ TestLoginButton::leave_emits_unhovered () {
 #ifdef QTTEXMACS
 QTEST_MAIN (TestLoginButton)
 #else
-int main () { return 0; }
+int
+main () {
+  return 0;
+}
 #endif
 #include "login_button_test.moc"

--- a/tests/Plugins/Qt/login_button_test.cpp
+++ b/tests/Plugins/Qt/login_button_test.cpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * MODULE     : login_button_test.cpp
+ * DESCRIPTION : LoginButton 悬浮信号的单元测试（hovered/unhovered）
+ * COPYRIGHT  : (C) 2026 Liii
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "base.hpp"
+
+#include <QApplication>
+#include <QEnterEvent>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "QWindowKit/loginbutton.hpp"
+
+class TestLoginButton : public QObject {
+  Q_OBJECT
+private slots:
+  void init () { init_lolly (); }
+  void cleanup () { cleanup_qt_top_level_widgets (); }
+
+  void enter_emits_hovered ();
+  void leave_emits_unhovered ();
+};
+
+void
+TestLoginButton::enter_emits_hovered () {
+  QWK::LoginButton btn;
+  QSignalSpy       spy (&btn, &QWK::LoginButton::hovered);
+  QEnterEvent      enter (QPointF (1, 1), QPointF (1, 1), QPointF (1, 1));
+  QApplication::sendEvent (&btn, &enter);
+  QCOMPARE (spy.count (), 1);
+}
+
+void
+TestLoginButton::leave_emits_unhovered () {
+  QWK::LoginButton btn;
+  QEnterEvent      enter (QPointF (1, 1), QPointF (1, 1), QPointF (1, 1));
+  QApplication::sendEvent (&btn, &enter);
+  QSignalSpy spy (&btn, &QWK::LoginButton::unhovered);
+  QEvent     leave (QEvent::Leave);
+  QApplication::sendEvent (&btn, &leave);
+  QCOMPARE (spy.count (), 1);
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestLoginButton)
+#else
+int main () { return 0; }
+#endif
+#include "login_button_test.moc"


### PR DESCRIPTION
## 概述

商业版：鼠标悬浮在窗口栏用户中心（登录）按钮上时直接显示用户中心弹窗，无需点击。社区版保持原有行为（点击跳转官网）。

## 改动

- `QWK::LoginButton` 新增 `hovered()` / `unhovered()` 信号（`enterEvent` / `leaveEvent` 中 emit）
- `qt_tm_widget_rep::showUserCenterOnHover ()`：
  - 社区版直接 return，保持点击行为
  - 弹窗已可见时不做 toggle 隐藏（与点击路径的差异）
  - `m_userCenterHoverPending` 标志保证同一次悬浮只触发一次，避免网络请求在途时重复 Enter 导致并发拉取用户信息；`unhovered` 时重置
- 新增 `tests/Plugins/Qt/login_button_test.cpp`（QSignalSpy 断言信号触发，TDD 先红后绿）

## 验证

- `xmake r login_button_test`：4 passed, 0 failed
- `xmake b stem` 编译通过
- `gf fmt --changed-since=main` 无格式改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)