### PR TITLE
[0949] 修复 win 下复制/剪切/粘贴快捷键显示错误

### DIFF
--- a/TeXmacs/plugins/gnome/progs/init-gnome.scm
+++ b/TeXmacs/plugins/gnome/progs/init-gnome.scm
@@ -67,6 +67,17 @@
     ("structured:cmd right" (kbd-select-if-active traverse-right))
   ) ;kbd-map
 
+  ;; C-insert/S-insert/S-delete/F16/F18/F20 等传统备用键注册晚于 generic-kbd 的
+  ;; std 主键，而菜单快捷键反查（kbd-find-inv-binding）按后注册先出取键，会把
+  ;; 复制/剪切/粘贴显示成 Ctrl+Ins/Shift+Del/Shift+Ins（或 F16/F18/F20）。这里
+  ;; 重绑 std 主键把 C-c/C-x/C-v 顶回队首；std v/std V 的偏好分支须与
+  ;; generic-kbd.scm 的 kbd-apply-magic-paste-shortcut 保持一致。
+  (kbd-map (:profile gnome) ("std c" (kbd-copy)) ("std x" (kbd-cut)))
+  (if (== (get-preference "magic-paste-shortcut") "ctrl+v")
+    (kbd-map ("std v" (kbd-magic-paste)) ("std V" (kbd-paste)))
+    (kbd-map ("std v" (kbd-paste)) ("std V" (kbd-magic-paste)))
+  ) ;if
+
   (kbd-map (:profile gnome)
     (:require (and (not (in-prog?)) (not (in-verbatim?))))
     ("M-space" (make-space "0.2spc"))

--- a/TeXmacs/plugins/kde/progs/init-kde.scm
+++ b/TeXmacs/plugins/kde/progs/init-kde.scm
@@ -63,6 +63,17 @@
     ("structured:cmd right" (kbd-select-if-active traverse-right))
   ) ;kbd-map
 
+  ;; C-insert/S-insert/S-delete/F16/F18/F20 等传统备用键注册晚于 generic-kbd 的
+  ;; std 主键，而菜单快捷键反查（kbd-find-inv-binding）按后注册先出取键，会把
+  ;; 复制/剪切/粘贴显示成 Ctrl+Ins/Shift+Del/Shift+Ins（或 F16/F18/F20）。这里
+  ;; 重绑 std 主键把 C-c/C-x/C-v 顶回队首；std v/std V 的偏好分支须与
+  ;; generic-kbd.scm 的 kbd-apply-magic-paste-shortcut 保持一致。
+  (kbd-map (:profile kde) ("std c" (kbd-copy)) ("std x" (kbd-cut)))
+  (if (== (get-preference "magic-paste-shortcut") "ctrl+v")
+    (kbd-map ("std v" (kbd-magic-paste)) ("std V" (kbd-paste)))
+    (kbd-map ("std v" (kbd-paste)) ("std V" (kbd-magic-paste)))
+  ) ;if
+
   (kbd-map (:profile kde)
     (:require (and (not (in-prog?)) (not (in-verbatim?))))
     ("M-space" (make-space "0.2spc"))

--- a/TeXmacs/plugins/windows/progs/init-windows.scm
+++ b/TeXmacs/plugins/windows/progs/init-windows.scm
@@ -131,6 +131,17 @@
     ("C-P" (toggle-preamble-mode))
   ) ;kbd-map
 
