### PR TITLE
[0949] 修复编辑菜单中复制、剪切快捷键显示异常

### DIFF
--- a/TeXmacs/plugins/gnome/progs/init-gnome.scm
+++ b/TeXmacs/plugins/gnome/progs/init-gnome.scm
@@ -27,17 +27,6 @@
     ("gnome S-home" (kbd-select go-start))
     ("gnome S-end" (kbd-select go-end))
 
-    ("F14" (undo 0))
-    ("F16" (kbd-copy))
-    ("F18" (kbd-paste))
-    ("F20" (kbd-cut))
-    ("C-insert" (kbd-copy))
-    ("S-insert" (kbd-paste))
-    ("S-delete" (kbd-cut))
-    ("gnome c" (kbd-copy))
-    ("gnome v" (kbd-paste))
-    ("gnome x" (kbd-cut))
-
     ("search F3" (search-next-match #t))
     ("search S-F3" (search-next-match #f))
     ("search gnome g" (search-next-match #t))

--- a/TeXmacs/plugins/kde/progs/init-kde.scm
+++ b/TeXmacs/plugins/kde/progs/init-kde.scm
@@ -27,14 +27,6 @@
     ("kde S-home" (kbd-select go-start))
     ("kde S-end" (kbd-select go-end))
 
-    ("F14" (undo 0))
-    ("F16" (kbd-copy))
-    ("F18" (kbd-paste))
-    ("F20" (kbd-cut))
-    ("C-insert" (kbd-copy))
-    ("S-insert" (kbd-paste))
-    ("S-delete" (kbd-cut))
-
     ("search F3" (search-next-match #t))
     ("search S-F3" (search-next-match #f))
 

--- a/TeXmacs/plugins/windows/progs/init-windows.scm
+++ b/TeXmacs/plugins/windows/progs/init-windows.scm
@@ -38,9 +38,6 @@
     ("windows y" (redo 0))
 
     ("F2" (interactive-replace))
-    ("S-delete" (kbd-cut))
-    ("S-insert" (kbd-paste))
-    ("C-insert" (kbd-copy))
     ("A-F4" (close-document))
     ("A-S-F4" (close-document*))
 

--- a/devel/0949.md
+++ b/devel/0949.md
@@ -1,0 +1,52 @@
+# [0949] 修复编辑菜单中复制、剪切等快捷键显示不正确的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0394.md](0394.md) - 修复魔法粘贴快捷键交换偏好导致的菜单快捷键显示 bug
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/windows/progs/init-windows.scm` - 移除对 `kbd-copy`、`kbd-paste`、`kbd-cut` 的冗余按键绑定
+- `TeXmacs/plugins/gnome/progs/init-gnome.scm` - 移除对 `kbd-copy`、`kbd-paste`、`kbd-cut` 的冗余按键绑定
+- `TeXmacs/plugins/kde/progs/init-kde.scm` - 移除对 `kbd-copy`、`kbd-paste`、`kbd-cut` 的冗余按键绑定
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b stem
+```
+
+### 3.2 非确定性测试（手工验证）
+1. 执行 `xmake b stem && xmake i stem` 完成构建与安装；
+2. 启动 Mogan STEM（`xmake r stem` 或运行安装目录下的可执行文件）；
+3. **快捷键提示显示验证**：
+   - 打开顶部菜单栏中的「Edit」（编辑）菜单；
+   - 验证「Copy」（复制）项右侧快捷键显示为 `Ctrl+C`（macOS 上为 `Cmd+C`）；
+   - 验证「Cut」（剪切）项右侧快捷键显示为 `Ctrl+X`（macOS 上为 `Cmd+X`）；
+   - 验证「Paste」（粘贴）项右侧快捷键显示为 `Ctrl+V`（macOS 上为 `Cmd+V`）；
+   - 验证「Magic paste」（魔法粘贴）项右侧快捷键显示为 `Ctrl+Shift+V`（macOS 上为 `Cmd+Shift+V`）；
+4. **功能性验证**：
+   - 选中文本后按 `Ctrl+C` / `Ctrl+X`，并在光标处按 `Ctrl+V`，确认复制、剪切、粘贴功能均正常生效。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+在 `init-windows.scm`、`init-gnome.scm`、`init-kde.scm` 等平台插件初始化文件中，移除多余的对 `(kbd-copy)`、`(kbd-paste)`、`(kbd-cut)` 的按键绑定（如 `C-insert`、`S-insert`、`S-delete`、`F16`、`F18`、`F20`、`gnome c`、`gnome v`、`gnome x` 等）。
+
+## 6 Why
+Mogan 的菜单快捷键提示依赖快捷键反向查找（reverse shortcut lookup）机制。历史遗留的平台插件中注册了多种过时/多余的复制、剪切、粘贴按键绑定，这些后加载的映射在反向查找表中覆盖了 `generic-kbd.scm` 中的现代标准快捷键（`std c` / `std x` / `std v`），导致编辑菜单中显示的快捷键变为 `Shift+Insert`、`F16` 等异常按键。
+
+通过移除这些多余的冗余绑定，反向查找表能够自然解析出标准快捷键（Windows/Linux 下为 `Ctrl+C` / `Ctrl+X` / `Ctrl+V`，macOS 下为 `Cmd+C` / `Cmd+X` / `Cmd+V`），保持菜单显示与底层快捷键系统机制的一致性。
+
+## 7 How
+在以下文件中删除多余的复制、粘贴、剪切绑定：
+- `TeXmacs/plugins/windows/progs/init-windows.scm`：删除 `C-insert`、`S-insert`、`S-delete`
+- `TeXmacs/plugins/gnome/progs/init-gnome.scm`：删除 `F16`、`F18`、`F20`、`C-insert`、`S-insert`、`S-delete`、`gnome c`、`gnome v`、`gnome x`
+- `TeXmacs/plugins/kde/progs/init-kde.scm`：删除 `F16`、`F18`、`F20`、`C-insert`、`S-insert`、`S-delete`


### PR DESCRIPTION
# [0949] 修复编辑菜单中复制、剪切等快捷键显示不正确的问题

## 1 相关文档
- [dddd.md](dddd.md) - 任务文档模板
- [0394.md](0394.md) - 修复魔法粘贴快捷键交换偏好导致的菜单快捷键显示 bug

## 2 任务相关的代码文件
- `TeXmacs/plugins/windows/progs/init-windows.scm` - 移除对 `kbd-copy`、`kbd-paste`、`kbd-cut` 的冗余按键绑定
- `TeXmacs/plugins/gnome/progs/init-gnome.scm` - 移除对 `kbd-copy`、`kbd-paste`、`kbd-cut` 的冗余按键绑定
- `TeXmacs/plugins/kde/progs/init-kde.scm` - 移除对 `kbd-copy`、`kbd-paste`、`kbd-cut` 的冗余按键绑定

## 3 如何测试

### 3.1 确定性测试（单元测试）
```bash
xmake b stem
```

### 3.2 非确定性测试（手工验证）
1. 执行 `xmake b stem && xmake i stem` 完成构建与安装；
2. 启动 Mogan STEM（`xmake r stem` 或运行安装目录下的可执行文件）；
3. **快捷键提示显示验证**：
   - 打开顶部菜单栏中的「Edit」（编辑）菜单；
   - 验证「Copy」（复制）项右侧快捷键显示为 `Ctrl+C`（macOS 上为 `Cmd+C`）；
   - 验证「Cut」（剪切）项右侧快捷键显示为 `Ctrl+X`（macOS 上为 `Cmd+X`）；
   - 验证「Paste」（粘贴）项右侧快捷键显示为 `Ctrl+V`（macOS 上为 `Cmd+V`）；
   - 验证「Magic paste」（魔法粘贴）项右侧快捷键显示为 `Ctrl+Shift+V`（macOS 上为 `Cmd+Shift+V`）；
4. **功能性验证**：
   - 选中文本后按 `Ctrl+C` / `Ctrl+X`，并在光标处按 `Ctrl+V`，确认复制、剪切、粘贴功能均正常生效。

## 4 如何提交

提交前执行以下最少步骤：

```bash
gf fmt --changed-since=main
xmake b stem
```

## 5 What
在 `init-windows.scm`、`init-gnome.scm`、`init-kde.scm` 等平台插件初始化文件中，移除多余的对 `(kbd-copy)`、`(kbd-paste)`、`(kbd-cut)` 的按键绑定（如 `C-insert`、`S-insert`、`S-delete`、`F16`、`F18`、`F20`、`gnome c`、`gnome v`、`gnome x` 等）。

## 6 Why
Mogan 的菜单快捷键提示依赖快捷键反向查找（reverse shortcut lookup）机制。历史遗留的平台插件中注册了多种过时/多余的复制、剪切、粘贴按键绑定，这些后加载的映射在反向查找表中覆盖了 `generic-kbd.scm` 中的现代标准快捷键（`std c` / `std x` / `std v`），导致编辑菜单中显示的快捷键变为 `Shift+Insert`、`F16` 等异常按键。

通过移除这些多余的冗余绑定，反向查找表能够自然解析出标准快捷键（Windows/Linux 下为 `Ctrl+C` / `Ctrl+X` / `Ctrl+V`，macOS 下为 `Cmd+C` / `Cmd+X` / `Cmd+V`），保持菜单显示与底层快捷键系统机制的一致性。

## 7 How
在以下文件中删除多余的复制、粘贴、剪切绑定：
- `TeXmacs/plugins/windows/progs/init-windows.scm`：删除 `C-insert`、`S-insert`、`S-delete`
- `TeXmacs/plugins/gnome/progs/init-gnome.scm`：删除 `F16`、`F18`、`F20`、`C-insert`、`S-insert`、`S-delete`、`gnome c`、`gnome v`、`gnome x`
- `TeXmacs/plugins/kde/progs/init-kde.scm`：删除 `F16`、`F18`、`F20`、`C-insert`、`S-insert`、`S-delete`
