### PR TITLE
[2085] QML 重构最近打开文档搜索

### DIFF
--- a/TeXmacs/progs/doc/docgrep.scm
+++ b/TeXmacs/progs/doc/docgrep.scm
@@ -243,3 +243,15 @@
     (load-document (string-append "tmfs://grep/" query))
   ) ;with
 ) ;tm-define
+
+(tm-define (recent-documents-for-qml) (map url->system (recent-file-list 25)))
+
+(tm-define (open-search-recent-documents)
+  (:interactive #t)
+  (with path
+    (cpp-search-recent-documents-dialog)
+    (when (!= path "")
+      (load-document (system->url path))
+    ) ;when
+  ) ;with
+) ;tm-define

--- a/TeXmacs/progs/texmacs/menus/edit-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/edit-menu.scm
@@ -99,7 +99,7 @@
     ) ;->
   ) ;if
   ---
-  ("Search recent documents" (interactive docgrep-in-recent))
+  ("Search recent documents" (open-search-recent-documents))
   ---
   (if (use-menus?) (-> "Preferences" (link preferences-menu)))
   (if (use-popups?) ("Preferences" (open-preferences)))

--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -299,6 +299,76 @@
       box-shadow: var(--shadow);
     }
 
+    .recent-search-shell {
+      width: min(620px, 100%);
+      background: #ffffff;
+      border: 1px solid #d6dfdf;
+      border-radius: var(--radius);
+      padding: 22px;
+      box-shadow: var(--shadow);
+    }
+
+    .recent-search-shell h3 {
+      text-align: center;
+      font-size: 18px;
+      margin-bottom: 18px;
+    }
+
+    .recent-search-input {
+      width: 100%;
+      height: 38px;
+      border: 1px solid #9fcac7;
+      border-radius: 10px;
+      padding: 0 12px;
+      background: #f9fcfc;
+      color: #25353a;
+      font: inherit;
+    }
+
+    .recent-results {
+      list-style: none;
+      margin-top: 14px;
+      border: 1px solid #cad7d7;
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .recent-result {
+      padding: 10px 12px;
+      border-bottom: 1px solid #e4eeee;
+      cursor: pointer;
+    }
+
+    .recent-result:last-child {
+      border-bottom: 0;
+    }
+
+    .recent-result.active {
+      background: #dff3f1;
+      color: #194f53;
+    }
+
+    .recent-result strong,
+    .recent-result span {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .recent-result span {
+      margin-top: 3px;
+      color: #60787e;
+      font-size: 12px;
+    }
+
+    .recent-empty {
+      display: none;
+      padding: 18px;
+      color: var(--muted);
+      text-align: center;
+    }
+
     .field {
       display: grid;
       grid-template-columns: 120px 1fr;
@@ -1035,6 +1105,7 @@
       <button class="nav-btn" data-target="version">Version.qml</button>
       <button class="nav-btn" data-target="preferences">Preferences.qml</button>
       <button class="nav-btn" data-target="confirmRestart">ConfirmRestart.qml</button>
+      <button class="nav-btn" data-target="recentSearch">SearchRecentDocuments.qml</button>
       <button class="nav-btn" data-target="updater">UpdaterProgress.qml</button>
       <div class="sidebar-foot">模拟目标: DialogShell / DialogButtons / EnumCombo / SelectableList / PreviewPane 组合逻辑。</div>
     </aside>
@@ -1683,6 +1754,38 @@
         </p>
       </section>
 
+      <!-- 最近文档搜索（SearchRecentDocuments.qml）：模糊筛选 + 显式选择后打开 -->
+      <section class="panel" id="panel-recent-search">
+        <article class="recent-search-shell">
+          <h3>Search recent documents</h3>
+          <input class="recent-search-input" id="recent-search-input" type="text" placeholder="Search">
+          <ul class="recent-results" id="recent-results">
+            <li class="recent-result" data-name="National Natural Science Foundation proposal" data-path="C:\\Users\\Mogan\\Documents\\National Natural Science Foundation proposal.tmu">
+              <strong>National Natural Science Foundation proposal</strong>
+              <span>C:\\Users\\Mogan\\Documents\\National Natural Science Foundation proposal.tmu</span>
+            </li>
+            <li class="recent-result" data-name="Research notes" data-path="C:\\Users\\Mogan\\Documents\\Research notes.tm">
+              <strong>Research notes</strong>
+              <span>C:\\Users\\Mogan\\Documents\\Research notes.tm</span>
+            </li>
+            <li class="recent-result" data-name="Thesis outline" data-path="D:\\Writing\\Thesis outline.tmu">
+              <strong>Thesis outline</strong>
+              <span>D:\\Writing\\Thesis outline.tmu</span>
+            </li>
+            <li class="recent-empty" id="recent-empty">No matching recent documents</li>
+          </ul>
+          <div class="btn-row" style="justify-content: flex-end; margin-top: 14px;">
+            <button class="btn primary" id="recent-open">Open</button>
+            <button class="btn" data-log="SearchRecentDocuments: cancel()">Cancel</button>
+          </div>
+        </article>
+        <p class="legend">
+          QML: <code>recentDocuments + fuzzyScore()</code>
+          <code>onTextChanged -> updateMatches()</code>
+          <code>Open -> recentSearchBridge.open(path)</code>
+        </p>
+      </section>
+
 
     </main>
   </div>
@@ -1699,7 +1802,8 @@
         version: document.getElementById('panel-version'),
         preferences: document.getElementById('panel-preferences'),
         confirmRestart: document.getElementById('panel-confirm-restart'),
-        updater: document.getElementById('panel-updater')
+        updater: document.getElementById('panel-updater'),
+        recentSearch: document.getElementById('panel-recent-search')
       };
 
       const titleMap = {
@@ -1711,7 +1815,8 @@
         statistics: 'Statistics.qml 模拟',
         preferences: 'Preferences.qml 模拟',
         confirmRestart: 'ConfirmRestart.qml 模拟',
-        updater: 'UpdaterProgress.qml 模拟'
+        updater: 'UpdaterProgress.qml 模拟',
+        recentSearch: 'SearchRecentDocuments.qml 模拟'
       };
 
       const codeMap = {
@@ -1723,7 +1828,8 @@
         statistics: 'statsModel: [{label, value}, ...] + closeBridge.choose(0) 关闭',
         preferences: 'prefTabs(5) + subTabs(6) + EnumCombo + Toggle + 纯 OK 提交',
         confirmRestart: 'message + buttonLabels + closeBridge.choose(index)',
-        updater: 'dialogMessage + onCancel no-op + open/close 成对 glue'
+        updater: 'dialogMessage + onCancel no-op + open/close 成对 glue',
+        recentSearch: 'recentDocuments + fuzzyScore() + recentSearchBridge.open(path)'
       };
 
       const viewTitle = document.getElementById('view-title');
@@ -1750,6 +1856,46 @@
           viewCode.textContent = codeMap[target];
           log(`切换组件 -> ${titleMap[target]}`);
         });
