### PR TITLE
[0941] PDF 截图结果提示顶部居中显示，任意后续操作立即消失

### DIFF
--- a/devel/0941.md
+++ b/devel/0941.md
@@ -1,0 +1,34 @@
+# 0941 PDF 截图结果提示居中并及时消失
+
+## 测试步骤
+
+1. 用 PDF 阅读器打开一份 PDF，点击工具栏截图按钮进入选区模式
+2. 两次点击确定选区完成截图
+3. 验证 "Copied to Clipboard!" 提示出现在阅读区视口中央（原来在左上角）
+4. 随后进行任意操作（点击、滚轮、按键、缩放手势），提示立即消失
+5. 若仍处于截图选区模式，提示消失后恢复左上角的操作指引提示
+
+## What
+
+- 截图完成后的 "Copied to Clipboard!" 提示从左上角改为视口中央显示
+- 任何后续用户操作（鼠标按下/双击、滚轮、按键、手势）立即清除该提示
+- 若截图选区模式仍开启，清除提示后恢复左上角的选区操作指引
+
+## Why
+
+截图成功提示出现在左上角与用户视线焦点（选区中央）不符，且原提示会一直保留，容易被误认为未消失的状态信息。
+
+## How
+
+- `PDFReaderWidget` 新增 `showHintToast`/`restoreSelectHint`/`dismissHintToast`
+  三个方法及 `hintToastActive_` 状态位
+- `finishRectSelect` 改用 `showHintToast`，按视口尺寸计算居中位置
+- `eventFilter`（视口事件）与 `event`（手势等）在收到用户输入事件时若
+  toast 处于激活状态则调用 `dismissHintToast`
+- `setRectSelectMode` 复用 `restoreSelectHint`，并在退出选区模式时清除
+  toast 状态
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_pdf_reader_widget.hpp`
+- `src/Plugins/Qt/qt_pdf_reader_widget.cpp`

--- a/devel/0941.md
+++ b/devel/0941.md
@@ -4,13 +4,13 @@
 
 1. 用 PDF 阅读器打开一份 PDF，点击工具栏截图按钮进入选区模式
 2. 两次点击确定选区完成截图
-3. 验证 "Copied to Clipboard!" 提示出现在阅读区视口中央（原来在左上角）
+3. 验证 "Copied to Clipboard!" 提示出现在阅读区顶部水平居中处（原来在左上角）
 4. 随后进行任意操作（点击、滚轮、按键、缩放手势），提示立即消失
 5. 若仍处于截图选区模式，提示消失后恢复左上角的操作指引提示
 
 ## What
 
-- 截图完成后的 "Copied to Clipboard!" 提示从左上角改为视口中央显示
+- 截图完成后的 "Copied to Clipboard!" 提示从左上角改为顶部水平居中显示
 - 任何后续用户操作（鼠标按下/双击、滚轮、按键、手势）立即清除该提示
 - 若截图选区模式仍开启，清除提示后恢复左上角的选区操作指引
 
@@ -22,7 +22,7 @@
 
 - `PDFReaderWidget` 新增 `showHintToast`/`restoreSelectHint`/`dismissHintToast`
   三个方法及 `hintToastActive_` 状态位
-- `finishRectSelect` 改用 `showHintToast`，按视口尺寸计算居中位置
+- `finishRectSelect` 改用 `showHintToast`，按视口宽度水平居中、垂直保持原提示位
 - `eventFilter`（视口事件）与 `event`（手势等）在收到用户输入事件时若
   toast 处于激活状态则调用 `dismissHintToast`
 - `setRectSelectMode` 复用 `restoreSelectHint`，并在退出选区模式时清除

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -70,15 +70,15 @@ PDFReaderWidget::PDFReaderWidget (QWidget* parent)
     : QWidget (parent), scrollArea_ (nullptr), contentWidget_ (nullptr),
       pageLayout_ (nullptr), mainLayout_ (nullptr), rubberBand_ (nullptr),
       rectSelectMode_ (false), rectSelectDragging_ (false),
-      hintLabel_ (nullptr), browseDragging_ (false), browseDragActive_ (false),
-      scroller_ (nullptr), pageCount_ (0), hasError_ (false),
-      targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0), pageAspectRatio_ (0.0),
-      pageBaseWidthPts_ (0.0), overLink_ (false), zoomDebounceTimer_ (nullptr),
-      resizeDebounceTimer_ (nullptr), gestureSafetyTimer_ (nullptr),
-      inPinchGesture_ (false), blockRender_ (false), autoFitApplied_ (false),
-      pinchStartZoom_ (1.0), zoomAnchorContentY_ (0.0),
-      zoomAnchorViewportY_ (0.0), zoomAnchorOldZoom_ (1.0),
-      hasZoomAnchor_ (false), renderCallCount_ (0) {
+      hintLabel_ (nullptr), hintToastActive_ (false), browseDragging_ (false),
+      browseDragActive_ (false), scroller_ (nullptr), pageCount_ (0),
+      hasError_ (false), targetDpi_ (DEFAULT_DPI), zoomFactor_ (1.0),
+      pageAspectRatio_ (0.0), pageBaseWidthPts_ (0.0), overLink_ (false),
+      zoomDebounceTimer_ (nullptr), resizeDebounceTimer_ (nullptr),
+      gestureSafetyTimer_ (nullptr), inPinchGesture_ (false),
+      blockRender_ (false), autoFitApplied_ (false), pinchStartZoom_ (1.0),
+      zoomAnchorContentY_ (0.0), zoomAnchorViewportY_ (0.0),
+      zoomAnchorOldZoom_ (1.0), hasZoomAnchor_ (false), renderCallCount_ (0) {
 
   mainLayout_= new QVBoxLayout (this);
   mainLayout_->setContentsMargins (0, 0, 0, 0);
@@ -470,31 +470,69 @@ PDFReaderWidget::setRectSelectMode (bool checked) {
   }
   rectSelectDragging_= false;
 
-  if (rectSelectMode_) {
-    if (!hintLabel_) {
-      hintLabel_= new QLabel (contentWidget_);
-      hintLabel_->setObjectName ("rectSelectHint");
-      hintLabel_->setStyleSheet (
-          "QLabel { background-color: rgba(0, 0, 0, 180); color: white; "
-          "padding: 4px 8px; border-radius: 4px; font-size: 12px; }");
-    }
-#ifdef Q_OS_MACOS
-    QString shortcut= "Cmd+Shift+v";
-#else
-    QString shortcut= "Ctrl+Shift+v";
-#endif
-    hintLabel_->setText (QString ("Click two corners to select, then use %1 to "
-                                  "magic paste!")
-                             .arg (shortcut));
-    hintLabel_->adjustSize ();
-    hintLabel_->move (PAGE_MARGIN, PAGE_MARGIN);
-    hintLabel_->show ();
-  }
-  else if (hintLabel_) {
-    hintLabel_->hide ();
-  }
+  if (rectSelectMode_) restoreSelectHint ();
+  else if (hintLabel_) hintLabel_->hide ();
+  hintToastActive_= false;
 
   Q_EMIT rectSelectModeChanged (checked);
+}
+
+/**
+ * @brief 在视口中央显示临时提示（如"已复制到剪贴板"）
+ *
+ * 提示相对视口居中，任何后续用户操作会通过 dismissHintToast 立即清除。
+ */
+void
+PDFReaderWidget::showHintToast (const QString& text) {
+  if (!hintLabel_ || !scrollArea_ || !scrollArea_->viewport ()) return;
+  hintLabel_->setText (text);
+  hintLabel_->adjustSize ();
+  QWidget* vp    = scrollArea_->viewport ();
+  QPoint   center= QPoint ((vp->width () - hintLabel_->width ()) / 2,
+                           (vp->height () - hintLabel_->height ()) / 2);
+  hintLabel_->move (contentWidget_->mapFrom (vp, center));
+  hintLabel_->show ();
+  hintLabel_->raise ();
+  hintToastActive_= true;
+}
+
+/**
+ * @brief 恢复截图选区模式的左上角操作提示
+ */
+void
+PDFReaderWidget::restoreSelectHint () {
+  if (!hintLabel_) {
+    hintLabel_= new QLabel (contentWidget_);
+    hintLabel_->setObjectName ("rectSelectHint");
+    hintLabel_->setStyleSheet (
+        "QLabel { background-color: rgba(0, 0, 0, 180); color: white; "
+        "padding: 4px 8px; border-radius: 4px; font-size: 12px; }");
+  }
+#ifdef Q_OS_MACOS
+  QString shortcut= "Cmd+Shift+v";
+#else
+  QString shortcut= "Ctrl+Shift+v";
+#endif
+  hintLabel_->setText (QString ("Click two corners to select, then use %1 to "
+                                "magic paste!")
+                           .arg (shortcut));
+  hintLabel_->adjustSize ();
+  hintLabel_->move (PAGE_MARGIN, PAGE_MARGIN);
+  hintLabel_->show ();
+  hintToastActive_= false;
+}
+
+/**
+ * @brief 清除居中的临时提示；若仍处于截图选区模式则恢复操作提示
+ */
+void
+PDFReaderWidget::dismissHintToast () {
+  if (!hintToastActive_) return;
+  if (rectSelectMode_) restoreSelectHint ();
+  else if (hintLabel_) {
+    hintLabel_->hide ();
+    hintToastActive_= false;
+  }
 }
 
 void
@@ -528,10 +566,7 @@ PDFReaderWidget::finishRectSelect (const QPoint& viewportPos) {
     }
   }
 
-  if (hintLabel_) {
-    hintLabel_->setText ("Copied to Clipboard!");
-    hintLabel_->adjustSize ();
-  }
+  if (hintLabel_) showHintToast ("Copied to Clipboard!");
 }
 
 QLabel*
@@ -1427,6 +1462,12 @@ PDFReaderWidget::keyPressEvent (QKeyEvent* event) {
 
 bool
 PDFReaderWidget::event (QEvent* event) {
+  if (hintToastActive_ &&
+      (event->type () == QEvent::Gesture ||
+       event->type () == QEvent::NativeGesture ||
+       event->type () == QEvent::Wheel || event->type () == QEvent::KeyPress)) {
+    dismissHintToast ();
+  }
   if (event->type () == QEvent::Gesture) {
     QGestureEvent* gestureEvent= static_cast<QGestureEvent*> (event);
     if (QPinchGesture* pinch= qobject_cast<QPinchGesture*> (
@@ -1500,6 +1541,13 @@ PDFReaderWidget::event (QEvent* event) {
 bool
 PDFReaderWidget::eventFilter (QObject* watched, QEvent* event) {
   if (watched == scrollArea_->viewport ()) {
+    // 居中的截图结果提示:任何后续用户操作立即清除
+    if (hintToastActive_ && (event->type () == QEvent::MouseButtonPress ||
+                             event->type () == QEvent::MouseButtonDblClick ||
+                             event->type () == QEvent::Wheel ||
+                             event->type () == QEvent::KeyPress)) {
+      dismissHintToast ();
+    }
     // Pre-compute viewport and content coordinates for mouse events.
     QPoint viewportPos, contentPos;
     bool   isMouseEvent= (event->type () == QEvent::MouseMove ||

--- a/src/Plugins/Qt/qt_pdf_reader_widget.cpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.cpp
@@ -478,19 +478,21 @@ PDFReaderWidget::setRectSelectMode (bool checked) {
 }
 
 /**
- * @brief 在视口中央显示临时提示（如"已复制到剪贴板"）
+ * @brief 在视口顶部水平居中处显示临时提示（如"已复制到剪贴板"）
  *
- * 提示相对视口居中，任何后续用户操作会通过 dismissHintToast 立即清除。
+ * 垂直位置与选区模式提示一致，水平相对视口居中；任何后续用户操作会通过
+ * dismissHintToast 立即清除。
  */
 void
 PDFReaderWidget::showHintToast (const QString& text) {
   if (!hintLabel_ || !scrollArea_ || !scrollArea_->viewport ()) return;
   hintLabel_->setText (text);
   hintLabel_->adjustSize ();
-  QWidget* vp    = scrollArea_->viewport ();
-  QPoint   center= QPoint ((vp->width () - hintLabel_->width ()) / 2,
-                           (vp->height () - hintLabel_->height ()) / 2);
-  hintLabel_->move (contentWidget_->mapFrom (vp, center));
+  // 垂直位置保持原左上角提示位,仅水平相对视口居中
+  QWidget* vp= scrollArea_->viewport ();
+  QPoint   anchor=
+      QPoint ((vp->width () - hintLabel_->width ()) / 2, PAGE_MARGIN);
+  hintLabel_->move (contentWidget_->mapFrom (vp, anchor));
   hintLabel_->show ();
   hintLabel_->raise ();
   hintToastActive_= true;

--- a/src/Plugins/Qt/qt_pdf_reader_widget.hpp
+++ b/src/Plugins/Qt/qt_pdf_reader_widget.hpp
@@ -136,6 +136,9 @@ private:
   int     pageWidth () const;
   void    applyZoomToLabels ();
   void    finishRectSelect (const QPoint& viewportPos);
+  void    showHintToast (const QString& text);
+  void    restoreSelectHint ();
+  void    dismissHintToast ();
   QLabel* findPageLabelAt (const QPoint& contentPos) const;
   QPixmap extractSelectionPixmap (QLabel*      label,
                                   const QRect& contentRect) const;
@@ -161,6 +164,7 @@ private:
   QPoint       rectSelectStart_;
   bool         rectSelectDragging_;
   QLabel*      hintLabel_;
+  bool         hintToastActive_;
 
   // Browse (hand) tool state
   bool       browseDragging_;


### PR DESCRIPTION
## 任务

0941：PDF 阅读器截图之后，结果提示 "Copied to Clipboard!" 原先固定在左上角（与选区位置无关），且会一直保留。本 PR 将其调整为**顶部水平居中**显示（垂直位置与原提示一致），且**任何后续用户操作立即消失**。

任务文档：`devel/0941.md`

## 改动

- `PDFReaderWidget` 新增 `showHintToast` / `restoreSelectHint` / `dismissHintToast` 三个方法及 `hintToastActive_` 状态位
- 截图完成（`finishRectSelect`）后调用 `showHintToast`：按视口宽度水平居中，垂直保持原左上角提示位（`PAGE_MARGIN`），并置顶显示
- `eventFilter`（视口鼠标按下/双击、滚轮、按键）与 `event`（手势、滚轮、按键）入口处：toast 激活时收到用户输入立即清除
- 清除后若仍处于截图选区模式，恢复左上角的操作指引提示；否则隐藏
- `setRectSelectMode` 复用 `restoreSelectHint`，退出选区模式时清除 toast 状态

## 验证

- [x] `xmake b stem` 构建通过
- [x] `xmake r qt_pdf_reader_widget_test`：47 passed, 0 failed
- [x] `gf fmt --changed-since=main` 已格式化
- [x] 手动 GUI 验证（开发者本人完成）：提示显示与任意操作（点击/滚轮/按键）后立即消失、选区指引恢复正常
- [x] 位置按 review 意见从「视口正中」调整为「顶部水平居中」后由需求方确认提交
