### PR TITLE
[0947] 补全 QML 弹窗 ai-docs 并补登 UpdaterProgress

### DIFF
--- a/ai-docs/qml/README.md
+++ b/ai-docs/qml/README.md
@@ -61,7 +61,7 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
 | `value-table-clean entry-keys` | cleanup（关窗） | 清整组防泄漏 |
 
 **不变量**：凡写文档树的路径（set/reset/cancel）都必须同步 `set!` 本表，否则表值与文档真相背离。
-当前两个使用者：
+使用者（凡带 reset 的 live 写回对话框必接入）：
 
 - **FontSelector**（`fonts/font-new-widgets.scm`）：entry-key = `(specs var buffer)`，fallback
   为字体专用 `initial-font-data`/`initial-customize-get`；Cancel 经 `font-selector-revert-to-snapshot`
@@ -70,6 +70,47 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
 - **ParagraphFormat**（`generic/paragraph-format-widgets.scm`）：entry-key = `(key var)`（key 为 register 返回的实例句柄），
   fallback 为 scope 路由的 `get-env`/`get-init`；register 填表、set 同步写、reset 段落级写快照值/
   文档级 init-default 后写 `get-init` 默认值、Cancel restore-snapshot 写快照值、cleanup 清表。
+
+## Preferences 契约（preferences-qml-meta / PreferencesBridge）
+
+Preferences（首选项）是 FormDialog 模式的变体：**本地暂存 + OK 一次性 diff 提交**。
+打开时 `prefBridge.meta()` 一次性拉全部 tab/字段描述符树（打开快照 `initialValues`）；
+用户改动只改 QML 本地 `values`（条件锁定 / radio 互斥纯 QML 本地，不往 facade 写）；
+OK 时算与快照的 diff → `prefBridge.submit(diff)` 一次性应用；Cancel 丢弃
+（`prefBridge.cancel()` 只关窗，scm 侧 no-op）。Preferences.qml 头注释引用本节。
+
+**prefBridge 契约**（`PreferencesBridge`，无状态透传——preferences 是全局的，bridge 不持有偏好数据）：
+
+| 方法 | 返回 / 语义 |
+|------|------------|
+| `meta()` | `{tabs: [{key, label, fields, subTabs?}]}`（subTabs 与 tab 同构） |
+| `submit(changed)` | `"applied"` / `"restart"` / `"later"` / `"cancel"` 四态：scm 先应用 diff；含需重启字段时先弹 `cpp-confirm-restart`，三选一映射 restart / later(保存稍后) / cancel(回退该字段) |
+| `cancel()` | 关窗，本地丢弃 |
+| `callAction(name)` | 行内按钮动作路由（如 `open-auto-backup-location`，label 与实现由插件注入） |
+
+**field-descriptor 字段**（scm 侧 `preferences-qml-field->descriptor` 产出，assoc-list）：
+
+| 字段 | 说明 |
+|------|------|
+| `kind` | `combo` / `toggle` / `info`（scm 按 options 非空 / key 空自动分流） |
+| `key` | preference 内部键（combo/toggle 必有；info 无、不入可编辑 map） |
+| `label` / `hint` / `group` | 已翻译文案（编码注意见下） |
+| `value` | wire 格式统一字符串：toggle 为 `"on"/"off"`，combo 为 options 内部键 |
+| `options` / `optionsTr` | 内部键 × 翻译显示，等长同序；动态字段（language、scripting language、image format）在 meta 构建期拉取，look and feel 按平台裁剪 |
+| `editable` | combo 双击可键入（透传 EnumCombo） |
+| `restart` | 改动需重启生效 |
+| `radioGroup` | 互斥组：开一则同组其它置 off（QML 本地） |
+| `enabledWhenKey` / `enabledWhenVal` | 条件锁定：依赖键等于值才可勾，否则 Toggle 锁定灰显（QML 本地） |
+| `layout` / `column` | `"two-col"` 双栏段与 0/1 列号（Mathematics / Experimental） |
+| `groupSpan` | 分组标题横跨整行（统领双栏两列，如 IR 遥控组） |
+| `buttonLabel` / `buttonAction` | combo 旁行内按钮，点击经 `callAction(buttonAction)` 路由 |
+
+编码注意：scm 字面量是 UTF-8，label/hint/group/buttonLabel 先 `utf8->cork` 再
+`translate`，bridge 侧 `cork_to_utf8` 还原——跳过归一化会让含非 ASCII 的文案
+（如 `TeXmacs → Html` 的箭头）被二次解码成乱码。偏好键一律走
+`pref-keys.scm` 的 `pref-*` 访问器。字段定义与 descriptor 构建在
+`TeXmacs/progs/texmacs/menus/preferences-tools.scm`，tab 组织与 submit 在
+`preferences-widgets.scm`；契约测试 `TeXmacs/tests/2044.scm`。
 
 ## 板块
 
@@ -80,27 +121,46 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
 - **`qml/`**（本目录）— 成品弹窗，`qml/qmldir` 登记。
 
 **原子**（`atoms/`，拼装用，勿自造外壳/配色）：
