### PR TITLE
[0940]修复右键 Magic paste 外部图像 OCR 失效

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1213,12 +1213,24 @@
 ;; ----
 ;; (ocr-paste source-format)
 
-(define (clipboard-tree-image? data)
+(tm-define (clipboard-tree-image? data)
   (or (tree-is? data 'image)
     (and (tree? data) (tree-compound? data) (tree-is? (tree-ref data 0) 'image))
     (and (tree-is? data 'with) (tree-is? (tree-ref data 2) 'image))
   ) ;or
-) ;define
+) ;tm-define
+
+;; 外部程序复制的图像经 (clipboard-get "primary") 得到 (extern "<texmacs-snippet>")，
+;; 真正内容在下标 1；内部复制时直接返回存储的 tree
+(tm-define (clipboard-get-data)
+  (with t
+    (clipboard-get "primary")
+    (if (and (tree? t) (tree-compound? t) (tree-is? (tree-ref t 0) 'extern))
+      (parse-texmacs-snippet (tree->string (tree-ref t 1)))
+      t
+    ) ;if
+  ) ;with
+) ;tm-define
 
 ;; 0-arg wrapper: keep backward compatibility with callers that call (ocr-paste)
 (tm-define (ocr-paste) (ocr-paste "image"))
@@ -1228,10 +1240,7 @@
     (use-modules (ocr liii-ocr))
   ) ;when
   (with data
-    (if (string=? source-format "texmacs-snippet")
-      (tree-ref (clipboard-get "primary") 0)
-      (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 0)))
-    ) ;if
+    (clipboard-get-data)
     (when (clipboard-tree-image? data)
       (ocr-to-latex-by-cursor data)
     ) ;when
@@ -1246,8 +1255,8 @@
 ;; (image-and-ocr-paste)
 (tm-define (image-and-ocr-paste)
   (with data
-    (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 0)))
-    (when (tree-is? (tree-ref data 0) 'image)
+    (clipboard-get-data)
+    (when (clipboard-tree-image? data)
       (kbd-paste)
       (kbd-return)
       (when (not (defined? 'ocr-to-latex-by-cursor))
@@ -1301,12 +1310,10 @@
     (use-modules (ocr liii-ocr))
   ) ;when
   (with img-tree
-    (tree-ref (clipboard-get "primary") 0)
-    (cond ((tree-is? img-tree 'image) (ocr-to-latex-by-cursor img-tree))
-          ((and (tree-is? img-tree 'with) (tree-is? (tree-ref img-tree 2) 'image))
-           (ocr-to-latex-by-cursor img-tree)
-          ) ;
-    ) ;cond
+    (clipboard-get-data)
+    (when (clipboard-tree-image? img-tree)
+      (ocr-to-latex-by-cursor img-tree)
+    ) ;when
   ) ;with
 ) ;tm-define
 
@@ -1432,7 +1439,7 @@
           ) ;
           ((string=? source-format "texmacs-snippet")
            (with data
-             (tree-ref (clipboard-get "primary") 0)
+             (clipboard-get-data)
              (if (clipboard-tree-image? data)
                (begin
                  (ocr-paste "texmacs-snippet")

--- a/TeXmacs/progs/generic/paste-widget.scm
+++ b/TeXmacs/progs/generic/paste-widget.scm
@@ -111,10 +111,7 @@
 ) ;define
 
 (tm-define (is-clipboard-image?)
-  (with data
-    (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 0)))
-    (if (tree-is? (tree-ref data 0) 'image) #t #f)
-  ) ;with
+  (with data (clipboard-get-data) (clipboard-tree-image? data))
 ) ;tm-define
 
 (tm-widget (clipboard-paste-from-widget cmd)

--- a/TeXmacs/tests/0940.scm
+++ b/TeXmacs/tests/0940.scm
@@ -1,0 +1,43 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0940.scm
+;; DESCRIPTION : Test clipboard image detection for magic paste（魔法粘贴图像判定）
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; 验证 clipboard-tree-image? 对四种剪贴板形态的判定：
+;; 1. extern 包装的图像 snippet（外部程序复制，经 clipboard-get-data 解包后）
+;; 2. 内部复制的 (document (image ...))
+;; 3. (with ... (image ...)) 形态
+;; 4. extern 文本（非图像）
+;;
+;; 运行：MOGAN_TEST_GUI=1 xmake r 0940
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. Details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (generic generic-edit))
+(import (liii check))
+
+(tm-define (test_0940)
+  ;; extern 包装的图像：经 clipboard-get-data 解包后得到 image 树
+  (let ((extern-img (stree->tree '(extern "(image (url \"/tmp/a.png\"))"))))
+    (check (clipboard-tree-image? (parse-texmacs-snippet (tree->string extern-img))) => #t)
+  ) ;let
+
+  ;; 内部复制：(document (image ...)) 复合树
+  (check (clipboard-tree-image? (stree->tree '(document (image (url "/tmp/a.png"))))) => #t)
+
+  ;; (with ... (image ...)) 形态
+  (check (clipboard-tree-image?
+           (stree->tree '(with "mode" "x" (image (url "/tmp/a.png"))))) => #t)
+
+  ;; extern 文本：非图像
+  (let ((extern-text (stree->tree '(extern "hello"))))
+    (check (clipboard-tree-image? (parse-texmacs-snippet (tree->string extern-text))) => #f)
+  ) ;let
+
+  ;; GUI 模式不自动 quit，延迟一拍退出（让 check 输出 flush 后关窗）
+  (exec-delayed-at (lambda () (quit-TeXmacs)) (+ (texmacs-time) 500))
+) ;tm-define

--- a/devel/0940.md
+++ b/devel/0940.md
@@ -1,0 +1,41 @@
+# 0940 修复右键菜单「Magic paste」对剪贴板图像失效
+
+## What
+
+外部程序（截图工具等）复制图像后，右键「Magic paste」（以及粘贴格式选择中的
+OCR 入口）不生效：`ocr-paste` 静默不做任何事。粘贴图片后手动点 OCR 不受影响。
+
+## Why
+
+上游提交 0d6239f63 [2049] 把 `ocr-paste` 等函数取剪贴板内容的方式从
+`(tree-ref (clipboard-get "primary") 1)` 改为 `tree-ref ... 0`。但
+`(clipboard-get "primary")` 对外部程序复制的图像返回 `(extern "<texmacs-snippet>")`，
+真正内容在下标 1（见 `src/Plugins/Qt/qt_gui.cpp` 的 `get_selection` 末尾
+`t = tuple ("extern", s)`；`src/Edit/Replace/edit_select.cpp` 的 `selection_paste`
+也用 `is_tuple (t, "extern", 1)` 取 `t[1]`）。只有软件内部复制时才直接返回存储的
+tree。下标 0 取到原子 `extern` → `clipboard-tree-image?` 判 `#f` → 静默返回。
+
+## How
+
+在 `TeXmacs/progs/generic/generic-edit.scm`：
+
+1. `clipboard-tree-image?` 由 `define` 改为 `tm-define`（导出供 paste-widget 复用）。
+2. 新增统一提取函数 `clipboard-get-data`：若剪贴板 tree 是 `(extern "...")`
+   包装则解析下标 1 的 texmacs snippet，否则原样返回。
+3. `ocr-paste`（不再区分 source-format）、`image-and-ocr-paste`、
+   `paste-as-texmacs`、`kbd-magic-paste` 的 texmacs-snippet 分支统一改用
+   `clipboard-get-data`；`image-and-ocr-paste` 内的裸 image 判定改用
+   `clipboard-tree-image?`。
+
+在 `TeXmacs/progs/generic/paste-widget.scm`：`is-clipboard-image?` 改用
+`clipboard-get-data` + `clipboard-tree-image?`。
+
+回归测试：`TeXmacs/tests/0940.scm`（`MOGAN_TEST_GUI=1 xmake r 0940`），
+验证 extern 包装图像、内部 `(document (image ...))`、`(with ... (image ...))`、
+extern 文本四种形态的判定。
+
+## 涉及文件
+
+- `TeXmacs/progs/generic/generic-edit.scm`
+- `TeXmacs/progs/generic/paste-widget.scm`
+- `TeXmacs/tests/0940.scm`（新增）


### PR DESCRIPTION
## 变更说明

修复外部程序复制图像后，右键「Magic paste」无法进入 OCR 的问题。

Qt 将外部剪贴板内容包装为 `(extern "<texmacs-snippet>")`，原逻辑读取了索引 0 的 `extern` 标签，导致图像判定失败。现在统一解包外部剪贴板内容，并保留内部 TeXmacs 剪贴板的处理方式。

## 涉及文件

- `TeXmacs/progs/generic/generic-edit.scm`
- `TeXmacs/progs/generic/paste-widget.scm`
- `TeXmacs/tests/0940.scm`
- `devel/0940.md`

## 验证

- `gf fix --dry-run TeXmacs/progs/generic/generic-edit.scm`
- `gf fix --dry-run TeXmacs/progs/generic/paste-widget.scm`
- `git diff --check origin/main...HEAD`
- 回归测试：`MOGAN_TEST_GUI=1 xmake r 0940`
- 已使用真实 Windows 图片剪贴板验证外部 `(extern ...)` 内容可正确解析为图片树。

GUI 回归测试未在本次自动流程中再次启动，需在 PR 环境中执行上述命令确认完整 OCR 网络链路。
