### PR TITLE
[0520] macOS arm64 Velopack 打包 CD 接入

### DIFF
--- a/.github/workflows/cd_on_macos_arm64.yml
+++ b/.github/workflows/cd_on_macos_arm64.yml
@@ -45,11 +45,17 @@ jobs:
         run: xmake build -vD stem
       - name: install
         run: xmake install -vD stem
+      # vpk 1.2.0 的 apphost 需要 .NET 10 runtime；macos-14 arm64 镜像自带的
+      # dotnet 版本较旧且不在 apphost 默认搜索路径（首跑实测 You must install
+      # .NET）。setup-dotnet 显式装 .NET 10 并设置 DOTNET_ROOT。
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
       - name: Install vpk
         shell: pwsh
         run: |
           dotnet tool install -g vpk --version 1.2.0
-          # mac runner 自带 dotnet SDK；pwsh 在 Unix 无 USERPROFILE，用 HOME
+          # pwsh 在 Unix 无 USERPROFILE，用 HOME
           Add-Content -Path $env:GITHUB_PATH -Value "$($env:HOME)/.dotnet/tools"
       # Apple 签名/公证 setup（mac 独有；Windows 的正式签名在 SafeNet 签名机
       # 事后完成，mac 未签名 pkg 会被 Gatekeeper 直接拦截，故在 CI 内完成）。

--- a/.github/workflows/cd_on_macos_arm64.yml
+++ b/.github/workflows/cd_on_macos_arm64.yml
@@ -16,9 +16,11 @@ jobs:
         os: [macos-14]
         arch: [arm64]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # Windows CD 为 45 分钟；mac 侧多出 vpk 签名 + notarytool 公证等待
+    # （package.scm 时代公证单独给了 60 分钟超时），放宽到 60。
+    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: xmake-io/github-action-setup-xmake@v1
@@ -27,30 +29,212 @@ jobs:
           actions-cache-folder: '.xmake-cache'
       - name: xmake repo --update
         run: xmake repo --update
-      - name: Config and build goldfish
+      # Noto 字体（与 Windows CD 相同来源）：原由 package.scm 内部下载，
+      # DMG 流程移除后必须在此落位，install 才会收进 .app 的 Resources。
+      - name: Noto fonts
         run: |
-          xmake config -m release -a ${{ matrix.arch }} -vD --loro=yes --yes
-          xmake build goldfish-bin
-          ls -la TeXmacs/plugins/goldfish/bin/ || echo "goldfish bin dir not found"
-      - name: Package with Goldfish
+          mkdir -p TeXmacs/fonts/opentype/noto
+          cd TeXmacs/fonts/opentype/noto
+          curl -fsSLO https://github.com/XmacsLabs/mogan/releases/download/v1.2.9.7/NotoSansCJK-Bold.ttc
+          curl -fsSLO https://github.com/XmacsLabs/mogan/releases/download/v1.2.9.7/NotoSansCJK-Regular.ttc
+          curl -fsSLO https://github.com/XmacsLabs/mogan/releases/download/v1.2.9.7/NotoSerifCJK-Bold.ttc
+          curl -fsSLO https://github.com/XmacsLabs/mogan/releases/download/v1.2.9.7/NotoSerifCJK-Regular.ttc
+      - name: config
+        run: xmake config -m release -a ${{ matrix.arch }} -vD --loro=yes --yes
+      - name: build
+        run: xmake build -vD stem
+      - name: install
+        run: xmake install -vD stem
+      - name: Install vpk
+        shell: pwsh
+        run: |
+          dotnet tool install -g vpk --version 1.2.0
+          # mac runner 自带 dotnet SDK；pwsh 在 Unix 无 USERPROFILE，用 HOME
+          Add-Content -Path $env:GITHUB_PATH -Value "$($env:HOME)/.dotnet/tools"
+      # Apple 签名/公证 setup（mac 独有；Windows 的正式签名在 SafeNet 签名机
+      # 事后完成，mac 未签名 pkg 会被 Gatekeeper 直接拦截，故在 CI 内完成）。
+      # keychain 命令序列照搬 packages/macos/package.scm 的 setup-keychain；
+      # 身份名动态解析后经 VPK_SIGN_* 环境变量注入 pack_velopack.lua（见
+      # tools/release/pack_velopack.lua 的 mac 签名参数透传），stage 侧检测到
+      # VPK_SIGN_APP_IDENTITY 即跳过 ad-hoc、交给 vpk 深签。
+      - name: Setup Apple signing
         env:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          chmod +x TeXmacs/plugins/goldfish/bin/goldfish