-- `DialogShell` — 外壳：圆角、无边框拖动、Esc、`content` 正文槽、共享下拉浮层
-- `DialogButtons` — 按钮行，只发 `clicked(index)`，语义由调用方映射
-- `MiniButton` — 紧凑小按钮（正文内辅助按钮组，如行间距预设），只发 `clicked()`
-- `EnumCombo` — 下拉 combo 行（浮层由 DialogShell 管），支持 optionsTr 翻译分离
-- `EnumComboList` — 可滚动的 EnumCombo 竖列（Filter/Advanced 选项卡内容）
+- `DialogShell` — 外壳：圆角、无边框拖动、Esc、`content` 正文槽、共享下拉浮层。
+  `onCancel`/`onActivate` 是可覆盖回调（默认 Esc → `closeBridge.cancel()`；FontSelector
+  覆盖转调 `fontBridge.cancel()`，UpdaterProgress 覆盖为 no-op 禁 Esc）
+- `DialogButtons` — 按钮行，只发 `clicked(index)`，`primaryIndex` 定主按钮配色，
+  语义由调用方映射
+- `MiniButton` — 正文内辅助按钮，`size` 两档：`"mini"` 紧凑小按钮（行间距预设组）、
+  `"normal"` 与 EnumCombo 行等高的行内 action 按钮（宽度按文案自适应），只发 `clicked()`
+- `EnumCombo` — 下拉 combo 行（浮层由 DialogShell 管），key/显示分离（`options` 英文键 ×
+  `optionsTr` 翻译显示）；`editable: true` 双击进可编辑输入态（Enter/失焦落定、Esc 撤销），
+  供数值类字段键入预设外的自定义值；`isNarrow` 双栏半宽列自适应；`actionLabel` 行内按钮
+  （发 `actionClicked`，如「打开备份目录」）
+- `EnumComboList` — 可滚动的 EnumCombo 竖列，两种取值模式：默认 meta 自带 value
+  （FontSelector）；`valueSource` 外部真相源 map 模式——改动只外发 `itemChanged`、由
+  调用方更新 map（live 写回且 get-env 重读有延迟的场景用，如段落格式，避免显示滞后一拍）
 - `SelectableList` — 常驻单选列表（family/style/size 三栏用），自带 `refreshTick`
-  驱动 currentValue 重算
+  驱动 currentValue 重算；值未变仅发信号时需调用方显式 `syncActiveValue()`
 - `PreviewPane` — 预览图区（显示 bridge 光栅化的 PNG data URL）
 - `TabBar` — 胶囊选项卡行
-- `TabPanel` — 带选项卡的容器面板（TabBar + content 槽）
-- `Theme` — 主题单例（scaleFactor / 暗色 / 配色 / 结构尺寸常量 `rowH`·`btnH`）
+- `TabPanel` — 带选项卡的容器面板（TabBar + content 槽；content 与 DialogShell 同样
+  由组件 reparent 锚定，调用方勿自行 anchors.fill）
+- `GroupHeader` — 分组小标题（加粗 + 对称间距，不画分隔线；`isFirst` 首组不加上间距）
+- `Toggle` — 布尔开关行（label + 可选 hint + 右侧 on/off 胶囊，切换滑动动画）；
+  `isNarrow` 双栏半宽列缩小字体加大 label 占比；`enabled: false` 锁定灰显
+  （enabledWhen 条件锁定用）
+- `Theme` — 主题单例（scaleFactor / 暗色 / 配色 / 尺寸与字号阶梯常量，分类规则见
+  「编码规矩」）
 
 **成品**：
 | 对话框 | 模态引擎 | 模型 |
 |--------|---------|------|
 | `ConfirmClose` | `run_qml_dialog`（exec） | 点按钮返回结果 |
-| `ConfirmQuestion` | `run_qml_dialog`（exec） | 默认按钮居右的确认弹窗（替换 question-no-cancel 的 QMessageBox），返回语义按钮下标 |
+| `ConfirmQuestion` | `run_qml_dialog`（exec） | 默认按钮居右的确认弹窗（替换 question-no-cancel 的 QMessageBox），返回语义按钮下标（按钮反序协议见「编码规矩」） |
 | `ConfirmRestart` | `run_qml_dialog`（exec） | 三按钮（立即重启/稍后/取消），返回 `"restart"/"later"/"cancel"` |
-| `FormDialog` | `run_qml_dialog`（exec） | 本地暂存 `values`，OK 一次性 submit |
+| `FormDialog` | `run_qml_dialog`（exec） | 本地暂存 `values`，OK 一次性 submit（页面设置走此弹窗） |
 | `FontSelector` | `run_modal_qml_dialog`（setModal+show） | live 写回文档，OK 落定 / Cancel 快照撤销 / Reset 按 global? 分流（文档级系统默认、段落级回快照） |
 | `ParagraphFormat` | `run_modal_qml_dialog`（setModal+show） | live 写回（段落 with / 文档 initial），按 scope 撤销 |