+      });
+
+      const recentSearchInput = document.getElementById('recent-search-input');
+      const recentResults = document.querySelectorAll('.recent-result');
+      const recentEmpty = document.getElementById('recent-empty');
+      let recentSelected = null;
+
+      function fuzzyMatch(text, query) {
+        let cursor = 0;
+        const haystack = text.toLowerCase();
+        for (const character of query.toLowerCase()) {
+          cursor = haystack.indexOf(character, cursor);
+          if (cursor < 0) return false;
+          cursor += 1;
+        }
+        return true;
+      }
+
+      recentSearchInput.addEventListener('input', () => {
+        const query = recentSearchInput.value.trim();
+        let visibleCount = 0;
+        recentResults.forEach((row) => {
+          const matched = !query || fuzzyMatch(row.dataset.name, query) || fuzzyMatch(row.dataset.path, query);
+          row.style.display = matched ? '' : 'none';
+          if (matched) visibleCount += 1;
+        });
+        recentEmpty.style.display = visibleCount ? 'none' : 'block';
+        recentSelected = null;
+        recentResults.forEach((row) => row.classList.remove('active'));
+      });
+
+      recentResults.forEach((row) => {
+        row.addEventListener('click', () => {
+          recentSelected = row;
+          recentResults.forEach((item) => item.classList.toggle('active', item === row));
+        });
+      });
+
+      document.getElementById('recent-open').addEventListener('click', () => {
+        if (recentSelected) log('SearchRecentDocuments: open("' + recentSelected.dataset.path + '")');
       });
 
       document.querySelectorAll('[data-log]').forEach((el) => {

--- a/devel/2085.md
+++ b/devel/2085.md
@@ -1,0 +1,68 @@
+# 2085 QML 重构最近打开文档搜索
+
+## 相关文档
+
+- [Issue #4143](https://github.com/MoganLab/mogan/issues/4143) - 采用 QML 重构并修复最近文档搜索
+- [QML 对话框指南](../ai-docs/qml/README.md) - 弹窗生命期、取消语义与测试要求
+
+## 任务相关的代码文件
+
+- `TeXmacs/progs/doc/docgrep.scm`
+- `TeXmacs/progs/texmacs/menus/edit-menu.scm`
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `src/Plugins/Qt/QTMQmlDialog.hpp`
+- `src/Plugins/Qt/RecentDocumentsSearchBridge.hpp`
+- `src/Plugins/Qt/RecentDocumentsSearchBridge.cpp`
+- `src/Plugins/Qt/qml/SearchRecentDocuments.qml`
+- `src/Plugins/Qt/moganqml.qrc`
+- `src/Plugins/Qt/qml/qmldir`
+- `src/Scheme/L5/glue_qt.lua`
+- `tests/Plugins/Qt/qml_dialog_test.cpp`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+- `ai-docs/qml/qml-dialog.html`
+
+## 如何测试
+
+```bash
+xmake b stem
+QT_QPA_PLATFORM=offscreen xmake r qml_load_test
+QT_QPA_PLATFORM=offscreen xmake r qml_dialog_test
+```
+
+启动 Mogan 后打开「编辑 -> 搜索最近打开的文档」：输入文件名片段确认实时模糊
+过滤（文件名优先、路径兜底）；上下键移动选择、Enter 或「打开」加载文档；
+取消 / Esc / 无匹配文案分别验证。
+
+## 2026/08/29 采用 QML 重构最近文档搜索
+
+### What
+
+- 用模态 QML 对话框（`SearchRecentDocuments.qml`）替换编辑菜单里旧的交互式
+  全文 grep 入口（`docgrep-in-recent`）。
+- 显示最近文档的文件名和完整路径，支持实时模糊筛选（子序列匹配：文件名优先、
+  路径兜底）与按匹配代价排序。
+- 对最近文件记录按规范化路径去重（Windows 下大小写折叠），保留首次出现。
+- 初始与筛选后均不默认选中，只有显式点选或键盘移动后才可打开，避免误开。
+- 补充 QML 加载测试、glue 返回值钩子测试，并在 `ai-docs/qml/qml-dialog.html`
+  补充该对话框的交互设计稿。
+
+### Why
+
+旧交互 `docgrep-in-recent` 是交互式参数输入 + tmfs 全文搜索：中文输入法确认
+候选字时会提前触发执行，且「全文内容搜索」语义不符合「按最近记录挑文档」的
+预期。QML 对话框让筛选发生在最近记录列表上，交互所见即所得。
+
+### How
+
+1. Scheme 侧 `docgrep.scm` 新增 `recent-documents-for-qml`（`url->system` 映射
+   最近 25 条记录，UTF-8 系统路径）与 `open-search-recent-documents`（调 glue
+   打开对话框，选中非空则 `load-document`）；`edit-menu.scm` 菜单项换绑后者。
+2. 新增 glue `cpp-search-recent-documents-dialog`（`glue_qt.lua` 注册，返回
+   string）：走 `run_qml_dialog`（exec 阻塞模态，一次性提交型），独立
+   `RecentDocumentsSearchBridge` 构造时经 `eval_scheme` 拉取最近文档并去重，
+   `open(path)` 记录所选路径后 `done(Accepted)`；路径全程 UTF-8（同
+   `qt_scheme_quote_utf8` 惯例），不经 Cork 转换以保留中文文件名。
+3. 通用 `QmlDialogBridge` 只承担取消 / Esc / 窗口拖动；筛选与选择状态留在 QML
+   本地，搜索过程不改写最近记录。
+4. 测试钩子 `MOGAN_TEST_SEARCH_RECENT_DOCUMENTS`：设为路径时直接返回该路径、
+   设为 `cancel` 返回空串，供 headless 自动化。

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -13,6 +13,7 @@
 #include "PreferencesBridge.hpp"
 #include "QTMQmlDialogBridge.hpp"
 #include "QTMQmlDialogInternal.hpp"
+#include "RecentDocumentsSearchBridge.hpp"
 #include "VersionDialogBridge.hpp"
 
 #include "analyze.hpp" // occurs
@@ -798,4 +799,42 @@ cpp_preferences_dialog () {
       620, 600);
   delete bridge;
   return tree (TUPLE);
+}
+
+/**
+ * @brief 最近文档搜索 QML 对话框的 glue 入口（声明/语义见 QTMQmlDialog.hpp）。
+ *
+ * @details 走 run_qml_dialog（exec 阻塞模态，一次性提交型）。独立
+ * RecentDocumentsSearchBridge 构造时经 eval_scheme 拉取最近文档并去重，QML
+ * 筛选/选择状态留在本地，open() 记录所选路径后结束模态；closeBridge 只承担
+ * 取消 / Esc / 拖动。路径全程 UTF-8（同 qt_scheme_quote_utf8 惯例）。
+ *
+ * 测试钩子 MOGAN_TEST_SEARCH_RECENT_DOCUMENTS：设为路径时直接返回该路径、设为
+ * "cancel" 返回空串，均不弹窗（供 headless 自动化）。
+ */
+string
+cpp_search_recent_documents_dialog () {
+  string preset= get_env ("MOGAN_TEST_SEARCH_RECENT_DOCUMENTS");
+  if (preset != "") return preset == "cancel" ? string ("") : preset;
+
+  array<string>                buttons= {string ("Open"), string ("Cancel")};
+  QmlDialogBridge*             closeBridge = nullptr;
+  RecentDocumentsSearchBridge* searchBridge= nullptr;
+  run_qml_dialog (
+      "qrc:/qml/SearchRecentDocuments.qml", "SearchRecentDocuments.qml",
+      [&] (QQuickWidget* qw, QDialog& host) {
+        closeBridge = inject_common_context (qw, host);
+        searchBridge= new RecentDocumentsSearchBridge (&host);
+        qw->rootContext ()->setContextProperty ("recentSearchBridge",
+                                                searchBridge);
+        qw->rootContext ()->setContextProperty ("dialogButtons",
+                                                translate_buttons (buttons));
+      },
+      520, 450);
+
+  QString path;
+  if (searchBridge) path= searchBridge->selectedPath ();
+  delete closeBridge;
+  delete searchBridge;
+  return from_qstring_utf8 (path);
 }

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -228,6 +228,16 @@ bool cpp_version_dialog (string title, string message);
  */
 tree cpp_preferences_dialog ();
 
+/**
+ * @brief 打开最近文档搜索 QML 对话框。
+ * @return 用户显式选中的 UTF-8 系统路径；取消 / 关闭 / 加载失败返回空串。
+ * @note 候选模型由 RecentDocumentsSearchBridge 构造时经 scheme
+ *       recent-documents-for-qml 拉取；筛选与选择状态留在 QML 本地。
+ * @note 测试钩子 MOGAN_TEST_SEARCH_RECENT_DOCUMENTS：设为路径时直接返回该路径
+ *       、设为 "cancel" 返回空串，均不弹窗。
+ */
+string cpp_search_recent_documents_dialog ();
+
 // ---- 更新下载中间态弹窗
 // -------------------------------------------------------
 

--- a/src/Plugins/Qt/RecentDocumentsSearchBridge.cpp
+++ b/src/Plugins/Qt/RecentDocumentsSearchBridge.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * MODULE      : RecentDocumentsSearchBridge.cpp
+ * DESCRIPTION : 最近打开文档搜索 QML bridge 的数据与确认动作实现。
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+#include "RecentDocumentsSearchBridge.hpp"
+
+#include "qt_utilities.hpp" // qt_translate
+#include "s7_tm.hpp"        // eval_scheme + tmscm helpers
+
+#include <QDialog>
+#include <QDir>
+#include <QFileInfo>
+#include <QSet>
+#include <QVariantMap>
+
+RecentDocumentsSearchBridge::RecentDocumentsSearchBridge (QDialog* host)
+    : m_documents (recent_documents ()), m_host (host),
+      m_title (qt_translate ("Search recent documents")),
+      m_placeholder (qt_translate ("Search")),
+      m_emptyText (qt_translate ("No matching recent documents")) {
+  ASSERT (host != NULL,
+          "RecentDocumentsSearchBridge expects a valid QDialog host");
+}
+
+void
+RecentDocumentsSearchBridge::open (const QString& path) {
+  if (path.isEmpty ()) return;
+  m_selectedPath= path;
+  m_host->done (QDialog::Accepted);
+}
+
+QVariantList
+RecentDocumentsSearchBridge::recent_documents () {
+  QVariantList  documents;
+  QSet<QString> seenPaths;
+  tmscm         recentPaths= eval_scheme ("(recent-documents-for-qml)");
+  for (tmscm cur= recentPaths; !tmscm_is_null (cur); cur= tmscm_cdr (cur)) {
+    tmscm item= tmscm_car (cur);
+    if (!tmscm_is_string (item)) continue;
+
+    // url->system 已给出 UTF-8 系统路径；再转 Cork 会破坏非 ASCII 文件名。
+    QString path= QString::fromUtf8 (as_charp (tmscm_to_string (item)));
+    if (path.isEmpty ()) continue;
+    QString normalizedPath= QDir::cleanPath (QDir::fromNativeSeparators (path));
+#ifdef Q_OS_WIN
+    normalizedPath= normalizedPath.toCaseFolded ();
+#endif
+    if (seenPaths.contains (normalizedPath)) continue;
+    seenPaths.insert (normalizedPath);
+
+    QVariantMap document;
+    document["path"]= path;
+    document["name"]= QFileInfo (path).fileName ();
+    documents << document;
+  }
+  return documents;
+}

--- a/src/Plugins/Qt/RecentDocumentsSearchBridge.hpp
+++ b/src/Plugins/Qt/RecentDocumentsSearchBridge.hpp
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * MODULE      : RecentDocumentsSearchBridge.hpp
+ * DESCRIPTION : 最近打开文档搜索 QML 对话框的独立 bridge。
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+/*! @file RecentDocumentsSearchBridge.hpp
+ *  @brief 最近文档搜索 QML 对话框的 C++↔QML bridge。
+ *
+ * @par 设计
+ * - @b 只读数据：构造时读取 Scheme 最近文档并去重。路径保持 UTF-8 系统编码（同
+ *   `qt_scheme_quote_utf8` 惯例），QML 只读候选模型和翻译文案；筛选与选择状态
+ *   留在 QML 本地。
+ * - @b 确认回流：open() 保存用户显式选择的路径并结束模态；closeBridge 处理取消
+ *   、Esc 与窗口拖动。
+ *
+ * @note bridge 不挂 QObject parent，调用方在 exec 返回后删除；宿主 QDialog 只
+ *       在 open() 期间借用。
+ */
+
+#ifndef RECENT_DOCUMENTS_SEARCH_BRIDGE_HPP
+#define RECENT_DOCUMENTS_SEARCH_BRIDGE_HPP
+
+#include <QDialog>
+#include <QObject>
+#include <QString>
+#include <QVariantList>
+
+/**
+ * @brief 向 QML 暴露最近文档模型和确认动作。
+ */
+class RecentDocumentsSearchBridge : public QObject {
+  Q_OBJECT
+  Q_PROPERTY (QVariantList documents READ documents CONSTANT)
+  Q_PROPERTY (QString title READ title CONSTANT)
+  Q_PROPERTY (QString placeholder READ placeholder CONSTANT)
+  Q_PROPERTY (QString emptyText READ emptyText CONSTANT)
+
+public:
+  /**
+   * @brief 从 Scheme 的最近文档记录创建 bridge。
+   * @param host 宿主 QDialog；open() 调其 done(Accepted)，不接管其生命期。
+   */
+  explicit RecentDocumentsSearchBridge (QDialog* host);
+
+  const QVariantList& documents () const { return m_documents; }
+  const QString&      title () const { return m_title; }
+  const QString&      placeholder () const { return m_placeholder; }
+  const QString&      emptyText () const { return m_emptyText; }
+  QString             selectedPath () const { return m_selectedPath; }
+
+  /**
+   * @brief 记录用户显式选中的路径并结束对话框。
+   * @param path QML 当前选中候选项的原始路径。
+   */
+  Q_INVOKABLE void open (const QString& path);
+
+private:
+  /**
+   * @brief 将 Scheme 最近文档列表转换为 QML 候选模型。
+   * @return 以规范化路径去重后的 {name, path} 列表。
+   * @note url->system 已返回 UTF-8 系统路径，不能经 Cork 转换（会破坏中文文件名
+   *       ），同 qt_scheme_quote_utf8 的 UTF-8 通道惯例。
+   */
+  static QVariantList recent_documents ();
+
+  QVariantList m_documents;
+  QDialog*     m_host;
+  QString      m_title;
+  QString      m_placeholder;
+  QString      m_emptyText;
+  QString      m_selectedPath;
+};
+
+#endif // defined RECENT_DOCUMENTS_SEARCH_BRIDGE_HPP

--- a/src/Plugins/Qt/moganqml.qrc
+++ b/src/Plugins/Qt/moganqml.qrc
@@ -24,5 +24,6 @@
         <file>qml/Preferences.qml</file>
         <file>qml/Version.qml</file>
         <file>qml/UpdaterProgress.qml</file>
+        <file>qml/SearchRecentDocuments.qml</file>
     </qresource>
 </RCC>

--- a/src/Plugins/Qt/qml/SearchRecentDocuments.qml
+++ b/src/Plugins/Qt/qml/SearchRecentDocuments.qml
@@ -1,0 +1,228 @@
+// 筛选和选择留在 QML 本地，避免搜索过程改写 Scheme 的最近记录。
+
+import QtQuick
+import "atoms"
+
+DialogShell {
+    id: root
+    implicitWidth: 520
+    implicitHeight: 450
+    implicitMargins: Theme.margin
+    onActivate: root.openSelection()
+
+    property string title: typeof recentSearchBridge !== "undefined" ? recentSearchBridge.title : "Search recent documents"
+    property string placeholder: typeof recentSearchBridge !== "undefined" ? recentSearchBridge.placeholder : "Search"
+    property string emptyText: typeof recentSearchBridge !== "undefined" ? recentSearchBridge.emptyText : "No matching recent documents"
+    property var documents: typeof recentSearchBridge !== "undefined" ? recentSearchBridge.documents : []
+    property var buttonLabels: typeof dialogButtons !== "undefined" ? dialogButtons : ["Open", "Cancel"]
+    property var matches: []
+    property int selectedIndex: -1
+    readonly property real resultListHeight: 230 * Theme.scaleFactor
+
+    function fuzzyScore(text, query) {
+        var haystack = text.toLocaleLowerCase()
+        var needle = query.toLocaleLowerCase()
+        var cursor = 0
+        var score = 0
+        for (var i = 0; i < needle.length; ++i) {
+            var index = haystack.indexOf(needle.charAt(i), cursor)
+            if (index < 0)
+                return -1
+            score += index - cursor
+            cursor = index + 1
+        }
+        return score
+    }
+
+    function updateMatches() {
+        var query = searchInput.text.trim()
+        var next = []
+        for (var i = 0; i < documents.length; ++i) {
+            var document = documents[i]
+            var score = query.length === 0 ? i : fuzzyScore(document.name, query)
+            if (score < 0 && query.length > 0)
+                score = fuzzyScore(document.path, query)
+            if (score >= 0)
+                next.push({
+                    "name": document.name,
+                    "path": document.path,
+                    "score": score,
+                    "order": i
+                })
+        }
+        next.sort(function(a, b) {
+            return a.score === b.score ? a.order - b.order : a.score - b.score
+        })
+        root.matches = next
+        root.selectedIndex = -1
+    }
+
+    function moveSelection(step) {
+        if (matches.length === 0)
+            return
+        if (selectedIndex < 0)
+            selectedIndex = step > 0 ? 0 : matches.length - 1
+        else
+            selectedIndex = Math.max(0, Math.min(matches.length - 1, selectedIndex + step))
+        resultList.positionViewAtIndex(selectedIndex, ListView.Contain)
+    }
+
+    function openSelection() {
+        if (selectedIndex >= 0 && selectedIndex < matches.length)
+            recentSearchBridge.open(matches[selectedIndex].path)
+    }
+
+    Component.onCompleted: root.updateMatches()
+    onDocumentsChanged: root.updateMatches()
+
+    content: Column {
+        spacing: Theme.gapM
+
+        Text {
+            width: parent.width
+            height: Theme.titleH
+            text: root.title
+            color: Theme.fg
+            font.pixelSize: Theme.fontBody + Theme.padS
+            font.weight: Font.Bold
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+
+        Rectangle {
+            width: parent.width
+            height: Theme.rowH
+            radius: Theme.radius
+            color: Theme.fieldBg
+            border.width: Theme.borderW
+            border.color: searchInput.activeFocus ? Theme.dropdownBorder : Theme.borderClr
+
+            Text {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.comboPad
+                anchors.rightMargin: Theme.comboPad
+                text: root.placeholder
+                color: Theme.muted
+                font.pixelSize: Theme.fontBody
+                verticalAlignment: Text.AlignVCenter
+                visible: searchInput.text.length === 0 && !searchInput.activeFocus
+                elide: Text.ElideRight
+            }
+
+            TextInput {
+                id: searchInput
+                anchors.fill: parent
+                anchors.leftMargin: Theme.comboPad
+                anchors.rightMargin: Theme.comboPad
+                color: Theme.fg
+                font.pixelSize: Theme.fontBody
+                verticalAlignment: TextInput.AlignVCenter
+                selectByMouse: true
+                clip: true
+                focus: true
+                onTextChanged: root.updateMatches()
+                Component.onCompleted: forceActiveFocus()
+                Keys.onPressed: function(event) {
+                    if (event.key === Qt.Key_Down) {
+                        root.moveSelection(1)
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Up) {
+                        root.moveSelection(-1)
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                        root.openSelection()
+                        event.accepted = true
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            width: parent.width
+            height: root.resultListHeight
+            radius: Theme.radius
+            color: Theme.listBg
+            border.width: Theme.borderW
+            border.color: Theme.borderClr
+
+            Rectangle {
+                anchors.fill: parent
+                anchors.margins: parent.border.width
+                radius: Math.max(0, parent.radius - parent.border.width)
+                color: parent.color
+                clip: true
+
+                ListView {
+                    id: resultList
+                    anchors.fill: parent
+                    anchors.margins: Theme.padS
+                    clip: true
+                    boundsBehavior: Flickable.StopAtBounds
+                    model: root.matches
+
+                    delegate: Rectangle {
+                        width: resultList.width
+                        height: Theme.rowH + Theme.padS
+                        radius: Theme.radius
+                        color: root.selectedIndex === index ? Theme.selectBg : (resultMouse.containsMouse ? Theme.fieldBgHover : "transparent")
+                        border.width: root.selectedIndex === index ? Theme.borderW : 0
+                        border.color: Theme.selectBorder
+
+                        Column {
+                            anchors.fill: parent
+                            anchors.leftMargin: Theme.comboPad
+                            anchors.rightMargin: Theme.comboPad
+                            spacing: Theme.padS
+
+                            Text {
+                                width: parent.width
+                                text: modelData.name
+                                color: root.selectedIndex === index ? Theme.selectFg : Theme.fg
+                                font.pixelSize: Theme.fontBody
+                                font.weight: Font.DemiBold
+                                elide: Text.ElideRight
+                            }
+
+                            Text {
+                                width: parent.width
+                                text: modelData.path
+                                color: Theme.muted
+                                font.pixelSize: Theme.fontTiny
+                                elide: Text.ElideMiddle
+                            }
+                        }
+
+                        MouseArea {
+                            id: resultMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.selectedIndex = index
+                        }
+                    }
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    visible: root.matches.length === 0
+                    text: root.emptyText
+                    color: Theme.muted
+                    font.pixelSize: Theme.fontBody
+                }
+            }
+        }
+
+        DialogButtons {
+            anchors.horizontalCenter: parent.horizontalCenter
+            buttonLabels: root.buttonLabels
+            primaryIndex: 0
+            onClicked: function(index) {
+                if (index === 0)
+                    root.openSelection()
+                else
+                    closeBridge.cancel()
+            }
+        }
+    }
+}

--- a/src/Plugins/Qt/qml/qmldir
+++ b/src/Plugins/Qt/qml/qmldir
@@ -8,3 +8,4 @@ Statistics 1.0 Statistics.qml
 Preferences 1.0 Preferences.qml
 Version 1.0 Version.qml
 UpdaterProgress 1.0 UpdaterProgress.qml
+SearchRecentDocuments 1.0 SearchRecentDocuments.qml

--- a/src/Scheme/L5/glue_qt.lua
+++ b/src/Scheme/L5/glue_qt.lua
@@ -108,6 +108,12 @@ function main()
                 arg_list = {}
             },
             {
+                scm_name = "cpp-search-recent-documents-dialog",
+                cpp_name = "cpp_search_recent_documents_dialog",
+                ret_type = "string",
+                arg_list = {}
+            },
+            {
                 scm_name = "cpp-updater-dialog-open",
                 cpp_name = "cpp_updater_dialog_open",
                 ret_type = "void",

--- a/tests/Plugins/Qt/qml_dialog_test.cpp
+++ b/tests/Plugins/Qt/qml_dialog_test.cpp
@@ -73,6 +73,7 @@ private slots:
   void test_confirm_close_hook ();
   void test_confirm_question_hook ();
   void test_form_dialog_hook ();
+  void test_search_recent_documents_hook ();
 };
 
 // 字段下标协议常量与协议文档一致。
@@ -263,6 +264,21 @@ TestQmlDialog::test_form_dialog_hook () {
     tree    r= cpp_form_dialog (form);
     QVERIFY (is_compound (r));
     QCOMPARE (N (r), 0);
+  }
+}
+
+// MOGAN_TEST_SEARCH_RECENT_DOCUMENTS 钩子：设为路径时直接返回该路径（UTF-8
+// 系统路径，中文不破坏）、设为 cancel 时返回空串，均不弹窗。
+void
+TestQmlDialog::test_search_recent_documents_hook () {
+  {
+    string  path= "C:/文档/报告.tm";
+    EnvHook hook ("MOGAN_TEST_SEARCH_RECENT_DOCUMENTS", path);
+    QCOMPARE (cpp_search_recent_documents_dialog (), path);
+  }
+  {
+    EnvHook hook ("MOGAN_TEST_SEARCH_RECENT_DOCUMENTS", "cancel");
+    QCOMPARE (cpp_search_recent_documents_dialog (), string (""));
   }
 }
 

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -65,6 +65,30 @@ private:
                       "The latest stable version is v2026.2.6."};
 };
 
+// 最近文档搜索 bridge 占位：只读模型 + open 动作桩，加载层面验证文档实例化。
+class RecentDocumentsSearchStubBridge : public QObject {
+  Q_OBJECT
+  Q_PROPERTY (QVariantList documents READ documents CONSTANT)
+  Q_PROPERTY (QString title READ title CONSTANT)
+  Q_PROPERTY (QString placeholder READ placeholder CONSTANT)
+  Q_PROPERTY (QString emptyText READ emptyText CONSTANT)
+
+public:
+  explicit RecentDocumentsSearchStubBridge (QVariantList documents,
+                                            QObject*     p= nullptr)
+      : QObject (p), m_documents (documents) {}
+
+  QVariantList documents () const { return m_documents; }
+  QString      title () const { return "Search recent documents"; }
+  QString      placeholder () const { return "Search"; }
+  QString      emptyText () const { return "No matching recent documents"; }
+
+  Q_INVOKABLE void open (const QString&) {}
+
+private:
+  QVariantList m_documents;
+};
+
 // live 弹窗（FontSelector / ParagraphFormat）bridge 占位：加载阶段 QML 顶层会调
 // 一批 uiLabels/meta/currentXxx/requestXxx 取初始值，桩统一返回空（空串/空
 // list/空 map）， 仅保证文档能实例化、不验证交互语义。
@@ -220,6 +244,7 @@ private slots:
   void test_version_long_line_wraps ();
   void test_statistics_loads ();
   void test_updater_progress_loads ();
+  void test_search_recent_documents_loads ();
 };
 
 // 共用：构造带 closeBridge/dpScale/isDark 的 QQuickWidget，加载给定 qrc url。
@@ -284,9 +309,7 @@ TestQmlLoad::test_confirm_restart_loads () {
       QString (
           "This change requires restarting Mogan STEM to take full effect."));
   QStringList buttons;
-  buttons << "Restart"
-          << "Later"
-          << "Cancel";
+  buttons << "Restart" << "Later" << "Cancel";
   qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
   qw->setSource (QUrl ("qrc:/qml/ConfirmRestart.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
@@ -297,8 +320,7 @@ TestQmlLoad::test_form_dialog_loads () {
   // FormDialog 还需 formFields/dialogButtons；注入最小占位（空表 + 默认按钮）。
   QVariantList fields;
   QStringList  buttons;
-  buttons << "OK"
-          << "Cancel";
+  buttons << "OK" << "Cancel";
   // 重新走一遍，多注入两个 context property。
   QDialog       host;
   QQuickWidget* qw= new QQuickWidget (&host);
@@ -409,6 +431,39 @@ TestQmlLoad::test_updater_progress_loads () {
       "dialogMessage", QString ("Downloading the update..."));
   qw->setSource (QUrl ("qrc:/qml/UpdaterProgress.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
+}
+
+void
+TestQmlLoad::test_search_recent_documents_loads () {
+  // SearchRecentDocuments 需要 closeBridge + recentSearchBridge +
+  // dialogButtons；加载层面验证文档实例化、初始不选中（selectedIndex==-1）与
+  // 按钮文案注入形状。
+  QVariantMap document;
+  document["name"]= QString ("notes.tm");
+  document["path"]= QString ("C:/docs/notes.tm");
+  QVariantList documents;
+  documents << document;
+
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge* closeBridge= new StubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", closeBridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  RecentDocumentsSearchStubBridge* searchBridge=
+      new RecentDocumentsSearchStubBridge (documents, qw);
+  qw->rootContext ()->setContextProperty ("recentSearchBridge", searchBridge);
+  qw->rootContext ()->setContextProperty ("dialogButtons",
+                                          QStringList{"Open", "Cancel"});
+  qw->setSource (QUrl ("qrc:/qml/SearchRecentDocuments.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  QCOMPARE (qw->rootObject ()->property ("selectedIndex").toInt (), -1);
+  const QVariantList buttonLabels=
+      qw->rootObject ()->property ("buttonLabels").toList ();
+  QCOMPARE (buttonLabels.size (), 2);
+  QCOMPARE (buttonLabels[0].toString (), QString ("Open"));
+  QCOMPARE (buttonLabels[1].toString (), QString ("Cancel"));
 }
 
 void


### PR DESCRIPTION
## What
将「编辑 → 搜索最近打开的文档」从旧的交互式全文 grep（`docgrep-in-recent`）重构为 QML 对话框：列出最近 25 个文档（文件名 + 完整路径，按规范化路径去重），输入框实时模糊过滤（子序列匹配，文件名优先、路径兜底，按匹配代价稳定排序），上下键移动选择、Enter 或「打开」加载文档，取消 / Esc / 无匹配文案均有对应行为。

## Why
旧交互是 interactive 参数输入 + tmfs 全文搜索：中文输入法确认候选字会提前触发执行，且「全文搜索」语义不符合「按最近记录挑文档」的预期。QML 对话框让筛选发生在最近记录列表上，所见即所得，且筛选/选择状态留在 QML 本地，不改写 Scheme 的最近记录。

## How
- 独立 `RecentDocumentsSearchBridge`（QObject）：构造时经 `eval_scheme("(recent-documents-for-qml)")` 拉取记录，`QDir::cleanPath` 去重（Windows 下大小写折叠）；路径全程 UTF-8（同 `qt_scheme_quote_utf8` 惯例），不经 Cork 转换以保留中文文件名
- glue `cpp-search-recent-documents-dialog`（`glue_qt.lua` 注册，返回 string），走 `run_qml_dialog`（exec 阻塞模态，一次性提交型）；通用 `closeBridge` 只承担取消 / Esc / 拖动
- Scheme 侧 `docgrep.scm` 新增 `recent-documents-for-qml` 与 `open-search-recent-documents`，`edit-menu.scm` 菜单项换绑；初始与筛选后均不默认选中，避免误开
- 测试钩子 `MOGAN_TEST_SEARCH_RECENT_DOCUMENTS`（设为路径直接返回 / `cancel` 返回空串）供 headless 自动化

## Tests
- `QT_QPA_PLATFORM=offscreen xmake r qml_load_test`：17 passed（含 `test_search_recent_documents_loads`：qrc 加载 Ready、初始 `selectedIndex == -1`、按钮文案注入形状）
- `QT_QPA_PLATFORM=offscreen xmake r qml_dialog_test`：15 passed（含 UTF-8 路径 / cancel 钩子用例）
- headless 编码诊断：`recent-documents-for-qml` 对含中文的真实路径输出正确 UTF-8
- GUI 手工验收：过滤 / 上下键 / Enter 打开 / 取消 / 无匹配文案
- 补登 `ai-docs/qml/qml-dialog.html` 该对话框的交互设计稿