### PR TITLE
[1256] 修复含 \< 的文档反复选中后排版引擎卡死

### DIFF
--- a/TeXmacs/tests/tmu/1256.tmu
+++ b/TeXmacs/tests/tmu/1256.tmu
@@ -1,0 +1,21 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  Remark 2.1.1 Given a space V with a basis <math|B = {\|a <rsub|i>⟩} <rsub|i=1><rsup|n>>, the span of any m vectors <math|(m \< n)> of B is an m-dimensional subspace of V.
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-height|auto>
+    <associate|page-orientation|portrait>
+    <associate|page-screen-margin|false>
+    <associate|page-type|a4>
+    <associate|page-width|auto>
+    <associate|preamble|false>
+    <associate|stem-doc-id|5530CADA-D8FA-4470-8FC3-871ACE43B090>
+  </collection>
+</initial>

--- a/devel/1256.md
+++ b/devel/1256.md
@@ -1,0 +1,154 @@
+# [1256] 含 `\<` 的文档在公式附近反复选中后排版引擎卡死
+
+## 1 问题描述
+
+打开 `TeXmacs/tests/tmu/1256.tmu`（正文含公式 `<math|(m \< n)>`），在
+`(m < n)` 附近反复做鼠标框选、双击选中、Shift+方向键扩选、单击移动光标等
+操作后，软件"卡死"：文档界面完全停止更新，之后输入任何字符都不再显示。
+
+注意卡死的是**排版引擎**，不是 UI 线程：
+
+- Qt 事件循环仍然存活：`QTMWidget::keyPressEvent` 照常收到按键并写入日志，
+  后台遥测定时器照常运行，窗口可以拖动、最小化；
+- 进程 CPU 占用为 0（不是死循环空转）；
+- 但文档内容、光标、选区永远不再重绘。
+
+因此「窗口是否响应系统消息」（`SendMessageTimeout`）**不能**作为卡死判据。
+可靠的判据（hello 测试）：
+
+1. 点击文档 → `Ctrl+End` → 输入 `hello` → 截图；
+2. 按 5 次退格 → 再截图；
+3. 排版引擎活着则 `hello` 先出现再消失（两张截图与基线均有显著像素差异）；
+   卡死则三张截图完全一致。
+
+## 2 稳定复现
+
+复现脚本（本地产物，未入库）：
+
+- `devel/round_1256.sh <tag>`：一轮完整流程——杀旧进程 → 把 tmu 复制到
+  `$TEMP/1256_repro.tmu`（防止测试过程污染仓库里的 tmu）→ `xmake r stem`
+  启动 → PowerShell 聚焦窗口 → 跑 `repro_1256.py` → 结束后杀进程；
+- `devel/repro_1256.py <tag>`：每批 10 次混合操作（跨公式左右框选、反向
+  框选、文本→公式框选、公式→下一行框选、双击、Shift+单击、边界点击+
+  方向键、Shift+方向键扩选），每批后做一次 hello 测试判定死活。
+
+要点：
+
+- pyautogui 测试前用 `WM_INPUTLANGCHANGEREQUEST` 把窗口线程切到英文
+  （美式键盘）布局，避免按 Shift 触发微软拼音中/英切换引入输入法干扰；
+- 每次操作前必须把 Mogan 窗口切到前台；
+- 卡死之后不需要再点击，直接关闭软件即可。
+
+修复前 4/4 轮全部复现，且**每轮都在第一批约 10 次操作内即卡死**
+（早期用错判据时误以为要上百次）。
+
+## 3 根因分析
+
+### 3.1 触发源
+
+tmu 里的 `\<` 是不规范的写法（应为 `<less>`），解析出的公式树存在结构
+异常。拖动选中经过该公式时，选区路径 `[8]` 超出树的实际范围，moebius 的
+`pre_correct()`（`moebius/Data/Tree/tree_cursor.cpp`）命中
+
+```cpp
+cerr << "Precorrecting " << p << " in " << t << "\n";
+TM_FAILED ("bad path");
+```
+
+`TM_FAILED` → `tm_throw` → **抛出 C++ `string` 异常**。
+
+`\<` 的规范化处理是另一个任务，本任务只做防御：即使这类异常抛出，
+也不允许排版引擎永久停摆。
+
+### 3.2 异常为何能逃逸
+
+鼠标事件在编辑器层有两条路径：
+
+- **同步路径**：`edit_interface_rep::handle_mouse` 有现成的
+  `try { ... } catch (string msg)` 保护，异常被捕获，事件泵幸存；
+- **延迟路径**：`start-drag-left` 时 `delayed_call_mouse_event()` 把
+  `(mouse-event "dragging-left" ...)` 包成 `(delayed (:idle 1) ...)` 挂进
+  延时命令队列。该队列由 `command_queue::exec_pending()` 在
+  `qt_gui_rep::update()` 里逐条 `call()` 执行——**这里没有任何异常保护**。
+  Scheme 侧 `(mouse-event ...)` 经 glue 直达 `mouse_any`，C++ 异常直接
+  穿过 s7 解释器（s7 无法捕获 C++ 异常）一路向上逃逸。
+
+日志实证（卡死瞬间）：
+
+```
+[dbg] mouse_any dragging-left (875880, -191160) mods=1
+WARN: Precorrecting [ 8 ] in (m < n)
+Throwing bad path
+          <-- 之后只剩 add_event，update() 再也没有运行过
+```
+
+### 3.3 为什么表现为"排版引擎永久卡死"
+
+`qt_gui_rep::update()` 的结构：
+
+```cpp
+updatetimer->stop ();
+updating= true;
+... process_delayed_commands / process_queued_events / interpose / repaint ...
+updatetimer->start (delay);   // 异常逃逸时永不执行
+updating= false;              // 异常逃逸时永不执行
+```
+
+异常从 `update()` 逃逸后：
+
+1. `updatetimer` 停在停止状态，`updating` 永远为 `true`；
+2. 之后所有 Qt 事件只进 `add_event()` 排队，而 `need_update()` 见
+   `updating==true` 仅置标志位、不再启动定时器；
+3. `update()` 再也不运行 → 队列事件无人分发 → `apply_changes()` 无人调用
+   → 不排版、不重绘。
+
+Qt 事件循环本身未受影响（UI 可用、CPU 为 0），与观察到的现象完全一致。
+
+## 4 修复方案（双层防御）
+
+均位于 `src/Plugins/Qt/qt_gui.cpp`：
+
+### 4.1 `command_queue::exec_pending()` 逐条捕获
+
+每条延时命令的 `call()` 包上 `try/catch (string)`：失败的命令丢弃、记录
+日志、`handle_exceptions()` 清理异常状态后继续执行后续命令。与
+`handle_keypress`/`handle_mouse` 已有的捕获模式一致。
+
+### 4.2 `qt_gui_rep::update()` 整体兜底
+
+把延时命令处理、队列事件分发、interpose（`apply_changes`/排版）、
+`repaint_all` 整段包进 `try/catch (string)`：无论哪一环抛出异常，末尾的
+`updatetimer->start (delay)` 与 `updating= false` 必然执行，事件泵不会再
+永久停摆。`postpone_treatment` 提前初始化，catch 中复位事件计数器。
+
+## 5 涉及文件
+
+### 修改
+
+- `src/Plugins/Qt/qt_gui.cpp` — 上述两处防御
+
+### 测试文档（保持原样，勿改）
+
+- `TeXmacs/tests/tmu/1256.tmu` — 含 `<math|(m \< n)>` 的复现文档
+
+### 本地复现工具（未入库）
+
+- `devel/round_1256.sh`、`devel/repro_1256.py` — 见第 2 节
+
+## 6 验证
+
+| 轮次 | 构建 | 结果 |
+|------|------|------|
+| r1–r4 | 修复前 | 4/4 卡死，均在第一批 ~10 次操作内 |
+| fix1 | 修复后（带临时日志） | 800 次操作全程存活；日志中 `Throwing bad path` 出现 90 次，全部被 `exec_pending` 捕获丢弃 |
+| fix2 | 修复后（带临时日志） | 800 次操作全程存活 |
+| final | 修复后（日志已清理） | 见下方最终验证 |
+
+临时定位日志（`[dbg1256]`）验证完毕已从 `qt_gui.cpp`、
+`edit_interface.cpp`、`edit_mouse.cpp`、`edit_keyboard.cpp` 全部移除。
+
+## 7 后续工作
+
+- `\<` 在 tmu 解析/公式树中的规范化处理（应为 `<less>`），从源头消除
+  `pre_correct` 的 `bad path` 异常——另开任务；
+- 其余前端（CLI/ImGui）的延时命令队列存在同类隐患，如需可参照 4.1 处理。

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -959,53 +959,65 @@ qt_gui_rep::update () {
   // 2.
   // Manage delayed commands
 
-  if (delayed_commands.must_wait (now)) {
-    if (bench_chat_init) bench_start ("chat_init: update/delayed");
-    process_delayed_commands ();
-    if (bench_chat_init) bench_end ("chat_init: update/delayed", 10);
-  }
+  // 事件处理/延时命令/排版中抛出的 C++ 异常（如 bad path）若逃出本函数，
+  // updating 将永远为 true 且定时器不再重启，事件泵与排版引擎永久停摆。
+  // 这里统一兜底，保证末尾的定时器重启与 updating 复位必然执行。
+  bool postpone_treatment= false;
+  try {
+    if (delayed_commands.must_wait (now)) {
+      if (bench_chat_init) bench_start ("chat_init: update/delayed");
+      process_delayed_commands ();
+      if (bench_chat_init) bench_end ("chat_init: update/delayed", 10);
+    }
 
-  // 3.
-  // If there are pending events in the private queue process them until the
-  // limit in processed events is reached.
-  // If there are no events or the limit is reached then proceed to a redraw.
+    // 3.
+    // If there are pending events in the private queue process them until the
+    // limit in processed events is reached.
+    // If there are no events or the limit is reached then proceed to a redraw.
 
-  if (waiting_events.size () == 0) {
-    // If there are no waiting events call the interpose handler at least once
-    // if (the_interpose_handler) the_interpose_handler();
-  }
-  else
-    while (waiting_events.size () > 0 && count_events < max_proc_events) {
-      if (bench_chat_init) bench_start ("chat_init: update/queued");
-      process_queued_events (1);
-      if (bench_chat_init) bench_end ("chat_init: update/queued", 10);
-      count_events++;
+    if (waiting_events.size () == 0) {
+      // If there are no waiting events call the interpose handler at least once
       // if (the_interpose_handler) the_interpose_handler();
     }
-  // Repaint invalid regions and redraw
-  bool postpone_treatment= (keyboard_events > 0 && keyboard_special == 0);
-  keyboard_events        = 0;
-  keyboard_special       = 0;
-  count_events           = 0;
+    else
+      while (waiting_events.size () > 0 && count_events < max_proc_events) {
+        if (bench_chat_init) bench_start ("chat_init: update/queued");
+        process_queued_events (1);
+        if (bench_chat_init) bench_end ("chat_init: update/queued", 10);
+        count_events++;
+        // if (the_interpose_handler) the_interpose_handler();
+      }
+    // Repaint invalid regions and redraw
+    postpone_treatment= (keyboard_events > 0 && keyboard_special == 0);
+    keyboard_events   = 0;
+    keyboard_special  = 0;
+    count_events      = 0;
 
-  interrupted = false;
-  timeout_time= texmacs_time () + time_credit;
+    interrupted = false;
+    timeout_time= texmacs_time () + time_credit;
 
-  if (!postpone_treatment) {
-    if (bench_chat_init) bench_start ("chat_init: update/interpose");
-    if (the_interpose_handler) the_interpose_handler ();
-    if (bench_chat_init) bench_end ("chat_init: update/interpose", 10);
+    if (!postpone_treatment) {
+      if (bench_chat_init) bench_start ("chat_init: update/interpose");
+      if (the_interpose_handler) the_interpose_handler ();
+      if (bench_chat_init) bench_end ("chat_init: update/interpose", 10);
 #ifdef LORO_ENABLED
-    static time_t last_loro_poll_time= 0;
-    if (now - last_loro_poll_time >= 1000 / 6) {
-      loro_collab_poll ();
-      loro_collab_apply ();
-      last_loro_poll_time= now;
-    }
+      static time_t last_loro_poll_time= 0;
+      if (now - last_loro_poll_time >= 1000 / 6) {
+        loro_collab_poll ();
+        loro_collab_apply ();
+        last_loro_poll_time= now;
+      }
 #endif
-    if (bench_chat_init) bench_start ("chat_init: update/repaint_all");
-    qt_simple_widget_rep::repaint_all ();
-    if (bench_chat_init) bench_end ("chat_init: update/repaint_all", 10);
+      if (bench_chat_init) bench_start ("chat_init: update/repaint_all");
+      qt_simple_widget_rep::repaint_all ();
+      if (bench_chat_init) bench_end ("chat_init: update/repaint_all", 10);
+    }
+  } catch (string msg) {
+    cout << "qt_gui: exception during update: " << msg << "\n";
+    keyboard_events = 0;
+    keyboard_special= 0;
+    count_events    = 0;
+    handle_exceptions ();
   }
   if (bench_chat_init) {
     bench_end ("chat_init: gui update", gui_update_logged ? 10 : 0);
@@ -1289,7 +1301,17 @@ command_queue::exec_pending () {
   for (i= 0; i < n; i++) {
     time_t now= texmacs_time ();
     if ((now - b[i]) >= 0) {
-      object obj= call (a[i]);
+      // 逐条捕获：单条延时命令抛出的 C++ 异常（如 bad path）不应中断
+      // 整个队列，否则异常逃出 update() 会使事件泵永久停摆
+      object obj;
+      try {
+        obj= call (a[i]);
+      } catch (string msg) {
+        cout << "exec_pending: discarding failed delayed command: " << msg
+             << "\n";
+        handle_exceptions ();
+        continue;
+      }
       if (is_int (obj) && (now - b[i] < 1000000000)) {
         time_t pause= as_int (obj);
         // cout << "pause = " << obj << "\n";


### PR DESCRIPTION
## 问题

打开含 `<math|(m \< n)>` 的文档，在公式附近反复选中/框选后，排版引擎永久卡死：UI 线程和 Qt 事件循环正常，但文档不再重绘、输入无响应。

## 根因

`\<` 解析出的公式树结构异常，拖动选中时 moebius `pre_correct()` 命中 `TM_FAILED ("bad path")` 抛出 C++ `string` 异常。鼠标事件走延迟路径（`delayed_call_mouse_event` → `command_queue::exec_pending()`）时没有任何异常保护，异常穿过 s7 解释器从 `qt_gui_rep::update()` 逃逸，导致：

1. `updatetimer` 停在停止状态、`updating` 永远为 `true`；
2. 之后所有事件只排队不再分发，排版/重绘永久停摆。

## 修复（双层防御，均在 `qt_gui.cpp`）

1. `command_queue::exec_pending()` 逐条 `try/catch (string)`：失败的延时命令丢弃并继续后续命令；
2. `qt_gui_rep::update()` 整体兜底 `try/catch (string)`：无论哪一环抛异常，末尾的定时器重启与 `updating=false` 必然执行。

## 验证

修复前 4/4 轮复现（均在第一批 ~10 次操作内卡死）；修复后 2 轮各 800 次混合操作全程存活，日志中 90 次 `bad path` 异常全部被捕获丢弃。详见 `devel/1256.md`。

## 后续

`\<` 的规范化处理（应为 `<less>`）另开任务，从源头消除异常。