### PR TITLE
[1247] 修复 image-and-ocr-paste 与 is-clipboard-image? 对外部图片剪贴板取错 child

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -1247,7 +1247,8 @@
 ;; (image-and-ocr-paste)
 (tm-define (image-and-ocr-paste)
   (with data
-    (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 0)))
+    ;; 外部剪贴板树为 (extern <snippet-string>)，内容在 child 1
+    (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 1)))
     (when (tree-is? (tree-ref data 0) 'image)
       (kbd-paste)
       (kbd-return)

--- a/TeXmacs/progs/generic/paste-widget.scm
+++ b/TeXmacs/progs/generic/paste-widget.scm
@@ -112,7 +112,8 @@
 
 (tm-define (is-clipboard-image?)
   (with data
-    (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 0)))
+    ;; 外部剪贴板树为 (extern <snippet-string>)，内容在 child 1
+    (parse-texmacs-snippet (tree->string (tree-ref (clipboard-get "primary") 1)))
     (if (tree-is? (tree-ref data 0) 'image) #t #f)
   ) ;with
 ) ;tm-define

--- a/devel/1247.md
+++ b/devel/1247.md
@@ -1,0 +1,50 @@
+# [1247] 修复 image-and-ocr-paste 与 is-clipboard-image? 对外部图片剪贴板取错 child
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1246.md](1246.md) - 同成因的前序修复（ocr-paste）
+- [2049.md](2049.md) - 引入回归的任务：将剪贴板内容索引由 1 改为 0
+  （修软件内复制、断外部图片）
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/generic/generic-edit.scm`（`image-and-ocr-paste`）
+- `TeXmacs/progs/generic/paste-widget.scm`（`is-clipboard-image?`）
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+无（GUI 剪贴板路径）。
+
+### 3.2 非确定性测试（文档验证）
+手动测试步骤（GUI）：
+
+1. 启动 Mogan（`xmake b stem && xmake r stem`），新建空白文档
+2. 系统截图（或从浏览器复制一张图片）到剪贴板
+3. 右键菜单打开「选择性粘贴」（Paste Special）对话框：
+   - 应出现 OCR / Image and OCR / Only image 三个图片选项
+   - 修复前 `is-clipboard-image?` 恒 #f，只会出现普通文本格式列表
+4. 选 Image and OCR 确认：应先插入原图，回车分隔，随后插入云识别结果
+5. 回归：Ctrl+Shift+V（或右键 Magic paste）应只插入识别结果
+   （1246 修复的路径，不受本次改动影响）
+6. 回归：复制纯文本（软件外），右键「选择性粘贴」应出现普通格式
+   列表，各格式粘贴正常
+
+## 4 如何提交
+
+```bash
+gf fmt TeXmacs/progs/generic/generic-edit.scm TeXmacs/progs/generic/paste-widget.scm
+```
+
+## 5 What
+`image-and-ocr-paste` 与 `is-clipboard-image?` 的剪贴板 snippet 提取由
+child 0 改为 child 1（仅外部剪贴板路径，与 1246 的 ocr-paste 修复一致）。
+
+## 6 Why
+外部剪贴板树为 `("extern" <snippet-string>)`：child 0 是标签 `"extern"`，
+内容在 child 1（C++ 侧 `qt_gui.cpp` 构造 `tuple("extern", s)`，
+`edit_select.cpp` 消费 `t[1]`）。#4081 将这两处由 1 改为 0，外部图片
+剪贴板恒解析失败：图片菜单探测恒 #f、Image and OCR 粘贴不生效。
+
+## 7 How
+仅改两处索引 0 -> 1；软件内复制的内部形状（"texmacs" 元组）不在本次
+范围内，维持现状。


### PR DESCRIPTION
## 问题

外部剪贴板树为 `("extern" <snippet-string>)`：child 0 是格式标签，真正的 snippet 在 child 1（C++ 侧 `qt_gui.cpp` 构造 `tuple("extern", s)`、`edit_select.cpp` 消费 `t[1]`）。

[2049](https://github.com/MoganLab/mogan/pull/4081)（#1246 修复 ocr-paste 时发现）将剪贴板内容索引由 1 改为 0，外部图片剪贴板恒解析失败：

- `is-clipboard-image?` 恒 `#f`——右键「选择性粘贴」出不来 OCR / Image and OCR / Only image 图片选项
- `image-and-ocr-paste` 取不到 image——Image and OCR 粘贴不生效

## 修复

两处 snippet 提取由 child 0 改为 child 1，与 #1246 的 ocr-paste 修复一致。仅外部剪贴板路径；软件内复制（`texmacs` 元组形状）不在本次范围。

## 手动测试

1. 截图到系统剪贴板
2. 右键菜单打开「选择性粘贴」：应出现 OCR / Image and OCR / Only image 三个选项
3. 选 Image and OCR：应先插入原图，回车分隔，随后插入云识别结果
4. 回归：Ctrl+Shift+V（Magic paste）只插入识别结果（#1246 路径）
5. 回归：复制外部纯文本，选择性粘贴出现普通格式列表且粘贴正常

任务文档：devel/1247.md（相关文档引用 devel/2049.md、devel/1246.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)