+| `Statistics` | `run_qml_dialog`（exec） | 纯展示统计行（`statsItems` 注入 `{label,value}`），Close 即关，无返回值 |
+| `Version` | `run_qml_dialog`（exec + 自适应高度） | `VersionDialogBridge` 只读（title/lines/buttonLabels）+ `confirm()`；单行超宽自动换行，定宽后读 implicitHeight 锁高（见「模态引擎」） |
+| `Preferences` | `run_qml_dialog`（exec） | 本地暂存 + OK 一次性 diff 提交（契约见上节）；含需重启字段时先弹 ConfirmRestart |
+| `UpdaterProgress` | `run_modal_qml_dialog`（setModal+show） | 更新下载中间态：无进度条只转圈；全局单例宿主（重复 open 不重弹）+ `cpp-updater-dialog-open/close` 成对 glue；Esc 禁用（onCancel 覆盖 no-op）。选 show 模态非为 live 重绘，而是 exec 嵌套循环会阻塞 scheme 的 delayed 轮询链 |
 
 ## 编码规矩
 
@@ -115,12 +175,14 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
   可保留字面量。
 - **cancel 走语义化入口**：`QmlDialogBridge.cancel()`（= `done(Rejected)`），勿散落
   `choose(-1)` 魔法值。`choose(n>=0)` 仍用于「选第 n 个按钮」（ConfirmClose）。
+- **ConfirmQuestion 按钮反序协议**：scm 传语义序 buttons（`buttons[0]` 为默认）；
+  C++ 注入 QML 前反序（默认按钮居右），`dialogPrimary` 指显示序最后一个；QML 回传
+  `choose` 为显示下标 +1，C++ 映射回语义下标 `N - choice`。动按钮顺序前先过一遍这条链。
 - **偏好键统一走 `pref-keys.scm`**：弹窗读写 preference 的 key 字符串一律在
   `TeXmacs/progs/kernel/texmacs/pref-keys.scm`（单一可信源）声明 `(define-public (pref-...) "...")`，
   调用方在 quasiquote 里用 `,(pref-...)` 引用而非裸字符串（key 改名会断 notify 回调链路）。
-  新增弹窗的字段键须补 pref-keys 声明——Page setup / Font selector 已覆盖，
-  ParagraphFormat 的 19 个 `par-*`（见 #2045）与 Preferences 的 ~85 个 key（见 #2044）
-  是近期补齐的两组。
+  新增弹窗的字段键须补 pref-keys 声明——现有 117 个访问器已覆盖 Page setup / Font
+  selector / ParagraphFormat（`pref-par-*`）/ Preferences 各组。
 - **绑定到无参 bridge 函数的属性不会自动重算**：bridge 内部状态变化 QML 感知不到，需靠
   外部计数器注入依赖。`SelectableList.refreshTick` 已封装此模式——调用方 currentValue 绑定
   读 `<listId>.refreshTick`，refresh 时 `<listId>.refreshTick++` 即可，勿手写假读样板。
@@ -132,6 +194,8 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
    在 scm 构造数据时即用 `translate` 包裹，不要硬编码英文。值（数字、内部 key）不翻译。
   字典条目按最小粒度登记（如 `"character count"` / `"with spaces"`），系统自动拼接
   （`"Character count (with spaces)"` → `"字符数（计空格）"`），不要为每种组合加整条字典。
+  三方分工：文案翻译收敛在 scm 构造侧，C++ 仅 `translate_buttons` 对注入的按钮文案兜底，
+  QML 内不硬编码用户可见文案（回退文案用 `qsTr`）。
 - **`translate` 的三条自动归一化**（实现在 `src/System/Language/dictionary.cpp` 的
   `dictionary_rep::translate`，`qt_translate` 同源）：
   1. **首字母大写折叠**：查表前把首字符转小写再查，命中后把结果首字母大写回。故字典
@@ -145,9 +209,12 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
 - **字典条目按字母序排列**：`TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` 等字典文件，
   新增条目按首字母段插入（大小写混排时以小写为准），保持可检索。
 - **跨弹窗复用的布局常量收进 `Theme.qml`**：行高、间距等可能被多个弹窗共用的数字，统一加在
-  `atoms/Theme.qml` 的结构尺寸/间距阶梯段。优先用已有常量组合（如 `Theme.btnH + Theme.padS * 2`
+  `atoms/Theme.qml`。优先用已有常量组合（如 `Theme.btnH + Theme.padS * 2`
   表示按钮区高度），避免为单一用途加新常量。成品弹窗只保留本弹窗专属的布局参数（如列宽比
   `labelW`），引用 Theme 常量（`Theme.pad`/`Theme.gapS`/`Theme.inlineGap`/`Theme.textRowH` 等）。
+  `Theme.qml` 内常量按段分类：配色 → 结构尺寸 → 圆角 → 字号阶梯 → 间距/边距阶梯 →
+  原子级布局常量（combo/toggle/tab/list/mini 各段，某原子专用）→ 双栏布局（`twoCol*`）。
+  新常量按类别归段，不另起散段。
 - **跨 parent 链查找的 property 不能喂给 binding**：如 EnumCombo 的 `dialogShell`（沿
   parent 链按 objectName 查找）是命令式 property，parent 变化不触发其重算，binding 会在
   创建瞬间读到 null 永久卡住。依赖它的几何（comboX/Y/W）须在展开时用 `updateGeometry()`
