### PR TITLE
[1251] 移除 init-windows.scm 中的 windows = 快捷键

### DIFF
--- a/TeXmacs/plugins/windows/progs/init-windows.scm
+++ b/TeXmacs/plugins/windows/progs/init-windows.scm
@@ -113,7 +113,6 @@
     ;; further shortcuts for Windows look and feel
     ("windows g" (selection-cancel))
     ("windows l" (refresh-window))
-    ("windows =" (change-zoom-factor 1.0))
 
     ("cmd q" (make 'symbol))
     ("altcmd g" (kbd-cancel))

--- a/devel/1251.md
+++ b/devel/1251.md
@@ -1,0 +1,29 @@
+# [1251] 移除 init-windows.scm 中的 windows = 快捷键
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/windows/progs/init-windows.scm`
+
+## 3 如何测试
+
+执行命令测试或验证快捷键加载正常：
+```bash
+xmake b stem && xmake r stem -headless
+```
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+在 `TeXmacs/plugins/windows/progs/init-windows.scm` 中移除 `("windows =" (change-zoom-factor 1.0))` 快捷键绑定。
+
+## 6 Why
+在常规键盘布局中，`=` 与 `+` 在同一个物理按键上，`Ctrl =` 实际上等同于 `Ctrl +`（用于视图放大）。原 `init-windows.scm` 中将 `windows =`（即 Windows 风格下的 `Ctrl =`）绑定为 `(change-zoom-factor 1.0)`，会与 `Ctrl =`（放大功能）发生键位冲突，导致视图放大（View -> Zoom in）的快捷键失效/丢失。因此需要移除 `windows =` 这一快捷键绑定。
+
+## 7 How
+编辑 `TeXmacs/plugins/windows/progs/init-windows.scm`，删除 `("windows =" (change-zoom-factor 1.0))` 这一行。


### PR DESCRIPTION
## What
在 `TeXmacs/plugins/windows/progs/init-windows.scm` 中移除 `("windows =" (change-zoom-factor 1.0))` 快捷键绑定。

## Why
在常规键盘布局中，`=` 与 `+` 在同一个物理按键上，`Ctrl =` 实际上等同于 `Ctrl +`（用于视图放大）。原 `init-windows.scm` 中将 `windows =`（即 Windows 风格下的 `Ctrl =`）绑定为 `(change-zoom-factor 1.0)`，会与 `Ctrl =`（放大功能）发生键位冲突，导致视图放大（View -> Zoom in）的快捷键失效/丢失。因此需要移除 `windows =` 这一快捷键绑定。

## How
编辑 `TeXmacs/plugins/windows/progs/init-windows.scm`，删除 `("windows =" (change-zoom-factor 1.0))` 这一行。