-          TeXmacs/plugins/goldfish/bin/goldfish packages/macos/package.scm
-      - name: Upload 
+          set -e
+          KEYCHAIN="$HOME/Library/Keychains/mogan-signing.keychain-db"
+          KEYCHAIN_PASS="$(openssl rand -base64 32)"
+          CERT=/tmp/mogan_cert.p12
+          printf '%s' "$APPLE_CERTIFICATE_P12_BASE64" | base64 -D -o "$CERT"
+          security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security import "$CERT" -P "$APPLE_CERTIFICATE_PASSWORD" -k "$KEYCHAIN" -T /usr/bin/codesign ||
+            security import "$CERT" -P "$APPLE_CERTIFICATE_PASSWORD" -k "$KEYCHAIN"
+          curl -fsSL -o /tmp/apple_devid_ca.cer https://www.apple.com/certificateauthority/DeveloperIDCA.cer
+          curl -fsSL -o /tmp/apple_devid_ca_g2.cer https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+          security add-certificates -k "$KEYCHAIN" /tmp/apple_devid_ca.cer /tmp/apple_devid_ca_g2.cer
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN"
+          LOGIN_KC="$HOME/Library/Keychains/login.keychain-db"
+          if [ -f "$LOGIN_KC" ]; then
+            security list-keychains -d user -s "$KEYCHAIN" "$LOGIN_KC" /Library/Keychains/System.keychain
+          else
+            security list-keychains -d user -s "$KEYCHAIN" /Library/Keychains/System.keychain
+          fi
+          security default-keychain -s "$KEYCHAIN"
+          # notarytool 凭据 profile（App Store Connect API key，同 package.scm）
+          KEY_DIR="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$KEY_DIR"
+          API_KEY="$KEY_DIR/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" | base64 -D -o "$API_KEY"
+          chmod 600 "$API_KEY"
+          xcrun notarytool store-credentials mogan-notary \
+            --key "$API_KEY" --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" --keychain "$KEYCHAIN"
+          # 身份名动态解析（P12 里证书的完整主题名因续期而变，不硬编码）
+          APP_IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" |
+            sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' | head -1)"
+          INSTALL_IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" |
+            sed -n 's/.*"\(Developer ID Installer:[^"]*\)".*/\1/p' | head -1)"
+          if [ -n "$APP_IDENTITY" ]; then
+            echo "VPK_SIGN_APP_IDENTITY=$APP_IDENTITY" >> "$GITHUB_ENV"
+          else
+            echo "::error::keychain 中未找到 Developer ID Application 证书"
+            exit 1
+          fi
+          # P12 可能只含 Application 证书；缺 Installer 时 vpk 跳过 .pkg 签名并
+          # 告警（app 仍签名），属可接受降级
+          if [ -n "$INSTALL_IDENTITY" ]; then
+            echo "VPK_SIGN_INSTALL_IDENTITY=$INSTALL_IDENTITY" >> "$GITHUB_ENV"
+            echo "INSTALL_IDENTITY=$INSTALL_IDENTITY"
+          else
+            echo "INSTALL_IDENTITY=（未找到 Developer ID Installer，pkg 将不签名）"
+          fi
+          echo "VPK_NOTARY_PROFILE=mogan-notary" >> "$GITHUB_ENV"
+          echo "VPK_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+          echo "APP_IDENTITY=$APP_IDENTITY"
+      - name: Stage Velopack
+        run: xmake l tools/release/stage_velopack.lua
+      # 从 GitHub Release 拉取上一版本的发布压缩包作为各通道的 delta 基线：
+      # 逻辑与 Windows CD 一致（列 100 个 release、排除 draft 与当前 tag、
+      # beta 必查 + 无 -rc 才查 stable、stable 只认非 rc release、同版本跳过、
+      # 解 zip 取该通道 full 包拷入 build/velopack_release_<channel>/）。
+      # 与 Windows 的两处差异：
+      #   1) zip 匹配模式带 -osx-arm64 平台段——同一 release 上还有 Windows 的
+      #      mogan-release-*-win-x64-<channel>.zip，nupkg 是平台专属的，不带
+      #      平台段会抓错平台基线；
+      #   2) 不做裸 nupkg 回退——Windows 的该回退对应其过渡期历史，mac 沿用
+      #      会抓到 Windows 的旧 full 包。
+      # 某通道首次发布（GitHub 上尚无 mac 归档 zip）时跳过属正常：没有基线
+      # 时 pack 只出 full 包，是合法状态。
+      # GITHUB_TOKEN 不会自动注入为环境变量，必须显式传入 secrets.GITHUB_TOKEN；
+      # 为空时回退为公开仓库的匿名访问。
+      - name: Fetch delta baselines from GitHub Release
+        shell: pwsh
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $headers = @{
+            Accept        = "application/vnd.github+json"
+            "User-Agent"  = "mogan-cd"
+          }
+          if ($env:GITHUB_TOKEN) {
+            $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+          }
+          $releases = Invoke-RestMethod -Headers $headers `
+            -Uri "https://api.github.com/repos/${{ github.repository }}/releases?per_page=100"
+          $releases = $releases |
+            Where-Object { -not $_.draft -and $_.tag_name -ne $env:GITHUB_REF_NAME }
+          # 本次要打的通道：beta 必打；stable 仅 tag 不含 -rc 时打
+          # （tag 名由 bump-version 流水线产生，-rc 与否即通道信息，无需透传）。
+          $tag = "${{ github.ref_name }}"
+          $channels = @("beta")
+          if ($tag -notmatch '-rc') { $channels += "stable" }
+          $vars = Get-Content xmake/vars.lua -Raw
+          $currentVer = [regex]::Match($vars, 'XMACS_VERSION\s*=\s*"([^"]+)"').Groups[1].Value
+          foreach ($channel in $channels) {
+            Write-Host "== 通道 $channel：查找 delta 基线 =="
+            foreach ($release in $releases) {
+              # stable 基线只认非 rc tag 的 release（rc release 无 stable 包）
+              if ($channel -eq "stable" -and $release.tag_name -match '-rc') {
+                continue
+              }
+              Remove-Item build/velopack_baseline -Recurse -Force -ErrorAction SilentlyContinue
+              New-Item -ItemType Directory -Path build/velopack_baseline -Force | Out-Null
+              # 按平台 + 通道名匹配 zip（分开上传的格式，名带平台与通道后缀，
+              # 只下载目标通道的归档，避免拉取无关平台的 1.5GB 包）
+              $zipPattern = "mogan-release-*-osx-arm64-$channel.zip"
+              $zip = $release.assets |
+                Where-Object { $_.name -like $zipPattern } |
+                Select-Object -First 1
+              if (-not $zip) { continue }
+              /usr/bin/curl -fsSL "$($zip.browser_download_url)" -o build/velopack_baseline.zip
+              Expand-Archive -Path build/velopack_baseline.zip `
+                -DestinationPath build/velopack_baseline -Force
+              $full = Get-ChildItem build/velopack_baseline -Filter "*-$channel-full.nupkg" |
+                Select-Object -First 1
+              if (-not $full) { continue }
+              $baselineVer = $full.Name -replace '^Mogan-', '' `
+                -replace "-$channel-full\.nupkg$", ''
+              if ($baselineVer -eq $currentVer) {
+                Write-Host "基线版本与当前版本相同（$baselineVer），跳过（重跑同一版本）"
+                break
+              }
+              $outDir = "build/velopack_release_$channel"
+              New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+              Copy-Item $full.FullName $outDir/
+              Write-Host "已就位 $channel delta 基线: $($full.Name)"
+              break
+            }
+          }
+      # vpk pack 在 outputDir 存在上一版本（上一步拉取的 full 包）时自动生成
+      # delta 增量包；首次发布无上一版本，只有全量包。beta/stable 各用独立
+      # 输出目录（vpk 把 outputDir 当 channel 累积目录，混用会互相干扰），
+      # 产物文件名带 channel 后缀，最后合并进同一 release 归档。
+      - name: Pack Velopack (beta)
+        env:
+          VPK_CHANNEL: beta
+          VPK_OUTPUT_DIR: build/velopack_release_beta
+        run: xmake l tools/release/pack_velopack.lua
+      - name: Pack Velopack (stable)
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        env:
+          VPK_CHANNEL: stable
+          VPK_OUTPUT_DIR: build/velopack_release_stable
+        run: xmake l tools/release/pack_velopack.lua
+      # 每个通道各自打一个 zip（Release 资产与下游 delta 基线按通道取用）：
+      # 文件名带平台与通道后缀 mogan-release-<ver>-osx-arm64-<channel>.zip，
+      # 命名规则与 Windows CD 的 win-x64 归档一致。
+      - name: Create release archive
+        shell: pwsh
+        run: |
+          $vars = Get-Content xmake/vars.lua -Raw
+          $ver = [regex]::Match($vars, 'XMACS_VERSION\s*=\s*"([^"]+)"').Groups[1].Value
+          $dirs = Get-ChildItem build -Directory -Filter 'velopack_release_*' |
+            Sort-Object Name
+          foreach ($d in $dirs) {
+            $channel = $d.Name -replace '^velopack_release_', ''
+            $archive = "build/mogan-release-$ver-osx-arm64-$channel.zip"
+            Compress-Archive -Path "$($d.FullName)/*" -DestinationPath $archive `
+              -CompressionLevel Optimal -Force
+            Get-Item $archive | Select-Object Name, Length
+          }
+      - name: Upload
         uses: actions/upload-artifact@v4
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         with:
-          path: build/*.dmg
+          path: |
+            build/velopack_release_*/*
+            build/mogan-release-*.zip
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: true
-          files: build/*.dmg
+          files: build/mogan-release-*.zip

--- a/.github/workflows/cd_research_on_windows.yml
+++ b/.github/workflows/cd_research_on_windows.yml
@@ -73,9 +73,11 @@ jobs:
       # stable full。所有发布都标了 prerelease，releases/latest 接口拿不到，
       # 这里列出最近 100 个 release，排除 draft 和当前 tag（重跑同一 tag 时
       # 避免把自己当基线），按通道各自向后遍历，wget 下载对应通道的 zip。
-      # 压缩包分两种：新版每通道各一个 zip（mogan-release-<ver>-win-x64-
-      # <channel>.zip，按通道名只下载目标通道的归档）；旧版是全部通道合并的
-      # 单一 zip（无通道后缀，兼容回退）。解压拣出对应通道的 full 包
+      # 压缩包分两种：新版每平台每通道各一个 zip（mogan-release-<ver>-
+      # <platform>-<channel>.zip，按平台与通道名匹配归档——mac CD 会向同一
+      # release 上传 osx-arm64 归档，nupkg 是平台专属的，不带平台段会抓错
+      # 基线）；旧版是全部通道合并的单一 zip（无通道后缀，仅 Windows 时代
+      # 存在，兼容回退）。解压拣出对应通道的 full 包
       # （stable 需逐个 release 尝试：rc tag 的 zip 里没有 stable 包，自然
       # 跳过）。某通道首次发布或 GitHub 上尚无压缩包时跳过属正常（没有基线
       # 时 pack 只出 full 包，是合法状态）。
@@ -116,16 +118,17 @@ jobs:
               }
               Remove-Item build/velopack_baseline -Recurse -Force -ErrorAction SilentlyContinue
               New-Item -ItemType Directory -Path build/velopack_baseline -Force | Out-Null
-              # 优先按通道名匹配 zip（分开上传的新格式，名带通道后缀，
-              # 只下载目标通道的归档，避免拉取无关通道的 1.5GB 包）；找不到
-              # 再回退旧合并 zip（无通道后缀，内含全部通道的包）。
-              $zipPattern = if ($channel -eq "beta") { '*beta*.zip' } else { '*stable*.zip' }
+              # 按平台 + 通道名匹配 zip（分开上传的新格式，名带平台与通道
+              # 后缀，只下载目标通道的归档，避免拉取无关通道/平台的 1.5GB
+              # 包）；找不到再回退旧合并 zip（无通道后缀、仅 Windows 时代
+              # 存在，内含全部通道的包）。
+              $zipPattern = "mogan-release-*-win-x64-$channel.zip"
               $zip = $release.assets |
                 Where-Object { $_.name -like $zipPattern } |
                 Select-Object -First 1
               if (-not $zip) {
                 $zip = $release.assets |
-                  Where-Object { $_.name -like 'mogan-release-*.zip' } |
+                  Where-Object { $_.name -like 'mogan-release-*-win-x64.zip' } |
                   Select-Object -First 1
               }
               if ($zip) {

--- a/devel/0520.md
+++ b/devel/0520.md
@@ -71,3 +71,38 @@ Windows CD 的基线 zip 匹配模式（`*beta*.zip` 等）不带平台段，mac
   属正常）、zip 命名与 release 资产、vpk 日志确认签名/公证完成。签名链路
   （vpk × hardened runtime × notarytool profile）是唯一无法本地验证的部分，
   若公证被拒，在 `--signEntitlements` 补最小权利文件。
+
+## 2026/08/28 CD 三轮 tag 实测（PR #4451）
+
+测试 tag：`v2026.4.0` → `v2026.4.1-rc.1` → `v2026.4.1`（均 prerelease），
+Windows 与 macOS CD 同跑同 tag。首轮 mac 两次失败，定位并修复两处：
+
+1. **vpk 找不到 .NET runtime**：vpk 1.2.0 的 apphost 需要 net10.0，
+   macos-14 arm64 镜像自带 dotnet 版本旧且不在 apphost 搜索路径。修复：
+   `actions/setup-dotnet@v4` 装 .NET 10（自动设 `DOTNET_ROOT`）。
+2. **公证判 Invalid**：两个未签名嵌套二进制——(a) xmake 安装 stem 时把
+   velopack shared 依赖额外装进 `Contents/Resources/lib/`（vpk 的
+   `codesign --deep` 只遍历 bundle/framework/PlugIns 结构，签不到），
+   修复：stem 的 after_install 清理该错位副本（与重复二进制清理同模式），
+   stage 加硬校验兜底；(b) `Resources/.../goldfish` 裸可执行文件同样对
+   `--deep` 不可见，修复：stage 在配置了 `VPK_SIGN_APP_IDENTITY` 时用
+   正式身份逐个预签 Resources 裸 Mach-O（`.dSYM` 按旧 DMG 流程先例不签），
+   bundle 本体仍交给 vpk 深签。修复后公证 **Accepted**（beta/stable 各
+   一次，~90s/次）+ staple 通过 + spctl 校验通过。
+
+三轮结果（两平台行为一致）：
+
+| 轮次 | tag | 断言 | 结果 |
+|------|-----|------|------|
+| 1 | v2026.4.0（无 rc） | 双渠道产出 | ✓ win/mac × beta/stable 四归档；win 基线取真实 release 2026.3.2 的对应通道 full（新模式 `mogan-release-*-win-x64-<channel>.zip` 生效），mac 首发无基线只出 full |
+| 2 | v2026.4.1-rc.1（rc） | 仅 beta + 以轮 1 beta 为基线 | ✓ 两平台仅 beta 归档；基线 `Mogan-2026.4.0-beta-full.nupkg`；delta 2026.4.0→2026.4.1-rc.1 |
+| 3 | v2026.4.1（无 rc） | 双渠道 + 基线穿越 | ✓ 四归档；stable 基线 `Mogan-2026.4.0-stable-full.nupkg`（跳过 rc release）；beta 基线 `Mogan-2026.4.1-rc.1-beta-full.nupkg`；delta 2026.4.0→2026.4.1 / 2026.4.1-rc.1→2026.4.1 |
+
+测试遗留（合并前需决策）：
+
+- 三个测试 release+tag（v2026.4.0 / v2026.4.1-rc.1 / v2026.4.1）在仓库中，
+  未来正式版本号必须高于 2026.4.1，或删除测试 release+tag 后基线链自动
+  回落到真实 release；
+- 分支上 `xmake/vars.lua` 当前为测试版本 2026.4.1，合并时需视发布节奏处理；
+- Debian13/Fedora CD 的 tag 触发仍是注释状态，正式发版前须恢复（两文件
+  内有标注）。

--- a/devel/0520.md
+++ b/devel/0520.md
@@ -1,0 +1,73 @@
+# 0520: macOS CD 接入 Velopack（对齐 Windows CD）
+
+## 2026/08/28 macOS CD 从 DMG 切换到 Velopack
+
+### What(本次改动做了什么)
+
+重写 `.github/workflows/cd_on_macos_arm64.yml`：移除旧的 goldfish +
+package.scm DMG 打包/签名/公证流程，改为与
+`cd_research_on_windows.yml` 行为一致的 Velopack 流程——build/install stem、
+安装 vpk、stage、从 GitHub Release 拉取各通道 delta 基线、beta/stable 双通道
+pack、按通道产出归档 zip `mogan-release-<版本>-osx-arm64-<渠道>.zip`、
+上传 artifact / 发布 Release。CI 内完成 Developer ID 签名 + 公证（复用现有
+APPLE_* secrets 构建 keychain 与 notarytool profile，经 0519 接好的
+VPK_SIGN_* 环境变量注入 vpk）。
+
+### Why(为什么这么做)
+
+- 0519 已落地 macOS 侧 Velopack 运行时与本地 stage/pack 脚本，CI 是最后一环；
+  release 产物从 DMG 迁移到 vpk 原生 .pkg + portable zip + nupkg feed，
+  获得 delta 增量更新与应用内自动更新能力。
+- 严格镜像 Windows CD 的步骤结构、通道规则与基线回退语义，两平台发布行为
+  可预测、可对照排障。
+- 签名公证留在 CI 内完成（而非像 Windows 那样事后签名机）：mac 未签名 pkg
+  下载即被 Gatekeeper 拦截，且现有 secrets 齐备，vpk 原生支持。
+
+### How(怎么做的)
+
+1. **Noto 字体外置**：原 package.scm 内部下载的 4 个 CJK ttc 改为独立步骤
+   （与 Windows CD 相同 URL），在 `xmake install stem` 前落进
+   `TeXmacs/fonts/opentype/noto/`。
+2. **签名 setup（mac 独有步骤）**：keychain 构建命令序列照搬
+   `packages/macos/package.scm`（create/unlock/import P12/import Developer ID
+   CA/set-key-partition-list/搜索列表+默认钥匙串）；App Store Connect API key
+   解出后 `xcrun notarytool store-credentials` 建 profile；身份名动态解析
+   （`security find-identity`），`VPK_SIGN_APP_IDENTITY`/
+   `VPK_SIGN_INSTALL_IDENTITY`（存在才导出）/`VPK_NOTARY_PROFILE`/
+   `VPK_KEYCHAIN` 写 GITHUB_ENV。
+3. **基线拉取**：逐行镜像 Windows CD 的 pwsh 逻辑（列 100 个 release、排除
+   draft 与当前 tag、beta 必查 + 无 `-rc` 才查 stable、stable 只认非 rc
+   release、同版本跳过、解 zip 取 `*-$channel-full.nupkg` 拷入
+   `build/velopack_release_<渠道>/`）。差异仅两处：zip 匹配模式带
+   `-osx-arm64` 平台段（release 上已有 Windows 同前缀 zip，不带平台段会抓
+   错平台基线）；**不做裸 nupkg 回退**（Windows 的该回退对应其过渡期历史，
+   mac 沿用会抓到 Windows 旧 full）。`wget` 换 `curl`。
+4. **双通道 pack / 归档 / 发布**：与 Windows CD 完全一致——beta 每个 tag 打、
+   tag 不含 `-rc` 加打 stable，各用独立 outputDir；归档
+   `build/mogan-release-<版本>-osx-arm64-<渠道>.zip`；非 tag 上传 artifact、
+   tag 以 prerelease 发布 `build/mogan-release-*.zip`。
+
+### 已知关联缺陷（本次不处理）
+
+Windows CD 的基线 zip 匹配模式（`*beta*.zip` 等）不带平台段，mac 归档上传到
+同一 release 后会被其误抓为基线；用户决定另行任务收紧 Windows CD 模式。
+
+### 不做什么
+
+- 不动 Windows CD（含上述缺陷）；
+- `packages/macos/package.scm` 文件保留在仓库（不再被 CD 引用，后续另行清理）；
+- osx-x64；服务端 feed 目录（/api/v1/public/update/osx-arm64）。
+
+### 涉及文件
+
+- `devel/0520.md`（本文件）
+- `.github/workflows/cd_on_macos_arm64.yml`（重写）
+
+### 如何测试
+
+- 本地：`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cd_on_macos_arm64.yml'))"`
+  过语法；actionlint（若可用）过两个 workflow；与 Windows CD 逐步骤结构对照。
+- 真实验证依赖首个 tag：观察双通道 pack、基线拉取日志（首版无基线只出 full
+  属正常）、zip 命名与 release 资产、vpk 日志确认签名/公证完成。签名链路
+  （vpk × hardened runtime × notarytool profile）是唯一无法本地验证的部分，
+  若公证被拒，在 `--signEntitlements` 补最小权利文件。

--- a/devel/0520.md
+++ b/devel/0520.md
@@ -98,11 +98,11 @@ Windows 与 macOS CD 同跑同 tag。首轮 mac 两次失败，定位并修复�
 | 2 | v2026.4.1-rc.1（rc） | 仅 beta + 以轮 1 beta 为基线 | ✓ 两平台仅 beta 归档；基线 `Mogan-2026.4.0-beta-full.nupkg`；delta 2026.4.0→2026.4.1-rc.1 |
 | 3 | v2026.4.1（无 rc） | 双渠道 + 基线穿越 | ✓ 四归档；stable 基线 `Mogan-2026.4.0-stable-full.nupkg`（跳过 rc release）；beta 基线 `Mogan-2026.4.1-rc.1-beta-full.nupkg`；delta 2026.4.0→2026.4.1 / 2026.4.1-rc.1→2026.4.1 |
 
-测试遗留（合并前需决策）：
+测试遗留（已于 2026/09/01 全部处理完毕）：
 
-- 三个测试 release+tag（v2026.4.0 / v2026.4.1-rc.1 / v2026.4.1）在仓库中，
-  未来正式版本号必须高于 2026.4.1，或删除测试 release+tag 后基线链自动
-  回落到真实 release；
-- 分支上 `xmake/vars.lua` 当前为测试版本 2026.4.1，合并时需视发布节奏处理；
-- Debian13/Fedora CD 的 tag 触发仍是注释状态，正式发版前须恢复（两文件
-  内有标注）。
+- ~~三个测试 release+tag（v2026.4.0 / v2026.4.1-rc.1 / v2026.4.1）~~ 已删除，
+  基线链自动回落到真实 release（下一个正式版本的基线仍取自 v2026.3.2 等
+  真实发布）；
+- ~~分支上 `xmake/vars.lua` 为测试版本 2026.4.1~~ 已恢复为 2026.3.2（与
+  main 一致，PR 净 diff 不含版本号变更）；
+- ~~Debian13/Fedora CD 的 tag 触发为注释状态~~ 已恢复，正式发版即正常触发。

--- a/tools/release/stage_velopack.lua
+++ b/tools/release/stage_velopack.lua
@@ -180,6 +180,11 @@ if os.host () == "macosx" then
     end
     need (os.isfile (path.join (dst_app, "Contents/Frameworks/libvelopack_libc.dylib")),
           "缺 Contents/Frameworks/libvelopack_libc.dylib（velopack_libc shared 目标应随构建部署）")
+    if os.isfile (path.join (dst_app, "Contents/Resources/lib/libvelopack_libc.dylib")) then
+        cprint ("${bright red}error: dylib 错位出现在 Contents/Resources/lib/（应在 Frameworks），" ..
+                "stem 的 after_install 应已清理${clear}")
+        ok = false
+    end
     if os.isfile (path.join (dst_app, "Contents/Resources/bin/MoganSTEM")) then
         cprint ("${bright red}error: Resources/bin/MoganSTEM 重复主程序未清除${clear}")
         ok = false
@@ -189,9 +194,39 @@ if os.host () == "macosx" then
     end
     if not ok then os.exit (1) end
 
-    -- 6) ad-hoc 签 staging 副本：无正式签名配置时保证 bundle 可加载；
-    --    配了 VPK_SIGN_APP_IDENTITY 则跳过，交给 vpk 深签
-    if (os.getenv ("VPK_SIGN_APP_IDENTITY") or "") == "" then
+    -- 6) 签名。正式身份（VPK_SIGN_APP_IDENTITY）时只预签 vpk --deep 覆盖不到的
+    --    Contents/Resources 裸 Mach-O（helper 可执行文件/dylib，如 goldfish）：
+    --    codesign --deep 只遍历 bundle/framework/PlugIns 这类结构，Resources 里
+    --    的裸二进制对它不可见，未签名会被公证判 Invalid；bundle 本体交给 vpk
+    --    深签。.dSYM 里的 DWARF 虽是 Mach-O，按旧 DMG 流程先例不签（可过公证）。
+    --    无正式身份时 ad-hoc 签整个 bundle，保证本地验证可加载。
+    local sign_identity = os.getenv ("VPK_SIGN_APP_IDENTITY") or ""
+    if sign_identity ~= "" then
+        local macho = {}
+        local function collect (d)
+            for _, sub in ipairs (os.dirs (path.join (d, "*"))) do
+                if not path.filename (sub):match ("%.dSYM$") then collect (sub) end
+            end
+            for _, f in ipairs (os.files (path.join (d, "*"))) do
+                local out = os.iorunv ("/usr/bin/file", {"-b", f})
+                if out and tostring (out):match ("^Mach%-O") then
+                    table.insert (macho, f)
+                end
+            end
+        end
+        collect (path.join (dst_app, "Contents", "Resources"))
+        for _, f in ipairs (macho) do
+            cprint ("预签 Resources 裸 Mach-O: " .. path.relative (f, dst_app))
+            code = os.execv ("codesign",
+                {"--force", "--options", "runtime", "--timestamp",
+                 "--sign", sign_identity, f}, {try = true})
+            if code ~= 0 then
+                cprint ("${bright red}error: 预签失败，退出码 " .. code .. ": " .. f .. "${clear}")
+                os.exit (1)
+            end
+        end
+        cprint ("${green}已预签 " .. #macho .. " 个 Resources 裸 Mach-O（bundle 交给 vpk 深签）${clear}")
+    else
         code = os.execv ("codesign", {"--force", "--deep", "--sign", "-", dst_app}, {try = true})
         if code ~= 0 then
             cprint ("${bright red}error: ad-hoc 签名失败，退出码 " .. code .. "${clear}")

--- a/xmake/targets/stem.lua
+++ b/xmake/targets/stem.lua
@@ -368,6 +368,19 @@ target("stem") do
                 os.rm(duplicate_binary)
                 print("Removed duplicate app binary: " .. duplicate_binary)
             end
+            if is_arch("arm64") then
+                -- xmake 安装 stem 时会把 shared 依赖（velopack_libc）的产物额外装进
+                -- installdir/lib（即 Contents/Resources/lib），dep 上的空 on_install
+                -- 拦不住。该 dylib 的正式位置是 Contents/Frameworks（构建期由 qt
+                -- 部署规则落位），Resources/lib 下的副本会让公证失败（vpk 的
+                -- --deep 签不到 Resources 里的裸 dylib）。
+                local stray = path.join(target:installdir(), "lib", "libvelopack_libc.dylib")
+                if os.isfile(stray) then
+                    os.rm(stray)
+                    os.rmdir(path.join(target:installdir(), "lib"))
+                    print("Removed stray velopack dylib: " .. stray)
+                end
+            end
             -- 幂等保险：只 install 不 rebuild 的场景下补拷 Velopack dylib
             -- （正常路径由构建期 velopack_libc shared 依赖经 qt 部署规则落位）
             if is_arch("arm64") and has_config("qt_frontend") then


### PR DESCRIPTION
## 概述

macOS arm64 接入与 Windows 相同的 Velopack 发布/更新链路（两个任务，0520 基于 0519）：

### 0519：运行时 + 本地打包
- vendor macOS velopack libc dylib（universal，install id 重写 + ad-hoc 重签，前置任务单独提交）
- xmake/C++ 集成：`USE_PLUGIN_VELOPACK` 扩到 macOS arm64，启动钩子/更新器后端/feed 平台段（`osx-arm64`）放开平台 guard；dylib 以 shared target 机制同时落位裸二进制（dev/CI 测试）与 `.app/Contents/Frameworks`（打包）
- `stage_velopack.lua`/`pack_velopack.lua` 增加 macOS 分支：ditto 拷贝保 framework 符号链接、自产 Info.plist、vpk `--runtime osx-arm64`、签名参数 `VPK_SIGN_*` 透传、产物改名；brew dotnet 自动注入 `DOTNET_ROOT`
- 验证：scheme 全套 1152 断言 0 挂；本地产出 pkg/zip/nupkg/feed；delta 链可用（详见 devel/0519.md）

### 0520：CD 接入（对齐 Windows CD）
- 重写 `cd_on_macos_arm64.yml`：移除旧 DMG 流程（goldfish/package.scm），改为 vpk 打包——基线拉取、beta/stable 双通道、归档 zip `mogan-release-<ver>-osx-arm64-<channel>.zip`、CI 内完成 Developer ID 签名 + 公证（复用 APPLE_* secrets）
- Windows CD 基线匹配加 `win-x64` 平台段（修复跨平台误抓缺陷）
- 测试期注释 Debian13/Fedora CD 的 tag 触发（恢复时取消注释）

🤖 Generated with [Claude Code](https://claude.com/claude-code)