### PR TITLE
[1245] 插入会话/代码块/脚本时样式包检查改用 .stem

### DIFF
--- a/TeXmacs/progs/dynamic/program-edit.scm
+++ b/TeXmacs/progs/dynamic/program-edit.scm
@@ -679,7 +679,7 @@
       prog-field-input-context?
       (with u
         (tree-ref t :previous 0)
-        (if (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append lan ".ts")))
+        (if (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append lan ".stem")))
           (add-style-package lan)
         ) ;if
         (program-feed lan ses :start u t '())

--- a/TeXmacs/progs/dynamic/scripts-edit.scm
+++ b/TeXmacs/progs/dynamic/scripts-edit.scm
@@ -138,7 +138,7 @@
 (tm-define (evaluate-context? t) (tree-in? t '(script-input script-output)))
 
 (tm-define (make-script-input* lan ses)
-  (if (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append lan ".ts")))
+  (if (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append lan ".stem")))
     (add-style-package lan)
   ) ;if
   (insert-go-to `(script-input ,lan ,ses ,"" ,"") '(2 0))

--- a/TeXmacs/progs/dynamic/session-edit.scm
+++ b/TeXmacs/progs/dynamic/session-edit.scm
@@ -940,7 +940,7 @@
       field-input-context?
       (with u
         (tree-ref t :previous 0)
-        (if (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append lan ".ts")))
+        (if (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append lan ".stem")))
           (add-style-package lan)
         ) ;if
         (if (not (has-style-package? "framed-session"))

--- a/devel/1245.md
+++ b/devel/1245.md
@@ -1,0 +1,50 @@
+# [1245] 插入会话时自动引入插件样式包仅检查 .ts，未适配 .stem
+
+## 1 相关文档
+- [1131.md](1131.md) - 添加 stem 格式并全量迁移 plugins 下 .ts → .stem
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/dynamic/session-edit.scm`（`make-session`）
+- `TeXmacs/progs/dynamic/program-edit.scm`（`make-program`）
+- `TeXmacs/progs/dynamic/scripts-edit.scm`（`make-script-input*`）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b stem && xmake r style-package-load-test
+```
+
+### 3.2 非确定性测试（文档验证）
+1. `xmake b stem`，启动 Mogan。
+2. `插入 -> 会话 -> Python` 插入 Python 会话：
+   - 输入代码（如 `def f(x): return x`），确认有语法高亮；
+   - 打开 `文档 -> 样式`，确认样式包列表中有 `python` 和 `framed-session`。
+3. `插入 -> 程序 -> 代码块 -> Python`（走 `make-program` 路径），同样确认有语法高亮。
+4. 回归：插入一个没有同名样式包的语言会话（如 Scheme），确认不报错。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+修复 `插入 -> 会话 -> Python` 后未自动引入 `python` 样式包（无语法高亮）的问题。
+
+1. `make-session` 的样式包存在性检查由 `<lan>.ts` 改为 `<lan>.stem`
+2. `make-program` 同上
+3. `make-script-input*` 同上
+
+## 6 Why
+1131 已将 plugins 下全部样式包从 `.ts` 迁移为 `.stem`（`python.ts` 已删除，
+只剩 `python.stem`），但上述三处插入点在 `add-style-package` 前仍用
+`url-exists?` 检查 `<lan>.ts`，检查失败导致跳过样式包引入。
+
+## 7 How
+三处检查统一改为 `.stem`。插件样式包已全量迁移，不再保留 `.ts` 回退；
+C++ 层（`exec_use_package` / `load_style_tree`）在 1131 已支持 `.stem`，
+本任务只补齐 Scheme 层遗漏的三处。


### PR DESCRIPTION
## 问题
`插入 -> 会话 -> Python` 后未自动引入 `python` 样式包，无语法高亮。

## 根因
1131 已将 plugins 下样式包全量迁移为 `.stem`（`python.ts` 已删除），但 Scheme 层三处插入点在 `add-style-package` 前仍只检查 `<lan>.ts`：

- `TeXmacs/progs/dynamic/session-edit.scm`（`make-session`）
- `TeXmacs/progs/dynamic/program-edit.scm`（`make-program`）
- `TeXmacs/progs/dynamic/scripts-edit.scm`（`make-script-input*`）

## 修复
三处 `url-exists?` 检查统一改为 `.stem`，不再回退 `.ts`。

任务文档：`devel/1245.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)