+  ;; C-insert/S-insert/S-delete 等传统备用键注册晚于 generic-kbd 的 std 主键，
+  ;; 而菜单快捷键反查（kbd-find-inv-binding）按后注册先出取键，会把复制/剪切/
+  ;; 粘贴显示成 Ctrl+Ins/Shift+Del/Shift+Ins。这里重绑 std 主键把 C-c/C-x/C-v
+  ;; 顶回队首；std v/std V 的偏好分支须与 generic-kbd.scm 的
+  ;; kbd-apply-magic-paste-shortcut 保持一致。
+  (kbd-map (:profile windows) ("std c" (kbd-copy)) ("std x" (kbd-cut)))
+  (if (== (get-preference "magic-paste-shortcut") "ctrl+v")
+    (kbd-map ("std v" (kbd-magic-paste)) ("std V" (kbd-paste)))
+    (kbd-map ("std v" (kbd-paste)) ("std V" (kbd-magic-paste)))
+  ) ;if
+
   (kbd-map (:profile windows)
     (:require (and (not (in-prog?)) (not (in-verbatim?))))
     ("M-space" (make-space "0.2spc"))

--- a/TeXmacs/tests/0949.scm
+++ b/TeXmacs/tests/0949.scm
@@ -1,0 +1,100 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 0949.scm
+;; DESCRIPTION : 回归测试：win/gnome/kde 外观下复制/剪切/粘贴菜单快捷键显示。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   [0949] 修复 Windows（含 gnome/kde 外观）下「编辑」菜单把复制/剪切/粘贴
+;;   显示成 Ctrl+Ins/Shift+Del/Shift+Ins 的问题。根因：init-windows/gnome/kde
+;;   注册的传统备用键（C-insert/S-insert/S-delete，kde/gnome 另有 F16/F18/F20）
+;;   晚于 generic-kbd 的 std 主键，而菜单快捷键反查 kbd-find-inv-binding 按
+;;   后注册先出取键，备用键顶掉了 C-c/C-x/C-v 的显示。修复：三个 LAF 插件在
+;;   备用键之后重绑 std 主键。本测试钉死（任一条回退都会红）：
+;;     1. std 外观（windows/gnome/kde）下，反查 (kbd-copy)/(kbd-cut)/(kbd-paste)
+;;        得 "C-c"/"C-x"/"C-v"（Qt 菜单据此显示 Ctrl+C/Ctrl+X/Ctrl+V）。
+;;     2. 传统备用键仍有效：C-insert→kbd-copy、S-insert→kbd-paste、
+;;        S-delete→kbd-cut（按键行为不回归）。
+;;     3. 任意外观下，三个命令的反查结果都不得落回备用键（防其它外观回归）。
+;;
+;; USAGE
+;;   xmake b stem && xmake install stem
+;;   MOGAN_TEST_GUI=1 xmake r 0949
+;;
+;; 注意：断言在异步链里，必须 MOGAN_TEST_GUI=1 才执行——headless 模式（xmake r
+;; 0949）启动即 (quit-TeXmacs)，异步链来不及调度，断言不跑（仅冒烟进程不崩）。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory of this file.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(check-set-mode! 'report-failed)
+
+;; 异步步长：只查键盘表（无排版/动画等待），500ms 足够 Qt 事件循环调度。
+
+(define step-delay-ms 500)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[0949-step] ")
+                           (display label)
+                           (newline)
+                           (act)
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+;; std 外观 = 使用 Ctrl 系 std 主键的三种 look and feel（emacs 用 A-/M- 系、
+;; macos 用 M- 系，均无备用键顶替问题，只跑第 3 组断言）。
+
+(define (std-laf?)
+  (or (like-windows?) (like-gnome?) (like-kde?))
+) ;define
+
+;; 传统备用键集合：历史上会顶掉 std 主键显示的键（含 kde/gnome 的 F16/F18/F20）。
+
+(define legacy-alt-keys '("C-insert" "S-insert" "S-delete" "F16" "F18" "F20"))
+
+(tm-define (test_0949)
+  (run-chain (list
+               ;; 先强制排空插件与键盘的惰性加载，断言面对确定性的最终表状态。
+               (cons "force lazy plugins/keyboard, assert inv bindings + alt keys"
+                 (lambda ()
+                   (lazy-plugin-force)
+                   (lazy-keyboard-force #t)
+                   (kbd-flush-pending)
+                   ;; 1 std 外观：反查必须得 std 主键（Qt 菜单显示 Ctrl+C/Ctrl+X/Ctrl+V）。
+                   (when (std-laf?)
+                     (check (kbd-find-inv-binding '(kbd-copy)) => "C-c")
+                     (check (kbd-find-inv-binding '(kbd-cut)) => "C-x")
+                     (check (kbd-find-inv-binding '(kbd-paste)) => "C-v")
+                   ) ;when
+                   ;; 2 传统备用键仍然有效（get-kbd-bindings 首项为 (条件 命令 帮助) 三元组）。
+                   (when (std-laf?)
+                     (check-true (equal? (cadr (car (get-kbd-bindings "C-insert"))) '(kbd-copy)))
+                     (check-true (equal? (cadr (car (get-kbd-bindings "S-insert"))) '(kbd-paste)))
+                     (check-true (equal? (cadr (car (get-kbd-bindings "S-delete"))) '(kbd-cut)))
+                   ) ;when
+                   ;; 3 任意外观：反查结果不得落回备用键。
+                   (check-true (not (member (kbd-find-inv-binding '(kbd-copy)) legacy-alt-keys)))
+                   (check-true (not (member (kbd-find-inv-binding '(kbd-cut)) legacy-alt-keys)))
+                   (check-true (not (member (kbd-find-inv-binding '(kbd-paste)) legacy-alt-keys)))
+                 ) ;lambda
+               ) ;cons
+               (cons "report + quit" (lambda () (check-report) (quit-TeXmacs)))
+             ) ;list
+  ) ;run-chain
+) ;tm-define

--- a/devel/0949.md
+++ b/devel/0949.md
@@ -1,0 +1,116 @@
+# [0949] 修复 win 下复制/剪切/粘贴快捷键显示错误
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0394.md](0394.md) - 魔法粘贴快捷键显示 bug（同一条菜单反查链路的前作）
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/windows/progs/init-windows.scm` - 传统备用键之后重绑 std c/x，
+  并按魔法粘贴偏好重绑 std v/std V
+- `TeXmacs/plugins/gnome/progs/init-gnome.scm` - 同上（gnome 外观，备用键另含
+  F16/F18/F20 与 gnome c/v/x）
+- `TeXmacs/plugins/kde/progs/init-kde.scm` - 同上（kde 外观，备用键另含 F16/F18/F20）
+- `TeXmacs/tests/0949.scm` - GUI 集成回归测试
+
+## 3 如何测试
+
+### 3.1 确定性测试（集成测试）
+
+```bash
+xmake b stem && xmake install stem
+MOGAN_TEST_GUI=1 xmake r 0949
+```
+
+断言（异步链内，需 `MOGAN_TEST_GUI=1`；headless 仅冒烟）：
+1. std 外观（windows/gnome/kde）下 `kbd-find-inv-binding` 反查
+   `(kbd-copy)/(kbd-cut)/(kbd-paste)` 得 `"C-c"/"C-x"/"C-v"`；
+2. 传统备用键仍有效：`C-insert→kbd-copy`、`S-insert→kbd-paste`、`S-delete→kbd-cut`；
+3. 任意外观下反查结果不得落回备用键集合（含 F16/F18/F20）。
+
+### 3.2 非确定性测试（手工验证）
+
+1. Windows 下启动 Mogan STEM，打开「编辑」菜单：
+   - 复制显示 `Ctrl+C`（修复前 `Ctrl+Ins`）
+   - 剪切显示 `Ctrl+X`（修复前 `Shift+Del`）
+   - 粘贴显示 `Ctrl+V`（修复前 `Shift+Ins`）
+   - 魔法粘贴仍显示 `Ctrl+Shift+V`
+2. 按键行为不回归：`Ctrl+C/X/V` 复制/剪切/粘贴正常；`Ctrl+Insert`、
+   `Shift+Insert`、`Shift+Delete` 三个传统备用键仍可用。
+3. Linux（gnome/kde 桌面会话）与 macOS 外观不受影响（macOS 复制仍显示 ⌘C）。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main          # 格式化变更的 .scm
+xmake b stem                          # 主项目构建
+```
+
+按 CLAUDE.md：第一个 commit 新建本任务文档，后续 commit 为代码改动；提交信息格式 `[0949] 简述`。
+
+## 5 What
+
+三个 look-and-feel 插件（windows/gnome/kde）在各自的传统备用键 kbd-map 之后，
+追加一段 std 主键重绑：
+
+```scheme
+(kbd-map (:profile windows)
+  ("std c" (kbd-copy))
+  ("std x" (kbd-cut)))
+(if (== (get-preference "magic-paste-shortcut") "ctrl+v")
+  (kbd-map ("std v" (kbd-magic-paste)) ("std V" (kbd-paste)))
+  (kbd-map ("std v" (kbd-paste)) ("std V" (kbd-magic-paste))))
+```
+
+## 6 Why
+
+### 6.1 问题现象
+
+Windows 下「编辑」菜单中复制/剪切/粘贴显示为 `Ctrl+Ins`/`Shift+Del`/`Shift+Ins`，
+而实际生效的主快捷键是 `Ctrl+C`/`Ctrl+X`/`Ctrl+V`（按键行为正确，仅显示错误）。
+
+### 6.2 根因
+
+菜单快捷键列来自 `kbd-find-shortcut` → `kbd-find-inv-binding`（`kbd-define.scm`）：
+按命令反查按键，`ctx-resolve` 取反查上下文列表中第一条可解析项，而
+`ctx-insert` 是前插——**后注册的绑定先被查出**。
+
+`(kbd-copy)` 同时绑在两处：
+- generic-kbd.scm 的 `("std c" (kbd-copy))`（经 `std→C-` 前置通配改写为 `C-c`）；
+- init-windows.scm 的 `("C-insert" (kbd-copy))`（Windows 传统备用键，gnome/kde
+  同理，另有 F16/F18/F20 与 gnome c/v/x）。
+
+启动时 generic-kbd 先加载，LAF 插件（lazy-plugin-initialize）后加载，于是
+`C-insert` 后注册、排在反查表队首，菜单就显示了备用键。emacs 外观无此问题
+（`emacs:meta w` 晚于 `emacs insert` 注册，队首恰是主键），macos 外观无备用键。
+
+### 6.3 为什么不删备用键、不改反查顺序
+
+- 删除 `C-insert/S-insert/S-delete` 绑定会改变按键行为（0394 的测试清单明确
+  要求 `S-insert` 等入口保持可用），超出"仅修显示"的任务范围；
+- 反查表的前插顺序同时承担"后绑定覆盖先绑定"的语义（快捷键编辑器改绑后新键
+  必须在菜单上显示为快捷键），改成后插或过滤都会破坏该语义；
+- 因此在声明侧解决：插件在注册完备用键之后立即重绑一遍 std 主键，`kbd-map`
+  对同键同条件的绑定是先删后插（`kbd-insert-key-binding`），重绑会把
+  `C-c/C-x/C-v` 移回反查表队首。该做法与注册顺序无关：无论插件先于还是后于
+  generic-kbd 加载，std 主键最终都在队首。
+
+### 6.4 为什么 std v 不直接写死、要按偏好分支
+
+`std v`/`std V` 按魔法粘贴偏好（0392/0394）绑向 `kbd-paste` 或 `kbd-magic-paste`，
+不能无条件写死。插件文件可能先于 generic-kbd 加载（插件加载顺序按哈希表遍历，
+不保证先后），直接调用 generic-kbd 的 `kbd-apply-magic-paste-shortcut` 有未定义
+风险，故内联同一偏好分支，并以注释标明两处须保持一致。
+
+## 7 How
+
+1. `init-windows.scm`：主 kbd-map 之后追加 `(:profile windows)` 的 std c/x 重绑
+   与 magic-paste 偏好分支（std v/std V）。
+2. `init-gnome.scm`、`init-kde.scm`：同样处理（profile 分别为 gnome/kde）。
+3. `TeXmacs/tests/0949.scm`：GUI 集成测试钉死反查结果与备用键行为。
+
+验证方式（Windows 本机，未重新构建，用已安装二进制 headless 加载仓库内改后
+的 init-windows.scm）：修复前反查 `copy="C-insert" cut="S-delete" paste="S-insert"`，
+加载修复后 `copy="C-c" cut="C-x" paste="C-v"`，`kbd-magic-paste` 仍反查 `C-V`，
+`C-insert/S-insert/S-delete` 三个备用键绑定保持不变；两种加载顺序下结果一致。


### PR DESCRIPTION
## 问题现象

Windows 下「编辑」菜单中复制/剪切/粘贴的快捷键列显示为 `Ctrl+Ins` / `Shift+Del` / `Shift+Ins`，而实际生效的主快捷键是 `Ctrl+C` / `Ctrl+X` / `Ctrl+V`（按键行为正确，仅显示错误）。

## 根因

菜单快捷键列通过 `kbd-find-inv-binding` 按命令反查按键：反查表 `ctx-insert` 前插、`ctx-resolve` 取第一条，即**后注册的绑定先被显示**。

`(kbd-copy)` 同时绑在两处：

- `generic-kbd.scm` 的 `("std c" (kbd-copy))`（经 `std→C-` 通配改写为 `C-c`，启动早期加载）
- `init-windows.scm` 的 `("C-insert" (kbd-copy))`（Windows 传统备用键，LAF 插件晚加载）

备用键后注册、排到反查表队首，菜单随之显示备用键。gnome/kde 外观同理（另有 F16/F18/F20 与 `gnome c/v/x`）；emacs（`A-w` 恰好后注册）与 macOS（无备用键）不受影响。

## 修复方案

三个 LAF 插件（windows/gnome/kde）在传统备用键之后重绑一遍 std 主键：`kbd-map` 对同键同条件的绑定是先删后插，重绑把 `C-c/C-x/C-v` 移回反查表队首。

- 与插件/generic-kbd 的加载先后无关，两种顺序下结果一致
- 不删除备用键：`Ctrl+Insert`、`Shift+Insert`、`Shift+Delete` 入口保持可用（0394 的约束）
- 不改反查表的覆盖语义：快捷键编辑器改绑后新键仍即时显示
- `std v/std V` 按魔法粘贴偏好（0392/0394）分支重绑

## 测试

新增 GUI 集成回归测试 `TeXmacs/tests/0949.scm`（`MOGAN_TEST_GUI=1 xmake r 0949`）：

1. std 外观（windows/gnome/kde）下反查 `(kbd-copy)/(kbd-cut)/(kbd-paste)` 必须得 `C-c/C-x/C-v`
2. 传统备用键仍有效：`C-insert→kbd-copy`、`S-insert→kbd-paste`、`S-delete→kbd-cut`
3. 任意外观下反查结果不得落回备用键集合（含 F16/F18/F20）

本机验证（Windows，LAF=windows，headless 复跑测试断言逻辑 6/6 PASS）：修复前反查 `C-insert/S-delete/S-insert`，修复后 `C-c/C-x/C-v`；`kbd-magic-paste` 仍反查 `C-V`（Ctrl+Shift+V）；备用键绑定不变。

## 手工验收

1. Windows 启动 Mogan STEM，「编辑」菜单：复制 `Ctrl+C`、剪切 `Ctrl+X`、粘贴 `Ctrl+V`、魔法粘贴 `Ctrl+Shift+V`
2. `Ctrl+Insert`、`Shift+Insert`、`Shift+Delete` 三个传统备用键仍可用
3. Linux（gnome/kde 会话）与 macOS 的快捷键显示不受影响
