### PR TITLE
[1258] 修复启动页最近文档下划线不可见，一屏显示10条

### DIFF
--- a/devel/1258.md
+++ b/devel/1258.md
@@ -1,0 +1,50 @@
+# 1258 启动页最近文档文件名中的下划线不可见
+
+## 问题现象
+
+启动页「最近文档」列表中，`draft_20260902012008.tmu` 这类文件名显示为
+`draft 20260902012008.tmu`，下划线 `_` 完全不可见（看起来像一个空格）。
+
+## 根因
+
+数据层没有问题：
+
+- `~/.mogan/system/recent-files.json` 中存储的 `name` 字段带下划线；
+- 运行时调试确认传入 `QLabel` 的字符串完整包含 U+005F，字体
+  （Microsoft YaHei UI）也含有下划线字形（advance=7）。
+
+问题出在渲染裁剪：Microsoft YaHei UI 的下划线墨迹位置远低于字体上报的
+descent（为适配 CJK 基线设计），而文件名 `QLabel` 以 `Qt::AlignVCenter`
+加入布局、高度仅为字体 `sizeHint`（约 fmHeight=19px），超出 descent 的
+下划线墨迹被 QLabel 自身矩形裁掉。
+
+验证过程：保持行高 40 不变、仅把字号临时调到 30px 时下划线仍不可见
+（整行文字被裁）；把行高调大到 100 后下划线完整显示，确认是裁剪问题
+而非字体缺字形。
+
+## 修复方案（改高度，不换字体）
+
+`src/Plugins/Qt/QTMHomePage.cpp`：
+
+1. 文件名/时间标签加入布局时不再传 `Qt::AlignVCenter`，让布局把控件
+   拉伸到整行高度；改用 `QLabel::setAlignment` 使文本在标签内部垂直居中，
+   标签矩形变高后下划线墨迹不再被裁剪。
+2. 调整行尺寸常量，保证一屏可见 10 条最近文档（原只能看到 7 条）且
+   下划线不被裁剪：行高 `kRecentItemHeight` 40 → 36、纵向边距
+   `kRecentItemMarginY` 2 → 0、纵向内边距 `kRecentItemPaddingY` 6 → 0。
+   注意行高不能继续压小：标签高度需比 fmHeight（15px 字号下约 19px）
+   多出足够余量，36px 行高下余量约 8.5px，实测下划线可见。
+
+## 涉及文件
+
+- `src/Plugins/Qt/QTMHomePage.cpp`
+
+## 验证
+
+`xmake b stem && xmake i stem && xmake r stem`，启动页最近文档列表中
+`draft_xxxxxxxxxxxxxx.tmu` 的下划线清晰可见，一屏可完整显示 10 条记录，
+排版无异常。
+
+注意：Windows 上 `xmake r stem` 运行的是安装目录副本
+（`build/packages/stem/data/bin/MoganSTEM.exe`），改动后必须先
+`xmake i stem` 再运行，否则看到的还是旧二进制。

