### PR TITLE
[1253] 修复 Ghostscript 输出路径包含空格时图片加载失败

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,8 @@ xmake test lolly_tests/hashmap_test   # 单个测试
 
 如果构建失败（例如配置缓存陈旧、依赖路径错乱），执行 `xmake f -c --yes` 清理配置缓存后重新构建。
 
+如果只是修改 Scheme 文件（`.scm`），不需要使用 xmake 重新编译，但在 Windows 下需要执行一下 `xmake i stem`（同步资源文件到运行目录）。
+
 ### Scheme Glue（C++ ↔ scheme 绑定）
 
 - **glue 声明在 `.lua` 不在 `.scm`**：mogan 的 glue 由 xmake 规则 `xmake/rules/glue.lua`

--- a/TeXmacs/plugins/binary/progs/binary/gs.scm
+++ b/TeXmacs/plugins/binary/progs/binary/gs.scm
@@ -113,7 +113,7 @@
                 " -sDEVICE=pdfwrite "
                 " -dAutoRotatePages=/None "
                 " -dCompatibilityLevel=1.4 "
-                (string-append " -sOutputFile=" (url->system to) " ")
+                (string-append " -sOutputFile=" (string-quote (url->system to)) " ")
                 (string-append " -c " (string-quote gs-inline))
                 (string-append " -f " (url-sys-concretize from) " ")
                 (string-append " -c " (string-quote " grestore "))
@@ -159,7 +159,7 @@
                                " -dGraphicsAlphaBits=4 "
                                " -dTextAlphaBits=4 "
                                page_size_in_px
-                               (string-append " -sOutputFile=" (url->system to) " ")
+                               (string-append " -sOutputFile=" (string-quote (url->system to)) " ")
                                resolution_in_px
                                (string-append " -c " (string-quote gs-inline))
                                (string-append " -f " (url-sys-concretize from) " ")
@@ -200,7 +200,7 @@
                                " -dGraphicsAlphaBits=4 "
                                " -dTextAlphaBits=4 "
                                " -dUseCropBox "
-                               (string-append " -sOutputFile=" (url->system to) " ")
+                               (string-append " -sOutputFile=" (string-quote (url->system to)) " ")
                                page_size_in_px
                                resolution_in_px
                                (url-sys-concretize from)

--- a/devel/1253.md
+++ b/devel/1253.md
@@ -1,0 +1,52 @@
+# [1253] 修复 Ghostscript 输出路径包含空格时图片加载失败的问题
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- Issue: [#3978 Embedded EPS is not loaded if the user name contains a space (Linux)](https://github.com/MoganLab/mogan/issues/3978)
+- PR: [#2859 [212_2703] Fix gs path quoting for paths with spaces on macOS](https://github.com/MoganLab/mogan/pull/2859)
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/binary/progs/binary/gs.scm`
+- `CLAUDE.md`
+
+## 3 如何测试
+
+### 3.1 资源同步
+修改 Scheme 代码后，在 Windows 下需执行资源同步安装命令：
+```bash
+xmake i stem
+```
+
+### 3.2 验证命令行拼接与路径引号处理
+使用 Mogan 执行 Scheme 表达式或通过 headless 模式验证 `string-quote` 正确处理带空格的路径：
+```scheme
+(import (binary gs))
+;; 模拟带空格的目标文件路径
+(define to-url (string->url "file:///tmp/User Name/output.png"))
+(string-append " -sOutputFile=" (string-quote (url->system to-url)) " ")
+;; 预期结果: " -sOutputFile=\"/tmp/User Name/output.png\" "
+```
+
+### 3.3 实际功能验证（EPS / PDF 图片加载渲染）
+1. 启动 Mogan STEM：
+   ```bash
+   xmake r stem
+   ```
+2. 打开一个包含嵌入式 EPS 图像的 `.tm` 文档（或者在包含空格的用户名/路径环境下插入 EPS/PDF 图像）。
+3. 检查控制台无 Ghostscript 参数解析截断错误（如 `Unrecoverable error` 或找不到文件），EPS/PDF 图像能正常转换为图片并清晰显示。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+1. 在 `TeXmacs/plugins/binary/progs/binary/gs.scm` 中的 `gs-eps-to-pdf`、`gs-eps-to-png`、`gs-pdf-to-png` 三处函数中，将 `-sOutputFile=` 的参数由 `(url->system to)` 改为 `(string-quote (url->system to))`。
+2. 更新 `CLAUDE.md` 开发规范文档，补充「仅修改 Scheme 代码时无需重新编译，在 Windows 下执行 `xmake i stem` 同步资源」的说明。
+
+## 6 Why
+当系统用户名或临时文件目录包含空格字符（例如 Linux/macOS 下 `/tmp/Kovács Zoltán/...`）时，未加引号的 `-sOutputFile=/tmp/Kovács Zoltán/...` 参数会被 Ghostscript 在空格处截断，导致 Ghostscript 将路径后半部分误识别为其他参数而报错退出，最终导致嵌入的 EPS/PDF 图片无法正常加载和显示。
+
+## 7 How
+通过 `string-quote` 对 `(url->system to)` 进行转义并包裹双引号，生成 `-sOutputFile="/path with space/output.png"` 的命令行参数，确保 Ghostscript 可以将包含空格的完整路径识别为单个参数。


### PR DESCRIPTION
## 关联 Issue
Closes #3978

## What
1. 在 `TeXmacs/plugins/binary/progs/binary/gs.scm` 中，为 `gs-eps-to-pdf`、`gs-eps-to-png` 和 `gs-pdf-to-png` 的 `-sOutputFile=` 参数值加上 `string-quote` 包裹。
2. 更新 `CLAUDE.md` 开发规范说明：修改 Scheme 代码无需重新编译，在 Windows 下执行 `xmake i stem` 同步资源。
3. 添加任务文档 `devel/1253.md`。

## Why
当用户名或临时目录路径包含空格（如 Linux/macOS 下 `/tmp/Kovács Zoltán/...`）时，未加引号的 `-sOutputFile=` 参数会被 Ghostscript 在空格处截断，导致 Ghostscript 报错无法生成目标文件，嵌入的 EPS/PDF 等图片无法加载显示。

## How
使用 `string-quote` 对 `(url->system to)` 进行转义包裹双引号，生成 `-sOutputFile="..."`，使 Ghostscript 能正确接收包含空格的目标文件路径。