### PR TITLE
[0948] 修复 Windows 下启动页最近文档移除无反应

### DIFF
--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
@@ -1,0 +1,67 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : tm-dialogue-test.scm
+;; DESCRIPTION : recent-files 路径归一的纯逻辑单元测试（不弹 GUI，headless 可跑）
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (kernel texmacs tm-dialogue-test)
+  (:use (kernel texmacs tm-dialogue))
+) ;texmacs-module
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for recent-files-canonical-path
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Windows 下 scheme 侧 url->system 记录 '\' 分隔，C++ 启动页
+;; QDir::fromNativeSeparators 传入 '/' 分隔；归一必须消除该差异，
+;; 否则 recent-files-remove-by-path 按路径移除失效（任务 0948 回归）。
+
+(define (test-canonical-path-win-separators)
+  (when (os-windows?)
+    (check (recent-files-canonical-path "C:/Users/a b/x.tmu")
+      => "C:\\Users\\a b\\x.tmu")
+    (check (recent-files-canonical-path "C:\\Users\\a b\\x.tmu")
+      => "C:\\Users\\a b\\x.tmu")
+    ;; 含中文与空格的真实路径
+    (check (recent-files-canonical-path "C:/Users/测试 文件/x.tmu")
+      => "C:\\Users\\测试 文件\\x.tmu")
+  ) ;when
+) ;define
+
+;; tmfs://（云端文档等虚拟路径）无盘符归一，往返后须原样保持。
+
+(define (test-canonical-path-tmfs)
+  (check (recent-files-canonical-path "tmfs://collab/8fc7bec4-f069-458f-8578-8fabcd4696a2")
+    => "tmfs://collab/8fc7bec4-f069-458f-8578-8fabcd4696a2")
+  (check (recent-files-canonical-path "tmfs://aux/test") => "tmfs://aux/test")
+) ;define
+
+;; 非 Windows 下 '/' 即系统分隔符，绝对路径归一幂等。
+
+(define (test-canonical-path-unix-idempotent)
+  (when (not (os-windows?))
+    (check (recent-files-canonical-path "/home/u/a b.tm") => "/home/u/a b.tm")
+  ) ;when
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test entry point
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (regtest-tm-dialogue)
+  (test-canonical-path-win-separators)
+  (test-canonical-path-tmfs)
+  (test-canonical-path-unix-idempotent)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
@@ -30,20 +30,29 @@
 (define (test-canonical-path-win-separators)
   (when (os-windows?)
     (check (recent-files-canonical-path "C:/Users/a b/x.tmu")
-      => "C:\\Users\\a b\\x.tmu")
+      =>
+      "C:\\Users\\a b\\x.tmu"
+    ) ;check
     (check (recent-files-canonical-path "C:\\Users\\a b\\x.tmu")
-      => "C:\\Users\\a b\\x.tmu")
+      =>
+      "C:\\Users\\a b\\x.tmu"
+    ) ;check
     ;; 含中文与空格的真实路径
     (check (recent-files-canonical-path "C:/Users/测试 文件/x.tmu")
-      => "C:\\Users\\测试 文件\\x.tmu")
+      =>
+      "C:\\Users\\测试 文件\\x.tmu"
+    ) ;check
   ) ;when
 ) ;define
 
 ;; tmfs://（云端文档等虚拟路径）无盘符归一，往返后须原样保持。
 
 (define (test-canonical-path-tmfs)
-  (check (recent-files-canonical-path "tmfs://collab/8fc7bec4-f069-458f-8578-8fabcd4696a2")
-    => "tmfs://collab/8fc7bec4-f069-458f-8578-8fabcd4696a2")
+  (check (recent-files-canonical-path "tmfs://collab/8fc7bec4-f069-458f-8578-8fabcd4696a2"
+         ) ;recent-files-canonical-path
+    =>
+    "tmfs://collab/8fc7bec4-f069-458f-8578-8fabcd4696a2"
+  ) ;check
   (check (recent-files-canonical-path "tmfs://aux/test") => "tmfs://aux/test")
 ) ;define
 

--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
@@ -393,16 +393,27 @@
 
 
 