--- a/devel/1258.md
+++ b/devel/1258.md
@@ -34,6 +34,8 @@ descent（为适配 CJK 基线设计），而文件名 `QLabel` 以 `Qt::AlignVC
    `kRecentItemMarginY` 2 → 0、纵向内边距 `kRecentItemPaddingY` 6 → 0。
    注意行高不能继续压小：标签高度需比 fmHeight（15px 字号下约 19px）
    多出足够余量，36px 行高下余量约 8.5px，实测下划线可见。
+3. 主页底部外边距独立为 `kMainMarginBottom` 32 → 16，最近文档外框
+   向下多延伸 16px，避免窗口稍矮时第 10 条被窗口底边裁掉一截。
 
 ## 涉及文件
 

--- a/src/Plugins/Qt/QTMHomePage.cpp
+++ b/src/Plugins/Qt/QTMHomePage.cpp
@@ -64,12 +64,12 @@ constexpr int kSectionTitleFontPx   = 16;  // 分区标题字号
 constexpr int kStyleIconFontPx      = 48;  // 样式图标字母字号
 constexpr int kStyleNameFontPx      = 14;  // 样式名称字号
 constexpr int kRecentListRadius     = 8;   // Recent 列表圆角
-constexpr int kRecentItemHeight     = 40;  // Recent 列表项高度
+constexpr int kRecentItemHeight     = 36;  // Recent 列表项高度
 constexpr int kRecentItemRadius     = 4;   // Recent 列表项圆角
 constexpr int kRecentItemMarginX    = 4;   // Recent 列表项横向边距
-constexpr int kRecentItemMarginY    = 2;   // Recent 列表项纵向边距
+constexpr int kRecentItemMarginY    = 0;   // Recent 列表项纵向边距
 constexpr int kRecentItemPaddingX   = 8;   // Recent 列表项横向内边距
-constexpr int kRecentItemPaddingY   = 6;   // Recent 列表项纵向内边距
+constexpr int kRecentItemPaddingY   = 0;   // Recent 列表项纵向内边距
 constexpr int kRecentItemSpacing    = 3;   // Recent 名称与时间标签间距
 constexpr int kRecentNameFontPx     = 15;  // Recent 文件名字号
 constexpr int kRecentTimeFontPx     = 11;  // Recent 时间字号
@@ -622,6 +622,9 @@ QTMHomePage::renderRecentDocs () {
         DpiUtils::scaledFont (nameLabel->font (), kRecentNameFontPx);
     nameFont.setBold (true);
     nameLabel->setFont (nameFont);
+    // Microsoft YaHei UI 的下划线墨迹远低于字体 descent，超出 sizeHint
+    // 高度的部分会被 QLabel 自身矩形裁掉；拉伸到整行高度，文本内部居中
+    nameLabel->setAlignment (Qt::AlignLeft | Qt::AlignVCenter);
 
     // 云文档名后追加「云端」小标签（objectName 供主题 CSS
     // 定制，内联样式作兜底）。
@@ -647,10 +650,10 @@ QTMHomePage::renderRecentDocs () {
 
     // 标题与「云端」标签按内容宽度依次排列，弹性空间留给中间 stretch，
     // 使标签紧跟标题而非被顶到行尾
-    rowLayout->addWidget (nameLabel, 0, Qt::AlignLeft | Qt::AlignVCenter);
+    rowLayout->addWidget (nameLabel, 0);
     if (cloudLabel) rowLayout->addWidget (cloudLabel, 0, Qt::AlignVCenter);
     rowLayout->addStretch (1);
-    rowLayout->addWidget (timeLabel, 0, Qt::AlignRight | Qt::AlignVCenter);
+    rowLayout->addWidget (timeLabel, 0);
     recentList_->setItemWidget (item, rowWidget);
   }
 

--- a/src/Plugins/Qt/QTMHomePage.cpp
+++ b/src/Plugins/Qt/QTMHomePage.cpp
@@ -49,7 +49,9 @@ static const int MAX_RECENT_DOCS       = 50;
 static const int MAX_GLOBAL_RECENT_DOCS= 100;
 
 namespace {
-constexpr int kMainMargin           = 32;  // 主内容区外边距
+constexpr int kMainMargin= 32; // 主内容区外边距
+constexpr int kMainMarginBottom=
+    16; // 主内容区底部外边距（让最近文档框多向下延伸）
 constexpr int kMainSpacing          = 24;  // 主纵向布局间距
 constexpr int kStyleCardWidth       = 160; // 样式卡片宽度
 constexpr int kStyleCardHeight      = 256; // 样式卡片高度
@@ -269,7 +271,7 @@ QTMHomePage::setupUI () {
   QVBoxLayout* mainLayout= new QVBoxLayout (this);
   mainLayout->setContentsMargins (
       DpiUtils::scaled (kMainMargin), DpiUtils::scaled (kMainMargin),
-      DpiUtils::scaled (kMainMargin), DpiUtils::scaled (kMainMargin));
+      DpiUtils::scaled (kMainMargin), DpiUtils::scaled (kMainMarginBottom));
   mainLayout->setSpacing (DpiUtils::scaled (kMainSpacing));
 
   // 1. 样式选择区


### PR DESCRIPTION
## 问题

启动页「最近文档」中 `draft_xxxxxxxxxxxxxx.tmu` 这类文件名的下划线 `_` 完全不可见（看起来像空格）。

## 根因

数据层无问题（JSON 存储与传入 QLabel 的字符串均含 U+005F）。Microsoft YaHei UI 的下划线墨迹远低于字体上报的 descent，而文件名 QLabel 以 `AlignVCenter` 加入布局、高度仅为字体 sizeHint（约 19px），超出部分被标签自身矩形裁剪。

## 修复

- 文件名/时间标签不再以 `AlignVCenter` 加入布局，改为拉伸到整行高度，文本在标签内部垂直居中
- 行尺寸收紧：行高 40→36、纵向边距 2→0、内边距 6→0，一屏可完整显示 10 条最近文档（原仅 7 条）
- 主页底部外边距独立为 16（原 32），外框向下延伸，避免第 10 条被窗口底边裁掉

## 验证

Windows 上 `xmake b stem && xmake i stem && xmake r stem` 截图确认：下划线清晰可见，10 条记录完整显示。

注：Windows 下 `xmake r stem` 运行的是安装目录副本，改动后需先 `xmake i stem`。