### PR TITLE
[0948] 修复 Windows Ctrl+- 与 Ctrl++ 缩放快捷键

### DIFF
--- a/devel/0948.md
+++ b/devel/0948.md
@@ -1,0 +1,31 @@
+# [0948] 修复 Windows 上 Ctrl+- 缩小快捷键
+
+## What
+
+- 恢复 Windows 上 `Ctrl+-` 的文档缩小快捷键。
+- 为 Windows 原生减号虚拟键码添加回归测试。
+
+## Why
+
+部分 Windows 键盘布局下，按住 Ctrl 时 Qt 无法将主键盘减号稳定转换为
+`Qt::Key_Minus`，导致快捷键没有传递给 Scheme 键绑定。
+
+## How
+
+- 仅在 Windows 平台，将带 Ctrl 的原生 `VK_OEM_MINUS` 规范化为
+  `Qt::Key_Minus`。
+- 在 Qt 键盘事件转换单元测试中验证该事件生成 `C--`。
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_utilities.cpp`：Windows 键盘事件规范化。
+- `tests/Plugins/Qt/qt_utilities_test.cpp`：快捷键回归测试。
+
+## 如何测试
+
+```powershell
+xmake build --yes qt_utilities_test
+xmake run qt_utilities_test
+```
+
+手动验证：Windows 编辑器中按 `Ctrl+-`，页面缩小；`Ctrl+=` 放大仍正常。

--- a/devel/0948.md
+++ b/devel/0948.md
@@ -1,20 +1,20 @@
-# [0948] 修复 Windows 上 Ctrl+- 缩小快捷键
+# [0948] 修复 Windows 上 Ctrl+- 与 Ctrl++ 缩放快捷键
 
 ## What
 
-- 恢复 Windows 上 `Ctrl+-` 的文档缩小快捷键。
-- 为 Windows 原生减号虚拟键码添加回归测试。
+- 恢复 Windows 上 `Ctrl+-` 缩小和 `Ctrl+=`/`Ctrl++` 放大文档的快捷键。
+- 为 Windows 原生加减号虚拟键码添加回归测试。
 
 ## Why
 
-部分 Windows 键盘布局下，按住 Ctrl 时 Qt 无法将主键盘减号稳定转换为
-`Qt::Key_Minus`，导致快捷键没有传递给 Scheme 键绑定。
+部分 Windows 键盘布局下，按住 Ctrl 时 Qt 无法将主键盘加减号稳定转换为
+对应的 Qt 键值，导致缩放快捷键没有传递给 Scheme 键绑定。
 
 ## How
 
-- 仅在 Windows 平台，将带 Ctrl 的原生 `VK_OEM_MINUS` 规范化为
-  `Qt::Key_Minus`。
-- 在 Qt 键盘事件转换单元测试中验证该事件生成 `C--`。
+- 仅在 Windows 平台，将带 Ctrl 的原生 `VK_OEM_MINUS` 和 `VK_OEM_PLUS`
+  规范化为对应的 Qt 键值。
+- 在 Qt 键盘事件转换单元测试中验证事件分别生成 `C--`、`C-=` 和 `C-+`。
 
 ## 涉及文件
 
@@ -28,4 +28,5 @@ xmake build --yes qt_utilities_test
 xmake run qt_utilities_test
 ```
 
-手动验证：Windows 编辑器中按 `Ctrl+-`，页面缩小；`Ctrl+=` 放大仍正常。
+手动验证：Windows 编辑器中按 `Ctrl+-` 页面缩小，按 `Ctrl+=` 或 `Ctrl++`
+页面放大。

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -1202,8 +1202,8 @@ from_key_press_event (const QKeyEvent* event) {
     mods&= ~Qt::ControlModifier;
   }
 
-  // Qt may report the main keyboard plus/minus keys as Key_unknown while Ctrl
-  // is held. Use the Windows virtual keys to preserve zoom shortcuts.
+  // 按住 Ctrl 时 Qt 可能将主键盘加减号报告为 Key_unknown，故使用 Windows
+  // 原生虚拟键码保留缩放快捷键。
   if ((mods & Qt::ControlModifier) != 0 &&
       event->nativeVirtualKey () == WindowsVirtualKeyOemMinus)
     key= Qt::Key_Minus;

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -184,6 +184,10 @@ enum WindowsNativeModifiers {
   ScrollLock  = 0x00000400,
   ExtendedKey = 0x01000000,
 };
