### PR TITLE
[1249] 移除 Versioning tool 的全部 UI 入口

### DIFF
--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -589,7 +589,6 @@
 (define-secure-symbols preview-reference)
 
 ;; (display "Booting versioning facilities\n")
-(lazy-menu (version version-menu) version-menu)
 (lazy-define (version version-tmfs) update-buffer commit-buffer)
 
 ;; (display "Booting debugging and developer facilities\n")

--- a/TeXmacs/progs/texmacs/menus/main-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/main-menu.scm
@@ -66,7 +66,6 @@
     (=> "Part" (link document-part-menu))
   ) ;if
   (if (project-attached?) (=> "Project" (link project-menu)))
-  (if (with-versioning-tool?) (=> "Version" (link version-menu)))
   (=> "View::menu" (link view-menu))
   (if (qt-gui?) (=> "Go" (link go-menu)))
   (if (qt-gui?) (if (detailed-menus?) (=> "Tools" (link tools-menu))))
@@ -165,7 +164,6 @@
     (-> "Part" (link document-part-menu))
   ) ;if
   (if (project-attached?) (=> "Project" (link project-menu)))
-  (if (with-versioning-tool?) (-> "Version" (link version-menu)))
   (-> "View::menu" (link view-menu))
   (-> "Go" (link go-menu))
   (if (detailed-menus?) (-> "Tools" (link tools-menu)))

--- a/TeXmacs/progs/texmacs/menus/preferences-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/preferences-menu.scm
@@ -327,8 +327,7 @@
       (toggle ("Database tool" "database tool"))
       (toggle ("Debugging tool" "debugging tool"))
       (toggle ("Linking tool" "linking tool"))
-      (toggle ("Source macros tool" "source tool"))
-      (toggle ("Versioning tool" "versioning tool")))
+      (toggle ("Source macros tool" "source tool")))
     ---
     (enum ("Autosave" "autosave") ("On" "120") ("Off" "0"))
     (enum ("Bibtex command" "bibtex command")

--- a/TeXmacs/progs/texmacs/menus/tools-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tools-menu.scm
@@ -72,5 +72,4 @@
   ("Linking tool" (toggle-preference "linking tool"))
   ("Presentation tool" (toggle-preference "presentation tool"))
   ("Source macros tool" (toggle-preference "source tool"))
-  ("Versioning tool" (toggle-preference "versioning tool"))
 ) ;menu-bind

--- a/devel/1249.md
+++ b/devel/1249.md
@@ -1,0 +1,53 @@
+# [1249] 移除 Versioning tool 的全部 UI 入口
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/texmacs/menus/tools-menu.scm`（tools-menu）
+- `TeXmacs/progs/texmacs/menus/preferences-menu.scm`（other-preferences-menu 的 Tools 子菜单）
+- `TeXmacs/progs/init-research.scm`（version-menu 懒加载）
+- `TeXmacs/progs/texmacs/menus/main-menu.scm`（menu-bar / icon-bar 顶栏 Version 入口）
+
+## 3 如何测试
+
+启动 Mogan（`xmake b stem && xmake r stem`），检查菜单项不存在即可：
+
+- Tools 菜单中无 "Versioning tool"
+- 主菜单栏无 "Version" 菜单
+- Edit → Preferences → Other → Tools 无 "Versioning tool"
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+移除 versioning tool 的四个 UI 入口：
+
+1. Tools 菜单的 "Versioning tool" 开关
+2. Edit → Preferences → Other → Tools 的 "Versioning tool" 开关
+3. `init-research.scm` 中 version-menu 的 lazy-menu 声明
+4. `main-menu.scm` 两处 `(if (with-versioning-tool?) (=>/-> "Version" ...))`
+
+## 6 Why
+SVN 版本控制工具栏使用场景已过时，且 preference 默认 off，
+绝大多数用户不可见，清理菜单噪音。
+
+保留的部分（有意不动）：
+
+- `progs/version/` 模块整体保留（version-menu / version-svn /
+  version-tmfs / version-edit 等）：`version-edit` 仍被
+  `source/macro-widgets.scm`、`dynamic/calc-edit.scm` 依赖
+- `init-research.scm` 的 `(lazy-define (version version-tmfs)
+  update-buffer commit-buffer)` 保留：`tm-files.scm`、`tm-server.scm`
+  的 `:update`/`:commit` 选项仍调用这两个函数
+- `tm-modes.scm` 的 `with-versioning-tool%` 与 `tm-server.scm` 的
+  preference 默认值保留：`math-menu.scm` 的 "Correct manually"
+  仍以 `with-versioning-tool?` 为显隐条件
+  （preference 不再有 UI 开关，仅手改 preferences.json 可激活）
+
+## 7 How
+删除上述四处入口对应的 menu-bind / lazy-menu 行；version-menu
+不再被任何菜单 link，模块文件原样保留。


### PR DESCRIPTION
## What

移除 versioning tool 的四个 UI 入口：

1. Tools 菜单的 "Versioning tool" 开关（`tools-menu.scm`）
2. Edit → Preferences → Other → Tools 的 "Versioning tool" 开关（`preferences-menu.scm`）
3. `init-research.scm` 中 version-menu 的 lazy-menu 声明
4. `main-menu.scm` 两处 `(if (with-versioning-tool?) (=>/-> "Version" ...))`

## Why

SVN 版本控制工具栏使用场景已过时，且 preference 默认 off，绝大多数用户不可见，清理菜单噪音。

## 保留（有意不动）

- `progs/version/` 模块整体保留：`version-edit` 仍被 `source/macro-widgets.scm`、`dynamic/calc-edit.scm` 依赖
- `init-research.scm` 的 `(lazy-define (version version-tmfs) update-buffer commit-buffer)` 保留：`tm-files.scm`、`tm-server.scm` 的 `:update`/`:commit` 选项仍调用这两个函数
- `tm-modes.scm` 的 `with-versioning-tool%` 与 `tm-server.scm` 的 preference 默认值保留：`math-menu.scm` 的 "Correct manually" 仍以其为显隐条件

## Test

启动 Mogan，检查菜单项不存在即可：

- Tools 菜单中无 "Versioning tool"
- 主菜单栏无 "Version" 菜单
- Edit → Preferences → Other → Tools 无 "Versioning tool"

🤖 Generated with [Claude Code](https://claude.com/claude-code)