@@ -157,7 +224,25 @@ API 速查（`utils/library/dialog-value-table`，entry-key 由调用方自定�
 
 两个引擎都收敛了 QDialog 拼装 + setSource + 加载检查 + 定尺寸流程，差异只在 exec vs
 setModal+show（见上表）。新增模态对话框写 context 注入回调 + 解读返回值即可，不重抄
-宿主拼装。
+宿主拼装。共用 context property 由 `inject_common_context` 注入：`closeBridge`
+（`QmlDialogBridge`：choose/cancel/submit/startMove）、`dpScale`（DPI 缩放）、`isDark`
+（跟随 tm_style_sheet）。
+
+**选 show 模态（setModal+show）的两种理由**：① live 重绘文档（FontSelector /
+ParagraphFormat）；② 弹窗存续期间 scheme 的 `delayed` 轮询链必须继续跑——exec 的嵌套
+事件循环会阻塞它（UpdaterProgress：下载链由 scheme 轮询驱动）。除这两种外一律用 exec。
+
+**bridge 生命周期两式**：exec 型在 `exec()` 返回后手动 `delete bridge`（ConfirmClose /
+FormDialog / Preferences / Version 等）；show 型 bridge 不挂 parent，靠
+`connect(host, destroyed, bridge, deleteLater)` 自清（见开头「生命期」）。需跨函数持有
+show 型宿主的（UpdaterProgress 的 open/close 成对 glue），用 `QPointer<QDialog>` 全局
+引用防悬垂，关窗走 `host->close()` 而非 `done()`（不触发 WA_DeleteOnClose 析构）。
+
+**自适应高度（autofit_height）**：正文行数不定时（Version 长文案换行），引擎先按
+logic_w 锁宽、让 QML 完成换行布局，再读根 `implicitHeight` 锁高（logic_h 仅回退）。
+配套坑：QML 里文本宽度须绑「定宽逻辑值」（如 Version 的 `contentW` = implicitWidth ×
+scaleFactor − 2×margin），不能绑实际父宽——show 前 C++ 就要读 implicitHeight，此刻布局
+宽度尚未就位，绑父宽会量出错误的换行结果。
 
 ## 开发工作流（新增弹窗/原子）
 
@@ -169,9 +254,12 @@ setModal+show（见上表）。新增模态对话框写 context 注入回调 + �
    不可靠）。尺寸/字号尽量复用 `Theme` 常量；拼接布局数字（列宽/间距）可留字面量。
 3. **登记**：`qml/qmldir` 加 `Foo 1.0 Foo.qml`；`moganqml.qrc` 加 `<file>qml/Foo.qml</file>`
    （无 glob，漏登则运行期找不到）。新增原子同理放 `atoms/` 并登 `atoms/qmldir`。
-4. **bridge + glue**：若需 live 写回，仿 `FontSelectorBridge` 写 C++ bridge（注入 context
-   property）；在 `QTMQmlDialog.cpp` 加 glue 入口（选 `run_qml_dialog` exec 或
-   `run_modal_qml_dialog` setModal+show，按是否需 live 重绘文档决定）。**若带 reset/Cancel**，
+4. **bridge + glue**：若需 live 写回或行内动作，仿 `FontSelectorBridge` 写 C++ bridge
+   （独立 QObject + `Q_INVOKABLE` 透传 `eval_scheme`，**不继承 `QmlDialogBridge`**，注入为
+   context property）。引擎入口写在 `QTMQmlDialog.cpp`（选 `run_qml_dialog` exec 或
+   `run_modal_qml_dialog` setModal+show，理由见「模态引擎」节）；**glue 声明登记在
+   `src/Scheme/L5/glue_qt.lua`**（C++ 声明侧 `src/Scheme/L5/glue_l5_extra.hpp`）——不在
+   `src/Scheme/Glue/` 目录，编辑器方法 glue 才在那里。**若带 reset/Cancel**，
    scheme facade 接入 `utils/library/dialog-value-table` 做本地真相表（见「Cancel/重置撤销」节），
    否则 reset 会滞后一拍。
 5. **加载测试**：在 `tests/Plugins/Qt/qml_load_test.cpp` 加 `test_foo_loads()`，注入对应
@@ -188,12 +276,29 @@ setModal+show（见上表）。新增模态对话框写 context 注入回调 + �
 1. **QML 加载测试**（`tests/Plugins/Qt/qml_load_test.cpp`，`xmake b qml_load_test && xmake r
    qml_load_test`）：`setSource` 后断言 `status()==Ready`。不验交互，只挡 import 缺失、语法
    错、id 悬空、context property 误用——改 atoms/弹窗后跑一遍即可回归。新弹窗加一个
