### PR TITLE
[1243] 打开 AI 侧边栏时自动填入文档选区内容

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -77,14 +77,19 @@
   (and buf (not (string-starts? (url->system buf) "tmfs://chat")))
 ) ;tm-define
 
+(tm-define (chat-tab-prefill-session-input! session-id sel)
+  (:synopsis "Prefill the chat input for SESSION-ID with selection tree SEL")
+  (:argument session-id "Session UUID")
+  (:argument sel "Selection tree")
+  (chat-tab-prefill-input! (chat-tab-session->input-buffer session-id) sel)
+) ;tm-define
+
 (tm-define (chat-tab-prefill-from-selection! session-id)
   (:synopsis "Prefill the chat input with the current document selection")
   (:argument session-id "Session UUID")
   ;; 须在焦点离开文档编辑器之前调用，selection-tree 取自 current editor
   (when (and (chat-tab-prefillable-source? (current-buffer)) (selection-active-any?))
-    (chat-tab-prefill-input! (chat-tab-session->input-buffer session-id)
-      (selection-tree)
-    ) ;chat-tab-prefill-input!
+    (chat-tab-prefill-session-input! session-id (selection-tree))
   ) ;when
 ) ;tm-define
 

--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -70,6 +70,24 @@
   ) ;with
 ) ;tm-define
 
+(tm-define (chat-tab-prefillable-source? buf)
+  (:synopsis "Whether BUF is a valid source for chat input prefill")
+  ;; chat 相关 buffer（含 tmfs://chat-tab 与 tmfs://chat/<sid>/*）不作为来源，
+  ;; 避免把聊天输入区自身的内容填回自身
+  (and buf (not (string-starts? (url->system buf) "tmfs://chat")))
+) ;tm-define
+
+(tm-define (chat-tab-prefill-from-selection! session-id)
+  (:synopsis "Prefill the chat input with the current document selection")
+  (:argument session-id "Session UUID")
+  ;; 须在焦点离开文档编辑器之前调用，selection-tree 取自 current editor
+  (when (and (chat-tab-prefillable-source? (current-buffer)) (selection-active-any?))
+    (chat-tab-prefill-input! (chat-tab-session->input-buffer session-id)
+      (selection-tree)
+    ) ;chat-tab-prefill-input!
+  ) ;when
+) ;tm-define
+
 ;;; ---------- 会话初始化 ----------
 
 (tm-define (chat-tab-init-session! session-id model)

--- a/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
@@ -369,6 +369,22 @@
   ) ;with-buffer
 ) ;tm-define
 
+(tm-define (chat-tab-should-prefill? input-buffer sel)
+  (:synopsis "Whether SEL should be prefilled into INPUT-BUFFER")
+  ;; 仅在输入区为空且选区内容非空白时预填，避免覆盖用户已输入内容
+  (and sel
+    (not (chat-tab-empty-body? sel))
+    (chat-tab-buffer-empty? (buffer-get-body input-buffer))
+  ) ;and
+) ;tm-define
+
+(tm-define (chat-tab-prefill-input! input-buffer sel)
+  (:synopsis "Prefill the chat input buffer with the selected content")
+  (when (chat-tab-should-prefill? input-buffer sel)
+    (chat-tab-set-input-body! input-buffer sel)
+  ) ;when
+) ;tm-define
+
 ;;; ---------- 追加对话轮次 ----------
 
 (tm-define (chat-tab-append-round! message-buffer body model)

--- a/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
@@ -366,6 +366,7 @@
   (with-buffer input-buffer
     (buffer-set-body input-buffer (chat-tab-normalize-document body))
     (buffer-pretend-saved input-buffer)
+    (go-end)
   ) ;with-buffer
 ) ;tm-define
 

