### PR TITLE
[1254] 在同类标题结构中插入标题时先移出结构并回车

### DIFF
--- a/TeXmacs/progs/text/text-edit.scm
+++ b/TeXmacs/progs/text/text-edit.scm
@@ -494,8 +494,29 @@
   ) ;with
 ) ;define
 
+(define (section-heading-tree? t)
+  (or (section-context? t)
+    (and (tree-is? t 'concat)
+      (> (tree-arity t) 0)
+      (section-context? (tree-ref t 0))
+    ) ;and
+  ) ;or
+) ;define
+
+(define (current-section-node)
+  (let ((ft (focus-tree)))
+    (cond ((and ft (section-context? ft))
+           (if (and (tree-outer ft) (tree-is? (tree-outer ft) 'concat)) (tree-outer ft) ft)
+          ) ;
+          ((tree-innermost section-heading-tree?) => (lambda (t) t))
+          (else #f)
+    ) ;cond
+  ) ;let
+) ;define
+
 (tm-define (smart-insert-heading l)
   (:require (not (selection-active-non-small?)))
+  (and-with t (current-section-node) (tree-go-to t :end) (insert-return))
   (with star
     (string->symbol (string-append (symbol->string l) "*"))
     (let* ((tags (list l star))

--- a/TeXmacs/tests/1254.scm
+++ b/TeXmacs/tests/1254.scm
@@ -1,0 +1,123 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1254.scm
+;; DESCRIPTION : 集成测试：在 section/subsection/subsubsection 结构内插入同类结构
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;; USAGE
+;;   xmake r 1254
+;;   MOGAN_TEST_GUI=1 xmake r 1254
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (texmacs tests 1254))
+
+(import (liii check))
+(load "./TeXmacs/progs/text/text-edit.scm")
+
+(check-set-mode! 'report-failed)
+
+(define step-delay-ms 300)
+
+(define (run-chain steps)
+  (let loop
+    ((rest steps) (t (+ (texmacs-time) step-delay-ms)))
+    (when (pair? rest)
+      (let ((label (caar rest)) (act (cdar rest)))
+        (exec-delayed-at (lambda ()
+                           (display "[1254-step] ")
+                           (display label)
+                           (newline)
+                           (catch #t
+                             (lambda () (act))
+                             (lambda args
+                               (display "[1254-error] in step: ")
+                               (display label)
+                               (display " -> ")
+                               (write args)
+                               (newline)
+                             ) ;lambda
+                           ) ;catch
+                           (loop (cdr rest) (+ (texmacs-time) step-delay-ms))
+                         ) ;lambda
+          t
+        ) ;exec-delayed-at
+      ) ;let
+    ) ;when
+  ) ;let
+) ;define
+
+(define (get-heading-titles tag)
+  (let ((st (tree->stree (buffer-tree))))
+    (map caddr
+         (filter (lambda (item)
+                   (and (pair? item)
+                        (== (car item) 'concat)
+                        (pair? (cdr item))
+                        (pair? (cadr item))
+                        (== (caadr item) tag)))
+                 (cdr st)))))
+
+(tm-define (test_1254)
+  (run-chain (list
+    (cons "new document"
+      (lambda ()
+        (new-document)
+        (init-env "style" "generic")
+      ))
+    (cons "insert first section"
+      (lambda ()
+        (smart-insert-heading 'section)
+        (insert "Section 1")
+        (check (get-heading-titles 'section) => '("Section 1"))
+        (check-true (not (not (current-section-node))))
+      ))
+    (cons "insert section while cursor inside first section"
+      (lambda ()
+        ;; 光标在 Section 1 内部，此时插入 section
+        (smart-insert-heading 'section)
+        (insert "Section 2")
+        (check (get-heading-titles 'section) => '("Section 1" "Section 2"))
+      ))
+    (cons "insert subsection while cursor inside section"
+      (lambda ()
+        ;; 光标在 Section 2 内部，此时插入 subsection
+        (smart-insert-heading 'subsection)
+        (insert "Subsection 2.1")
+        (check (get-heading-titles 'section) => '("Section 1" "Section 2"))
+        (check (get-heading-titles 'subsection) => '("Subsection 2.1"))
+      ))
+    (cons "insert subsection while cursor inside subsection"
+      (lambda ()
+        ;; 光标在 Subsection 2.1 内部，此时插入 subsection
+        (smart-insert-heading 'subsection)
+        (insert "Subsection 2.2")
+        (check (get-heading-titles 'subsection) => '("Subsection 2.1" "Subsection 2.2"))
+      ))
+    (cons "insert subsubsection while cursor inside subsection"
+      (lambda ()
+        ;; 光标在 Subsection 2.2 内部，此时插入 subsubsection
+        (smart-insert-heading 'subsubsection)
+        (insert "Subsubsection 2.2.1")
+        (check (get-heading-titles 'subsection) => '("Subsection 2.1" "Subsection 2.2"))
+        (check (get-heading-titles 'subsubsection) => '("Subsubsection 2.2.1"))
+      ))
+    (cons "insert section while cursor inside subsubsection"
+      (lambda ()
+        ;; 光标在 Subsubsection 2.2.1 内部，此时插入 section
+        (smart-insert-heading 'section)
+        (insert "Section 3")
+        (check (get-heading-titles 'section) => '("Section 1" "Section 2" "Section 3"))
+        (check (get-heading-titles 'subsubsection) => '("Subsubsection 2.2.1"))
+      ))
+    (cons "report + quit"
+      (lambda ()
+        (check-report)
+        (quit-TeXmacs)
+      ))
+  ))
+) ;tm-define

--- a/devel/1254.md
+++ b/devel/1254.md
@@ -1,0 +1,57 @@
+# [1254] 在 section 等同类结构中插入标题时先移出结构并回车
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1234.md](1234.md) - Alt+0..3 智能插入有/无编号的标题
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/text/text-edit.scm`
+- `TeXmacs/tests/1254.scm`
+
+## 3 如何测试
+
+### 3.1 集成测试
+
+```bash
+xmake r 1254
+MOGAN_TEST_GUI=1 xmake r 1254
+```
+
+### 3.2 其它回归测试
+
+```bash
+xmake r smart-heading-test
+```
+
+### 3.3 手动 GUI 验证
+
+```bash
+xmake b stem && xmake r stem
+```
+
+1. 新建文档，按 `Alt+1` 插入 section，输入 "Section 1"
+2. 光标停留在 "Section 1" 内部，按 `Alt+1` 再次插入 section
+3. 验证：光标移出第一节并自动回车，在下一行成功创建新的 section，原有 "Section 1" 结构完好无损
+4. 在 section / subsection / subsubsection 之间互相嵌套插入，验证均能正常移出并回车创建新标题
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+```
+
+## 5 What
+
+在一个 `section`, `subsection`, `subsubsection` 等同类结构中插入同类标题结构的时候，先把光标移出这个结构并回车，再执行插入。
+
+## 6 Why
+
+当光标位于已有标题内部时，直接调用 `make-section` / `smart-insert-heading` 会导致旧标题被原处拆分破坏，甚至无法正确在文档中生成新的同级/子级标题结构。移出该结构并回车后再插入，能保证原有标题完整，并在其后新建段落插入新标题。
+
+## 7 How
+
+1. 在 `TeXmacs/progs/text/text-edit.scm` 中增加 `section-heading-tree?` 与 `current-section-node`，兼顾 `generic` 样式（`concat` 包裹 `(section)` 与标题文本）与 `article` 样式（`section` 直接包裹标题参数）两种 AST 结构，精准识别光标是否处于标题结构内部。
+2. 在 `smart-insert-heading` 入口处，若检测到光标处于标题结构 `t` 内，先通过 `(tree-go-to t :end)` 移出结构，再执行 `(insert-return)` 回车换行，之后正常执行后续同级/变体插入逻辑。
+3. 在 `TeXmacs/tests/1254.scm` 增加自动化集成测试，覆盖从 section、subsection、subsubsection 内部连续插入同类标题的各种场景。


### PR DESCRIPTION
详见 `devel/1254.md`。

### 改动内容
1. 在 `smart-insert-heading` 中检测光标是否处于同类标题结构中，若处于标题结构内部，先移出该结构并回车，再插入新标题；
2. 新增集成测试 `TeXmacs/tests/1254.scm`。
