### PR TITLE
[1248] diff 拒绝快捷键改为 ESC，弹窗跟随不再依赖插件

### DIFF
--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -181,8 +181,8 @@
 
 (tm-define (keyboard-press key time)
   (:require (is-diff-active?))
-  (cond ((== key "return") (accept-diff))
-        ((== key "backspace") (reject-diff))
+  (cond ((== key "right") (accept-diff))
+        ((== key "escape") (reject-diff))
         (else (former key time))
   ) ;cond
 ) ;tm-define

--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -19,12 +19,16 @@
 ;; =============================================================================
 
 (define (diff-check-popup)
-  ;; 先隐藏弹窗，避免位置错乱
+  ;; 先隐藏弹窗，避免位置错乱；弹窗函数由插件提供，社区版未定义时仅跟踪不显示
   (set! diff-active? #f)
-  (hide-diff-popup)
+  (when (defined? 'hide-diff-popup)
+    (hide-diff-popup)
+  ) ;when
   (when (tree-innermost 'version-both)
     (set! diff-active? #t)
-    (show-diff-popup)
+    (when (defined? 'show-diff-popup)
+      (show-diff-popup)
+    ) ;when
   ) ;when
 ) ;define
 
@@ -188,13 +192,11 @@
 ) ;tm-define
 
 (tm-define (keyboard-press key time)
-  (:require (diff-enable?))
   (former key time)
   (delayed (:idle 0) (diff-check-popup))
 ) ;tm-define
 
 (tm-define (mouse-event key x y mods time data)
-  (:require (diff-enable?))
   (former key x y mods time data)
   (when (not (== key "move"))
     (delayed (:idle 0) (diff-check-popup))

--- a/TeXmacs/progs/generic/diff-text.scm
+++ b/TeXmacs/progs/generic/diff-text.scm
@@ -185,7 +185,7 @@
 
 (tm-define (keyboard-press key time)
   (:require (is-diff-active?))
-  (cond ((== key "right") (accept-diff))
+  (cond ((== key "return") (accept-diff))
         ((== key "escape") (reject-diff))
         (else (former key time))
   ) ;cond

--- a/TeXmacs/tests/tmu/1248.tmu
+++ b/TeXmacs/tests/tmu/1248.tmu
@@ -3,9 +3,9 @@
 <style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
 
 <\body>
-  新
+  <version-both|旧|新>
 
-  ddddddd
+  <version-both|old|new>
 </body>
 
 <\initial>

--- a/TeXmacs/tests/tmu/1248.tmu
+++ b/TeXmacs/tests/tmu/1248.tmu
@@ -1,0 +1,18 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  新
+
+  ddddddd
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+    <associate|preamble|false>
+    <associate|stem-doc-id|B58D94E4-FE68-4140-81D4-87300049BBB0>
+  </collection>
+</initial>

--- a/devel/1248.md
+++ b/devel/1248.md
@@ -1,55 +1,47 @@
-# 1248 diff 接受/拒绝快捷键调整
+# 1248 diff 拒绝快捷键改为 ESC
 
 ## 任务
 
-diff 审阅（AI 补全建议）的键盘操作改为：
+diff 审阅（AI 补全建议 / 版本比较结果）的交互调整：
 
-- 接受 diff：右方向键（原 `return`）
 - 拒绝 diff：`escape`（原 `backspace`）
+- 接受 diff：保持 `Enter` 不变
+- 弹窗跟随与快捷键拦截不再依赖 diff 插件
 
 ## What
 
-`TeXmacs/progs/generic/diff-text.scm` 的 `keyboard-press`（diff 激活时的键处理）
-中，`return`→`accept-diff`、`backspace`→`reject-diff` 的绑定改为
-`right`→`accept-diff`、`escape`→`reject-diff`。
+1. `TeXmacs/progs/generic/diff-text.scm` 的 `keyboard-press`（diff 激活时的
+   键处理）中 `backspace`→`reject-diff` 改为 `escape`→`reject-diff`，
+   `return`→`accept-diff` 保持不变。
+2. 弹窗跟踪钩子（`keyboard-press` / `mouse-event` 里触发 `diff-check-popup`
+   的两个重载）去掉 `(:require (diff-enable?))`，改为无条件安装；
+   `diff-check-popup` 内 `hide-diff-popup` / `show-diff-popup` 调用加
+   `(defined? ...)` 守卫，社区版（无插件定义）只跟踪状态不显示弹窗。
+3. `src/Plugins/Qt/QTMUserPromptPopup.cpp` 中 `QTMDiffTextPopup` 构造传入的
+   按钮文案 `"拒绝  Backspace"` 改为 `"拒绝  ESC"`。
 
 ## Why
 
-右方向键表示「向前采纳」，escape 表示「放弃」，与 ghost-text
-（`TeXmacs/progs/generic/ghost-text.scm` 中 right 接受 / escape 拒绝）
-的交互约定保持一致，降低用户记忆成本。
+- 拒绝用 escape 与 ghost-text（`TeXmacs/progs/generic/ghost-text.scm` 中
+  escape 拒绝）的交互约定一致；
+- 接受保持 Enter：diff 激活期间光标仍可在文档内移动（弹窗只是跟随反馈），
+  右方向键必须留给光标移动，不能被拦截；
+- `version-both` 节点不只来自 AI 润色插件，核心版本比较
+  （`version/version-compare.scm`）也会产生。是否显示弹窗只应由
+  「光标是否在 `version-both` 内」决定，与插件是否加载无关。
 
 ## How
 
-只改 `keyboard-press` 的 `cond` 两个分支的键名匹配，其余逻辑
-（`former` 透传、diff-check-popup 调度）不变。全库检索确认
-`accept-diff` / `reject-diff` 仅此文件引用，无弹窗提示文案需要同步。
-
-## 追加：弹窗跟随不依赖 diff 插件
-
-### What
-
-- 弹窗跟踪钩子（`keyboard-press` / `mouse-event` 里触发 `diff-check-popup`
-  的两个重载）去掉 `(:require (diff-enable?))`，改为无条件安装；
-- `diff-check-popup` 内 `hide-diff-popup` / `show-diff-popup` 调用加
-  `(defined? ...)` 守卫，社区版（无插件定义）只跟踪状态不显示弹窗。
-
-### Why
-
-`version-both` 节点不只来自 AI 润色插件，核心版本比较
-（`version/version-compare.scm`）也会产生。是否显示弹窗只应由
-「光标是否在 `version-both` 内」决定，与插件是否加载无关。
-
-### How
-
-- 模块经 `generic-kbd.scm` 常规加载，钩子无条件安装后每次按键/点击
-  都会 `diff-check-popup`：隐藏→按 `tree-innermost 'version-both`
-  重显，同时维护 `diff-active?`；
-- 社区版无插件时 `diff-active?` 仍会在 diff 节点内置位，右方向键/escape
-  的接受/拒绝拦截因此对核心版本比较结果同样生效（纯树操作，无需插件）；
+- 只改 `keyboard-press` 的 `cond` 分支键名匹配与按钮文案字符串；
+- 模块经 `generic-kbd.scm` 常规加载，钩子无条件安装后每次按键/点击都会
+  `diff-check-popup`：隐藏→按 `tree-innermost 'version-both` 重显，同时维护
+  `diff-active?`；
+- 社区版无插件时 `diff-active?` 仍会在 diff 节点内置位，Enter/escape 的
+  接受/拒绝拦截因此对核心版本比较结果同样生效（纯树操作，无需插件）；
 - 触发 AI 润色的 `kbd-tab` 仍保留 `diff-enable?` 门槛（真正依赖
   `diff-cloud-polish`）。
 
 ## 涉及文件
 
 - `TeXmacs/progs/generic/diff-text.scm`
+- `src/Plugins/Qt/QTMUserPromptPopup.cpp`

--- a/devel/1248.md
+++ b/devel/1248.md
@@ -1,0 +1,30 @@
+# 1248 diff 接受/拒绝快捷键调整
+
+## 任务
+
+diff 审阅（AI 补全建议）的键盘操作改为：
+
+- 接受 diff：右方向键（原 `return`）
+- 拒绝 diff：`escape`（原 `backspace`）
+
+## What
+
+`TeXmacs/progs/generic/diff-text.scm` 的 `keyboard-press`（diff 激活时的键处理）
+中，`return`→`accept-diff`、`backspace`→`reject-diff` 的绑定改为
+`right`→`accept-diff`、`escape`→`reject-diff`。
+
+## Why
+
+右方向键表示「向前采纳」，escape 表示「放弃」，与 ghost-text
+（`TeXmacs/progs/generic/ghost-text.scm` 中 right 接受 / escape 拒绝）
+的交互约定保持一致，降低用户记忆成本。
+
+## How
+
+只改 `keyboard-press` 的 `cond` 两个分支的键名匹配，其余逻辑
+（`former` 透传、diff-check-popup 调度）不变。全库检索确认
+`accept-diff` / `reject-diff` 仅此文件引用，无弹窗提示文案需要同步。
+
+## 涉及文件
+
+- `TeXmacs/progs/generic/diff-text.scm`

--- a/devel/1248.md
+++ b/devel/1248.md
@@ -25,6 +25,31 @@ diff 审阅（AI 补全建议）的键盘操作改为：
 （`former` 透传、diff-check-popup 调度）不变。全库检索确认
 `accept-diff` / `reject-diff` 仅此文件引用，无弹窗提示文案需要同步。
 
+## 追加：弹窗跟随不依赖 diff 插件
+
+### What
+
+- 弹窗跟踪钩子（`keyboard-press` / `mouse-event` 里触发 `diff-check-popup`
+  的两个重载）去掉 `(:require (diff-enable?))`，改为无条件安装；
+- `diff-check-popup` 内 `hide-diff-popup` / `show-diff-popup` 调用加
+  `(defined? ...)` 守卫，社区版（无插件定义）只跟踪状态不显示弹窗。
+
+### Why
+
+`version-both` 节点不只来自 AI 润色插件，核心版本比较
+（`version/version-compare.scm`）也会产生。是否显示弹窗只应由
+「光标是否在 `version-both` 内」决定，与插件是否加载无关。
+
+### How
+
+- 模块经 `generic-kbd.scm` 常规加载，钩子无条件安装后每次按键/点击
+  都会 `diff-check-popup`：隐藏→按 `tree-innermost 'version-both`
+  重显，同时维护 `diff-active?`；
+- 社区版无插件时 `diff-active?` 仍会在 diff 节点内置位，右方向键/escape
+  的接受/拒绝拦截因此对核心版本比较结果同样生效（纯树操作，无需插件）；
+- 触发 AI 润色的 `kbd-tab` 仍保留 `diff-enable?` 门槛（真正依赖
+  `diff-cloud-polish`）。
+
 ## 涉及文件
 
 - `TeXmacs/progs/generic/diff-text.scm`

--- a/devel/1248.md
+++ b/devel/1248.md
@@ -41,6 +41,32 @@ diff 审阅（AI 补全建议 / 版本比较结果）的交互调整：
 - 触发 AI 润色的 `kbd-tab` 仍保留 `diff-enable?` 门槛（真正依赖
   `diff-cloud-polish`）。
 
+## 如何测试
+
+### 确定性测试（单元测试）
+
+无：快捷键拦截是 GUI 键盘交互，无纯逻辑改动，不新增单元测试。
+
+### 非确定性测试（文档验证）
+
+测试文档 `TeXmacs/tests/tmu/1248.tmu`，内含两个现成的 `version-both`
+节点（`旧|新`、`old|new`），不依赖 AI 插件即可覆盖接受/拒绝全流程：
+
+```bash
+xmake b stem && xmake r stem TeXmacs/tests/tmu/1248.tmu
+```
+
+（也可启动后通过 文件 → 打开 选择该文件。）
+
+| 步骤 | 操作 | 预期 |
+|------|------|------|
+| 1 | 光标移入任一 `version-both` 节点（点击或方向键） | diff 激活；插件版弹出「接受 Enter / 拒绝 ESC」悬浮框跟随光标，社区版无弹窗但拦截同样生效 |
+| 2 | `Enter` | 接受：节点替换为第二个子节点（`新` / `new`），光标自动跳到下一处 diff |
+| 3 | `Escape` | 拒绝：节点替换为第一个子节点（`旧` / `old`），同样跳到下一处 |
+| 4 | `Backspace` | 不再触发拒绝，执行普通退格编辑（旧行为已移除） |
+| 5 | 方向键移动光标 | 光标在文档内正常移动不被拦截；弹窗随光标进出 `version-both` 显示/隐藏 |
+| 6 | 两处 diff 均处理完 | 文档内无残留 `version-both` 节点，弹窗消失 |
+
 ## 涉及文件
 
 - `TeXmacs/progs/generic/diff-text.scm`

--- a/src/Plugins/Qt/QTMUserPromptPopup.cpp
+++ b/src/Plugins/Qt/QTMUserPromptPopup.cpp
@@ -277,7 +277,7 @@ QTMGhostTextPopup::onBadClicked () {
 // =============================================================================
 QTMDiffTextPopup::QTMDiffTextPopup (QWidget*              parent,
                                     qt_simple_widget_rep* owner)
-    : QTMUserPromptPopup (parent, owner, "接受  Enter", "拒绝  Backspace") {
+    : QTMUserPromptPopup (parent, owner, "接受  Enter", "拒绝  ESC") {
   setObjectName ("diff_text_popup");
 }
 


### PR DESCRIPTION
## 改动

- **拒绝 diff 改为 `escape`**（原 `backspace`）；接受保持 `Enter` 不变——diff 激活期间光标仍需在文档内移动，右方向键不能被拦截（`TeXmacs/progs/generic/diff-text.scm`）
- **弹窗按钮文案**同步为「接受 Enter / 拒绝 ESC」（`src/Plugins/Qt/QTMUserPromptPopup.cpp` `QTMDiffTextPopup`）
- **弹窗跟随与快捷键拦截去掉 `diff-enable?` 门槛**：是否显示弹窗只由「光标是否在 `version-both` 节点内」决定；`show-diff-popup`/`hide-diff-popup` 加 `defined?` 守卫，社区版只跟踪状态不显示。核心版本比较产生的 `version-both` 因此同样可用 Enter/escape 接受/拒绝；触发 AI 润色的 `kbd-tab` 仍保留插件门槛

任务文档：`devel/1248.md`

## 测试

- GUI 手动验证 diff 弹窗：Enter 接受、ESC 拒绝、文案显示正确（用户已验证）
- 纯 `diff-text.scm` 逻辑改动无需重建；C++ 仅一行字符串改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)