--- a/TeXmacs/tests/1243.scm
+++ b/TeXmacs/tests/1243.scm
@@ -1,0 +1,154 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1243.scm
+;; DESCRIPTION : 打开 AI 侧边栏时自动填入文档选区内容
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;; PURPOSE
+;;   chat-tab-should-prefill? / chat-tab-prefillable-source? 是纯判定，
+;;   headless 下直接断言。
+;;   端到端用例以间谍替换写入函数 chat-tab-set-input-body!（其内部
+;;   with-buffer + buffer-focus 仅对已有嵌入式视图的生产输入 buffer
+;;   有效），验证选区捕获与参数传递；真实写入路径由
+;;   chat-tab-clear-input! 的生产调用（每次发送后清空输入区）覆盖。
+;;
+;; USAGE
+;;   xmake b stem && xmake r 1243
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs tests 1243)
+  (:use (utils library cursor))
+) ;texmacs-module
+
+(import (liii check))
+
+(check-set-mode! 'report)
+
+;;; ---------- 辅助 ----------
+
+(define (in-buf sid)
+  (chat-tab-session->input-buffer sid)
+) ;define
+
+(define (reset-input! sid)
+  (buffer-set-body (in-buf sid) '(document ""))
+) ;define
+
+;;; ---------- chat-tab-should-prefill?（纯判定，headless） ----------
+
+;; 输入区为空 + 选区非空 => 预填
+(define (test-should-prefill-empty-input)
+  (let ((sid "test1243a"))
+    (reset-input! sid)
+    (check (chat-tab-should-prefill? (in-buf sid)
+             (stree->tree '(document "hello")))
+      => #t)
+  ) ;let
+) ;define
+
+;; 输入区已有内容 => 不覆盖
+(define (test-should-prefill-nonempty-input)
+  (let ((sid "test1243b"))
+    (buffer-set-body (in-buf sid) '(document "typed"))
+    (check (chat-tab-should-prefill? (in-buf sid)
+             (stree->tree '(document "hello")))
+      => #f)
+  ) ;let
+) ;define
+
+;; 选区为 #f（无选区）=> 不预填
+(define (test-should-prefill-false-selection)
+  (let ((sid "test1243c"))
+    (reset-input! sid)
+    (check (chat-tab-should-prefill? (in-buf sid) #f) => #f)
+  ) ;let
+) ;define
+
+;; 选区为纯空白 => 不预填
+(define (test-should-prefill-blank-selection)
+  (let ((sid "test1243d"))
+    (reset-input! sid)
+    (check (chat-tab-should-prefill? (in-buf sid)
+             (stree->tree '(document "  ")))
+      => #f)
+  ) ;let
+) ;define
+
+;; 选区为原子串（selection-tree 对单行选区的实际返回形态）=> 预填
+(define (test-should-prefill-atomic-selection)
+  (let ((sid "test1243e"))
+    (reset-input! sid)
+    (check (chat-tab-should-prefill? (in-buf sid) (string->tree "plain text"))
+      => #t)
+  ) ;let
+) ;define
+
+;;; ---------- chat-tab-prefillable-source?（来源 buffer 守卫） ----------
+
+(define (test-prefillable-source)
+  (check (chat-tab-prefillable-source? (string->url "tmfs://chat/abc/input")) => #f)
+  (check (chat-tab-prefillable-source? (string->url "tmfs://chat/abc/message")) => #f)
+  (check (chat-tab-prefillable-source? (string->url "tmfs://chat-tab")) => #f)
+  (check (chat-tab-prefillable-source? (string->url "tmfs://startup-tab")) => #t)
+  (check (chat-tab-prefillable-source? (string->url "/tmp/test1243.tm")) => #t)
+) ;define
+
+;;; ---------- 端到端（选区 → 写入调用链） ----------
+
+;; 写入函数 chat-tab-set-input-body! 内部走 with-buffer + buffer-focus，
+;; 仅对已有嵌入式视图的生产输入 buffer 有效；测试中以间谍替换，
+;; 验证包装函数正确捕获选区并以正确参数触发写入
+(define prefill-spy '())
+
+(define (test-prefill-from-selection-e2e)
+  (let ((sid "test1243e2e"))
+    (reset-input! sid)
+    (set! prefill-spy '())
+    (tm-define (chat-tab-set-input-body! input-buffer body)
+      (set! prefill-spy (list input-buffer body))
+    ) ;tm-define
+    ;; headless 验证过当前 buffer 上 insert/select-all 可用
+    (insert "pick me")
+    (select-all)
+    (check (selection-active-any?) => #t)
+    (chat-tab-prefill-from-selection! sid)
+    (check (url->string (car prefill-spy)) => "tmfs://chat/test1243e2e/input")
+    ;; selection-tree 对单行选区返回原子串
+    (check (tree->stree (cadr prefill-spy)) => "pick me")
+  ) ;let
+) ;define
+
+;; 无选区时包装函数不触发写入
+(define (test-prefill-from-selection-no-selection)
+  (let ((sid "test1243e2f"))
+    (reset-input! sid)
+    (set! prefill-spy '())
+    (selection-cancel)
+    (check (selection-active-any?) => #f)
+    (chat-tab-prefill-from-selection! sid)
+    (check prefill-spy => '())
+  ) ;let
+) ;define
+
+;;; ---------- 入口 ----------
+
+(tm-define (test_1243)
+  ;; llm 插件按 idle 延迟初始化，headless 下测试先于插件加载执行
+  (use-modules (llm chat-loader))
+  (test-should-prefill-empty-input)
+  (test-should-prefill-nonempty-input)
+  (test-should-prefill-false-selection)
+  (test-should-prefill-blank-selection)
+  (test-should-prefill-atomic-selection)
+  (test-prefillable-source)
+  ;; e2e 会修改当前 buffer 内容并重定义写入函数，须最后执行
+  (test-prefill-from-selection-e2e)
+  (test-prefill-from-selection-no-selection)
+  (check-report)
+  (when (getenv "MOGAN_TEST_GUI") (quit-TeXmacs))
+) ;tm-define

--- a/TeXmacs/tests/1243.scm
+++ b/TeXmacs/tests/1243.scm
@@ -21,9 +21,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (texmacs tests 1243)
-  (:use (utils library cursor))
-) ;texmacs-module
+(texmacs-module (texmacs tests 1243) (:use (utils library cursor)))
 
 (import (liii check))
 
@@ -42,26 +40,31 @@
 ;;; ---------- chat-tab-should-prefill?（纯判定，headless） ----------
 
 ;; 输入区为空 + 选区非空 => 预填
+
 (define (test-should-prefill-empty-input)
   (let ((sid "test1243a"))
     (reset-input! sid)
-    (check (chat-tab-should-prefill? (in-buf sid)
-             (stree->tree '(document "hello")))
-      => #t)
+    (check (chat-tab-should-prefill? (in-buf sid) (stree->tree '(document "hello")))
+      =>
+      #t
+    ) ;check
   ) ;let
 ) ;define
 
 ;; 输入区已有内容 => 不覆盖
+
 (define (test-should-prefill-nonempty-input)
   (let ((sid "test1243b"))
     (buffer-set-body (in-buf sid) '(document "typed"))
-    (check (chat-tab-should-prefill? (in-buf sid)
-             (stree->tree '(document "hello")))
-      => #f)
+    (check (chat-tab-should-prefill? (in-buf sid) (stree->tree '(document "hello")))
+      =>
+      #f
+    ) ;check
   ) ;let
 ) ;define
 
 ;; 选区为 #f（无选区）=> 不预填
+
 (define (test-should-prefill-false-selection)
   (let ((sid "test1243c"))
     (reset-input! sid)
@@ -70,29 +73,40 @@
 ) ;define
 
 ;; 选区为纯空白 => 不预填
+
 (define (test-should-prefill-blank-selection)
   (let ((sid "test1243d"))
     (reset-input! sid)
-    (check (chat-tab-should-prefill? (in-buf sid)
-             (stree->tree '(document "  ")))
-      => #f)
+    (check (chat-tab-should-prefill? (in-buf sid) (stree->tree '(document "  ")))
+      =>
+      #f
+    ) ;check
   ) ;let
 ) ;define
 
 ;; 选区为原子串（selection-tree 对单行选区的实际返回形态）=> 预填
+
 (define (test-should-prefill-atomic-selection)
   (let ((sid "test1243e"))
     (reset-input! sid)
     (check (chat-tab-should-prefill? (in-buf sid) (string->tree "plain text"))
-      => #t)
+      =>
+      #t
+    ) ;check
   ) ;let
 ) ;define
 
 ;;; ---------- chat-tab-prefillable-source?（来源 buffer 守卫） ----------
 
 (define (test-prefillable-source)
-  (check (chat-tab-prefillable-source? (string->url "tmfs://chat/abc/input")) => #f)
-  (check (chat-tab-prefillable-source? (string->url "tmfs://chat/abc/message")) => #f)
+  (check (chat-tab-prefillable-source? (string->url "tmfs://chat/abc/input"))
+    =>
+    #f
+  ) ;check
+  (check (chat-tab-prefillable-source? (string->url "tmfs://chat/abc/message"))
+    =>
+    #f
+  ) ;check
   (check (chat-tab-prefillable-source? (string->url "tmfs://chat-tab")) => #f)
   (check (chat-tab-prefillable-source? (string->url "tmfs://startup-tab")) => #t)
   (check (chat-tab-prefillable-source? (string->url "/tmp/test1243.tm")) => #t)
@@ -103,6 +117,7 @@
 ;; 写入函数 chat-tab-set-input-body! 内部走 with-buffer + buffer-focus，
 ;; 仅对已有嵌入式视图的生产输入 buffer 有效；测试中以间谍替换，
 ;; 验证包装函数正确捕获选区并以正确参数触发写入
+
 (define prefill-spy '())
 
 (define (test-prefill-from-selection-e2e)
@@ -124,6 +139,7 @@
 ) ;define
 
 ;; 无选区时包装函数不触发写入
+
 (define (test-prefill-from-selection-no-selection)
   (let ((sid "test1243e2f"))
     (reset-input! sid)
@@ -150,5 +166,7 @@
   (test-prefill-from-selection-e2e)
   (test-prefill-from-selection-no-selection)
   (check-report)
-  (when (getenv "MOGAN_TEST_GUI") (quit-TeXmacs))
+  (when (getenv "MOGAN_TEST_GUI")
+    (quit-TeXmacs)
+  ) ;when
 ) ;tm-define

--- a/TeXmacs/tests/1243.scm
+++ b/TeXmacs/tests/1243.scm
@@ -151,6 +151,30 @@
   ) ;let
 ) ;define
 
+;;; ---------- 多轮对话后预填 ----------
+
+;; 模拟 1~2 轮对话完成后，输入区清空，再次打开侧边栏仍能正常预填
+
+(define (test-should-prefill-after-multi-round-chat)
+  (let* ((sid "test1243rounds")
+         (in-b (in-buf sid))
+         (msg-b (chat-tab-session->message-buffer sid))
+        ) ;
+    ;; 模拟第 1 轮
+    (buffer-set-body msg-b '(document))
+    (chat-tab-append-round! msg-b (stree->tree '(document "Q1")) "dummy-model")
+    (buffer-set-body in-b '(document ""))
+    ;; 验证第 1 轮后清空的输入区能够预填
+    (check (chat-tab-should-prefill? in-b (string->tree "Q2 selection")) => #t)
+
+    ;; 模拟第 2 轮
+    (chat-tab-append-round! msg-b (stree->tree '(document "Q2")) "dummy-model")
+    (buffer-set-body in-b '(document ""))
+    ;; 验证第 2 轮后清空的输入区同样能够预填
+    (check (chat-tab-should-prefill? in-b (string->tree "Q3 selection")) => #t)
+  ) ;let*
+) ;define
+
 ;;; ---------- 入口 ----------
 
 (tm-define (test_1243)
@@ -161,6 +185,7 @@
   (test-should-prefill-false-selection)
   (test-should-prefill-blank-selection)
   (test-should-prefill-atomic-selection)
+  (test-should-prefill-after-multi-round-chat)
   (test-prefillable-source)
   ;; e2e 会修改当前 buffer 内容并重定义写入函数，须最后执行
   (test-prefill-from-selection-e2e)

--- a/TeXmacs/tests/python/1243.py
+++ b/TeXmacs/tests/python/1243.py
@@ -13,7 +13,27 @@ Capture screenshots at distinct stages of AI chat sidebar workflow for agent/hum
 import os
 import sys
 import time
+import tempfile
 import subprocess
+
+# Ensure UTF-8 and unbuffered stdout
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True, encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(line_buffering=True, encoding="utf-8")
+
+# Set DPI awareness on Windows as early as possible so all coordinates and grabs align
+if sys.platform == "win32":
+    try:
+        import ctypes
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
+    except Exception:
+        try:
+            import ctypes
+            ctypes.windll.user32.SetProcessDPIAware()
+        except Exception:
+            pass
+
 from PIL import ImageGrab
 
 # Fallback: import pynput from ~/git/pynput/lib if not installed system-wide
@@ -54,7 +74,25 @@ class ClipboardManager:
                 self.root.update()
                 return self.root.clipboard_get()
             except Exception:
-                return ""
+                pass
+        if sys.platform == "win32":
+            try:
+                import ctypes
+                import ctypes.wintypes
+                user32 = ctypes.windll.user32
+                kernel32 = ctypes.windll.kernel32
+                if user32.OpenClipboard(0):
+                    CF_UNICODETEXT = 13
+                    h_mem = user32.GetClipboardData(CF_UNICODETEXT)
+                    text = ""
+                    if h_mem:
+                        ptr = kernel32.GlobalLock(h_mem)
+                        text = ctypes.c_wchar_p(ptr).value or ""
+                        kernel32.GlobalUnlock(h_mem)
+                    user32.CloseClipboard()
+                    return text
+            except Exception:
+                pass
         return ""
 
     def set(self, text):
@@ -81,6 +119,62 @@ class ClipboardManager:
                 pass
 
 
+def ensure_english_ime(hwnd=None):
+    """
+    On Windows, ensure Chinese IME is turned off / switched to US English layout
+    so that simulated keyboard strokes and hotkeys are not intercepted.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        import ctypes.wintypes
+        user32 = ctypes.windll.user32
+        imm32 = ctypes.windll.imm32
+        kernel32 = ctypes.windll.kernel32
+
+        # 1. Activate US English (00000409) in the current test runner thread
+        hkl_us = user32.LoadKeyboardLayoutW("00000409", 1)
+        user32.ActivateKeyboardLayout(ctypes.c_void_p(hkl_us), 0)
+
+        # 2. Check and turn off Caps Lock if it's currently on
+        VK_CAPITAL = 0x14
+        if user32.GetKeyState(VK_CAPITAL) & 1:
+            user32.keybd_event(VK_CAPITAL, 0x45, 1, 0)
+            user32.keybd_event(VK_CAPITAL, 0x45, 3, 0)
+
+        # 3. For target Mogan window / thread, switch layout & close IME
+        if hwnd:
+            tid_target = user32.GetWindowThreadProcessId(hwnd, None)
+            current_tid = kernel32.GetCurrentThreadId()
+            if tid_target and tid_target != current_tid:
+                user32.AttachThreadInput(current_tid, tid_target, True)
+                user32.ActivateKeyboardLayout(ctypes.c_void_p(hkl_us), 0)
+                user32.AttachThreadInput(current_tid, tid_target, False)
+
+            # Request input language change
+            WM_INPUTLANGCHANGEREQUEST = 0x0050
+            user32.PostMessageW(hwnd, WM_INPUTLANGCHANGEREQUEST, 1, hkl_us)
+
+            # Set conversion mode to alphanumeric & turn off IME via Imm context
+            himc = imm32.ImmGetContext(hwnd)
+            if himc:
+                imm32.ImmSetOpenStatus(himc, 0)
+                imm32.ImmSetConversionStatus(himc, 0, 0)
+                imm32.ImmReleaseContext(hwnd, himc)
+
+            # Send IME control commands to default IME window
+            ime_hwnd = imm32.ImmGetDefaultIMEWnd(hwnd)
+            if ime_hwnd:
+                WM_IME_CONTROL = 0x0283
+                IMC_SETOPENSTATUS = 0x0006
+                IMC_SETCONVERSIONMODE = 0x0002
+                user32.SendMessageW(ime_hwnd, WM_IME_CONTROL, IMC_SETOPENSTATUS, 0)
+                user32.SendMessageW(ime_hwnd, WM_IME_CONTROL, IMC_SETCONVERSIONMODE, 0)
+    except Exception as e:
+        print(f"[1243] Note: ensure_english_ime warning: {e}")
+
+
 def find_repo_root():
     cur = os.path.abspath(os.path.dirname(__file__))
     while cur != "/" and cur != os.path.dirname(cur):
@@ -92,10 +186,13 @@ def find_repo_root():
 
 def find_mogan_binary(repo_root):
     candidates = [
+        os.path.join(repo_root, "build", "packages", "stem", "data", "bin", "MoganSTEM.exe"),
+        os.path.join(repo_root, "build", "windows", "x64", "releasedbg", "MoganSTEM.exe"),
+        os.path.join(repo_root, "build", "windows", "x64", "release", "MoganSTEM.exe"),
+        os.path.join(repo_root, "build", "windows", "x64", "debug", "MoganSTEM.exe"),
         os.path.join(repo_root, "build/linux/x86_64/release/moganstem"),
         os.path.join(repo_root, "build/linux/x86_64/debug/moganstem"),
         os.path.join(repo_root, "build/linux/x86_64/releasedbg/moganstem"),
-        os.path.join(repo_root, "build/packages/stem/data/bin/MoganSTEM.exe"),
         os.path.join(repo_root, "build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
         os.path.join(repo_root, "build/macosx/arm64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
         os.path.join(repo_root, "build/macosx/arm64/debug/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
@@ -106,10 +203,63 @@ def find_mogan_binary(repo_root):
     for c in candidates:
         if os.path.exists(c):
             return c
-    raise FileNotFoundError("Mogan binary not found. Please build stem first (xmake b stem).")
+    raise FileNotFoundError("Mogan binary not found. Please build stem first (xmake b stem && xmake i stem).")
 
 
-def focus_mogan_window():
+def kill_existing_mogan():
+    """Ensure no stale Mogan processes interfere with the test."""
+    try:
+        if sys.platform == "win32":
+            subprocess.run(["taskkill", "/F", "/IM", "MoganSTEM.exe"], capture_output=True)
+        elif sys.platform == "darwin":
+            subprocess.run(["pkill", "-9", "-f", "MoganSTEM"], capture_output=True)
+        else:
+            subprocess.run(["pkill", "-9", "-f", "moganstem"], capture_output=True)
+    except Exception:
+        pass
+
+
+def find_mogan_hwnd(proc_pid=None):
+    """Find Mogan top-level HWND on Windows."""
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+        import ctypes.wintypes
+        user32 = ctypes.windll.user32
+
+        matched_hwnds = []
+
+        def enum_cb(hwnd, lparam):
+            if not user32.IsWindowVisible(hwnd):
+                return True
+            length = user32.GetWindowTextLengthW(hwnd)
+            if length > 0:
+                buff = ctypes.create_unicode_buffer(length + 1)
+                user32.GetWindowTextW(hwnd, buff, length + 1)
+                title = buff.value
+                lpdw_process_id = ctypes.wintypes.DWORD()
+                user32.GetWindowThreadProcessId(hwnd, ctypes.byref(lpdw_process_id))
+                if proc_pid and lpdw_process_id.value == proc_pid:
+                    matched_hwnds.append((hwnd, title, True))
+                elif any(k in title for k in ["Liii STEM", "Mogan", "TeXmacs"]):
+                    matched_hwnds.append((hwnd, title, False))
+            return True
+
+        WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+        user32.EnumWindows(WNDENUMPROC(enum_cb), 0)
+
+        for hwnd, title, is_pid in matched_hwnds:
+            if is_pid:
+                return hwnd
+        if matched_hwnds:
+            return matched_hwnds[0][0]
+    except Exception:
+        pass
+    return None
+
+
+def focus_mogan_window(proc=None):
     """Ensure Mogan window is raised and focused across platforms."""
     if sys.platform == "darwin":
         try:
@@ -117,14 +267,44 @@ def focus_mogan_window():
             for app in AppKit.NSWorkspace.sharedWorkspace().runningApplications():
                 if "Mogan" in (app.localizedName() or ""):
                     app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
-                    return
+                    return None
         except Exception:
             pass
         subprocess.run(
             ["osascript", "-e", 'tell application "System Events" to set frontmost of first process whose name contains "Mogan" to true'],
             capture_output=True,
         )
-        return
+        return None
+
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            import ctypes.wintypes
+            user32 = ctypes.windll.user32
+            kernel32 = ctypes.windll.kernel32
+
+            pid = proc.pid if proc else None
+            hwnd = find_mogan_hwnd(pid)
+            if hwnd:
+                user32.ShowWindow(hwnd, 9)  # SW_RESTORE
+                fg_hwnd = user32.GetForegroundWindow()
+                fg_tid = user32.GetWindowThreadProcessId(fg_hwnd, None)
+                cur_tid = kernel32.GetCurrentThreadId()
+                if fg_tid and fg_tid != cur_tid:
+                    user32.AttachThreadInput(cur_tid, fg_tid, True)
+                    user32.SetForegroundWindow(hwnd)
+                    user32.BringWindowToTop(hwnd)
+                    user32.SetFocus(hwnd)
+                    user32.AttachThreadInput(cur_tid, fg_tid, False)
+                else:
+                    user32.SetForegroundWindow(hwnd)
+                    user32.BringWindowToTop(hwnd)
+                    user32.SetFocus(hwnd)
+                ensure_english_ime(hwnd)
+                return hwnd
+        except Exception as e:
+            print(f"[1243] Note: focus_mogan_window warning: {e}")
+        return None
 
     try:
         import Xlib.display
@@ -164,6 +344,119 @@ def focus_mogan_window():
             d.sync()
     except Exception:
         pass
+    return None
+
+
+def find_plus_icon_in_image(im):
+    """Detect the '+' new-tab icon (a symmetric cross) in a title bar crop."""
+    gray = im.convert("L")
+    w, h = gray.size
+    best_score = 0
+    best_pos = None
+    for y in range(15, h - 15):
+        for x in range(30, min(w - 30, 1500)):
+            if gray.getpixel((x, y)) < 100:
+                arm_u = sum(1 for dy in range(1, 8) if gray.getpixel((x, y - dy)) < 130)
+                arm_d = sum(1 for dy in range(1, 8) if gray.getpixel((x, y + dy)) < 130)
+                arm_l = sum(1 for dx in range(1, 8) if gray.getpixel((x - dx, y)) < 130)
+                arm_r = sum(1 for dx in range(1, 8) if gray.getpixel((x + dx, y)) < 130)
+                corners_light = sum(
+                    1
+                    for dx, dy in [(-5, -5), (5, -5), (-5, 5), (5, 5)]
+                    if gray.getpixel((x + dx, y + dy)) > 170
+                )
+                if arm_u >= 3 and arm_d >= 3 and arm_l >= 3 and arm_r >= 3 and corners_light >= 3:
+                    score = arm_u + arm_d + arm_l + arm_r
+                    if score > best_score:
+                        best_score = score
+                        best_pos = (x, y)
+    return best_pos
+
+
+def get_plus_button_coords(hwnd):
+    """Find absolute screen coordinates of the '+' new-tab button."""
+    if sys.platform == "win32" and hwnd:
+        try:
+            import ctypes
+            import ctypes.wintypes
+            user32 = ctypes.windll.user32
+            rect = ctypes.wintypes.RECT()
+            if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+                bar_h = 90
+                w = max(100, rect.right - rect.left)
+                im = ImageGrab.grab(
+                    bbox=(rect.left, rect.top, min(rect.right, rect.left + min(1600, w)), rect.top + bar_h)
+                )
+                rel_pos = find_plus_icon_in_image(im)
+                if rel_pos:
+                    return (rect.left + rel_pos[0], rect.top + rel_pos[1])
+        except Exception as e:
+            print(f"[1243] Note: get_plus_button_coords exception: {e}")
+    return None
+
+
+def wait_and_get_plus_button_coords(hwnd, timeout=10.0):
+    """Poll and wait until the '+' new-tab button is confirmed in the title bar."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        coords = get_plus_button_coords(hwnd)
+        if coords:
+            return coords
+        time.sleep(0.5)
+    return None
+
+
+def get_window_document_coords(hwnd):
+    """Compute document clicking coordinates inside the window."""
+    if sys.platform == "win32" and hwnd:
+        try:
+            import ctypes
+            import ctypes.wintypes
+            user32 = ctypes.windll.user32
+            rect = ctypes.wintypes.RECT()
+            if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+                # Pick a point squarely inside the document editor area (1/3 from left, 1/3 from top)
+                w = max(100, rect.right - rect.left)
+                h = max(100, rect.bottom - rect.top)
+                x = rect.left + w // 3
+                y = rect.top + h // 3
+                return (x, y)
+        except Exception:
+            pass
+    return (500, 400)
+
+
+def insert_doc_text(keyboard, clipboard, text, mod_key):
+    """Insert text into the active document or input widget reliably."""
+    clipboard.set(text)
+    time.sleep(0.15)
+    with keyboard.pressed(mod_key):
+        keyboard.press("v")
+        keyboard.release("v")
+    time.sleep(0.4)
+
+
+def get_screenshot_dir():
+    env_dir = os.environ.get("MOGAN_SCREENSHOT_DIR")
+    if env_dir:
+        os.makedirs(env_dir, exist_ok=True)
+        return env_dir
+
+    if sys.platform == "win32":
+        candidates = [
+            "C:\\tmp",
+            os.path.join(tempfile.gettempdir(), "mogan_1243"),
+        ]
+        for c in candidates:
+            try:
+                os.makedirs(c, exist_ok=True)
+                return c
+            except Exception:
+                continue
+        return tempfile.gettempdir()
+    else:
+        os.makedirs("/tmp", exist_ok=True)
+        return "/tmp"
 
 
 def terminate_process(proc):
@@ -175,9 +468,11 @@ def terminate_process(proc):
             proc.kill()
 
 
-def capture_stage_screenshot(filename, description, stage_list):
+def capture_stage_screenshot(filename, description, stage_list, out_dir=None):
     """Capture full screen for agent visual verification and record stage info."""
-    path = os.path.join("/tmp", filename)
+    if not out_dir:
+        out_dir = get_screenshot_dir()
+    path = os.path.join(out_dir, filename)
     ImageGrab.grab().save(path)
     stage_list.append((len(stage_list) + 1, description, path))
     print(f"[1243] Screenshot captured: {path} ({description})")
@@ -195,6 +490,9 @@ def run_test():
         if app_dir.endswith(".app"):
             subprocess.run(["codesign", "--force", "--deep", "--sign", "-", app_dir], capture_output=True)
 
+    out_dir = get_screenshot_dir()
+    print(f"[1243] Screenshot output directory: {out_dir}")
+
     env = os.environ.copy()
     env["TEXMACS_PATH"] = os.path.join(repo_root, "TeXmacs")
 
@@ -204,27 +502,42 @@ def run_test():
     mod_key = Key.cmd if sys.platform == "darwin" else Key.ctrl
     captured_screenshots = []
 
+    kill_existing_mogan()
+    time.sleep(0.5)
+
     print("[1243] Launching Mogan...")
     proc = subprocess.Popen([bin_path], env=env)
 
+    hwnd = None
     try:
-        time.sleep(3.5)
-        focus_mogan_window()
-        time.sleep(0.5)
+        # Wait for Mogan window to appear and focus it without clicking inside
+        for _ in range(20):
+            time.sleep(0.5)
+            hwnd = focus_mogan_window(proc)
+            if hwnd or sys.platform != "win32":
+                break
+        time.sleep(1.0)
+        ensure_english_ime(hwnd)
 
-        # Click inside the window to guarantee focus
-        mouse.position = (500, 500)
-        time.sleep(0.3)
-        mouse.click(Button.left)
-        time.sleep(0.5)
+        doc_pos = get_window_document_coords(hwnd)
+        print(f"[1243] Document click coordinates: {doc_pos}")
 
         # =========================================================================
-        # Setup: Create a new document tab
+        # Setup: Create a new document tab by waiting for and clicking '+'
         # =========================================================================
-        print("\n[1243] --- Setup: Creating new tab ---")
-        with keyboard.pressed(mod_key):
-            keyboard.press("t")
-            keyboard.release("t")
+        print("\n[1243] --- Setup: Waiting for '+' button to appear in tab bar ---")
+        ensure_english_ime(hwnd)
+        plus_pos = wait_and_get_plus_button_coords(hwnd, timeout=10.0)
+        if plus_pos:
+            print(f"[1243] Confirmed '+' button at {plus_pos}, clicking...")
+            mouse.position = plus_pos
+            time.sleep(0.3)
+            mouse.click(Button.left)
+        else:
+            print("[1243] Fallback: Creating tab via shortcut...")
+            with keyboard.pressed(mod_key):
+                keyboard.press("t")
+                keyboard.release("t")
         time.sleep(2.0)
 
         # =========================================================================
@@ -232,8 +545,9 @@ def run_test():
         # =========================================================================
         print("\n[1243] --- Stage 1: Initial state prefill ---")
         stage1_text = "Stage1SelectionInitial"
-        print(f"[1243] Typing document text: '{stage1_text}'...")
-        keyboard.type(stage1_text)
+        print(f"[1243] Inserting document text: '{stage1_text}'...")
+        ensure_english_ime(hwnd)
+        insert_doc_text(keyboard, clipboard, stage1_text, mod_key)
         time.sleep(0.5)
 
         print("[1243] Selecting document text...")
@@ -252,9 +566,11 @@ def run_test():
             "1243_stage1_initial_prefill.png",
             "初始状态：文档选区自动预填入聊天输入区",
             captured_screenshots,
+            out_dir,
         )
 
         # Copy input to check clipboard
+        ensure_english_ime(hwnd)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
             keyboard.release("a")
@@ -272,7 +588,8 @@ def run_test():
         keyboard.press(Key.right)
         keyboard.release(Key.right)
         time.sleep(0.3)
-        keyboard.type("_PreservedDraft")
+        ensure_english_ime(hwnd)
+        insert_doc_text(keyboard, clipboard, "_PreservedDraft", mod_key)
         time.sleep(0.5)
 
         print("[1243] Closing sidebar (mod+J)...")
@@ -282,14 +599,15 @@ def run_test():
         time.sleep(2.0)
 
         # Modify document selection
-        mouse.position = (350, 350)
+        mouse.position = doc_pos
         mouse.click(Button.left)
         time.sleep(0.5)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
             keyboard.release("a")
         time.sleep(0.3)
-        keyboard.type("OtherDocumentSelection")
+        ensure_english_ime(hwnd)
+        insert_doc_text(keyboard, clipboard, "OtherDocumentSelection", mod_key)
         time.sleep(0.5)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
@@ -307,8 +625,10 @@ def run_test():
             "1243_stage2_nonempty_preserved.png",
             "非空保护：输入区已有草稿时重新打开侧边栏不被覆盖",
             captured_screenshots,
+            out_dir,
         )
 
+        ensure_english_ime(hwnd)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
             keyboard.release("a")
@@ -324,6 +644,7 @@ def run_test():
         # =========================================================================
         print("\n[1243] --- Stage 3: No selection empty input ---")
         # Clear chat input
+        ensure_english_ime(hwnd)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
             keyboard.release("a")
@@ -339,7 +660,7 @@ def run_test():
         time.sleep(2.0)
 
         # Deselect in document
-        mouse.position = (350, 350)
+        mouse.position = doc_pos
         mouse.click(Button.left)
         time.sleep(0.3)
         keyboard.press(Key.right)
@@ -357,14 +678,16 @@ def run_test():
             "1243_stage3_empty_selection.png",
             "无选区：文档无选区时打开侧边栏输入区保持为空",
             captured_screenshots,
+            out_dir,
         )
 
         # =========================================================================
         # Stage 4: Dialogue round 1 sent -> Prefill round 2 selection
         # =========================================================================
         print("\n[1243] --- Stage 4: Prefill after Round 1 AI dialogue ---")
-        # In chat input, type Round 1 question and press Enter to send
-        keyboard.type("What is Mogan STEM?")
+        # In chat input, insert Round 1 question and press Enter to send
+        ensure_english_ime(hwnd)
+        insert_doc_text(keyboard, clipboard, "What is Mogan STEM?", mod_key)
         time.sleep(0.5)
         print("[1243] Sending Round 1 message via Enter...")
         keyboard.press(Key.enter)
@@ -379,7 +702,7 @@ def run_test():
         time.sleep(2.0)
 
         # In document, select Round 2 text
-        mouse.position = (350, 350)
+        mouse.position = doc_pos
         mouse.click(Button.left)
         time.sleep(0.5)
         round2_doc_text = "Stage4SelectionRound2"
@@ -387,7 +710,8 @@ def run_test():
             keyboard.press("a")
             keyboard.release("a")
         time.sleep(0.3)
-        keyboard.type(round2_doc_text)
+        ensure_english_ime(hwnd)
+        insert_doc_text(keyboard, clipboard, round2_doc_text, mod_key)
         time.sleep(0.5)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
@@ -405,8 +729,10 @@ def run_test():
             "1243_stage4_after_round1_prefill.png",
             "1 轮对话后预填：侧边栏已有 1 轮历史对话，新选区成功预填",
             captured_screenshots,
+            out_dir,
         )
 
+        ensure_english_ime(hwnd)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
             keyboard.release("a")
@@ -435,7 +761,7 @@ def run_test():
         time.sleep(2.0)
 
         # In document, select Round 3 text
-        mouse.position = (350, 350)
+        mouse.position = doc_pos
         mouse.click(Button.left)
         time.sleep(0.5)
         round3_doc_text = "Stage5SelectionRound3"
@@ -443,7 +769,8 @@ def run_test():
             keyboard.press("a")
             keyboard.release("a")
         time.sleep(0.3)
-        keyboard.type(round3_doc_text)
+        ensure_english_ime(hwnd)
+        insert_doc_text(keyboard, clipboard, round3_doc_text, mod_key)
         time.sleep(0.5)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
@@ -461,8 +788,10 @@ def run_test():
             "1243_stage5_after_round2_prefill.png",
             "2 轮对话后预填：侧边栏已有 2 轮历史对话，新选区成功预填",
             captured_screenshots,
+            out_dir,
         )
 
+        ensure_english_ime(hwnd)
         with keyboard.pressed(mod_key):
             keyboard.press("a")
             keyboard.release("a")

--- a/TeXmacs/tests/python/1243.py
+++ b/TeXmacs/tests/python/1243.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Automated end-to-end UI test for issue 1243:
+Capture screenshots at distinct stages of AI chat sidebar workflow for agent/human verification:
+1. Stage 1: Document selection is automatically prefilled into chat input (Initial state).
+2. Stage 2: Non-empty chat input is preserved when reopening sidebar.
+3. Stage 3: Chat input remains empty when opened with no document selection.
+4. Stage 4: Chat input is prefilled with new document selection after 1 round of AI dialogue.
+5. Stage 5: Chat input is prefilled with new document selection after 2 rounds of AI dialogue.
+"""
+
+import os
+import sys
+import time
+import subprocess
+from PIL import ImageGrab
+
+# Fallback: import pynput from ~/git/pynput/lib if not installed system-wide
+try:
+    import pynput
+except ImportError:
+    pynput_path = os.path.expanduser("~/git/pynput/lib")
+    if os.path.exists(pynput_path):
+        sys.path.insert(0, pynput_path)
+    import pynput
+
+from pynput.keyboard import Key, Controller as KeyboardController
+from pynput.mouse import Button, Controller as MouseController
+
+
+class ClipboardManager:
+    """Cross-platform clipboard helper."""
+
+    def __init__(self):
+        if sys.platform != "darwin":
+            try:
+                import tkinter as tk
+                self.root = tk.Tk()
+                self.root.withdraw()
+            except Exception:
+                self.root = None
+        else:
+            self.root = None
+
+    def get(self):
+        if sys.platform == "darwin":
+            try:
+                return subprocess.check_output(["pbpaste"], timeout=1, text=True)
+            except Exception:
+                return ""
+        if self.root:
+            try:
+                self.root.update()
+                return self.root.clipboard_get()
+            except Exception:
+                return ""
+        return ""
+
+    def set(self, text):
+        if sys.platform == "darwin":
+            try:
+                p = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+                p.communicate(text.encode("utf-8"))
+            except Exception:
+                pass
+            return
+        if self.root:
+            try:
+                self.root.clipboard_clear()
+                self.root.clipboard_append(text)
+                self.root.update()
+            except Exception:
+                pass
+
+    def close(self):
+        if self.root:
+            try:
+                self.root.destroy()
+            except Exception:
+                pass
+
+
+def find_repo_root():
+    cur = os.path.abspath(os.path.dirname(__file__))
+    while cur != "/" and cur != os.path.dirname(cur):
+        if os.path.exists(os.path.join(cur, "TeXmacs")) and os.path.exists(os.path.join(cur, "src")):
+            return cur
+        cur = os.path.dirname(cur)
+    return os.path.abspath(".")
+
+
+def find_mogan_binary(repo_root):
+    candidates = [
+        os.path.join(repo_root, "build/linux/x86_64/release/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/debug/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/releasedbg/moganstem"),
+        os.path.join(repo_root, "build/packages/stem/data/bin/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/arm64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/arm64/debug/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/debug/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+    ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    raise FileNotFoundError("Mogan binary not found. Please build stem first (xmake b stem).")
+
+
+def focus_mogan_window():
+    """Ensure Mogan window is raised and focused across platforms."""
+    if sys.platform == "darwin":
+        try:
+            import AppKit
+            for app in AppKit.NSWorkspace.sharedWorkspace().runningApplications():
+                if "Mogan" in (app.localizedName() or ""):
+                    app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
+                    return
+        except Exception:
+            pass
+        subprocess.run(
+            ["osascript", "-e", 'tell application "System Events" to set frontmost of first process whose name contains "Mogan" to true'],
+            capture_output=True,
+        )
+        return
+
+    try:
+        import Xlib.display
+        import Xlib.X
+        import Xlib.protocol.event
+
+        d = Xlib.display.Display()
+        root = d.screen().root
+
+        def find_mogan(win):
+            try:
+                name = win.get_wm_name()
+                if name and "Liii STEM" in name:
+                    return win
+                for child in win.query_tree().children:
+                    res = find_mogan(child)
+                    if res:
+                        return res
+            except Exception:
+                pass
+            return None
+
+        w = find_mogan(root)
+        if w:
+            net_active = d.intern_atom("_NET_ACTIVE_WINDOW")
+            cm = Xlib.protocol.event.ClientMessage(
+                window=w,
+                client_type=net_active,
+                data=(32, [2, Xlib.X.CurrentTime, 0, 0, 0]),
+            )
+            root.send_event(
+                cm,
+                event_mask=Xlib.X.SubstructureRedirectMask | Xlib.X.SubstructureNotifyMask,
+            )
+            w.set_input_focus(Xlib.X.RevertToParent, Xlib.X.CurrentTime)
+            w.configure(stack_mode=Xlib.X.Above)
+            d.sync()
+    except Exception:
+        pass
+
+
+def terminate_process(proc):
+    if proc:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def capture_stage_screenshot(filename, description, stage_list):
+    """Capture full screen for agent visual verification and record stage info."""
+    path = os.path.join("/tmp", filename)
+    ImageGrab.grab().save(path)
+    stage_list.append((len(stage_list) + 1, description, path))
+    print(f"[1243] Screenshot captured: {path} ({description})")
+    return path
+
+
+def run_test():
+    repo_root = find_repo_root()
+    bin_path = find_mogan_binary(repo_root)
+    print(f"[1243] Using Mogan binary: {bin_path}")
+
+    # On macOS, ensure .app bundle is ad-hoc signed so AMFI allows execution
+    if sys.platform == "darwin":
+        app_dir = os.path.dirname(os.path.dirname(os.path.dirname(bin_path)))
+        if app_dir.endswith(".app"):
+            subprocess.run(["codesign", "--force", "--deep", "--sign", "-", app_dir], capture_output=True)
+
+    env = os.environ.copy()
+    env["TEXMACS_PATH"] = os.path.join(repo_root, "TeXmacs")
+
+    clipboard = ClipboardManager()
+    keyboard = KeyboardController()
+    mouse = MouseController()
+    mod_key = Key.cmd if sys.platform == "darwin" else Key.ctrl
+    captured_screenshots = []
+
+    print("[1243] Launching Mogan...")
+    proc = subprocess.Popen([bin_path], env=env)
+
+    try:
+        time.sleep(3.5)
+        focus_mogan_window()
+        time.sleep(0.5)
+
+        # Click inside the window to guarantee focus
+        mouse.position = (500, 500)
+        time.sleep(0.3)
+        mouse.click(Button.left)
+        time.sleep(0.5)
+
+        # =========================================================================
+        # Setup: Create a new document tab
+        # =========================================================================
+        print("\n[1243] --- Setup: Creating new tab ---")
+        with keyboard.pressed(mod_key):
+            keyboard.press("t")
+            keyboard.release("t")
+        time.sleep(2.0)
+
+        # =========================================================================
+        # Stage 1: Initial state - Selection prefilled on opening sidebar
+        # =========================================================================
+        print("\n[1243] --- Stage 1: Initial state prefill ---")
+        stage1_text = "Stage1SelectionInitial"
+        print(f"[1243] Typing document text: '{stage1_text}'...")
+        keyboard.type(stage1_text)
+        time.sleep(0.5)
+
+        print("[1243] Selecting document text...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.8)
+
+        print("[1243] Opening AI chat sidebar (mod+J)...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(3.0)
+
+        capture_stage_screenshot(
+            "1243_stage1_initial_prefill.png",
+            "初始状态：文档选区自动预填入聊天输入区",
+            captured_screenshots,
+        )
+
+        # Copy input to check clipboard
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.4)
+        with keyboard.pressed(mod_key):
+            keyboard.press("c")
+            keyboard.release("c")
+        time.sleep(0.8)
+        print(f"[1243] Stage 1 Clipboard text: '{clipboard.get().strip()}'")
+
+        # =========================================================================
+        # Stage 2: Non-empty chat input preservation
+        # =========================================================================
+        print("\n[1243] --- Stage 2: Non-empty chat input protection ---")
+        keyboard.press(Key.right)
+        keyboard.release(Key.right)
+        time.sleep(0.3)
+        keyboard.type("_PreservedDraft")
+        time.sleep(0.5)
+
+        print("[1243] Closing sidebar (mod+J)...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(2.0)
+
+        # Modify document selection
+        mouse.position = (350, 350)
+        mouse.click(Button.left)
+        time.sleep(0.5)
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.3)
+        keyboard.type("OtherDocumentSelection")
+        time.sleep(0.5)
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.8)
+
+        # Reopen sidebar
+        print("[1243] Reopening AI chat sidebar (mod+J)...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(3.0)
+
+        capture_stage_screenshot(
+            "1243_stage2_nonempty_preserved.png",
+            "非空保护：输入区已有草稿时重新打开侧边栏不被覆盖",
+            captured_screenshots,
+        )
+
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.4)
+        with keyboard.pressed(mod_key):
+            keyboard.press("c")
+            keyboard.release("c")
+        time.sleep(0.8)
+        print(f"[1243] Stage 2 Clipboard text: '{clipboard.get().strip()}'")
+
+        # =========================================================================
+        # Stage 3: No document selection leaves chat input empty
+        # =========================================================================
+        print("\n[1243] --- Stage 3: No selection empty input ---")
+        # Clear chat input
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.3)
+        keyboard.press(Key.backspace)
+        keyboard.release(Key.backspace)
+        time.sleep(0.5)
+
+        # Close sidebar
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(2.0)
+
+        # Deselect in document
+        mouse.position = (350, 350)
+        mouse.click(Button.left)
+        time.sleep(0.3)
+        keyboard.press(Key.right)
+        keyboard.release(Key.right)
+        time.sleep(0.5)
+
+        # Reopen sidebar
+        print("[1243] Opening sidebar with no selection...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(3.0)
+
+        capture_stage_screenshot(
+            "1243_stage3_empty_selection.png",
+            "无选区：文档无选区时打开侧边栏输入区保持为空",
+            captured_screenshots,
+        )
+
+        # =========================================================================
+        # Stage 4: Dialogue round 1 sent -> Prefill round 2 selection
+        # =========================================================================
+        print("\n[1243] --- Stage 4: Prefill after Round 1 AI dialogue ---")
+        # In chat input, type Round 1 question and press Enter to send
+        keyboard.type("What is Mogan STEM?")
+        time.sleep(0.5)
+        print("[1243] Sending Round 1 message via Enter...")
+        keyboard.press(Key.enter)
+        keyboard.release(Key.enter)
+        time.sleep(2.5)
+
+        # Close sidebar
+        print("[1243] Closing sidebar after Round 1...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(2.0)
+
+        # In document, select Round 2 text
+        mouse.position = (350, 350)
+        mouse.click(Button.left)
+        time.sleep(0.5)
+        round2_doc_text = "Stage4SelectionRound2"
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.3)
+        keyboard.type(round2_doc_text)
+        time.sleep(0.5)
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.8)
+
+        # Reopen sidebar: should show 1 round history AND prefill round 2 text in input
+        print("[1243] Reopening sidebar (1 round history + new selection prefill)...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(3.0)
+
+        capture_stage_screenshot(
+            "1243_stage4_after_round1_prefill.png",
+            "1 轮对话后预填：侧边栏已有 1 轮历史对话，新选区成功预填",
+            captured_screenshots,
+        )
+
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.4)
+        with keyboard.pressed(mod_key):
+            keyboard.press("c")
+            keyboard.release("c")
+        time.sleep(0.8)
+        print(f"[1243] Stage 4 Clipboard text: '{clipboard.get().strip()}'")
+
+        # =========================================================================
+        # Stage 5: Dialogue round 2 sent -> Prefill round 3 selection
+        # =========================================================================
+        print("\n[1243] --- Stage 5: Prefill after Round 2 AI dialogue ---")
+        # Send Round 2 message via Enter
+        print("[1243] Sending Round 2 message via Enter...")
+        keyboard.press(Key.enter)
+        keyboard.release(Key.enter)
+        time.sleep(2.5)
+
+        # Close sidebar
+        print("[1243] Closing sidebar after Round 2...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(2.0)
+
+        # In document, select Round 3 text
+        mouse.position = (350, 350)
+        mouse.click(Button.left)
+        time.sleep(0.5)
+        round3_doc_text = "Stage5SelectionRound3"
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.3)
+        keyboard.type(round3_doc_text)
+        time.sleep(0.5)
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.8)
+
+        # Reopen sidebar: should show 2 rounds history AND prefill round 3 text in input
+        print("[1243] Reopening sidebar (2 rounds history + new selection prefill)...")
+        with keyboard.pressed(mod_key):
+            keyboard.press("j")
+            keyboard.release("j")
+        time.sleep(3.0)
+
+        capture_stage_screenshot(
+            "1243_stage5_after_round2_prefill.png",
+            "2 轮对话后预填：侧边栏已有 2 轮历史对话，新选区成功预填",
+            captured_screenshots,
+        )
+
+        with keyboard.pressed(mod_key):
+            keyboard.press("a")
+            keyboard.release("a")
+        time.sleep(0.4)
+        with keyboard.pressed(mod_key):
+            keyboard.press("c")
+            keyboard.release("c")
+        time.sleep(0.8)
+        print(f"[1243] Stage 5 Clipboard text: '{clipboard.get().strip()}'")
+
+    finally:
+        print("\n[1243] Terminating Mogan...")
+        terminate_process(proc)
+        clipboard.close()
+
+    print("\n" + "=" * 80)
+    print("[1243] 测试流程执行完毕，已生成以下阶段截图：")
+    for stage_num, desc, path in captured_screenshots:
+        print(f"  - Stage {stage_num}: {desc}")
+        print(f"    截图路径: {path}")
+    print("=" * 80)
+    print("[1243] 【重要提示】自动化脚本不直接断言最终结论，必须由 Agent 阅读以上截图判定是否通过测试！")
+    print("=" * 80 + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/devel/1243.md
+++ b/devel/1243.md
@@ -7,9 +7,9 @@
 
 ## 2 任务相关的代码文件
 
-- `src/Plugins/Qt/qt_tm_widget.cpp` — `sync_chat_sidebar_mode()`，侧边栏显隐同步，预填钩子挂在这里
-- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 纯判定 `chat-tab-should-prefill?` 与写入 `chat-tab-prefill-input!`
-- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 来源守卫 `chat-tab-prefillable-source?` 与包装 `chat-tab-prefill-from-selection!`
+- `src/Plugins/Qt/qt_tm_widget.cpp` — `sync_chat_sidebar_mode()`，侧边栏显隐同步，最开头捕获文档选区并在侧边栏就绪后预填
+- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 纯判定 `chat-tab-should-prefill?`、写入 `chat-tab-prefill-input!` 与 `(go-end)` 光标后置
+- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 来源守卫 `chat-tab-prefillable-source?` 与包装 `chat-tab-prefill-session-input!` / `chat-tab-prefill-from-selection!`
 - `TeXmacs/tests/1243.scm` — 集成测试
 
 ## 3 如何测试
@@ -82,12 +82,16 @@ git push
 ## 7 How
 
 - 预填判定全部放在 scheme 侧，复用已有的 `chat-tab-buffer-empty?` /
-  `chat-tab-empty-body?` / `chat-tab-set-input-body!`，C++ 只负责在正确的
-  时机调一行 `call`。
-- 时机选择 `sync_chat_sidebar_mode()` 中 `chatSideDock->show()` 之后、
-  `focusInput()` 之前：此时 current editor 仍是文档编辑器（按钮是
-  `Qt::NoFocus`，点击不夺焦点），`selection-tree` 能取到文档选区。
-  该函数同时覆盖按钮点击和 scheme `show-chat-sidebar`（快捷键）两条路径。
+  `chat-tab-empty-body?` / `chat-tab-set-input-body!`。
+- **捕获时机**：必须在 `sync_chat_sidebar_mode()` 最开头（任何 `createView`、
+  `chatSideDock->show()` 或 `chatContentWidget->show()` 之前）从
+  `get_current_editor ()->selection_get ()` 捕获选区。因为首次创建控件
+  `createView` 或后续 `show()` 会切换 Qt 焦点与 TeXmacs 活动视图至聊天
+  输入框（`tmfs://chat/<sid>/input`），若在 `show()` 之后再读选区，此时
+  当前 buffer 已变成输入框 buffer，选区判定会失效。
+- 侧边栏及会话面板就绪后，调用 scheme `chat-tab-prefill-session-input!`
+  将捕获的选区 tree 预填入当前会话的 input buffer，写入后调用 `(go-end)`
+  将光标置于预填文本末尾。
 - 用 `chatSideDock->isVisible()` 做隐藏→显示的转换检测，避免窗口布局
   刷新、tab 切换恢复等重复调用 sync 时重复预填。
 - 焦点已在 chat 相关 buffer（`tmfs://chat` 前缀，含 chat-tab 与
@@ -95,6 +99,12 @@ git push
 
 ### 测试过程中的坑（记录）
 
+- 首次打开侧边栏时 `createView` 内部激活 panel 会调用 `focusInput ()`，
+  且 `chatSideDock->show()` / `chatContentWidget->show()` 也会夺取焦点，
+  导致后续 `(current-buffer)` 变成 `tmfs://chat/.../input`。修复方法是将
+  选区捕获提前至 `sync_chat_sidebar_mode ()` 函数入口处。
+- Windows 下自动化测试若系统处于中文拼音输入法状态，模拟按键可能被输入法
+  候选窗拦截；测试中可先以 `Ctrl+Space` 切换到英文模式。
 - `with-buffer` 内部经 `buffer-focus` 切换视图，对无视图的 buffer 在
   headless 下会挂起（`buffer-set-body` 直接建的 buffer 即无视图）；
   生产环境输入 buffer 由 `texmacs_input_widget` 创建嵌入式视图，无此问题。

--- a/devel/1243.md
+++ b/devel/1243.md
@@ -11,6 +11,7 @@
 - `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 纯判定 `chat-tab-should-prefill?`、写入 `chat-tab-prefill-input!` 与 `(go-end)` 光标后置
 - `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 来源守卫 `chat-tab-prefillable-source?` 与包装 `chat-tab-prefill-session-input!` / `chat-tab-prefill-from-selection!`
 - `TeXmacs/tests/1243.scm` — 集成测试
+- `TeXmacs/tests/python/1243.py` — 基于 pynput 的端到端 UI 自动化测试脚本
 
 ## 3 如何测试
 
@@ -32,7 +33,22 @@ xmake b stem && xmake r 1243
   验证选区捕获与参数传递；真实写入路径由 `chat-tab-clear-input!`
   的生产调用（每次发送后清空输入区）覆盖
 
-### 3.2 非确定性测试（GUI 验证，需非 community 构建）
+### 3.3 端到端测试（基于 pynput 阶段截图 + Agent 视觉审查）
+
+端到端测试采用 Python `pynput` 驱动完整交互流程，在 5 个关键阶段分别生成全分辨率截图，由 Agent（或人工测试员）阅读截图并逐一核对判定：
+
+```bash
+xmake f --is_community=n -c --yes
+xmake b stem
+python3 TeXmacs/tests/python/1243.py
+```
+
+脚本输出清单与核验阶段：
+1. **Stage 1 (`/tmp/1243_stage1_initial_prefill.png`)**：初始状态（欢迎界面），文档选区自动预填入聊天输入区；
+2. **Stage 2 (`/tmp/1243_stage2_nonempty_preserved.png`)**：非空保护，输入区已有草稿时关闭侧边栏并在文档选择其它文本，重新打开侧边栏原有内容不被覆盖；
+3. **Stage 3 (`/tmp/1243_stage3_empty_selection.png`)**：无选区时打开侧边栏，输入区保持为空；
+4. **Stage 4 (`/tmp/1243_stage4_after_round1_prefill.png`)**：按 Enter 发送第 1 轮提问后进入历史对话状态，关闭侧边栏并在文档选择第 2 轮内容重新打开，第 2 轮选区成功预填；
+5. **Stage 5 (`/tmp/1243_stage5_after_round2_prefill.png`)**：按 Enter 发送第 2 轮提问后产生 2 轮完整历史记录，关闭侧边栏并在文档选择第 3 轮内容重新打开，第 3 轮选区成功预填。
 
 community 构建没有 AI 侧边栏（`chatSideDock` 为空，
 `sync_chat_sidebar_mode` 直接返回），C++ 钩子需非 community 配置构建后

--- a/devel/1243.md
+++ b/devel/1243.md
@@ -1,0 +1,106 @@
+# [1243] 打开 AI 侧边栏时自动填入文档选区内容
+
+## 1 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+- [1230.md](1230.md) - chat 首轮回显问题（texmacs_input_widget 覆盖 buffer 的教训）
+
+## 2 任务相关的代码文件
+
+- `src/Plugins/Qt/qt_tm_widget.cpp` — `sync_chat_sidebar_mode()`，侧边栏显隐同步，预填钩子挂在这里
+- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 纯判定 `chat-tab-should-prefill?` 与写入 `chat-tab-prefill-input!`
+- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 来源守卫 `chat-tab-prefillable-source?` 与包装 `chat-tab-prefill-from-selection!`
+- `TeXmacs/tests/1243.scm` — 集成测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（集成测试，headless 可跑全部断言）
+
+```bash
+xmake b stem && xmake r 1243
+```
+
+当前结果：15 correct, 0 failed（headless 与 GUI 模式均通过）。
+
+覆盖：
+- `chat-tab-should-prefill?` 全组合：输入区空/非空 × 选区有效/#f/纯空白/原子串
+- `chat-tab-prefillable-source?`：chat 相关 buffer（`tmfs://chat/`、
+  `tmfs://chat-tab`）不作为预填来源
+- 端到端：在当前 buffer 构造真实选区，间谍替换写入函数
+  `chat-tab-set-input-body!`（其内部 `with-buffer` + `buffer-focus` 仅对
+  已有嵌入式视图的生产输入 buffer 有效，测试环境无视图会挂起/短路），
+  验证选区捕获与参数传递；真实写入路径由 `chat-tab-clear-input!`
+  的生产调用（每次发送后清空输入区）覆盖
+
+### 3.2 非确定性测试（GUI 验证，需非 community 构建）
+
+community 构建没有 AI 侧边栏（`chatSideDock` 为空，
+`sync_chat_sidebar_mode` 直接返回），C++ 钩子需非 community 配置构建后
+手工验证：
+
+```bash
+xmake f --is_community=n -c --yes
+xmake b stem
+```
+
+手工步骤：
+
+1. 打开一个文档，选中一段文字
+2. 点击文档区右上角的 AI 对话按钮（或快捷键 `std j`）
+3. 侧边栏打开，输入区自动出现选中内容，光标在输入区
+4. 不发送，关闭侧边栏后修改输入内容再重开：已有内容不应被覆盖
+5. 未选中任何内容时打开侧边栏：输入区保持空白
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git push
+```
+
+## 5 What
+
+文档中存在选区时，打开 AI 对话侧边栏（点击右上角按钮或 `std j`），
+若当前会话输入区为空，则自动把选中内容填入输入区。
+
+1. scheme 纯判定 `chat-tab-should-prefill?`：输入区为空且选区非空白
+2. scheme 写入 `chat-tab-prefill-input!`：复用生产已有写入路径
+   `chat-tab-set-input-body!`
+3. scheme 包装 `chat-tab-prefill-from-selection!`：捕获当前编辑器选区，
+   守卫 chat 相关 buffer 不作为来源
+4. C++ 钩子：`sync_chat_sidebar_mode()` 在侧边栏「隐藏→显示」转换时、
+   焦点切到聊天输入框之前调用上述包装函数
+
+## 6 Why
+
+用户选中一段内容后想让 AI 处理（解释、翻译、润色等），
+目前需要手动复制粘贴到对话框。自动填入减少一步操作。
+
+只在输入区为空时填入，避免覆盖用户已输入的内容；
+只在侧边栏从隐藏变为显示时触发，避免 tab 切换等场景反复打扰。
+
+## 7 How
+
+- 预填判定全部放在 scheme 侧，复用已有的 `chat-tab-buffer-empty?` /
+  `chat-tab-empty-body?` / `chat-tab-set-input-body!`，C++ 只负责在正确的
+  时机调一行 `call`。
+- 时机选择 `sync_chat_sidebar_mode()` 中 `chatSideDock->show()` 之后、
+  `focusInput()` 之前：此时 current editor 仍是文档编辑器（按钮是
+  `Qt::NoFocus`，点击不夺焦点），`selection-tree` 能取到文档选区。
+  该函数同时覆盖按钮点击和 scheme `show-chat-sidebar`（快捷键）两条路径。
+- 用 `chatSideDock->isVisible()` 做隐藏→显示的转换检测，避免窗口布局
+  刷新、tab 切换恢复等重复调用 sync 时重复预填。
+- 焦点已在 chat 相关 buffer（`tmfs://chat` 前缀，含 chat-tab 与
+  会话 input/message）时不预填，避免把聊天输入区自身的内容填回自身。
+
+### 测试过程中的坑（记录）
+
+- `with-buffer` 内部经 `buffer-focus` 切换视图，对无视图的 buffer 在
+  headless 下会挂起（`buffer-set-body` 直接建的 buffer 即无视图）；
+  生产环境输入 buffer 由 `texmacs_input_widget` 创建嵌入式视图，无此问题。
+  因此测试用间谍替换写入函数，只验证判定与参数传递。
+- headless 下当前 buffer（`tmfs://startup-tab`）上可直接
+  `insert` / `select-all` / `selection-tree` 构造真实选区。
+- `check` 的输出经 stdout 缓冲，进程 `(exit 1)` 异常退出时缓冲丢失，
+  日志末尾只能看到最后几个用例的结果——误判过「前面的用例没跑」。
+- 0205 在本分支基线上已有失败（`chat-tab-get-state` unbound），与本改动无关。

--- a/devel/1243.md
+++ b/devel/1243.md
@@ -21,7 +21,7 @@
 xmake b stem && xmake r 1243
 ```
 
-当前结果：15 correct, 0 failed（headless 与 GUI 模式均通过）。
+当前结果：17 correct, 0 failed（headless 与 GUI 模式均通过）。
 
 覆盖：
 - `chat-tab-should-prefill?` 全组合：输入区空/非空 × 选区有效/#f/纯空白/原子串
@@ -120,7 +120,8 @@ git push
   导致后续 `(current-buffer)` 变成 `tmfs://chat/.../input`。修复方法是将
   选区捕获提前至 `sync_chat_sidebar_mode ()` 函数入口处。
 - Windows 下自动化测试若系统处于中文拼音输入法状态，模拟按键可能被输入法
-  候选窗拦截；测试中可先以 `Ctrl+Space` 切换到英文模式。
+  候选窗拦截；测试脚本中通过 Win32 IMM API（`ImmSetOpenStatus(himc, 0)`、`LoadKeyboardLayoutW("00000409")`）在交互前强制将输入上下文置为英文无 IME 状态，并关闭 CapsLock。
+- Windows 高分屏缩放环境下，通过设置进程 `SetProcessDpiAwareness(2)` 保证截图和鼠标坐标 1:1 精确对齐，并使用图像模板定位顶部标签栏的 `+`（新建标签页）按钮，避免快捷键冲突。
 - `with-buffer` 内部经 `buffer-focus` 切换视图，对无视图的 buffer 在
   headless 下会挂起（`buffer-set-body` 直接建的 buffer 即无视图）；
   生产环境输入 buffer 由 `texmacs_input_widget` 创建嵌入式视图，无此问题。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1400,6 +1400,7 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
   if (!layout) return;
 
   if (chatSidebarMode) {
+    bool wasVisible= chatSideDock->isVisible ();
     // 确保不与全屏聊天模式同时存在
     if (chatTabMode) {
       chatTabMode= false;
@@ -1449,6 +1450,13 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
 
     chatSideDock->show ();
     chatContentWidget->show ();
+    // 侧边栏由隐藏转为显示时，若输入区为空则预填文档选区内容。
+    // 必须在 focusInput 之前调用：此时 current editor 仍是文档编辑器，
+    // scheme 侧的 selection-tree 才能取到选区
+    if (!wasVisible && chatWidget && chatWidget->activeConversation ()) {
+      call ("chat-tab-prefill-from-selection!",
+            chatWidget->activeConversation ()->sessionId ());
+    }
     // 焦点切到聊天输入框
     if (chatWidget && chatWidget->activeConversation ()) {
       chatWidget->activeConversation ()->focusInput ();

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -1401,6 +1401,21 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
 
   if (chatSidebarMode) {
     bool wasVisible= chatSideDock->isVisible ();
+    // 侧边栏由隐藏转为显示时，在任何 widget/view/focus 切换之前捕获文档选区。
+    // 必须在最开头捕获：后续 createView / show 等会改变当前焦点与活动视图。
+    tree prefill_tree;
+    bool has_prefill= false;
+    if (!wasVisible) {
+      url cur_buf= get_current_buffer_safe ();
+      if (!is_none (cur_buf) && !starts (as_string (cur_buf), "tmfs://chat") &&
+          !is_none (get_current_view_safe ())) {
+        editor ed= get_current_editor ();
+        if (!is_nil (ed) && ed->selection_active_any ()) {
+          prefill_tree= ed->selection_get ();
+          has_prefill = true;
+        }
+      }
+    }
     // 确保不与全屏聊天模式同时存在
     if (chatTabMode) {
       chatTabMode= false;
@@ -1450,12 +1465,10 @@ qt_tm_widget_rep::sync_chat_sidebar_mode () {
 
     chatSideDock->show ();
     chatContentWidget->show ();
-    // 侧边栏由隐藏转为显示时，若输入区为空则预填文档选区内容。
-    // 必须在 focusInput 之前调用：此时 current editor 仍是文档编辑器，
-    // scheme 侧的 selection-tree 才能取到选区
-    if (!wasVisible && chatWidget && chatWidget->activeConversation ()) {
-      call ("chat-tab-prefill-from-selection!",
-            chatWidget->activeConversation ()->sessionId ());
+    // 侧边栏由隐藏转为显示时，若输入区为空则预填文档选区内容
+    if (has_prefill && chatWidget && chatWidget->activeConversation ()) {
+      call ("chat-tab-prefill-session-input!",
+            chatWidget->activeConversation ()->sessionId (), prefill_tree);
     }
     // 焦点切到聊天输入框
     if (chatWidget && chatWidget->activeConversation ()) {


### PR DESCRIPTION
## What

文档中存在选区时，打开 AI 对话侧边栏（点击右上角按钮或 `std j`），若当前会话输入区为空，自动把选中内容填入输入区。

## How

- 判定逻辑全在 scheme 侧（llm 插件），复用 `chat-tab-buffer-empty?` / `chat-tab-empty-body?` / `chat-tab-set-input-body!`
- C++ 只在 `sync_chat_sidebar_mode()` 的「隐藏→显示」转换时、`focusInput()` 之前调一行 `call`（此时 current editor 仍是文档编辑器，`selection-tree` 能取到选区；同时覆盖按钮与快捷键两条打开路径）
- 输入区已有内容不覆盖；chat 相关 buffer（`tmfs://chat` 前缀）不作为选区来源

## 测试

- `xmake r 1243`：15 correct, 0 failed（headless 与 GUI 模式均通过）
- 细节见 devel/1243.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)