### PR TITLE
[1242] 修复快捷键切换结构变体后焦点工具栏不刷新

### DIFF
--- a/TeXmacs/progs/utils/edit/tests/variants-test.scm
+++ b/TeXmacs/progs/utils/edit/tests/variants-test.scm
@@ -1,0 +1,27 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : variants-test.scm
+;; DESCRIPTION : Test suite for variant switching
+;; COPYRIGHT   : (C) 2026  Mogan STEM authors
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (utils edit variants))
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(define (test-variant-menu-categories)
+  ;; 变体切换只影响焦点工具栏，不请求其它菜单段重建
+  (check (variant-menu-categories) => '(icons-focus))
+) ;define
+
+(tm-define (regtest-variants)
+  (test-variant-menu-categories)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/utils/edit/tests/variants-test.scm
+++ b/TeXmacs/progs/utils/edit/tests/variants-test.scm
@@ -21,7 +21,4 @@
   (check (variant-menu-categories) => '(icons-focus))
 ) ;define
 
-(tm-define (regtest-variants)
-  (test-variant-menu-categories)
-  (check-report)
-) ;tm-define
+(tm-define (regtest-variants) (test-variant-menu-categories) (check-report))

--- a/TeXmacs/progs/utils/edit/variants.scm
+++ b/TeXmacs/progs/utils/edit/variants.scm
@@ -267,11 +267,16 @@
 
 (tm-define (focus-tree-modified t) (noop))
 
+;; 变体切换后焦点树路径不变，光标驱动的菜单刷新判等不会触发，
+;; 需显式请求重建焦点工具栏（ICONS_FOCUS）
+(tm-define (variant-menu-categories) '(icons-focus))
+
 (tm-define (variant-set t by)
   (with-focus-after t
     (with i
       (tree-down-index t)
       (tree-assign-node! t by)
+      (apply update-menus (variant-menu-categories))
       (focus-tree-modified t)
       (when (and i (not (tree-accessible-child? t i)))
         (with ac

--- a/TeXmacs/tests/1242.scm
+++ b/TeXmacs/tests/1242.scm
@@ -1,0 +1,81 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1242.scm
+;; DESCRIPTION : GUI 集成测试：快捷键切换结构变体后焦点工具栏刷新
+;; COPYRIGHT   : (C) 2026  Mogan STEM authors
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;; USAGE
+;;   xmake b stem
+;;   MOGAN_TEST_GUI=1 xmake r 1242      # 真实 GUI，跑断言链
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(load "./TeXmacs/progs/utils/edit/variants.scm")
+(load "./TeXmacs/progs/text/text-drd.scm")
+
+(define step-delay-ms 300)
+
+(define section-tree #f)
+
+(define (ancestor-with-label t lab)
+  (cond ((not t) #f)
+        ((== (tree-label t) lab) t)
+        (else (ancestor-with-label (tree-outer t) lab)))
+) ;define
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1242-step] ")
+                           (display label)
+                           (newline)
+                           (catch #t
+                             (lambda () (act))
+                             (lambda args
+                               (display "[1242-error] in step: ")
+                               (display label)
+                               (display " -> ")
+                               (write args)
+                               (newline)
+                             ) ;lambda
+                           ) ;catch
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(tm-define (test_1242)
+  (run-chain (list
+    (cons "new document"
+      (lambda ()
+        (new-document)))
+    (cons "insert section"
+      (lambda ()
+        (init-env "style" "article")
+        (set! section-tree (tree 'section "x"))
+        (insert section-tree)
+        ;; 从光标位置取回 buffer 内的 section（insert 可能复制树）
+        (set! section-tree (ancestor-with-label (cursor-tree) 'section))
+        (check (not (not section-tree)) => #t)))
+    (cons "circulate variant like structured:cmd tab"
+      (lambda ()
+        ;; 与快捷键 (variant-circulate (focus-tree) #t) 相同入口；
+        ;; 修复后 variant-set 内部会请求重建焦点工具栏（ICONS_FOCUS）
+        (variant-circulate section-tree #t)
+        (check (tree-label section-tree) => 'subsection)))
+    (cons "report + quit"
+      (lambda () (check-report) (quit-TeXmacs)))
+  ))
+) ;tm-define

--- a/TeXmacs/tests/1242.scm
+++ b/TeXmacs/tests/1242.scm
@@ -25,7 +25,8 @@
 (define (ancestor-with-label t lab)
   (cond ((not t) #f)
         ((== (tree-label t) lab) t)
-        (else (ancestor-with-label (tree-outer t) lab)))
+        (else (ancestor-with-label (tree-outer t) lab))
+  ) ;cond
 ) ;define
 
 (define (run-chain steps)
@@ -57,25 +58,26 @@
 ) ;define
 
 (tm-define (test_1242)
-  (run-chain (list
-    (cons "new document"
-      (lambda ()
-        (new-document)))
-    (cons "insert section"
-      (lambda ()
-        (init-env "style" "article")
-        (set! section-tree (tree 'section "x"))
-        (insert section-tree)
-        ;; 从光标位置取回 buffer 内的 section（insert 可能复制树）
-        (set! section-tree (ancestor-with-label (cursor-tree) 'section))
-        (check (not (not section-tree)) => #t)))
-    (cons "circulate variant like structured:cmd tab"
-      (lambda ()
-        ;; 与快捷键 (variant-circulate (focus-tree) #t) 相同入口；
-        ;; 修复后 variant-set 内部会请求重建焦点工具栏（ICONS_FOCUS）
-        (variant-circulate section-tree #t)
-        (check (tree-label section-tree) => 'subsection)))
-    (cons "report + quit"
-      (lambda () (check-report) (quit-TeXmacs)))
-  ))
+  (run-chain (list (cons "new document" (lambda () (new-document)))
+               (cons "insert section"
+                 (lambda ()
+                   (init-env "style" "article")
+                   (set! section-tree (tree 'section "x"))
+                   (insert section-tree)
+                   ;; 从光标位置取回 buffer 内的 section（insert 可能复制树）
+                   (set! section-tree (ancestor-with-label (cursor-tree) 'section))
+                   (check (not (not section-tree)) => #t)
+                 ) ;lambda
+               ) ;cons
+               (cons "circulate variant like structured:cmd tab"
+                 (lambda ()
+                   ;; 与快捷键 (variant-circulate (focus-tree) #t) 相同入口；
+                   ;; 修复后 variant-set 内部会请求重建焦点工具栏（ICONS_FOCUS）
+                   (variant-circulate section-tree #t)
+                   (check (tree-label section-tree) => 'subsection)
+                 ) ;lambda
+               ) ;cons
+               (cons "report + quit" (lambda () (check-report) (quit-TeXmacs)))
+             ) ;list
+  ) ;run-chain
 ) ;tm-define

--- a/devel/1242.md
+++ b/devel/1242.md
@@ -1,12 +1,65 @@
-# 1242 快捷键切换结构变体后焦点工具栏不刷新
+# [1242] 快捷键切换结构变体后焦点工具栏不刷新
 
-## 问题
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
 
-用快捷键 `Alt+Shift+↓` / `Alt+Shift+↑`（`generic-kbd.scm` 中 `A-S-down`/
-`A-S-up`，即 `(variant-circulate (focus-tree) #t/#f)`）切换结构变体（如
-section → subsection）后，焦点工具栏仍显示旧变体；从菜单切换则正常。
+## 2 任务相关的代码文件
+- TeXmacs/progs/utils/edit/variants.scm - 修复本体（`variant-set`）
+- TeXmacs/progs/generic/generic-kbd.scm - 快捷键绑定（`A-S-up` / `A-S-down`）
+- TeXmacs/progs/kernel/gui/menu-widget.scm - `update-menus` 掩码入口
+- src/Edit/Interface/edit_interface.cpp - `update_menus` / 菜单刷新触发处
+- TeXmacs/progs/utils/edit/tests/variants-test.scm - 纯逻辑测试
+- TeXmacs/tests/1242.scm - GUI 集成测试
 
-## 原因
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+xmake r variants-test            # 纯逻辑：variant-menu-categories 契约
+MOGAN_TEST_GUI=1 xmake r 1242    # GUI 集成：variant-circulate 后变体变为 subsection
+```
+
+### 3.2 非确定性测试（文档验证）
+```
+前置：xmake b stem && xmake r stem 启动真实 GUI。
+
+1. 新建文档（默认样式），插入一个标题（如 section），光标置于标题文字内，
+   此时焦点工具栏显示 Section 相关控件。
+2. 按 Alt+Shift+↓：标题变体切到下一级（section → subsection），
+   焦点工具栏应立即显示 Subsection（修复前仍显示 Section）。
+3. 连续按 Alt+Shift+↓ 继续循环：subsection → subsubsection → paragraph →
+   subparagraph → … → section，每按一次工具栏都同步刷新。
+4. 按 Alt+Shift+↑ 反向切换，工具栏同样同步。
+5. 回归确认菜单路径：焦点工具栏的变体下拉 / Insert 菜单切换变体仍正常。
+6. 其它同样走 variant-set 的快捷键路径顺带验证：
+   Alt+Shift+*（numbered/unnumbered 切换，如 section ↔ section*）后工具栏同步。
+```
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+xmake r variants-test
+MOGAN_TEST_GUI=1 xmake r 1242
+```
+
+## 5 What
+
+用快捷键 `Alt+Shift+↓` / `Alt+Shift+↑`（`A-S-down`/`A-S-up`，即
+`(variant-circulate (focus-tree) #t/#f)`）切换结构变体（如 section →
+subsection）后，焦点工具栏仍显示旧变体；从菜单切换则正常。本任务修复该问题。
+
+1. `variants.scm` 新增 `variant-menu-categories`（返回 `'(icons-focus)`，
+   即 ICONS_FOCUS 掩码）
+2. `variant-set` 在 `tree-assign-node!` 后
+   `(apply update-menus (variant-menu-categories))`，仅重建焦点工具栏
+3. 新增纯逻辑测试与 GUI 集成测试各一份
+
+## 6 Why
 
 - 菜单路径：action 执行完走 `after_menu_action` → `notify_change(THE_MENUS)` →
   全量 `update_menus`，工具栏随之重建。
@@ -14,41 +67,13 @@ section → subsection）后，焦点工具栏仍显示旧变体；从菜单切�
   变体切换后焦点树 *路径* 不变，`edit_interface.cpp` 中 `THE_CURSOR` 分支的
   `fp != menu_focus_path` 判等不成立，ICONS_FOCUS 段不会重建。
 
-## 修复（What/How）
+该修复覆盖所有变体切换入口：kbd `variant-circulate`、`numbered-toggle`、
+`alternate-toggle`、焦点菜单 `variant-set-keep-numbering`。
 
-在 `TeXmacs/progs/utils/edit/variants.scm` 的 `variant-set` 中，`tree-assign-node!`
-之后显式请求仅重建焦点工具栏：
+## 7 How
 
-- 新增 `variant-menu-categories`（返回 `'(icons-focus)`，即 ICONS_FOCUS 掩码），
-  `variant-set` 内 `(apply update-menus (variant-menu-categories))`。
-- 该路径覆盖所有变体切换入口：kbd `variant-circulate`、`numbered-toggle`、
-  `alternate-toggle`、焦点菜单 `variant-set-keep-numbering`。
+在 `variant-set` 内、`tree-assign-node!` 之后显式请求仅重建焦点工具栏
+（ICONS_FOCUS），不做全量 `update_menus`，避免无谓的菜单段 scheme 求值开销。
 
-## 涉及文件
-
-- `TeXmacs/progs/utils/edit/variants.scm`：修复本体
-- `TeXmacs/progs/utils/edit/tests/variants-test.scm`：纯逻辑测试
-  （`variant-menu-categories` 契约），`xmake r variants-test`
-- `TeXmacs/tests/1242.scm`：GUI 集成测试（新建文档插入 section，走与快捷键相同的
-  `variant-circulate` 入口断言变为 subsection），`MOGAN_TEST_GUI=1 xmake r 1242`
-  （2 correct；运行日志中 `update_menus: icons2-focus` 出现 2 次，确认焦点工具栏重建）
-
-## 手动测试
-
-前置：`xmake b stem && xmake r stem` 启动真实 GUI。
-
-1. 新建文档（默认样式），插入一个标题（如 section），光标置于标题文字内，
-   此时焦点工具栏显示 Section 相关控件。
-2. 按 `Alt+Shift+↓`：标题变体切到下一级（section → subsection），
-   **焦点工具栏应立即显示 Subsection**（修复前仍显示 Section）。
-3. 连续按 `Alt+Shift+↓` 继续循环：subsection → subsubsection → paragraph →
-   subparagraph → … → section，每按一次工具栏都同步刷新。
-4. 按 `Alt+Shift+↑` 反向切换，工具栏同样同步。
-5. 回归确认菜单路径：焦点工具栏的变体下拉/`Insert` 菜单切换变体仍正常。
-6. 其它同样走 `variant-set` 的快捷键路径顺带验证：
-   `Alt+Shift+*`（numbered/unnumbered 切换，如 section ↔ section*）后工具栏同步。
-
-## 备注
-
-测试编写时发现的坑：`new-document` 后立即 `insert`，scheme 树对象可能未挂到
+备注（测试编写时的坑）：`new-document` 后立即 `insert`，scheme 树对象可能未挂到
 buffer 树上（insert 复制树）；需从 `cursor-tree` 向外找 ancestor 取回活树。

--- a/devel/1242.md
+++ b/devel/1242.md
@@ -1,0 +1,38 @@
+# 1242 快捷键切换结构变体后焦点工具栏不刷新
+
+## 问题
+
+用快捷键（`structured:cmd tab`，即 `variant-circulate (focus-tree)`）切换结构变体
+（如 section → subsection）后，焦点工具栏仍显示旧变体；从菜单切换则正常。
+
+## 原因
+
+- 菜单路径：action 执行完走 `after_menu_action` → `notify_change(THE_MENUS)` →
+  全量 `update_menus`，工具栏随之重建。
+- 快捷键路径：`variant-circulate` → `variant-set` → `tree-assign-node!` 只改树，
+  变体切换后焦点树 *路径* 不变，`edit_interface.cpp` 中 `THE_CURSOR` 分支的
+  `fp != menu_focus_path` 判等不成立，ICONS_FOCUS 段不会重建。
+
+## 修复（What/How）
+
+在 `TeXmacs/progs/utils/edit/variants.scm` 的 `variant-set` 中，`tree-assign-node!`
+之后显式请求仅重建焦点工具栏：
+
+- 新增 `variant-menu-categories`（返回 `'(icons-focus)`，即 ICONS_FOCUS 掩码），
+  `variant-set` 内 `(apply update-menus (variant-menu-categories))`。
+- 该路径覆盖所有变体切换入口：kbd `variant-circulate`、`numbered-toggle`、
+  `alternate-toggle`、焦点菜单 `variant-set-keep-numbering`。
+
+## 涉及文件
+
+- `TeXmacs/progs/utils/edit/variants.scm`：修复本体
+- `TeXmacs/progs/utils/edit/tests/variants-test.scm`：纯逻辑测试
+  （`variant-menu-categories` 契约），`xmake r variants-test`
+- `TeXmacs/tests/1242.scm`：GUI 集成测试（新建文档插入 section，走与快捷键相同的
+  `variant-circulate` 入口断言变为 subsection），`MOGAN_TEST_GUI=1 xmake r 1242`
+  （2 correct；运行日志中 `update_menus: icons2-focus` 出现 2 次，确认焦点工具栏重建）
+
+## 备注
+
+测试编写时发现的坑：`new-document` 后立即 `insert`，scheme 树对象可能未挂到
+buffer 树上（insert 复制树）；需从 `cursor-tree` 向外找 ancestor 取回活树。

--- a/devel/1242.md
+++ b/devel/1242.md
@@ -2,8 +2,9 @@
 
 ## 问题
 
-用快捷键（`structured:cmd tab`，即 `variant-circulate (focus-tree)`）切换结构变体
-（如 section → subsection）后，焦点工具栏仍显示旧变体；从菜单切换则正常。
+用快捷键 `Alt+Shift+↓` / `Alt+Shift+↑`（`generic-kbd.scm` 中 `A-S-down`/
+`A-S-up`，即 `(variant-circulate (focus-tree) #t/#f)`）切换结构变体（如
+section → subsection）后，焦点工具栏仍显示旧变体；从菜单切换则正常。
 
 ## 原因
 
@@ -31,6 +32,21 @@
 - `TeXmacs/tests/1242.scm`：GUI 集成测试（新建文档插入 section，走与快捷键相同的
   `variant-circulate` 入口断言变为 subsection），`MOGAN_TEST_GUI=1 xmake r 1242`
   （2 correct；运行日志中 `update_menus: icons2-focus` 出现 2 次，确认焦点工具栏重建）
+
+## 手动测试
+
+前置：`xmake b stem && xmake r stem` 启动真实 GUI。
+
+1. 新建文档（默认样式），插入一个标题（如 section），光标置于标题文字内，
+   此时焦点工具栏显示 Section 相关控件。
+2. 按 `Alt+Shift+↓`：标题变体切到下一级（section → subsection），
+   **焦点工具栏应立即显示 Subsection**（修复前仍显示 Section）。
+3. 连续按 `Alt+Shift+↓` 继续循环：subsection → subsubsection → paragraph →
+   subparagraph → … → section，每按一次工具栏都同步刷新。
+4. 按 `Alt+Shift+↑` 反向切换，工具栏同样同步。
+5. 回归确认菜单路径：焦点工具栏的变体下拉/`Insert` 菜单切换变体仍正常。
+6. 其它同样走 `variant-set` 的快捷键路径顺带验证：
+   `Alt+Shift+*`（numbered/unnumbered 切换，如 section ↔ section*）后工具栏同步。
 
 ## 备注
 


### PR DESCRIPTION
## 问题

用快捷键（`structured:cmd tab`，即 `variant-circulate (focus-tree)`）切换结构变体（如 section → subsection）后，焦点工具栏仍显示旧变体；从菜单切换则正常。

## 原因

- 菜单路径：action 执行完走 `after_menu_action` → `notify_change(THE_MENUS)` → 全量 `update_menus`，工具栏随之重建
- 快捷键路径：`variant-circulate` → `variant-set` → `tree-assign-node!` 只改树，变体切换后焦点树**路径**不变，`THE_CURSOR` 分支的 `fp != menu_focus_path` 判等不成立，ICONS_FOCUS 段不会重建

## 修复

`TeXmacs/progs/utils/edit/variants.scm`：

- 新增 `variant-menu-categories`（返回 `'(icons-focus)`，即 ICONS_FOCUS 掩码）
- `variant-set` 在 `tree-assign-node!` 后 `(apply update-menus (variant-menu-categories))`，仅重建焦点工具栏
- 覆盖所有变体切换入口：kbd `variant-circulate`、`numbered-toggle`、`alternate-toggle`、焦点菜单 `variant-set-keep-numbering`

## 测试

- 新增纯逻辑测试 `TeXmacs/progs/utils/edit/tests/variants-test.scm`：`xmake r variants-test` → 1 correct
- 新增 GUI 集成测试 `TeXmacs/tests/1242.scm`：真实 GUI 中走与快捷键相同的 `variant-circulate` 入口断言 section → subsection；`MOGAN_TEST_GUI=1 xmake r 1242` → 2 correct, 0 failed，日志中 `update_menus: icons2-focus` 出现 2 次，确认焦点工具栏实际重建

🤖 Generated with [Claude Code](https://claude.com/claude-code)