-   `test_xxx_loads` 用例。
+   `test_xxx_loads` 用例。桩类四种：`StubBridge`（closeBridge 占位）、`StubLiveBridge`
+   （FontSelector+ParagraphFormat 全空桩）、`PrefStubBridge`（Preferences 最小字段树，
+   覆盖 group/two-col/column/sub-tab 渲染分支）、`VersionStubBridge`（只读属性）。
+   原子无独立加载用例——经成品弹窗间接覆盖是有意策略，新原子至少要被一个成品的加载
+   路径触达。Version 另有 4 个行为用例（打开聚焦、ESC 取消、ESC 无焦点兜底、长行换行）。
 2. **数据契约测试**（scheme 集成，`TeXmacs/tests/<编号>.scm`，`xmake b stem && xmake r <编号>`）：
    模态弹窗 C++ 单测无法 exec 阻塞跑，用环境变量钩子绕弹窗、直接走 facade 验 meta 形状 /
-   live 写回 / 快照撤销（字体：`MOGAN_TEST_FONT_SELECTOR=ok|cancel`，表单：
-   `MOGAN_TEST_FORM_DIALOG`，段落/确认关闭同理）。`MOGAN_TEST_GUI=1` 去 headless 在真实
-   GUI 跑交互链。
+   live 写回 / 快照撤销。钩子全表（实现在 `QTMQmlDialog.cpp` 各入口的 `get_env`）：
+
+   | 钩子 | 对话框 | 消费 |
+   |------|--------|------|
+   | `MOGAN_TEST_CONFIRM_CLOSE` | ConfirmClose | 2021.scm、qt_qml_dialog_test、qml_dialog_test |
+   | `MOGAN_TEST_CONFIRM_RESTART` | ConfirmRestart | 2040.scm、2044.scm、preferences-widgets-test.scm |
+   | `MOGAN_TEST_CONFIRM_QUESTION` | ConfirmQuestion | qml_dialog_test（C++ 侧） |
+   | `MOGAN_TEST_FORM_DIALOG` | FormDialog（页面设置） | 2023.scm、qml_dialog_test |
+   | `MOGAN_TEST_FONT_SELECTOR` | FontSelector | 2028.scm、font_selector_bridge_test |
+   | `MOGAN_TEST_PARAGRAPH_FORMAT` | ParagraphFormat | 2029.scm |
+   | `MOGAN_TEST_VERSION_DIALOG` | Version | 2080.scm |
+   | `MOGAN_TEST_PREFERENCES` | Preferences | preferences_bridge_test（C++ 侧；scheme 契约由 2044.scm 直调 facade 覆盖） |
+
+   Statistics / UpdaterProgress 无钩子（纯展示、无返回值分支）。另有 2036.scm
+   （ParagraphFormat 重置即时性 + value-table 缓存，facade 直调）。
+   `MOGAN_TEST_GUI=1` 去 headless 在真实 GUI 跑交互链。
 3. **手动 GUI 验证**：真实点选/双击/Esc/Cancel 等交互无法在 scheme 测试触及，靠打开弹窗
    观察确认。
 
@@ -201,11 +306,20 @@ setModal+show（见上表）。新增模态对话框写 context 注入回调 + �
 
 ## 相关
 
-- `src/Plugins/Qt/qml/atoms/` — 原子板块
-- `src/Plugins/Qt/qml/` — 成品弹窗（ConfirmClose/FormDialog/FontSelector/ParagraphFormat）
+- `src/Plugins/Qt/qml/atoms/` — 原子板块（12 个）
+- `src/Plugins/Qt/qml/` — 成品弹窗（ConfirmClose / ConfirmQuestion / ConfirmRestart /
+  FormDialog / FontSelector / ParagraphFormat / Statistics / Version / Preferences /
+  UpdaterProgress）
 - `src/Plugins/Qt/moganqml.qrc` — 逐文件登记 qml（无 glob，新增/移动须同步）
 - `src/Plugins/Qt/QTMQmlDialog.cpp` — 模态引擎 + 各对话框 glue 入口
 - `src/Plugins/Qt/QTMQmlDialogBridge.hpp` — `QmlDialogBridge`（choose/submit/cancel 回流）
-- `src/Plugins/Qt/FontSelectorBridge.*` — live + 快照撤销 bridge 样板
+  与 `QmlDialogEscFilter`（ESC 兜底）
+- `src/Plugins/Qt/FontSelectorBridge.*` / `ParagraphFormatBridge.*` / `PreferencesBridge.*` /
+  `VersionDialogBridge.*` — 各专用 bridge（独立 QObject 透传样板）
+- `src/Scheme/L5/glue_qt.lua` — QML 对话框 glue 声明（cpp-confirm-close 等 11 个入口）
+- scheme facade：`fonts/font-new-widgets.scm`（字体）、`generic/paragraph-format-widgets.scm`
+  （段落）、`texmacs/menus/preferences-widgets.scm` + `preferences-tools.scm`（首选项）、
+  `texmacs/menus/print-widgets.scm`（页面设置 → FormDialog）、`texmacs/texmacs/tm-tools.scm`
+  （统计）、`utils/misc/updater.scm`（更新下载 / ConfirmQuestion）、`doc/help-funcs.scm`（版本）
 - `tests/Plugins/Qt/qml_load_test.cpp` — QML 加载测试（新增弹窗在此加用例）
 - `ai-docs/qml/qml-dialog.html` — 设计稿

--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -960,6 +960,46 @@
       font-weight: 700;
     }
 
