### PR TITLE
[1246] 修复魔法粘贴对图片剪贴板取错 child 导致 OCR 不触发

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1230,7 +1230,8 @@
   (with data
     (if (string=? source-format "texmacs-snippet")
       (tree-ref (clipboard-get "primary") 0)
-      (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 0)))
+      ;; 剪贴板树为 (clipboard <label> <snippet-string>)，内容在 child 1
+      (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 1)))
     ) ;if
     (when (clipboard-tree-image? data)
       (ocr-to-latex-by-cursor data)

--- a/devel/1246.md
+++ b/devel/1246.md
@@ -1,0 +1,36 @@
+# [1246] 修复魔法粘贴对图片剪贴板取错 child 导致 OCR 不触发
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/generic-edit.scm`（`ocr-paste`）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无（GUI 剪贴板路径）。
+
+### 3.2 非确定性测试（文档验证）
+1. 截图复制到系统剪贴板
+2. Mogan 中 Ctrl+Shift+V（或右键菜单 Magic paste）
+3. 应触发云识别并插入识别结果；修复前无任何反应
+
+## 4 如何提交
+
+```bash
+gf fmt TeXmacs/progs/generic/generic-edit.scm
+```
+
+## 5 What
+`ocr-paste` 的 image 分支剪贴板 snippet 提取由 child 0 改为 child 1。
+
+## 6 Why
+剪贴板树为 `(clipboard <label> <snippet-string>)`：child 0 是格式标签
+（图片剪贴板时为 `"extern"`），内容在 child 1。误取 child 0 时
+`parse-texmacs-snippet "extern"` 得到非 image 文档，`clipboard-tree-image?`
+恒为 `#f`，OCR 从不触发。
+
+## 7 How
+只改一处索引：与 `session-edit.scm` 取剪贴板内容的写法、原 `ocr-silent`
+图片提取（`tree-ref clip 1`）一致。


### PR DESCRIPTION
## 问题

剪贴板树结构为 `(clipboard <label> <snippet-string>)`：child 0 是格式标签（图片剪贴板时为 `"extern"`），真正的 snippet 字符串在 child 1。

`ocr-paste`（generic-edit.scm）的 image 分支误取 child 0，`parse-texmacs-snippet "extern"` 得到非 image 文档，`clipboard-tree-image?` 恒为 `#f`——魔法粘贴截图时 OCR 从不触发。

## 修复

image 分支的 snippet 提取由 child 0 改为 child 1（与 `session-edit.scm` 取剪贴板内容、原 ocr-silent 图片提取的索引一致）。净 diff 一行。

## 测试

1. 截图复制到系统剪贴板
2. Mogan 中 Ctrl+Shift+V（或右键菜单 Magic paste）
3. 触发云识别并插入识别结果（修复前无任何反应）

任务文档：devel/1246.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)