### PR TITLE
[2084] 文件 → 打印 → 选择打印为文件采用 QML 重构，并优化功能

### DIFF
--- a/TeXmacs/plugins/emacs/progs/init-emacs.scm
+++ b/TeXmacs/plugins/emacs/progs/init-emacs.scm
@@ -143,9 +143,9 @@
     ("S-F3" (choose-file save-buffer-as "Save TeXmacs file" "action_save_as"))
     ("F4" (preview-buffer))
     ("S-F4" (print-buffer))
-    ("C-F4" (interactive print-to-file))
+    ("C-F4" (open-print-to-file))
     ("M-F4" (interactive print-pages))
-    ("M-S-F4" (interactive print-pages-to-file))
+    ("M-S-F4" (open-page-selection-to-file))
 
     ("emacs =" (interactive-replace))
     ("emacs:meta g" (kbd-cancel))

--- a/TeXmacs/progs/texmacs/menus/file-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/file-menu.scm
@@ -318,10 +318,10 @@
    ("Print page selection" (interactive print-pages))
   ) ;if
   ("Print buffer to file"
-    (choose-file print-to-file "Print all to file" "postscript")
+    (open-print-to-file)
   ) ;
   ("Print page selection to file"
-    (interactive choose-file-and-print-page-selection)
+    (open-page-selection-to-file)
   ) ;
 ) ;menu-bind
 
@@ -329,7 +329,7 @@
  ("Preview" (preview-buffer))
  (if (use-print-dialog?)
    (if (has-printing-cmd?) ("Print" (print-buffer)))
-   ("Print to file" (choose-file print-to-file "Print all to file" "postscript"))
+   ("Print to file" (open-print-to-file))
  ) ;if
  (if (not (use-print-dialog?)) (-> "Print" (link print-menu-sub)))
  (if (use-menus?) (-> "Page setup" (link page-setup-menu)))
@@ -340,7 +340,7 @@
  ("Preview" (preview-buffer))
  (if (use-print-dialog?)
    (if (has-printing-cmd?) ("Print" (print-buffer)))
-   ("Print to file" (choose-file print-to-file "Print all to file" "postscript"))
+   ("Print to file" (open-print-to-file))
  ) ;if
  (if (not (use-print-dialog?)) --- (link print-menu-sub) ---)
  (if (use-menus?) (-> "Page setup" (link page-setup-menu)))

--- a/TeXmacs/progs/texmacs/menus/file-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/file-menu.scm
@@ -318,10 +318,10 @@
    ("Print page selection" (interactive print-pages))
   ) ;if
   ("Print buffer to file"
-    (open-print-to-file)
+    (choose-file print-to-file "Print all to file" "postscript")
   ) ;
   ("Print page selection to file"
-    (open-page-selection-to-file)
+    (interactive choose-file-and-print-page-selection)
   ) ;
 ) ;menu-bind
 
@@ -329,7 +329,7 @@
  ("Preview" (preview-buffer))
  (if (use-print-dialog?)
    (if (has-printing-cmd?) ("Print" (print-buffer)))
-   ("Print to file" (open-print-to-file))
+   ("Print to file" (choose-file print-to-file "Print all to file" "postscript"))
  ) ;if
  (if (not (use-print-dialog?)) (-> "Print" (link print-menu-sub)))
  (if (use-menus?) (-> "Page setup" (link page-setup-menu)))
@@ -340,7 +340,7 @@
  ("Preview" (preview-buffer))
  (if (use-print-dialog?)
    (if (has-printing-cmd?) ("Print" (print-buffer)))
-   ("Print to file" (open-print-to-file))
+   ("Print to file" (choose-file print-to-file "Print all to file" "postscript"))
  ) ;if
  (if (not (use-print-dialog?)) --- (link print-menu-sub) ---)
  (if (use-menus?) (-> "Page setup" (link page-setup-menu)))

--- a/TeXmacs/progs/texmacs/menus/tests/print-widgets-test.scm
+++ b/TeXmacs/progs/texmacs/menus/tests/print-widgets-test.scm
@@ -17,6 +17,7 @@
 (check-set-mode! 'report-failed)
 
 (load "./TeXmacs/progs/texmacs/menus/print-widgets.scm")
+(load "./TeXmacs/progs/texmacs/texmacs/tm-print.scm")
 
 ;; enum-field：value 已在 options 时，options 原样保留（不重复插入）。
 
@@ -98,6 +99,48 @@
   ) ;let*
 ) ;define
 