+    /* 更新下载中间态弹窗（UpdaterProgress.qml）：无限转圈 + 文案，无按钮、Esc 禁用 */
+    .updater-shell {
+      width: min(420px, 100%);
+      background: #ffffff;
+      border: 1px solid #d6dfdf;
+      border-radius: var(--radius);
+      padding: 28px 24px 22px;
+      box-shadow: var(--shadow);
+      text-align: center;
+    }
+
+    .spinner {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      border: 3px solid #e3eaea;
+      border-top-color: #1d2629;
+      animation: spin 0.9s linear infinite;
+      margin: 0 auto 18px;
+    }
+
+    .updater-shell .updater-message {
+      font-size: 15px;
+      font-weight: 700;
+      color: #1d2629;
+      line-height: 1.6;
+    }
+
+    .updater-shell .updater-note {
+      margin-top: 12px;
+      font-size: 12px;
+      color: #8aa0a6;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
     @media (max-width: 760px) {
       .workspace {
         padding: 16px;
@@ -995,6 +1035,7 @@
       <button class="nav-btn" data-target="version">Version.qml</button>
       <button class="nav-btn" data-target="preferences">Preferences.qml</button>
       <button class="nav-btn" data-target="confirmRestart">ConfirmRestart.qml</button>
+      <button class="nav-btn" data-target="updater">UpdaterProgress.qml</button>
       <div class="sidebar-foot">模拟目标: DialogShell / DialogButtons / EnumCombo / SelectableList / PreviewPane 组合逻辑。</div>
     </aside>
 
@@ -1624,6 +1665,24 @@
         </p>
       </section>
 
+      <!-- 更新下载中间态弹窗（UpdaterProgress.qml）：无限转圈 + 已翻译文案，无进度条；
+           下载中不可关闭（Esc 经 DialogShell onCancel 覆盖为 no-op 禁用） -->
+      <section class="panel" id="panel-updater">
+        <div class="cards">
+          <article class="updater-shell">
+            <div class="spinner"></div>
+            <p class="updater-message">正在下载更新…</p>
+            <p class="updater-note">无按钮、Esc 已禁用；下载完成后由 scheme 调 cpp-updater-dialog-close 关窗，再弹重启确认</p>
+          </article>
+        </div>
+        <p class="legend">
+          对应 QML: <code>dialogMessage + dpScale/isDark/closeBridge</code>
+          <code>onCancel 覆盖为 no-op（禁 Esc）</code>
+          run_modal_qml_dialog(setModal+show)——选非阻塞模态非为 live 重绘，而是 exec 嵌套事件循环会阻塞 scheme 的 delayed 轮询链；
+          全局单例宿主（QPointer，重复 open 不重弹）+ <code>cpp-updater-dialog-open/close</code> 成对 glue
+        </p>
+      </section>
+
 
     </main>
   </div>
@@ -1639,7 +1698,8 @@
         statistics: document.getElementById('panel-statistics'),
         version: document.getElementById('panel-version'),
         preferences: document.getElementById('panel-preferences'),
-        confirmRestart: document.getElementById('panel-confirm-restart')
+        confirmRestart: document.getElementById('panel-confirm-restart'),
+        updater: document.getElementById('panel-updater')
       };
 
       const titleMap = {
@@ -1650,7 +1710,8 @@
         paragraph: 'ParagraphFormat.qml 模拟',
         statistics: 'Statistics.qml 模拟',
         preferences: 'Preferences.qml 模拟',
-        confirmRestart: 'ConfirmRestart.qml 模拟'
+        confirmRestart: 'ConfirmRestart.qml 模拟',
+        updater: 'UpdaterProgress.qml 模拟'
       };
 
       const codeMap = {
@@ -1661,7 +1722,8 @@
         paragraph: 'EnumCombo x N + tabs(基础/高级) + make-multi-line-with 写回',
         statistics: 'statsModel: [{label, value}, ...] + closeBridge.choose(0) 关闭',
         preferences: 'prefTabs(5) + subTabs(6) + EnumCombo + Toggle + 纯 OK 提交',
-        confirmRestart: 'message + buttonLabels + closeBridge.choose(index)'
+        confirmRestart: 'message + buttonLabels + closeBridge.choose(index)',
+        updater: 'dialogMessage + onCancel no-op + open/close 成对 glue'
       };
 
       const viewTitle = document.getElementById('view-title');

--- a/devel/0947.md
+++ b/devel/0947.md
@@ -1,0 +1,68 @@
+# 0947: 补全 QML 弹窗 ai-docs 并补登 UpdaterProgress
+
+## 2026/08/28 QML ai-docs 补全与 UpdaterProgress 登记/测试
+
+### What(本次改动做了什么)
+
+1. `ai-docs/qml/README.md`（主体）：
+   - 成品表 6→10：补 Statistics / Version / Preferences / UpdaterProgress 四行
+     （各自的模态引擎、bridge、数据模型说明）。
+   - 原子清单 10→12：补 Toggle、GroupHeader；更新 EnumCombo（editable 双击编辑 /
+     isNarrow / actionLabel+actionClicked）、EnumComboList（valueSource 外部真相源
+     双模式）、MiniButton（size 两档）、TabPanel（content reparent 坑）、
+     SelectableList（syncActiveValue）、DialogShell（onCancel/onActivate 可覆盖）。
+   - 新增「Preferences 契约」节：prefBridge 契约（meta/submit 四态/cancel/callAction）
+     + field-descriptor 全字段表 + utf8->cork 翻译编码注意——补上 Preferences.qml
+     头注释引用、但此前不存在的章节。
+   - 模态引擎节：补选 show 模态的两种理由（live 重绘 / scheme delayed 轮询链不可被
+     exec 嵌套循环阻塞）、bridge 生命周期两式、autofit_height 与 contentW 绑定坑。
+   - 开发工作流第 4 步：写明 glue 声明登记在 `src/Scheme/L5/glue_qt.lua`
+     （C++ 声明侧 glue_l5_extra.hpp），纠正「在 QTMQmlDialog.cpp 加入口」的不完整表述
+     及 CLAUDE.md 中 Glue/ 目录的误导。
+   - 测试节：四种桩类说明、8 个 Mogan_TEST_* 钩子与消费测试对照全表、原子经成品
+     间接覆盖的策略说明。
+   - 编码规矩：补 ConfirmQuestion 按钮反序协议、Theme 常量分段分类规则、translate
+     三方分工；pref-keys 表述稳定化（现有 117 个访问器）。
+   - 相关清单：补 4 个专用 bridge、L5/glue_qt.lua、7 个 scheme facade 文件。
+2. `ai-docs/qml/qml-dialog.html`：补 UpdaterProgress 设计面板（spinner CSS 动画 +
+   nav 按钮 + panel + JS 三处登记），设计稿 9→10 面板。
+3. `src/Plugins/Qt/qml/qmldir`：补登 `UpdaterProgress 1.0 UpdaterProgress.qml`，
+   消除与「成品弹窗须登 qmldir」规矩的矛盾（[0518] 遗漏）。
+4. `tests/Plugins/Qt/qml_load_test.cpp`：新增 `test_updater_progress_loads` 加载用例
+   （补上 UpdaterProgress 唯一的测试缺口）；文件头过时的「四个成品」描述更新为十个。
+
+### Why(为什么这么做)
+
+- README 停更于 [0926]，其后 [2039]/[2040]/[2044]/[2080]/[0518] 落地的对话框、原子、
+  机制（第三种模态引擎理由、Preferences 契约等）均未入册，新对话框开发者拿到的
+  是过期指引。
+- Preferences.qml:12 引用「README 的 Preferences 契约」一节，该章节从未存在——
+  代码与文档断链。
+- [0518]（UpdaterProgress，作者 MoonL79）未登记 qmldir、未加设计稿面板与加载测试。
+  本次全部为文档/登记/测试增量，不触碰其运行时代码，零功能影响。
+- CLAUDE.md 称 glue 声明在 `src/Scheme/Glue/glue_*.lua`，QML 对话框实际在
+  `src/Scheme/L5/glue_qt.lua`，新人按 CLAUDE.md 找不到登记处。
+
+### How(怎么做的)
+
+- 只读梳理全链路（Scheme facade → L5 glue → QTMQmlDialog 引擎 → bridge → QML →
+  测试）后逐节核对补写；文档中 21 处文件引用逐一验证存在；markdown 表格列数
+  脚本校验通过。
+- UpdaterProgress 的 qmldir 补登不影响加载路径（所有顶层弹窗均经 qrc 直接
+  setSource，不经 qmldir import），仅消除登记矛盾。
+- 加载用例按 Statistics 用例样式编写（注入 dialogMessage + 共用桩），gf fmt 后
+  复跑通过。
+
+### 涉及文件
+
+- `ai-docs/qml/README.md`
+- `ai-docs/qml/qml-dialog.html`
+- `src/Plugins/Qt/qml/qmldir`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+
+### 测试
+
+- `xmake b --yes qml_load_test && xmake r qml_load_test`：16 passed, 0 failed
+  （含新增 `test_updater_progress_loads`）。
+- 手动验证建议（可选）：浏览器打开 `ai-docs/qml/qml-dialog.html`，左侧切到
+  UpdaterProgress.qml 查看新增面板与转圈动画。

--- a/src/Plugins/Qt/qml/qmldir
+++ b/src/Plugins/Qt/qml/qmldir
@@ -7,3 +7,4 @@ ParagraphFormat 1.0 ParagraphFormat.qml
 Statistics 1.0 Statistics.qml
 Preferences 1.0 Preferences.qml
 Version 1.0 Version.qml
+UpdaterProgress 1.0 UpdaterProgress.qml

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -1,8 +1,10 @@
 /******************************************************************************
  * MODULE     : qml_load_test.cpp
  * DESCRIPTION: 加载真实 QML 弹窗文档，断言 setSource 后 status()==Ready。
- *              安全网：改造四个成品弹窗（ConfirmClose / FormDialog /
- *              FontSelector / ParagraphFormat）与 atoms/ 原子板块后，确保 QML
+ *              安全网：改造成品弹窗（ConfirmClose / ConfirmQuestion /
+ *              ConfirmRestart / FormDialog / FontSelector / ParagraphFormat /
+ *              Statistics / Version / Preferences / UpdaterProgress）与 atoms/
+ *              原子板块后，确保 QML
  *              仍能解析、实例化。不验证交互（需可见窗口 + 人工），只验证
  *              「文档加载不失败」——import 缺失、语法错、id 悬空、context
  *              property 误用的第一道关。新增弹窗在此加一个 test_xxx_loads
@@ -217,6 +219,7 @@ private slots:
   void test_version_escape_fallback_without_focus ();
   void test_version_long_line_wraps ();
   void test_statistics_loads ();
+  void test_updater_progress_loads ();
 };
 
 // 共用：构造带 closeBridge/dpScale/isDark 的 QQuickWidget，加载给定 qrc url。
@@ -386,6 +389,25 @@ TestQmlLoad::test_statistics_loads () {
   qw->rootContext ()->setContextProperty ("statsItems", model);
   qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
   qw->setSource (QUrl ("qrc:/qml/Statistics.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+}
+
+void
+TestQmlLoad::test_updater_progress_loads () {
+  // UpdaterProgress 只需 dialogMessage（closeBridge/dpScale/isDark
+  // 为共用注入）； 无专用 bridge、无按钮（下载不可中断，ESC 经 DialogShell
+  // onCancel 覆盖为 no-op 禁用——加载层面只验证文档实例化，含 RotationAnimation
+  // 转圈）。
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge* bridge= new StubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", bridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  qw->rootContext ()->setContextProperty (
+      "dialogMessage", QString ("Downloading the update..."));
+  qw->setSource (QUrl ("qrc:/qml/UpdaterProgress.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
 }
 


### PR DESCRIPTION
## 背景

`ai-docs/qml/README.md` 停更于 [0926]，其后 [2039]（Statistics）、[2040]（ConfirmRestart）、[2044]（Preferences）、[2080]（Version）、[0518]（UpdaterProgress）落地的对话框、原子与机制均未入册；且 `Preferences.qml` 头注释引用的「README 的 Preferences 契约」一节从未存在，代码与文档断链。[0518] 还遗漏了 `qml/qmldir` 登记、设计稿面板与加载测试。

本 PR 全部为**文档 / 登记 / 测试增量**，不改动任何对话框的运行时行为（不触碰 [0518] 的功能代码，零影响）。

## 改动内容

**`ai-docs/qml/README.md`（主体）**
- 成品表 6→10：补 Statistics / Version / Preferences / UpdaterProgress（各自模态引擎、bridge、数据模型）
- 原子清单 10→12：补 Toggle、GroupHeader；更新 EnumCombo（editable 双击编辑 / isNarrow / actionLabel）、EnumComboList（valueSource 外部真相源双模式）、MiniButton（size 两档）、TabPanel（content reparent 坑）、SelectableList（syncActiveValue）、DialogShell（onCancel/onActivate 可覆盖）
- 新增「Preferences 契约」节：prefBridge 四态契约（meta / submit / cancel / callAction）+ field-descriptor 全字段表 + utf8→cork 翻译编码注意——补上 `Preferences.qml:12` 引用却缺失的章节
- 模态引擎节：补选 show 模态的两种理由（live 重绘；scheme delayed 轮询链不可被 exec 嵌套循环阻塞）、bridge 生命周期两式、autofit_height 与 contentW 绑定坑
- 开发工作流：写明 glue 声明登记在 `src/Scheme/L5/glue_qt.lua`（与 CLAUDE.md 所述 `src/Scheme/Glue/` 目录不同，避免误导）
- 测试节：四种桩类说明、8 个 `MOGAN_TEST_*` 钩子与消费测试对照全表
- 编码规矩：ConfirmQuestion 按钮反序协议、Theme 常量分段规则、translate 三方分工；pref-keys 表述稳定化（现有 117 个访问器）
- 相关清单补齐：4 个专用 bridge、L5/glue_qt.lua、7 个 scheme facade

**其余**
- `ai-docs/qml/qml-dialog.html`：补 UpdaterProgress 设计面板（spinner 动画），9→10 面板
- `src/Plugins/Qt/qml/qmldir`：补登 `UpdaterProgress 1.0`（顶层弹窗均经 qrc 直接 setSource 加载，补登仅为消除与登记规矩的矛盾，不影响加载路径）
- `tests/Plugins/Qt/qml_load_test.cpp`：新增 `test_updater_progress_loads`（补上 UpdaterProgress 唯一的测试缺口）；文件头「四个成品」过时描述更新为十个

## 验证

- `xmake b --yes qml_load_test && xmake r qml_load_test`：**16 passed, 0 failed**（含新增用例；gf fmt 后复跑通过）
- README 中 21 处文件引用逐一验证存在；markdown 表格列数脚本校验通过
- 手动验证建议（可选）：浏览器打开 `ai-docs/qml/qml-dialog.html`，左侧切换到 UpdaterProgress.qml 查看新增面板与转圈动画

## 后续

0928（QML 调色板）、2085（QML 最近文档）合入后，成品表各需追加一行——本 PR 补全表结构后，追加只是一行改动。
