### PR TITLE
[1257] 草稿文件名用 _ 分隔日期与时刻

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files-test.scm
@@ -17,6 +17,7 @@
 
 (import (liii check))
 (import (only (liii path) path-join path->string))
+(import (only (liii string) string-starts? string-ends? string-index))
 
 (check-set-mode! 'report-failed)
 
@@ -49,11 +50,51 @@
 ) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for draft_YYYYMMDD_HHMMSS naming (1257)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (draft-test-url name) (system->url name))
+
+(define (draft-name-stamp-part name)
+  (let* ((body (substring name 6 (- (string-length name) 4)))
+         (cut (or (string-index body #\-) (string-length body)))
+        ) ;
+    (substring body 0 cut)
+  ) ;let*
+) ;define
+
+(define (test-scratch-buffer-name-has-date-time-underscore)
+  (let* ((path (scratch-buffer-name))
+         (name (url->string (url-tail (system->url path))))
+         (stamp (draft-name-stamp-part name))
+        ) ;
+    (check (string-starts? name "draft_") => #t)
+    (check (string-ends? name ".tmu") => #t)
+    ;; YYYYMMDD_HHMMSS → 长度 15,第 9 个字符是 _
+    (check (string-length stamp) => 15)
+    (check (substring stamp 8 9) => "_")
+  ) ;let*
+) ;define
+
+(define (test-scratch-buffer-title-old-and-new-stamp)
+  ;; 往年草稿不显示时刻,新旧文件名必须得到同一标题
+  (let ((old (scratch-buffer-title (draft-test-url "draft_20250802153000.tmu")))
+        (new (scratch-buffer-title (draft-test-url "draft_20250802_153000.tmu")))
+        (new-n (scratch-buffer-title (draft-test-url "draft_20250802_153000-1.tmu")))
+       ) ;
+    (check old => new)
+    (check new => new-n)
+  ) ;let
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test entry point
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (tm-define (regtest-tm-files)
   (test-auto-backup-official-url)
   (test-auto-backup-texmacs-path-buffer?)
+  (test-scratch-buffer-name-has-date-time-underscore)
+  (test-scratch-buffer-title-old-and-new-stamp)
   (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/texmacs/texmacs/tm-files-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files-test.scm
@@ -17,7 +17,9 @@
 
 (import (liii check))
 (import (only (liii path) path-join path->string))
-(import (only (liii string) string-starts? string-ends? string-index))
+(import (only (liii string) string-starts? string-ends? string-index string-contains?)
+) ;import
+(import (only (liii time) current-date date->string))
 
 (check-set-mode! 'report-failed)
 
@@ -53,7 +55,9 @@
 ;; Tests for draft_YYYYMMDD_HHMMSS naming (1257)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (draft-test-url name) (system->url name))
+(define (draft-test-url name)
+  (system->url name)
+) ;define
 
 (define (draft-name-stamp-part name)
   (let* ((body (substring name 6 (- (string-length name) 4)))
@@ -87,6 +91,29 @@
   ) ;let
 ) ;define
 
+(define (test-scratch-buffer-title-legacy-one-underscore-this-week)
+  ;; 本周旧名只有 draft_ 一个下划线;标题须含文件名里的 HH:MM:SS
+  (let* ((now (date->string (current-date) "~Y~m~d~H~M~S"))
+         (day (substring now 0 8))
+         (hms (substring now 8 14))
+         (clock (string-append (substring hms 0 2)
+                  ":"
+                  (substring hms 2 4)
+                  ":"
+                  (substring hms 4 6)
+                ) ;string-append
+         ) ;clock
+         (old (scratch-buffer-title (draft-test-url (string-append "draft_" now ".tmu")))
+         ) ;old
+         (new (scratch-buffer-title (draft-test-url (string-append "draft_" day "_" hms ".tmu"))
+              ) ;scratch-buffer-title
+         ) ;new
+        ) ;
+    (check old => new)
+    (check (string-contains? old clock) => #t)
+  ) ;let*
+) ;define
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test entry point
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -96,5 +123,6 @@
   (test-auto-backup-texmacs-path-buffer?)
   (test-scratch-buffer-name-has-date-time-underscore)
   (test-scratch-buffer-title-old-and-new-stamp)
+  (test-scratch-buffer-title-legacy-one-underscore-this-week)
   (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -1186,7 +1186,7 @@
 (tm-define (linked-file-list) (linked-files-inside (buffer-tree)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Scratch buffers (draft_YYYYMMDDHH[MM][SS].tmu)
+;; Scratch buffers (draft_YYYYMMDD_HHMMSS.tmu; 旧稿无 _ 仍可解析)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; scratch buffer 所在目录
@@ -1217,7 +1217,8 @@
   ) ;let
 ) ;define
 
-;; 新 scratch buffer 的名字:精确到秒(标题需统一显示时分秒),冲突加 -N
+;; 新 scratch buffer 的名字:日期与时刻用 _ 分开,精确到秒,冲突加 -N
+;; 例: draft_20260901_194700.tmu / draft_20260901_194700-1.tmu
 ;; 返回系统路径字符串(供 C++ make_new_buffer 使用)
 (tm-define (scratch-buffer-name)
   (with dir
@@ -1226,13 +1227,15 @@
       (system-mkdir dir)
     ) ;when
     (with full
-      (date->string (current-date) "~Y~m~d~H~M~S")
+      (date->string (current-date) "~Y~m~d_~H~M~S")
       (url->system (scratch-unique-name dir full 0))
     ) ;with
   ) ;with
 ) ;tm-define
 
-;; draft 文件名 → 时间戳数字串("draft_202608242127-2.tmu" → "202608242127"),
+;; draft 文件名 → 纯数字时间戳,供标题按位切分(YYYYMMDDHH[MM][SS])。
+;; 新格式 "draft_20260901_194700.tmu" → "20260901194700";
+;; 旧格式 "draft_202608242127-2.tmu" → "202608242127";
 ;; 非 draft 名返回 #f
 
 (define (draft-stamp u)
@@ -1242,7 +1245,9 @@
       (string-ends? name ".tmu")
       (let* ((body (substring name 6 (- (string-length name) 4)))
              (cut (or (string-index body #\-) (string-length body)))
-             (digits (substring body 0 cut))
+             (raw (substring body 0 cut))
+             ;; 去掉日期与时刻之间的 _,标题逻辑仍按连续数字下标切
+             (digits (string-join (string-split raw "_") ""))
             ) ;
         (and (>= (string-length digits) 12) digits)
       ) ;let*

--- a/devel/1257.md
+++ b/devel/1257.md
@@ -1,0 +1,67 @@
+# [1257] 草稿文件名用 `_` 分隔日期与时刻
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1240.md](1240.md) - 新文档 no_name 改为 `draft_` 时间戳命名（标题规则、落盘目录）
+- Issue: [mogan#4469](https://github.com/MoganLab/mogan/issues/4469)
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/texmacs/texmacs/tm-files.scm` — `scratch-buffer-name` / `draft-stamp`
+- `TeXmacs/progs/texmacs/texmacs/tm-files-test.scm` — 新文件名形状 + 新旧标题一致
+- `src/Texmacs/Data/new_buffer.cpp` — 未改：仍调 scheme 命名，仍按 `draft_` + `.tmu` 走标题
+
+## 3 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b tm-files-test
+xmake r tm-files-test
+```
+预期：新建名带 `YYYYMMDD_HHMMSS`；往年旧格式 `draft_20250802153000.tmu` 与新格式 `draft_20250802_153000.tmu`（含 `-1` 冲突后缀）标题相同。
+
+### 3.2 非确定性测试（文档验证）
+
+Windows 须先 install，否则 `xmake r stem` 可能启动旧程序：
+
+```
+xmake b stem
+xmake install stem
+xmake r stem
+```
+
+Linux / macOS 不必 install：`xmake b stem && xmake r stem`。
+
+1. Ctrl+T 新建标签。标题仍为本周规则：`草稿（周几 HH:MM:SS）` / `Draft Weekday HH:MM:SS`，**不要**显示文件名。
+2. 草稿刚创建时可能还不落盘。等自动保存后查看 `~/Documents/LiiiSTEM/no_name/`（中文系统 `~/文档/LiiiSTEM/no_name/`）：
+   文件名形如 `draft_20260901_194700.tmu`（日期与时刻之间有 `_`，可读的时间线）。
+3. 同一秒快速连建两份：第二份为 `draft_YYYYMMDD_HHMMSS-1.tmu`。
+4. 打开一份旧稿 `draft_20260825112126.tmu`：标签仍按 1240 的本周 / 今年非本周 / 往年规则，不乱码、不错成「no name」。
+
+## 4 如何提交
+
+提交前执行 `gf fmt --changed-since=main`。
+
+## 5 What
+
+1. 新草稿文件名由 `draft_YYYYMMDDHHMMSS.tmu` 改为 `draft_YYYYMMDD_HHMMSS.tmu`。
+2. 同秒冲突后缀仍是 `-N`，写在时刻之后：`draft_20260901_194700-1.tmu`。
+3. `draft-stamp` 去掉 `_` 后再交给原标题切分逻辑，旧无下划线文件继续可用。
+4. 标签页标题规则不改。
+
+## 6 Why
+
+连续 14 位数字难读。用 `_` 分开日期和时刻后，磁盘上的草稿名与标题里的时间能对上看。
+
+## 7 How
+
+数据流（1240 未改）：
+
+1. C++ `make_new_buffer` 调 `(scratch-buffer-name)`，得到系统路径字符串。
+2. 自动保存把内容写到该路径（目录仍是 `LiiiSTEM/no_name/`）。
+3. C++ `propose_title` 见 `draft_*.tmu` 则调 `(scratch-buffer-title u)`。
+4. `scratch-buffer-title` 依赖 `draft-stamp` 返回的**连续数字**，用 `substring` 切日/时/分/秒。
+
+因此只改两处：
+
+- **生成**：`date->string` 模板 `~Y~m~d~H~M~S` → `~Y~m~d_~H~M~S`。`scratch-candidate` 仍是 `"draft_" + stamp + ".tmu"`，stamp 里已含 `_`。
+- **解析**：文件名去掉 `draft_` / `.tmu` 后，先按 `-` 丢掉冲突序号，再 `string-split` 掉 `_` 拼回数字。新名 `20260901_194700` → `20260901194700`；旧名 `20260825112126` 不变。若不剥 `_`，`substring stamp 8 10` 会切到 `_1`，本周标题坏掉。

--- a/devel/1257.md
+++ b/devel/1257.md
@@ -7,7 +7,7 @@
 
 ## 2 任务相关的代码文件
 - `TeXmacs/progs/texmacs/texmacs/tm-files.scm` — `scratch-buffer-name` / `draft-stamp`
-- `TeXmacs/progs/texmacs/texmacs/tm-files-test.scm` — 新文件名形状 + 新旧标题一致
+- `TeXmacs/progs/texmacs/texmacs/tm-files-test.scm` — 新文件名形状、新旧标题一致、本周旧名（一个下划线）含时刻
 - `src/Texmacs/Data/new_buffer.cpp` — 未改：仍调 scheme 命名，仍按 `draft_` + `.tmu` 走标题
 
 ## 3 如何测试
@@ -17,7 +17,7 @@
 xmake b tm-files-test
 xmake r tm-files-test
 ```
-预期：新建名带 `YYYYMMDD_HHMMSS`；往年旧格式 `draft_20250802153000.tmu` 与新格式 `draft_20250802_153000.tmu`（含 `-1` 冲突后缀）标题相同。
+预期：新建名带 `YYYYMMDD_HHMMSS`；往年旧格式 `draft_20250802153000.tmu` 与新格式 `draft_20250802_153000.tmu`（含 `-1` 冲突后缀）标题相同；本周旧格式（仅 `draft_` 一个下划线）与新格式标题相同，且标题含文件名里的 `HH:MM:SS`。
 
 ### 3.2 非确定性测试（文档验证）
 
@@ -35,7 +35,13 @@ Linux / macOS 不必 install：`xmake b stem && xmake r stem`。
 2. 草稿刚创建时可能还不落盘。等自动保存后查看 `~/Documents/LiiiSTEM/no_name/`（中文系统 `~/文档/LiiiSTEM/no_name/`）：
    文件名形如 `draft_20260901_194700.tmu`（日期与时刻之间有 `_`，可读的时间线）。
 3. 同一秒快速连建两份：第二份为 `draft_YYYYMMDD_HHMMSS-1.tmu`。
-4. 打开一份旧稿 `draft_20260825112126.tmu`：标签仍按 1240 的本周 / 今年非本周 / 往年规则，不乱码、不错成「no name」。
+4. **存量兼容（仅一个下划线的旧名）**。标签上的人性化提示（如「草稿（周三 10:26:04）」）是从文件名里的数字推断的，不是另存字段。磁盘上已有大量 `draft_YYYYMMDDHHMMSS.tmu`（`draft_` 之后是连续 14 位，日期与时刻中间没有 `_`）。必须仍能打开并显示正确时间。
+
+   手测：在 `no_name` 目录放入或找到本周旧格式文件，例如今天 10:26:04 对应 `draft_20260902102604.tmu`（不要写成 `draft_20260902_102604.tmu`）。用 STEM 打开后，标签须为「草稿（周几 10:26:04）」/ `Draft Weekday 10:26:04`，时分秒与文件名数字一致，不能变成「no name」，也不能把不存在的 `_` 解析错。
+
+   若本地没有旧文件，可把任意本周新草稿复制一份，把文件名里日期与时刻之间的 `_` 删掉后再打开。
+
+5. 打开一份往年旧稿 `draft_20250802153000.tmu`：标签按 1240 规则只显示日期（不带时刻），不乱码、不错成「no name」。
 
 ## 4 如何提交
 


### PR DESCRIPTION
## Summary
- 新草稿落盘名改为 `draft_YYYYMMDD_HHMMSS.tmu`，同秒冲突仍用 `-N`。
- `draft-stamp` 去掉 `_` 后再走原标题切分，旧无下划线文件标题不变。
- 补充 `tm-files-test` 与 `devel/1257.md`。Closes MoganLab/mogan#4469。

## Test plan
- [ ] `xmake b stem && xmake install stem`（Windows）后启动
- [ ] Ctrl+T 后自动保存，`no_name` 下出现 `draft_日期_时刻.tmu`
- [ ] 标签仍为「草稿（周几 HH:MM:SS）」
- [ ] 打开旧稿 `draft_YYYYMMDDHHMMSS.tmu`，标题规则仍按 1240