+
+;; QML print-to-file dialog returns a named tuple. Lookup must not depend on
+;; QVariantMap iteration order, because the C++ bridge owns that representation.
+
+(define (test-print-to-file-dialog-value)
+  (let ((values '((tuple "last" "4")
+                  (tuple "file" "out.pdf")
+                  (tuple "range" "all"))))
+    (check (print-to-file-dialog-value values "file" "") => "out.pdf")
+    (check (print-to-file-dialog-value values "first" "1") => "1")
+  ) ;let
+) ;define
+
+;; The dialog result must drive the same print operation as the legacy menu:
+;; all pages use print-to-file, while a selected range preserves both bounds.
+
+(define (test-print-to-file-dispatch)
+  (let ((calls '()))
+    (dispatch-print-to-file-result (stree->tree '(tuple (tuple "file" "all.pdf")
+                                                   (tuple "range" "all")
+                                                   (tuple "first" "1")
+                                                   (tuple "last" "4"))
+                                   ) ;stree->tree
+      4
+      (lambda (name) (set! calls (list "all" name)))
+      (lambda (name first last) (set! calls (list "range" name first last)))
+    ) ;dispatch-print-to-file-result
+    (check calls => '("all" "all.pdf"))
+    (dispatch-print-to-file-result (stree->tree '(tuple (tuple "file"
+                                                          "selection.ps")
+                                                   (tuple "range" "range")
+                                                   (tuple "first" "2")
+                                                   (tuple "last" "3"))
+                                   ) ;stree->tree
+      4
+      (lambda (name) (set! calls (list "all" name)))
+      (lambda (name first last) (set! calls (list "range" name first last)))
+    ) ;dispatch-print-to-file-result
+    (check calls => '("range" "selection.ps" "2" "3"))
+  ) ;let
+) ;define
+
 (tm-define (regtest-print-widgets)
   (test-enum-field-value-in-options)
   (test-enum-field-value-not-in-options)
@@ -105,5 +148,7 @@
   (test-option-lists)
   (test-ok-result-destructuring)
   (test-cancel-empty-result-no-op)
+  (test-print-to-file-dialog-value)
+  (test-print-to-file-dispatch)
   (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/texmacs/texmacs/tm-print.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-print.scm
@@ -285,3 +285,52 @@
     "postscript"
   ) ;choose-file
 ) ;tm-define
+
+(define (print-to-file-dialog-value values key fallback)
+  (let loop
+    ((remaining values))
+    (if (null? remaining)
+      fallback
+      (let* ((entry (car remaining))
+             ;; 兼容 tree->stree 的 tuple 形状及测试直接传入的 pair。
+             (pair (if (and (pair? entry) (eq? (car entry) 'tuple)) (cdr entry) entry))
+            ) ;
+        (if (and (pair? pair) (pair? (cdr pair)) (string=? (car pair) key))
+          (cadr pair)
+          (loop (cdr remaining))
+        ) ;if
+      ) ;let*
+    ) ;if
+  ) ;let
+) ;define
+
+(define (dispatch-print-to-file-result result page-count print-all print-range)
+  (let* ((values (cdr (tree->stree result)))
+         (name (print-to-file-dialog-value values "file" ""))
+         (range (print-to-file-dialog-value values "range" "all"))
+         (first (print-to-file-dialog-value values "first" "1"))
+         (last (print-to-file-dialog-value values "last" (number->string page-count)))
+        ) ;
+    (when (not (string=? name ""))
+      (if (string=? range "range") (print-range name first last) (print-all name))
+    ) ;when
+  ) ;let*
+) ;define
+
+(define (open-print-to-file* page-range?)
+  (let ((page-count (get-page-count)))
+    (dispatch-print-to-file-result (cpp-print-to-file-dialog (propose-postscript-name) page-count page-range?)
+      page-count
+      ;; 与 choose-file 一致，将系统路径转换为 Mogan url。
+      (lambda (name) (print-to-file (system->url name)))
+      (lambda (name first last) (print-pages-to-file (system->url name) first last))
+    ) ;dispatch-print-to-file-result
+  ) ;let
+) ;define
+
+(tm-define (open-print-to-file) (:interactive #t) (open-print-to-file* #f))
+
+(tm-define (open-page-selection-to-file)
+  (:interactive #t)
+  (open-print-to-file* #t)
+) ;tm-define

--- a/ai-docs/qml/qml-dialog.html
+++ b/ai-docs/qml/qml-dialog.html
@@ -1029,6 +1029,7 @@
       <button class="nav-btn active" data-target="confirm">ConfirmClose.qml</button>
       <button class="nav-btn" data-target="confirmQuestion">ConfirmQuestion.qml</button>
       <button class="nav-btn" data-target="form">FormDialog.qml</button>
+      <button class="nav-btn" data-target="printToFile">PrintToFile.qml</button>
       <button class="nav-btn" data-target="font">FontSelector.qml</button>
       <button class="nav-btn" data-target="paragraph">ParagraphFormat.qml</button>
       <button class="nav-btn" data-target="statistics">Statistics.qml</button>
@@ -1136,6 +1137,47 @@
           对应 QML: <code>fields: formFields</code>
           <code>values[key] = selectedValue</code>
           <code>submit -> closeBridge.submit(values)</code>
+        </p>
+      </section>
+
+      <section class="panel" id="panel-print-to-file">
+        <article class="form-shell">
+          <div class="field">
+            <label for="print-file-name">文件</label>
+            <input id="print-file-name" value="document.ps" />
+            <button class="btn" id="print-browse">浏览</button>
+          </div>
+          <div class="field">
+            <label for="print-format">格式</label>
+            <select id="print-format">
+              <option value="postscript">PostScript</option>
+              <option value="pdf">PDF</option>
+            </select>
+          </div>
+          <div class="field">
+            <label>页面</label>
+            <div class="btn-row" style="justify-content: flex-start;">
+              <button class="btn primary" data-print-range="all">全部页面</button>
+              <button class="btn" data-print-range="range">页面范围</button>
+            </div>
+          </div>
+          <div class="field" id="print-range-fields" style="display: none;">
+            <label>范围</label>
+            <div class="btn-row" style="justify-content: flex-start;">
+              <input id="print-first-page" type="number" min="1" value="1" style="width: 72px;" />
+              <span>至</span>
+              <input id="print-last-page" type="number" min="1" value="3" style="width: 72px;" />
+            </div>
+          </div>
+          <div class="btn-row" style="justify-content: flex-end; margin-top: 8px;">
+            <button class="btn primary" id="print-submit">打印</button>
+            <button class="btn" data-log="PrintToFile: cancel">取消</button>
+          </div>
+        </article>
+        <p class="legend">
+          对应 QML: <code>printBridge.chooseSaveFile()</code>
+          <code>TabBar: all/range</code>
+          <code>closeBridge.submit(values)</code>
         </p>
       </section>
 
@@ -1693,6 +1735,7 @@
       const panels = {
         confirm: document.getElementById('panel-confirm'),
         form: document.getElementById('panel-form'),
+        printToFile: document.getElementById('panel-print-to-file'),
         font: document.getElementById('panel-font'),
         paragraph: document.getElementById('panel-paragraph'),
         statistics: document.getElementById('panel-statistics'),
@@ -1706,6 +1749,7 @@
         version: 'Version.qml preview',
         confirm: 'ConfirmClose.qml 模拟',
         form: 'FormDialog.qml 模拟',
+        printToFile: 'PrintToFile.qml 模拟',
         font: 'FontSelector.qml 模拟',
         paragraph: 'ParagraphFormat.qml 模拟',
         statistics: 'Statistics.qml 模拟',
@@ -1718,6 +1762,7 @@
         version: 'versionTitle + versionLines + closeBridge.choose(1)',
         confirm: 'dialogMessage + dialogButtons + closeBridge.choose()',
         form: 'formFields + values 收集 + closeBridge.submit(values)',
+        printToFile: 'printBridge.chooseSaveFile() + TabBar + closeBridge.submit(values)',
         font: 'fontBridge 联动: family/style/filter/customize/preview',
         paragraph: 'EnumCombo x N + tabs(基础/高级) + make-multi-line-with 写回',
         statistics: 'statsModel: [{label, value}, ...] + closeBridge.choose(0) 关闭',
@@ -1750,6 +1795,29 @@
           viewCode.textContent = codeMap[target];
           log(`切换组件 -> ${titleMap[target]}`);
         });
+      });
+
+      let printRange = 'all';
+      const printRangeFields = document.getElementById('print-range-fields');
+      document.querySelectorAll('[data-print-range]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          printRange = btn.getAttribute('data-print-range');
+          document.querySelectorAll('[data-print-range]').forEach((b) => b.classList.toggle('primary', b === btn));
+          printRangeFields.style.display = printRange === 'range' ? '' : 'none';
+          log('PrintToFile: page range -> ' + printRange);
+        });
+      });
+      document.getElementById('print-browse').addEventListener('click', () => {
+        log('PrintToFile: printBridge.chooseSaveFile()');
+      });
+      document.getElementById('print-submit').addEventListener('click', () => {
+        log('PrintToFile: closeBridge.submit(' + JSON.stringify({
+          file: document.getElementById('print-file-name').value,
+          format: document.getElementById('print-format').value,
+          range: printRange,
+          first: document.getElementById('print-first-page').value,
+          last: document.getElementById('print-last-page').value
+        }) + ')');
       });
 
       document.querySelectorAll('[data-log]').forEach((el) => {

--- a/devel/2084.md
+++ b/devel/2084.md
@@ -16,7 +16,6 @@
 - `src/Plugins/Qt/qml/qmldir`
 - `src/Scheme/L5/glue_qt.lua`
 - `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
-- `TeXmacs/progs/texmacs/menus/file-menu.scm`
 - `TeXmacs/plugins/emacs/progs/init-emacs.scm`
 - `src/Edit/Editor/edit_main.cpp`
 - `tests/Plugins/Qt/qml_dialog_test.cpp`
@@ -69,10 +68,8 @@ M-S-F4 确认默认选中页面范围。Esc / 取消确认不产生文件。
    兼容 tuple 形状，不依赖 QVariantMap 迭代顺序）、`dispatch-print-to-file-
    result`（range 分发 `print-to-file` / `print-pages-to-file`，系统路径先
    `system->url`）与 `open-print-to-file` / `open-page-selection-to-file`
-   两个 interactive 入口；`file-menu.scm` 的三个「打印为文件」菜单项
-   （print-menu-sub / print-menu / print-menu-inline）与 emacs 仿真插件
-   （当前 main 上 C-F4 / M-S-F4 的唯一定义处，`init-emacs.scm`）均换绑，
-   菜单与快捷键走同一 QML 对话框。
+   两个 interactive 入口；emacs 仿真插件（当前 main 上 C-F4 / M-S-F4 的唯一定义
+   处，`init-emacs.scm`）换绑这两个快捷键。
 4. `edit_main.cpp` 的 `print_to_file` 按输出文件是否存在提示完成或失败。
 5. 测试：QML 加载（stub bridge 断言 Ready 与默认值）、glue 钩子
    （MOGAN_TEST_PRINT_TO_FILE=ok/cancel）、scheme 纯逻辑

--- a/devel/2084.md
+++ b/devel/2084.md
@@ -16,7 +16,7 @@
 - `src/Plugins/Qt/qml/qmldir`
 - `src/Scheme/L5/glue_qt.lua`
 - `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
-- `TeXmacs/progs/generic/generic-kbd.scm`
+- `TeXmacs/plugins/emacs/progs/init-emacs.scm`
 - `src/Edit/Editor/edit_main.cpp`
 - `tests/Plugins/Qt/qml_dialog_test.cpp`
 - `tests/Plugins/Qt/qml_load_test.cpp`
@@ -68,7 +68,8 @@ M-S-F4 确认默认选中页面范围。Esc / 取消确认不产生文件。
    兼容 tuple 形状，不依赖 QVariantMap 迭代顺序）、`dispatch-print-to-file-
    result`（range 分发 `print-to-file` / `print-pages-to-file`，系统路径先
    `system->url`）与 `open-print-to-file` / `open-page-selection-to-file`
-   两个 interactive 入口；`generic-kbd.scm` 的 C-F4 / M-S-F4 换绑。
+   两个 interactive 入口；emacs 仿真插件（当前 main 上 C-F4 / M-S-F4 的唯一定义
+   处，`init-emacs.scm`）换绑这两个快捷键。
 4. `edit_main.cpp` 的 `print_to_file` 按输出文件是否存在提示完成或失败。
 5. 测试：QML 加载（stub bridge 断言 Ready 与默认值）、glue 钩子
    （MOGAN_TEST_PRINT_TO_FILE=ok/cancel）、scheme 纯逻辑

--- a/devel/2084.md
+++ b/devel/2084.md
@@ -1,0 +1,75 @@
+# 2084 文件 → 打印 → 选择打印为文件采用 QML 重构
+
+## 相关文档
+
+- [Issue #4142](https://github.com/MoganLab/mogan/issues/4142) - 采用 QML 重构选择打印为文件流程
+- [QML 对话框指南](../ai-docs/qml/README.md) - 弹窗生命期、取消语义与测试要求
+
+## 任务相关的代码文件
+
+- `src/Plugins/Qt/PrintToFileBridge.hpp`
+- `src/Plugins/Qt/PrintToFileBridge.cpp`
+- `src/Plugins/Qt/qml/PrintToFile.qml`
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `src/Plugins/Qt/QTMQmlDialog.hpp`
+- `src/Plugins/Qt/moganqml.qrc`
+- `src/Plugins/Qt/qml/qmldir`
+- `src/Scheme/L5/glue_qt.lua`
+- `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
+- `TeXmacs/progs/generic/generic-kbd.scm`
+- `src/Edit/Editor/edit_main.cpp`
+- `tests/Plugins/Qt/qml_dialog_test.cpp`
+- `tests/Plugins/Qt/qml_load_test.cpp`
+- `TeXmacs/progs/texmacs/menus/tests/print-widgets-test.scm`
+- `ai-docs/qml/qml-dialog.html`
+
+## 如何测试
+
+```bash
+xmake b stem
+QT_QPA_PLATFORM=offscreen xmake r qml_load_test
+QT_QPA_PLATFORM=offscreen xmake r qml_dialog_test
+xmake r print-widgets-test
+```
+
+启动 Mogan 后按 C-F4 打开「打印为文件」对话框：Browse 选择输出路径（含非
+ASCII 字符的路径）；切换 PDF / PostScript 确认扩展名跟随；选页面范围并输入
+非法边界确认被拦截；确认输出文件生成、失败时状态栏提示而非「Done printing」。
+M-S-F4 确认默认选中页面范围。Esc / 取消确认不产生文件。
+
+## 2026/08/29 采用 QML 重构选择打印为文件
+
+### What
+
+- 用模态 QML 对话框（`PrintToFile.qml`）替换 C-F4 / M-S-F4 快捷键触发的
+  交互式参数输入（旧路径需先弹参数框再弹系统保存框，两段式）。
+- 单一对话框内完成：输出文件名（可 Browse 调系统保存对话框）、PDF /
+  PostScript 格式切换（扩展名自动同步）、全部页面 / 页面范围（范围校验
+  1..页数，非法值显示错误提示并阻止提交）。
+- 修复两个缺陷：非 ASCII 输出路径经 Cork 转换会乱码（改走 UTF-8 通道）；
+  打印失败仍提示「Done printing」（按输出文件是否存在区分提示）。
+
+### Why
+
+旧交互是 `interactive print-to-file` 两段式输入：先交互式问参数、再弹系统
+保存框，页面范围只能在参数框里输入、无校验；中文路径在 glue 转换中会破坏。
+单一 QML 对话框一次完成全部选择并即时校验，减少误操作。
+
+### How
+
+1. C++ 侧新增独立 `PrintToFileBridge`（Q_INVOKABLE `chooseSaveFile` 调
+   `QFileDialog::getSaveFileName`，返回后重新激活宿主窗口，避免 QML 模态窗
+   落到后台），通用 `QmlDialogBridge` 继续只承担取消 / Esc / 拖动。
+2. 新增 glue `cpp-print-to-file-dialog(string filename, int page_count, bool
+   page_range)`：defaults 注入 + 标签经 `qt_translate` 翻译，结果
+   QVariantMap 转 tuple 树；file 值走 `from_qstring_utf8` 保留 UTF-8 路径
+   （匹配 `choose-file` 的 `system->url` 转换），其余字段走常规转换。
+3. Scheme 侧 `tm-print.scm` 新增 `print-to-file-dialog-value`（按 key 查值，
+   兼容 tuple 形状，不依赖 QVariantMap 迭代顺序）、`dispatch-print-to-file-
+   result`（range 分发 `print-to-file` / `print-pages-to-file`，系统路径先
+   `system->url`）与 `open-print-to-file` / `open-page-selection-to-file`
+   两个 interactive 入口；`generic-kbd.scm` 的 C-F4 / M-S-F4 换绑。
+4. `edit_main.cpp` 的 `print_to_file` 按输出文件是否存在提示完成或失败。
+5. 测试：QML 加载（stub bridge 断言 Ready 与默认值）、glue 钩子
+   （MOGAN_TEST_PRINT_TO_FILE=ok/cancel）、scheme 纯逻辑
+   （dialog-value 查找与 all/range 分发，headless 秒级回归）。

--- a/devel/2084.md
+++ b/devel/2084.md
@@ -16,6 +16,7 @@
 - `src/Plugins/Qt/qml/qmldir`
 - `src/Scheme/L5/glue_qt.lua`
 - `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
+- `TeXmacs/progs/texmacs/menus/file-menu.scm`
 - `TeXmacs/plugins/emacs/progs/init-emacs.scm`
 - `src/Edit/Editor/edit_main.cpp`
 - `tests/Plugins/Qt/qml_dialog_test.cpp`
@@ -68,8 +69,10 @@ M-S-F4 确认默认选中页面范围。Esc / 取消确认不产生文件。
    兼容 tuple 形状，不依赖 QVariantMap 迭代顺序）、`dispatch-print-to-file-
    result`（range 分发 `print-to-file` / `print-pages-to-file`，系统路径先
    `system->url`）与 `open-print-to-file` / `open-page-selection-to-file`
-   两个 interactive 入口；emacs 仿真插件（当前 main 上 C-F4 / M-S-F4 的唯一定义
-   处，`init-emacs.scm`）换绑这两个快捷键。
+   两个 interactive 入口；`file-menu.scm` 的三个「打印为文件」菜单项
+   （print-menu-sub / print-menu / print-menu-inline）与 emacs 仿真插件
+   （当前 main 上 C-F4 / M-S-F4 的唯一定义处，`init-emacs.scm`）均换绑，
+   菜单与快捷键走同一 QML 对话框。
 4. `edit_main.cpp` 的 `print_to_file` 按输出文件是否存在提示完成或失败。
 5. 测试：QML 加载（stub bridge 断言 Ready 与默认值）、glue 钩子
    （MOGAN_TEST_PRINT_TO_FILE=ok/cancel）、scheme 纯逻辑

--- a/src/Edit/Editor/edit_main.cpp
+++ b/src/Edit/Editor/edit_main.cpp
@@ -286,7 +286,8 @@ edit_main_rep::print_doc (url name, bool conform, int first, int last) {
 void
 edit_main_rep::print_to_file (url name, string first, string last) {
   print_doc (name, false, as_int (first), as_int (last));
-  set_message ("Done printing", "print to file");
+  if (exists (name)) set_message ("Done printing", "print to file");
+  else set_message ("Failed to write output file", "print to file");
 }
 
 void

--- a/src/Edit/Modify/edit_modify.cpp
+++ b/src/Edit/Modify/edit_modify.cpp
@@ -22,6 +22,7 @@
  * Loro related externs and statics
  ******************************************************************************/
 
+#ifdef LORO_ENABLED
 extern void (*g_loro_broadcast_update) (string bytes);
 
 static void
@@ -39,6 +40,7 @@ local_update_cb (void* user_data, const uint8_t* bytes, size_t len) {
                  << "registered.\n";
   }
 }
+#endif // LORO_ENABLED
 
 /******************************************************************************
  * Constructors and destructors

--- a/src/Plugins/Qt/PrintToFileBridge.cpp
+++ b/src/Plugins/Qt/PrintToFileBridge.cpp
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * MODULE      : PrintToFileBridge.cpp
+ * DESCRIPTION : Native save-file access for the QML print-to-file dialog.
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes with NO WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+/*! @file PrintToFileBridge.cpp
+ *  @brief 选择打印为文件对话框的原生保存路径实现。
+ */
+
+#include "PrintToFileBridge.hpp"
+
+#include <QFileDialog>
+
+QString
+PrintToFileBridge::chooseSaveFile (const QString& currentFileName,
+                                   const QString& format,
+                                   const QString& title) {
+  const QString filter=
+      format == "pdf" ? "PDF files (*.pdf)" : "PostScript files (*.ps)";
+  const QString selected=
+      QFileDialog::getSaveFileName (m_host, title, currentFileName, filter);
+  if (m_host) {
+    m_host->raise ();
+    m_host->activateWindow ();
+  }
+  return selected;
+}

--- a/src/Plugins/Qt/PrintToFileBridge.hpp
+++ b/src/Plugins/Qt/PrintToFileBridge.hpp
@@ -1,0 +1,51 @@
+/******************************************************************************
+ * MODULE      : PrintToFileBridge.hpp
+ * DESCRIPTION : Native save-file access for the QML print-to-file dialog.
+ * COPYRIGHT   : (C) 2026 Mogan STEM
+ *
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes with NO WARRANTY whatsoever. Details see LICENSE.
+ ******************************************************************************/
+
+/*! @file PrintToFileBridge.hpp
+ *  @brief 选择打印为文件对话框的专用 QML bridge。
+ *
+ *  @par 设计
+ *  通用 QmlDialogBridge 只维护模态对话框的提交与取消；原生文件选择属于打印
+ *  领域交互，由本类隔离，避免其它对话框获得无关 API。
+ */
+
+#ifndef PRINT_TO_FILE_BRIDGE_HPP
+#define PRINT_TO_FILE_BRIDGE_HPP
+
+#include "boot.hpp"
+
+#include <QDialog>
+#include <QObject>
+#include <QString>
+
+class PrintToFileBridge : public QObject {
+  Q_OBJECT
+
+public:
+  explicit PrintToFileBridge (QDialog* host) : QObject (), m_host (host) {
+    ASSERT (host != NULL, "PrintToFileBridge expects a valid QDialog host");
+  }
+
+  /**
+   * @brief 打开系统保存文件对话框。
+   * @param currentFileName 当前建议的输出路径。
+   * @param format 输出格式标识，支持 pdf 与 postscript。
+   * @param title 原生对话框标题。
+   * @return 用户选择的系统路径；取消时返回空字符串。
+   * @note 返回后重新激活宿主窗口，避免原生对话框关闭后 QML 模态窗落到后台。
+   */
+  Q_INVOKABLE QString chooseSaveFile (const QString& currentFileName,
+                                      const QString& format,
+                                      const QString& title);
+
+private:
+  QDialog* m_host;
+};
+
+#endif // defined PRINT_TO_FILE_BRIDGE_HPP

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -11,6 +11,7 @@
 #include "FontSelectorBridge.hpp"
 #include "ParagraphFormatBridge.hpp"
 #include "PreferencesBridge.hpp"
+#include "PrintToFileBridge.hpp"
 #include "QTMQmlDialogBridge.hpp"
 #include "QTMQmlDialogInternal.hpp"
 #include "VersionDialogBridge.hpp"
@@ -39,6 +40,8 @@ using moebius::data::tree_to_scheme_tree;
 #include <QVariantMap>
 
 #include <QPointer>
+
+#include <algorithm>
 
 #include <functional>
 
@@ -565,6 +568,90 @@ cpp_form_dialog (tree fields) {
     tree kv (TUPLE);
     kv << tree (from_qstring (it.key ()));
     kv << tree (from_qstring (it.value ().toString ()));
+    r << kv;
+  }
+  return r;
+}
+
+/**
+ * @brief 选择打印为文件 QML 弹窗（声明/语义见 QTMQmlDialog.hpp）。
+ *
+ * @details 走 run_qml_dialog（exec 阻塞模态，一次性提交型）。defaults 经
+ * printDefaults 注入初始值，标签文案经 qt_translate 注入；原生保存对话框属
+ * 打印领域交互，由独立 PrintToFileBridge 承载，通用 QmlDialogBridge 只承担
+ * submit / cancel / Esc / 拖动。结果 QVariantMap 转 (tuple (tuple key
+ * value)...)；file 是系统路径，须保留 UTF-8（匹配 scheme 侧 system->url），
+ * 其余字段走常规转换。
+ *
+ * 测试钩子 MOGAN_TEST_PRINT_TO_FILE：cancel 返回空 tuple；ok 返回 defaults
+ * 组成的 tuple，均不弹窗（供 headless 自动化）。
+ */
+tree
+cpp_print_to_file_dialog (string filename, int page_count, bool page_range) {
+  string preset= get_env ("MOGAN_TEST_PRINT_TO_FILE");
+  if (preset == "cancel") return tree (TUPLE);
+
+  QVariantMap defaults;
+  defaults["file"]  = to_qstring (filename);
+  defaults["format"]= "postscript";
+  defaults["range"] = page_range ? "range" : "all";
+  defaults["first"] = "1";
+  defaults["last"]  = QString::number (std::max (1, page_count));
+
+  if (preset == "ok") {
+    tree r (TUPLE);
+    for (auto it= defaults.begin (); it != defaults.end (); ++it) {
+      tree kv (TUPLE);
+      kv << tree (from_qstring (it.key ()))
+         << tree (from_qstring (it.value ().toString ()));
+      r << kv;
+    }
+    return r;
+  }
+
+  QmlDialogBridge* bridge = nullptr;
+  array<string>    buttons= {string ("Print"), string ("Cancel")};
+  run_qml_dialog (
+      "qrc:/qml/PrintToFile.qml", "PrintToFile.qml",
+      [&] (QQuickWidget* qw, QDialog& host) {
+        bridge                        = inject_common_context (qw, host);
+        PrintToFileBridge* printBridge= new PrintToFileBridge (&host);
+        qw->rootContext ()->setContextProperty ("printBridge", printBridge);
+        QObject::connect (&host, &QDialog::destroyed, printBridge,
+                          &QObject::deleteLater);
+        qw->rootContext ()->setContextProperty ("printDefaults", defaults);
+        qw->rootContext ()->setContextProperty ("printTitle",
+                                                qt_translate ("Print to file"));
+        qw->rootContext ()->setContextProperty ("fileLabel",
+                                                qt_translate ("File:"));
+        qw->rootContext ()->setContextProperty ("formatLabel",
+                                                qt_translate ("Format:"));
+        qw->rootContext ()->setContextProperty ("pagesLabel",
+                                                qt_translate ("Pages:"));
+        qw->rootContext ()->setContextProperty ("allPagesLabel",
+                                                qt_translate ("All pages"));
+        qw->rootContext ()->setContextProperty ("pageRangeLabel",
+                                                qt_translate ("Page range"));
+        qw->rootContext ()->setContextProperty ("fromLabel",
+                                                qt_translate ("From"));
+        qw->rootContext ()->setContextProperty ("toLabel", qt_translate ("To"));
+        qw->rootContext ()->setContextProperty ("browseLabel",
+                                                qt_translate ("Browse"));
+        qw->rootContext ()->setContextProperty ("dialogButtons",
+                                                translate_buttons (buttons));
+      },
+      500, 430);
+
+  tree               r (TUPLE);
+  const QVariantMap& res= bridge ? bridge->results () : QVariantMap ();
+  delete bridge;
+  for (auto it= res.begin (); it != res.end (); ++it) {
+    tree kv (TUPLE);
+    // 路径须保留 UTF-8，匹配 choose-file 的 system->url 转换。
+    const string value= it.key () == "file"
+                            ? from_qstring_utf8 (it.value ().toString ())
+                            : from_qstring (it.value ().toString ());
+    kv << tree (from_qstring (it.key ())) << tree (value);
     r << kv;
   }
   return r;

--- a/src/Plugins/Qt/QTMQmlDialog.hpp
+++ b/src/Plugins/Qt/QTMQmlDialog.hpp
@@ -160,6 +160,20 @@ int cpp_confirm_question (string message, array<string> buttons);
 tree cpp_form_dialog (tree fields);
 
 /**
+ * @brief 选择打印为文件 QML 弹窗的 glue 入口。
+ * @param filename 建议的输出路径（propose-postscript-name 给出的系统路径）。
+ * @param page_count 当前文档页数，用于页面范围默认值与校验上界。
+ * @param page_range 弹窗初始是否选中「页面范围」。
+ * @return 用户点 Print 返回 (tuple (tuple "file" <路径>) (tuple "format"
+ * <pdf|postscript>) (tuple "range" <all|range>) (tuple "first" ...)
+ * (tuple "last" ...))；file 为 UTF-8 系统路径。Cancel / 关闭 / 加载失败返回
+ * 空 tuple。
+ * @note 测试钩子 MOGAN_TEST_PRINT_TO_FILE=ok|cancel 命中时不弹窗。
+ */
+tree cpp_print_to_file_dialog (string filename, int page_count,
+                               bool page_range);
+
+/**
  * @brief 字体选择器 QML 对话框的 glue 入口。
  * @param specs_key scheme specs-registry 的 int 句柄
  *（font-selector-register-specs 返回值）。

--- a/src/Plugins/Qt/moganqml.qrc
+++ b/src/Plugins/Qt/moganqml.qrc
@@ -24,5 +24,6 @@
         <file>qml/Preferences.qml</file>
         <file>qml/Version.qml</file>
         <file>qml/UpdaterProgress.qml</file>
+        <file>qml/PrintToFile.qml</file>
     </qresource>
 </RCC>

--- a/src/Plugins/Qt/qml/PrintToFile.qml
+++ b/src/Plugins/Qt/qml/PrintToFile.qml
@@ -1,0 +1,280 @@
+// PrintToFile.qml - QML workflow for choosing a printable output file.
+
+import QtQuick
+import "atoms"
+
+DialogShell {
+    id: root
+    implicitWidth: 500
+    implicitHeight: 430
+
+    property var defaults: typeof printDefaults !== "undefined" ? printDefaults : ({})
+    property var buttonLabels: typeof dialogButtons !== "undefined" ? dialogButtons : ["Print", "Cancel"]
+    property string titleText: typeof printTitle !== "undefined" ? printTitle : "Print to file"
+    property string fileText: typeof fileLabel !== "undefined" ? fileLabel : "File:"
+    property string formatText: typeof formatLabel !== "undefined" ? formatLabel : "Format:"
+    property string pagesText: typeof pagesLabel !== "undefined" ? pagesLabel : "Pages:"
+    property string allPagesText: typeof allPagesLabel !== "undefined" ? allPagesLabel : "All pages"
+    property string pageRangeText: typeof pageRangeLabel !== "undefined" ? pageRangeLabel : "Page range"
+    property string fromText: typeof fromLabel !== "undefined" ? fromLabel : "From"
+    property string toText: typeof toLabel !== "undefined" ? toLabel : "To"
+    property string browseText: typeof browseLabel !== "undefined" ? browseLabel : "Browse"
+    property string fileName: defaults.file !== undefined ? defaults.file : ""
+    property string format: defaults.format !== undefined ? defaults.format : "postscript"
+    property string range: defaults.range !== undefined ? defaults.range : "all"
+    property string firstPage: defaults.first !== undefined ? defaults.first : "1"
+    property string lastPage: defaults.last !== undefined ? defaults.last : "1"
+    property int pageCount: {
+        var count = Number(defaults.last);
+        return count > 0 && Math.floor(count) === count ? count : 1;
+    }
+    property string errorText: ""
+    property bool browsing: false
+
+    function extensionForFormat(value) {
+        return value === "pdf" ? "pdf" : "ps";
+    }
+
+    function fileWithExtension(path, extension) {
+        var separator = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+        var dot = path.lastIndexOf(".");
+        return dot > separator ? path.slice(0, dot + 1) + extension : path + "." + extension;
+    }
+
+    function submit() {
+        var first = Number(firstPage);
+        var last = Number(lastPage);
+        if (fileName.trim().length === 0) {
+            errorText = fileText;
+            return;
+        }
+        if (range === "range" && (Math.floor(first) !== first || Math.floor(last) !== last || first < 1 || last < first || last > pageCount)) {
+            errorText = pageRangeText;
+            return;
+        }
+        closeBridge.submit({
+            "file": fileWithExtension(fileName.trim(), extensionForFormat(format)),
+            "format": format,
+            "range": range,
+            "first": firstPage,
+            "last": lastPage
+        });
+    }
+
+    onCancel: () => {
+        if (!root.browsing)
+            closeBridge.cancel();
+    }
+
+    content: Column {
+        spacing: Theme.gapM
+
+        Text {
+            text: root.titleText
+            color: Theme.fg
+            font.pixelSize: Theme.fontBtn
+            font.weight: Font.DemiBold
+        }
+
+        Row {
+            width: parent.width
+            height: Theme.rowH
+            spacing: Theme.gapS
+
+            Text {
+                width: 72 * Theme.scaleFactor
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.fileText
+                color: Theme.fg
+                font.pixelSize: Theme.fontBody
+            }
+            Rectangle {
+                width: parent.width - 72 * Theme.scaleFactor - browseButton.width - 2 * Theme.gapS
+                height: Theme.rowH
+                radius: Theme.radius
+                color: Theme.fieldBg
+                border.width: Theme.borderW
+                border.color: fileInput.activeFocus ? Theme.accent : Theme.borderClr
+
+                Rectangle {
+                    anchors.fill: parent
+                    anchors.margins: parent.border.width
+                    radius: Math.max(0, parent.radius - parent.border.width)
+                    clip: true
+                    color: parent.color
+
+                    Text {
+                        anchors.fill: parent
+                        anchors.leftMargin: Theme.pad
+                        anchors.rightMargin: Theme.pad
+                        verticalAlignment: Text.AlignVCenter
+                        text: root.fileName
+                        color: Theme.fg
+                        font.pixelSize: Theme.fontBody
+                        elide: Text.ElideMiddle
+                        visible: !fileInput.activeFocus
+                    }
+                    TextInput {
+                        id: fileInput
+                        anchors.fill: parent
+                        anchors.leftMargin: Theme.pad
+                        anchors.rightMargin: Theme.pad
+                        verticalAlignment: Text.AlignVCenter
+                        color: Theme.fg
+                        font.pixelSize: Theme.fontBody
+                        selectByMouse: true
+                        visible: fileInput.activeFocus
+                        text: root.fileName
+                        onTextEdited: root.fileName = text
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        visible: !fileInput.activeFocus
+                        cursorShape: Qt.IBeamCursor
+                        onClicked: {
+                            fileInput.forceActiveFocus();
+                            fileInput.cursorPosition = fileInput.length;
+                        }
+                    }
+                }
+            }
+            MiniButton {
+                id: browseButton
+                size: "normal"
+                text: root.browseText
+                onClicked: {
+                    root.browsing = true;
+                    var picked = printBridge.chooseSaveFile(root.fileName, root.format, root.titleText);
+                    root.browsing = false;
+                    if (picked.length > 0)
+                        root.fileName = root.fileWithExtension(picked, root.extensionForFormat(root.format));
+                }
+            }
+        }
+
+        EnumCombo {
+            width: parent.width
+            label: root.formatText
+            options: ["pdf", "postscript"]
+            optionsTr: ["PDF", "PostScript"]
+            value: root.format
+            onChanged: function(value) {
+                root.format = value;
+                if (root.fileName.length > 0)
+                    root.fileName = root.fileWithExtension(root.fileName, root.extensionForFormat(value));
+            }
+        }
+
+        Row {
+            width: parent.width
+            height: Theme.rowH
+            spacing: Theme.gapS
+
+            Text {
+                width: 72 * Theme.scaleFactor
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.pagesText
+                color: Theme.fg
+                font.pixelSize: Theme.fontBody
+            }
+            TabBar {
+                anchors.verticalCenter: parent.verticalCenter
+                width: parent.width - 72 * Theme.scaleFactor - Theme.gapS
+                model: [
+                    { "key": "all", "label": root.allPagesText },
+                    { "key": "range", "label": root.pageRangeText }
+                ]
+                activeKey: root.range
+                onSelected: function(key) {
+                    root.range = key;
+                }
+            }
+        }
+
+        Row {
+            visible: root.range === "range"
+            width: parent.width
+            height: visible ? Theme.rowH : 0
+            spacing: Theme.gapS
+
+            Item { width: 72 * Theme.scaleFactor; height: 1 }
+            Text {
+                width: 40 * Theme.scaleFactor
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.fromText
+                color: Theme.muted
+                font.pixelSize: Theme.fontBody
+            }
+            Rectangle {
+                width: 82 * Theme.scaleFactor
+                height: Theme.rowH
+                radius: Theme.radius
+                color: Theme.fieldBg
+                border.width: Theme.borderW
+                border.color: firstInput.activeFocus ? Theme.accent : Theme.borderClr
+                TextInput {
+                    id: firstInput
+                    anchors.fill: parent
+                    anchors.margins: Theme.pad
+                    verticalAlignment: Text.AlignVCenter
+                    color: Theme.fg
+                    font.pixelSize: Theme.fontBody
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    validator: IntValidator { bottom: 1 }
+                    text: root.firstPage
+                    onTextEdited: root.firstPage = text
+                }
+            }
+            Text {
+                width: 24 * Theme.scaleFactor
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.toText
+                color: Theme.muted
+                font.pixelSize: Theme.fontBody
+            }
+            Rectangle {
+                width: 82 * Theme.scaleFactor
+                height: Theme.rowH
+                radius: Theme.radius
+                color: Theme.fieldBg
+                border.width: Theme.borderW
+                border.color: lastInput.activeFocus ? Theme.accent : Theme.borderClr
+                TextInput {
+                    id: lastInput
+                    anchors.fill: parent
+                    anchors.margins: Theme.pad
+                    verticalAlignment: Text.AlignVCenter
+                    color: Theme.fg
+                    font.pixelSize: Theme.fontBody
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    validator: IntValidator { bottom: 1 }
+                    text: root.lastPage
+                    onTextEdited: root.lastPage = text
+                }
+            }
+        }
+
+        Text {
+            width: parent.width
+            height: errorText.length > 0 ? implicitHeight : 0
+            visible: errorText.length > 0
+            text: errorText
+            color: Theme.muted
+            font.pixelSize: Theme.fontMini
+            elide: Text.ElideRight
+        }
+
+        Item { width: 1; height: Theme.padS }
+
+        DialogButtons {
+            anchors.horizontalCenter: parent.horizontalCenter
+            buttonLabels: root.buttonLabels
+            onClicked: function(index) {
+                if (index === 0)
+                    root.submit();
+                else
+                    closeBridge.cancel();
+            }
+        }
+    }
+}

--- a/src/Plugins/Qt/qml/qmldir
+++ b/src/Plugins/Qt/qml/qmldir
@@ -8,3 +8,4 @@ Statistics 1.0 Statistics.qml
 Preferences 1.0 Preferences.qml
 Version 1.0 Version.qml
 UpdaterProgress 1.0 UpdaterProgress.qml
+PrintToFile 1.0 PrintToFile.qml

--- a/src/Scheme/L5/glue_qt.lua
+++ b/src/Scheme/L5/glue_qt.lua
@@ -68,6 +68,16 @@ function main()
                 }
             },
             {
+                scm_name = "cpp-print-to-file-dialog",
+                cpp_name = "cpp_print_to_file_dialog",
+                ret_type = "tree",
+                arg_list = {
+                    "string",
+                    "int",
+                    "bool"
+                }
+            },
+            {
                 scm_name = "cpp-font-selector-dialog",
                 cpp_name = "cpp_font_selector_dialog",
                 ret_type = "tree",

--- a/tests/Plugins/Qt/qml_dialog_test.cpp
+++ b/tests/Plugins/Qt/qml_dialog_test.cpp
@@ -73,6 +73,7 @@ private slots:
   void test_confirm_close_hook ();
   void test_confirm_question_hook ();
   void test_form_dialog_hook ();
+  void test_print_to_file_dialog_hook ();
 };
 
 // 字段下标协议常量与协议文档一致。
@@ -261,6 +262,45 @@ TestQmlDialog::test_form_dialog_hook () {
   {
     EnvHook hook ("MOGAN_TEST_FORM_DIALOG", "cancel");
     tree    r= cpp_form_dialog (form);
+    QVERIFY (is_compound (r));
+    QCOMPARE (N (r), 0);
+  }
+}
+
+// MOGAN_TEST_PRINT_TO_FILE 钩子：ok 时返回 defaults 组成的 tuple（键序不依赖
+// QVariantMap 迭代顺序，逐 key 查找）；cancel 时返回空 tuple，均不弹窗。
+void
+TestQmlDialog::test_print_to_file_dialog_hook () {
+  {
+    EnvHook hook ("MOGAN_TEST_PRINT_TO_FILE", "ok");
+    tree    r= cpp_print_to_file_dialog ("out.ps", 4, false);
+    QVERIFY (is_compound (r));
+    QCOMPARE (N (r), 5);
+    bool sawFile= false, sawFormat= false, sawRange= false, sawLast= false;
+    for (int i= 0; i < N (r); i++) {
+      QVERIFY (is_compound (r[i]) && N (r[i]) == 2);
+      if (r[i][0]->label == "file") {
+        QCOMPARE (r[i][1]->label, string ("out.ps"));
+        sawFile= true;
+      }
+      else if (r[i][0]->label == "format") {
+        QCOMPARE (r[i][1]->label, string ("postscript"));
+        sawFormat= true;
+      }
+      else if (r[i][0]->label == "range") {
+        QCOMPARE (r[i][1]->label, string ("all"));
+        sawRange= true;
+      }
+      else if (r[i][0]->label == "last") {
+        QCOMPARE (r[i][1]->label, string ("4"));
+        sawLast= true;
+      }
+    }
+    QVERIFY (sawFile && sawFormat && sawRange && sawLast);
+  }
+  {
+    EnvHook hook ("MOGAN_TEST_PRINT_TO_FILE", "cancel");
+    tree    r= cpp_print_to_file_dialog ("out.ps", 4, false);
     QVERIFY (is_compound (r));
     QCOMPARE (N (r), 0);
   }

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -65,6 +65,19 @@ private:
                       "The latest stable version is v2026.2.6."};
 };
 
+// 打印为文件 bridge 占位：chooseSaveFile 桩（加载测试不打开原生文件框）。
+class PrintToFileStubBridge : public QObject {
+  Q_OBJECT
+
+public:
+  explicit PrintToFileStubBridge (QObject* p= nullptr) : QObject (p) {}
+
+  Q_INVOKABLE QString chooseSaveFile (const QString&, const QString&,
+                                      const QString&) {
+    return QString ();
+  }
+};
+
 // live 弹窗（FontSelector / ParagraphFormat）bridge 占位：加载阶段 QML 顶层会调
 // 一批 uiLabels/meta/currentXxx/requestXxx 取初始值，桩统一返回空（空串/空
 // list/空 map）， 仅保证文档能实例化、不验证交互语义。
@@ -220,6 +233,7 @@ private slots:
   void test_version_long_line_wraps ();
   void test_statistics_loads ();
   void test_updater_progress_loads ();
+  void test_print_to_file_loads ();
 };
 
 // 共用：构造带 closeBridge/dpScale/isDark 的 QQuickWidget，加载给定 qrc url。
@@ -284,9 +298,7 @@ TestQmlLoad::test_confirm_restart_loads () {
       QString (
           "This change requires restarting Mogan STEM to take full effect."));
   QStringList buttons;
-  buttons << "Restart"
-          << "Later"
-          << "Cancel";
+  buttons << "Restart" << "Later" << "Cancel";
   qw->rootContext ()->setContextProperty ("dialogButtons", buttons);
   qw->setSource (QUrl ("qrc:/qml/ConfirmRestart.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
@@ -297,8 +309,7 @@ TestQmlLoad::test_form_dialog_loads () {
   // FormDialog 还需 formFields/dialogButtons；注入最小占位（空表 + 默认按钮）。
   QVariantList fields;
   QStringList  buttons;
-  buttons << "OK"
-          << "Cancel";
+  buttons << "OK" << "Cancel";
   // 重新走一遍，多注入两个 context property。
   QDialog       host;
   QQuickWidget* qw= new QQuickWidget (&host);
@@ -409,6 +420,54 @@ TestQmlLoad::test_updater_progress_loads () {
       "dialogMessage", QString ("Downloading the update..."));
   qw->setSource (QUrl ("qrc:/qml/UpdaterProgress.qml"));
   QCOMPARE (qw->status (), QQuickWidget::Ready);
+}
+
+void
+TestQmlLoad::test_print_to_file_loads () {
+  // PrintToFile 需要 closeBridge + printBridge + printDefaults +
+  // dialogButtons + 各标签文案；加载层面验证文档实例化与默认值透传。
+  QVariantMap defaults;
+  defaults["file"]  = QString ("document.ps");
+  defaults["format"]= QString ("postscript");
+  defaults["range"] = QString ("all");
+  defaults["first"] = QString ("1");
+  defaults["last"]  = QString ("4");
+
+  QDialog       host;
+  QQuickWidget* qw= new QQuickWidget (&host);
+  qw->setResizeMode (QQuickWidget::SizeRootObjectToView);
+  StubBridge* closeBridge= new StubBridge (qw);
+  qw->rootContext ()->setContextProperty ("closeBridge", closeBridge);
+  qw->rootContext ()->setContextProperty ("dpScale", 1.0);
+  qw->rootContext ()->setContextProperty ("isDark", false);
+  PrintToFileStubBridge* printBridge= new PrintToFileStubBridge (qw);
+  qw->rootContext ()->setContextProperty ("printBridge", printBridge);
+  qw->rootContext ()->setContextProperty ("printDefaults", defaults);
+  qw->rootContext ()->setContextProperty ("printTitle",
+                                          QString ("Print to file"));
+  qw->rootContext ()->setContextProperty ("fileLabel", QString ("File:"));
+  qw->rootContext ()->setContextProperty ("formatLabel", QString ("Format:"));
+  qw->rootContext ()->setContextProperty ("pagesLabel", QString ("Pages:"));
+  qw->rootContext ()->setContextProperty ("allPagesLabel",
+                                          QString ("All pages"));
+  qw->rootContext ()->setContextProperty ("pageRangeLabel",
+                                          QString ("Page range"));
+  qw->rootContext ()->setContextProperty ("fromLabel", QString ("From"));
+  qw->rootContext ()->setContextProperty ("toLabel", QString ("To"));
+  qw->rootContext ()->setContextProperty ("browseLabel", QString ("Browse"));
+  qw->rootContext ()->setContextProperty ("dialogButtons",
+                                          QStringList{"Print", "Cancel"});
+  qw->setSource (QUrl ("qrc:/qml/PrintToFile.qml"));
+  QCOMPARE (qw->status (), QQuickWidget::Ready);
+  QCOMPARE (qw->rootObject ()->property ("fileName").toString (),
+            QString ("document.ps"));
+  QCOMPARE (qw->rootObject ()->property ("pageCount").toInt (), 4);
+  QCOMPARE (qw->rootObject ()->property ("range").toString (), QString ("all"));
+  const QVariantList buttonLabels=
+      qw->rootObject ()->property ("buttonLabels").toList ();
+  QCOMPARE (buttonLabels.size (), 2);
+  QCOMPARE (buttonLabels[0].toString (), QString ("Print"));
+  QCOMPARE (buttonLabels[1].toString (), QString ("Cancel"));
 }
 
 void


### PR DESCRIPTION
Closes #4142

## What
将「打印为文件」交互（emacs 键位 C-F4 / M-S-F4，当前 main 上这两组键的唯一定义处）重构为单一 QML 对话框：输出文件名（Browse 调系统保存对话框，返回后重新激活宿主窗口）、PDF / PostScript 格式切换（扩展名自动同步）、全部页面 / 页面范围（范围校验 1..页数，非法输入显示错误并阻止提交）。**按题目要求保留菜单「打印为文件」入口原有的系统保存框交互，QML 对话框仅接入快捷键。**

## 修复的两个缺陷
- 非 ASCII 输出路径传递：结果 `file` 字段走 `from_qstring_utf8`（其余字段常规转换），匹配 `choose-file` 的 `system->url`，中文文件名不再被 Cork 转换破坏
- 打印失败仍提示 "Done printing"：`edit_main.cpp` 的 `print_to_file` 按输出文件是否存在区分提示

## How
- 独立 `PrintToFileBridge` 承载原生保存框（打印领域交互不进通用 bridge）；Scheme 侧 `print-to-file-dialog-value` 按 key 查值（不依赖 QVariantMap 迭代顺序）、`dispatch-print-to-file-result` 分发 all/range 到既有 `print-to-file` / `print-pages-to-file`
- 测试钩子 `MOGAN_TEST_PRINT_TO_FILE=ok|cancel`；另含一个 debug 构建（loro 关闭）的链接错误修复：`edit_modify.cpp` 的 loro 回调补 `#ifdef LORO_ENABLED` 守卫（release/releasedbg 因优化剔除死代码未暴露）

## Tests
- `QT_QPA_PLATFORM=offscreen xmake r qml_load_test`：17 passed（含 `test_print_to_file_loads`：Ready、默认值透传）
- `QT_QPA_PLATFORM=offscreen xmake r qml_dialog_test`：15 passed（含 ok/cancel 钩子契约）
- `xmake r print-widgets-test`：27 checks passed（含 dialog-value 查找与 all/range 分发两个新 regtest）
- headless 端到端：scheme 调用 `cpp-print-to-file-dialog` 返回完整 tuple
- GUI 手工验收：C-F4 对话框各字段 / 校验 / Esc 取消；M-S-F4 默认选中页面范围

## 提交前最后核对（已替你确认）

- ✅ 两分支远端 SHA 与本地一致（2084= `edf80cf84`，2085= `434fbe82e`）
- ✅ 每个分支首提交都是 `devel/` 任务文档，提交信息 `[编号] 简述` 格式
- ✅ 测试全绿（32 项 C++ + 27 项 scheme）
- ✅ curl 的 `dl` 本地改动未混入任何提交（还在工作区，不影响 PR）
- 2084 分支里「菜单接线→按题目回退」两个提交是历史轨迹，PR 的 Files Changed 只显示净差异（即最终状态），不影响 review