+;; 路径归一为 url->system 规范形后再比较。Windows 下写入方分隔符不统一：
+;; scheme 侧 url->system 记录 '\'，C++ 启动页 QDir::fromNativeSeparators 传入
+;; '/'，裸字符串 equal? 会失配（如按路径移除失效）。经 system->url →
+;; url->system 往返统一分隔符；tmfs:// 等非 default 根的 URL 往返后原样保持。
+(define-public (recent-files-canonical-path p) (url->system (system->url p)))
+
 (define (recent-files-index-by-path recent-files path)
-  (let-njson ((files (njson-ref recent-files "files")))
-    (let loop
-      ((i 0))
-      (if (>= i (njson-size files))
-        #f
-        (if (equal? (njson-ref files i "path") path) i (loop (+ i 1)))
-      ) ;if
-    ) ;let
-  ) ;let-njson
+  (let* ((key (recent-files-canonical-path path)))
+    (let-njson ((files (njson-ref recent-files "files")))
+      (let loop
+        ((i 0))
+        (if (>= i (njson-size files))
+          #f
+          (if (equal? (recent-files-canonical-path (njson-ref files i "path")) key)
+            i
+            (loop (+ i 1))
+          ) ;if
+        ) ;if
+      ) ;let
+    ) ;let-njson
+  ) ;let*
 ) ;define
 
 (define (recent-files-paths recent-files)

--- a/devel/0948.md
+++ b/devel/0948.md
@@ -1,0 +1,39 @@
+# [0948] 修复 Windows 下启动页最近文档移除无反应
+
+## 如何测试
+
+1. 编译：`xmake b stem`（如需更新安装产物再 `xmake install stem`）。
+2. 纯逻辑回归：`xmake r tm-dialogue-test`（headless，校验路径归一）。
+3. 手工验收（Windows）：
+   - 启动 Mogan，打开启动页「最近文档」；
+   - 右键某个本地文档（路径含空格/中文更佳），点击「从列表移除」；
+   - 该条目应立即从列表消失，重启后也不出现；
+   - 文件菜单 **文件 -> 最近使用** 中对应条目同步消失；
+   - 「清空列表」与云端文档（tmfs://）移除行为不变。
+
+## What
+
+修复 Windows 下启动页「最近文档」右键「从列表移除」点击后无任何反应的问题。
+
+## Why
+
+最近文件路径存在两套分隔符形式：
+
+- Scheme 侧 `url->system` 记录的是系统原生形式（Windows 为 `\`，如 `C:\Users\a b\x.tmu`）；
+- C++ 启动页 `QTMHomePage::loadRecentDocs` 用 `QDir::fromNativeSeparators` 把路径统一成 `/` 后再存入列表，移除时把这个 `/` 形式路径传给 `startup-tab-clear-recent-doc`。
+
+而 `recent-files-remove-by-path` 依赖 `recent-files-index-by-path` 用裸字符串 `equal?` 查找，两种形式在 Windows 上不相等，查找落空导致什么都没删；随后 `refreshRecentDocs()` 又从 Scheme 侧内存状态重建列表，被"移除"的条目原样回来，表现为点击无反应。macOS/Linux 上系统分隔符就是 `/`，两种形式天然一致，故仅 Windows 受影响；云端文档（`tmfs://`）路径不含盘符分隔符差异，也不受影响。
+
+同一失配还影响 `recent-files-learn` 的按路径去重（0943 的菜单去重是在读取侧绕过该问题）。
+
+## How
+
+在 `tm-dialogue.scm` 新增 `recent-files-canonical-path`：经 `system->url` → `url->system` 往返把路径归一为 `url->system` 规范形（Windows 下 `/` 与 `\` 统一为 `\`；`tmfs://` 等非 default 根的 URL 往返后原样保持）。`recent-files-index-by-path` 改为对存储条目路径与查找路径两侧都先归一再比较。该函数是移除、按路径取 name、新增去重、旧数据导入的公共查找入口，单点修复即覆盖全部调用方；各调用方传入的形式不再需要约定一致。
+
+新增纯逻辑测试 `tm-dialogue-test.scm`（headless）：Windows 下正/反斜杠形式归一到同一规范形（含中文与空格路径）、tmfs 路径保持不变、非 Windows 幂等。
+
+## 涉及文件
+
+- `TeXmacs/progs/kernel/texmacs/tm-dialogue.scm`：新增 `recent-files-canonical-path`，`recent-files-index-by-path` 改为归一后比较。
+- `TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm`：新增路径归一回归测试。
+- `devel/0948.md`：任务说明与测试步骤。


### PR DESCRIPTION
## 问题

Windows 下启动页「最近文档」右键「从列表移除」点击后没有任何反应；macOS/Linux 不受影响，云端文档（tmfs://）不受影响。

任务文档：`devel/0948.md`

## 根因

最近文件路径存在两套分隔符形式：

- Scheme 侧 `url->system` 记录系统原生形式（Windows 为 `\`）；
- C++ 启动页 `QTMHomePage::loadRecentDocs` 用 `QDir::fromNativeSeparators` 统一为 `/` 后存入列表，移除时把 `/` 形式路径传给 `startup-tab-clear-recent-doc`。

`recent-files-index-by-path` 用裸字符串 `equal?` 查找，两种形式在 Windows 上不相等 → 移除落空 → `refreshRecentDocs()` 又从 Scheme 内存态重建列表，被「移除」的条目原样回来。同一失配也会使 `recent-files-learn` 的按路径去重失效（0943 的菜单去重是在读取侧绕过该问题）。

## 修复

- `tm-dialogue.scm` 新增 `recent-files-canonical-path`：经 `system->url` → `url->system` 往返归一为规范形（Windows 下 `/`、`\` 统一为 `\`；`tmfs://` 等非 default 根的 URL 往返后原样保持）；
- `recent-files-index-by-path` 对存储条目路径与查找路径两侧先归一再比较。该函数是移除、按路径取 name、新增去重、旧数据导入的公共查找入口，单点修复即覆盖全部调用方，各调用方传入形式不再需要约定一致。

## 测试

新增 headless 纯逻辑回归 `tm-dialogue-test`（`TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm`）：

- Windows 下正/反斜杠形式归一到同一规范形（含中文与空格路径）；
- `tmfs://` 虚拟路径保持不变；
- 非 Windows 下绝对路径归一幂等。

```bash
xmake r tm-dialogue-test
```

Windows 实测：`5 correct, 0 failed`。

## 手工验收

1. 启动页「最近文档」右键本地文档（路径含空格/中文更佳）→「从列表移除」→ 条目应立即消失，重启后也不出现；
2. 文件 → 最近使用 中对应条目同步消失；
3. 「清空列表」与云端文档移除行为不变。

## 涉及文件

- `TeXmacs/progs/kernel/texmacs/tm-dialogue.scm`
- `TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm`
- `devel/0948.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