+
+enum WindowsVirtualKeys {
+  WindowsVirtualKeyOemMinus= 0xBD,
+};
 #endif
 
 /******************************************************************************
@@ -1196,6 +1200,12 @@ from_key_press_event (const QKeyEvent* event) {
     mods&= ~Qt::AltModifier;
     mods&= ~Qt::ControlModifier;
   }
+
+  // Qt may report the main keyboard minus key as Key_unknown while Ctrl is
+  // held.  Use the Windows virtual key to preserve the C-- shortcut.
+  if ((mods & Qt::ControlModifier) != 0 &&
+      event->nativeVirtualKey () == WindowsVirtualKeyOemMinus)
+    key= Qt::Key_Minus;
 #endif
 
   string mods_text= from_modifiers (mods);

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -187,6 +187,7 @@ enum WindowsNativeModifiers {
 
 enum WindowsVirtualKeys {
   WindowsVirtualKeyOemMinus= 0xBD,
+  WindowsVirtualKeyOemPlus = 0xBB,
 };
 #endif
 
@@ -1201,11 +1202,14 @@ from_key_press_event (const QKeyEvent* event) {
     mods&= ~Qt::ControlModifier;
   }
 
-  // Qt may report the main keyboard minus key as Key_unknown while Ctrl is
-  // held.  Use the Windows virtual key to preserve the C-- shortcut.
+  // Qt may report the main keyboard plus/minus keys as Key_unknown while Ctrl
+  // is held. Use the Windows virtual keys to preserve zoom shortcuts.
   if ((mods & Qt::ControlModifier) != 0 &&
       event->nativeVirtualKey () == WindowsVirtualKeyOemMinus)
     key= Qt::Key_Minus;
+  if ((mods & Qt::ControlModifier) != 0 &&
+      event->nativeVirtualKey () == WindowsVirtualKeyOemPlus)
+    key= (mods & Qt::ShiftModifier) != 0 ? Qt::Key_Plus : Qt::Key_Equal;
 #endif
 
   string mods_text= from_modifiers (mods);

--- a/tests/Plugins/Qt/qt_utilities_test.cpp
+++ b/tests/Plugins/Qt/qt_utilities_test.cpp
@@ -81,6 +81,15 @@ TestQtUtilities::test_from_key_press_event () {
   auto ctrl_minus= QKeyEvent (QEvent::KeyPress, Qt::Key_unknown,
                               Qt::ControlModifier, 0, 0xBD, 0, "");
   qcompare (from_key_press_event (&ctrl_minus), "C--");
+
+  auto ctrl_equal= QKeyEvent (QEvent::KeyPress, Qt::Key_unknown,
+                              Qt::ControlModifier, 0, 0xBB, 0, "");
+  qcompare (from_key_press_event (&ctrl_equal), "C-=");
+
+  auto ctrl_plus=
+      QKeyEvent (QEvent::KeyPress, Qt::Key_unknown,
+                 Qt::ControlModifier | Qt::ShiftModifier, 0, 0xBB, 0, "");
+  qcompare (from_key_press_event (&ctrl_plus), "C-+");
 #endif
 
   if (os_macos ()) {

--- a/tests/Plugins/Qt/qt_utilities_test.cpp
+++ b/tests/Plugins/Qt/qt_utilities_test.cpp
@@ -77,6 +77,12 @@ TestQtUtilities::test_from_modifiers () {
 
 void
 TestQtUtilities::test_from_key_press_event () {
+#if defined(OS_MINGW) || defined(OS_WIN)
+  auto ctrl_minus= QKeyEvent (QEvent::KeyPress, Qt::Key_unknown,
+                              Qt::ControlModifier, 0, 0xBD, 0, "");
+  qcompare (from_key_press_event (&ctrl_minus), "C--");
+#endif
+
   if (os_macos ()) {
     auto ctrl_plus= QKeyEvent (QEvent::KeyPress, (int) '=',
                                Qt::ControlModifier | Qt::ShiftModifier, "=");


### PR DESCRIPTION
## What

- 修复 Windows 上 `Ctrl+-` 无法缩小、`Ctrl+=` / `Ctrl++` 无法放大文档的问题。
- 增加 Windows 原生加减号键码的回归测试。

## Why

部分 Windows 键盘布局在按住 Ctrl 时，主键盘加减号可能被 Qt 识别为 `Key_unknown`，导致缩放快捷键没有进入键绑定。

## How

- 仅在 Windows 下将带 Ctrl 的 `VK_OEM_MINUS` 和 `VK_OEM_PLUS` 规范化为对应的 Qt 键值。
- 覆盖原生事件到 `C--`、`C-=` 和 `C-+` 的转换结果。

## 测试

- `gf fmt --changed-since=main` 已执行。
- `git diff --check` 通过。
- 构建与 `qt_utilities_test` 由本地 Windows 环境执行确认，未在本次更新流程中重复运行。

## 手动验证

- Windows 编辑器中按 `Ctrl+-`，确认页面缩小。
- 按 `Ctrl+=` 或 `Ctrl++`，确认页面放大。
