### PR TITLE
[1259] 启动页最近文档默认上限提升到 50

### DIFF
--- a/TeXmacs/progs/startup-tab/startup-tab-file.scm
+++ b/TeXmacs/progs/startup-tab/startup-tab-file.scm
@@ -48,9 +48,10 @@
 (tm-define (startup-tab-get-recent-docs)
   ;; Get recent document paths with the same filtering and ordering
   ;; as File -> Recent used
+  ;; 条数上限对齐 C++ 侧 QTMHomePage.cpp 的 MAX_RECENT_DOCS = 50，超出无效
   (let* ((raw (string->number (get-preference "startup-tab:max-recent")))
-         (nr (if (number? raw) raw 10))
-         (nr (max 1 nr))
+         (nr (if (number? raw) raw 50))
+         (nr (min 50 (max 1 nr)))
         ) ;
     (map url->system (recent-file-list nr))
   ) ;let*

--- a/devel/1259.md
+++ b/devel/1259.md
@@ -1,0 +1,33 @@
+# [1259] 启动页最近文档数量上限提升到 50
+
+## What
+
+启动页（主页）「最近文档」列表的默认条数上限从 10 提升到 50，
+scheme 侧 clamp 区间对齐为 `[1, 50]`。
+
+## Why
+
+`startup-tab-get-recent-docs` 原先默认只取 10 条（`"startup-tab:max-recent"`
+首选项缺省值 10），且只做了下限保护（`max 1`），用户设置超大值时无上限约束。
+C++ 侧 `QTMHomePage.cpp` 的 `MAX_RECENT_DOCS` 本来就是 50（QListWidget
+纯文本条目、无缩略图，50 条渲染为毫秒级，无性能问题），scheme 默认 10
+平白浪费了这个容量。
+
+## How
+
+`TeXmacs/progs/startup-tab/startup-tab-file.scm` 的
+`startup-tab-get-recent-docs`：
+
+- 缺省值 `10` → `50`；
+- clamp 由 `(max 1 nr)` 改为 `(min 50 (max 1 nr))`，上限与 C++ 侧
+  `MAX_RECENT_DOCS = 50` 对齐，并加注释说明。
+
+## 涉及文件
+
+- `TeXmacs/progs/startup-tab/startup-tab-file.scm`
+
+## 测试
+
+手工 GUI 验证（Windows，`xmake i stem` 后 `xmake r stem`）：
+启动页最近文档列表渲染出远超 10 条的历史条目（含云文档「云端」标签），
+滚轮可滚动浏览至底部，渲染与滚动正常。


### PR DESCRIPTION
## What

启动页（主页）「最近文档」列表的默认条数上限从 10 提升到 50，scheme 侧 clamp 区间对齐为 `[1, 50]`。

## Why

`startup-tab-get-recent-docs` 原先默认只取 10 条（`startup-tab:max-recent` 首选项缺省值 10），且只做了下限保护。C++ 侧 `QTMHomePage.cpp` 的 `MAX_RECENT_DOCS` 本来就是 50（QListWidget 纯文本条目、无缩略图，50 条渲染为毫秒级，无性能问题），scheme 默认 10 平白浪费了这个容量。

## How

`TeXmacs/progs/startup-tab/startup-tab-file.scm`：

- 缺省值 `10` → `50`
- clamp 由 `(max 1 nr)` 改为 `(min 50 (max 1 nr))`，上限与 C++ 侧 `MAX_RECENT_DOCS = 50` 对齐，并加注释说明

## 测试

手工 GUI 验证（Windows，`xmake i stem` 后 `xmake r stem`）：启动页最近文档列表渲染出远超 10 条的历史条目（含云文档「云端」标签），滚轮可滚动浏览至底部，渲染与滚动正常。