### PR TITLE
[1254] 增加基于 pynput 的端到端自动化测试并完善各级标题插入支持

### DIFF
--- a/TeXmacs/progs/text/text-kbd.scm
+++ b/TeXmacs/progs/text/text-kbd.scm
@@ -422,9 +422,9 @@
   ("text 1" (smart-insert-heading 'section))
   ("text 2" (smart-insert-heading 'subsection))
   ("text 3" (smart-insert-heading 'subsubsection))
-  ("text 4" (make-section 'paragraph))
-  ("text 5" (make-section 'subparagraph))
-  ("text 6" (make-section 'appendix))
+  ("text 4" (smart-insert-heading 'paragraph))
+  ("text 5" (smart-insert-heading 'subparagraph))
+  ("text 6" (smart-insert-heading 'appendix))
 
   ("F5" (make 'em))
   ("F6" (make 'strong))

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -134,8 +134,8 @@
  ("Subsection" (smart-insert-heading 'subsection))
  ("Subsubsection" (smart-insert-heading 'subsubsection))
  ---
- ("Paragraph::section" (make-section 'paragraph))
- ("Subparagraph" (make-section 'subparagraph))
+ ("Paragraph::section" (smart-insert-heading 'paragraph))
+ ("Subparagraph" (smart-insert-heading 'subparagraph))
 ) ;menu-bind
 
 
@@ -152,10 +152,10 @@
   ("Subsection" (smart-insert-heading 'subsection))
   ("Subsubsection" (smart-insert-heading 'subsubsection))
   ---
-  ("Paragraph::section" (make-section 'paragraph))
-  ("Subparagraph" (make-section 'subparagraph))
+  ("Paragraph::section" (smart-insert-heading 'paragraph))
+  ("Subparagraph" (smart-insert-heading 'subparagraph))
   ---
-  ("Appendix" (make-section 'appendix))
+  ("Appendix" (smart-insert-heading 'appendix))
   ("Prologue::menu" (begin (make-unnamed-section 'prologue) (insert-return)))
   ("Epilogue" (begin (make-unnamed-section 'epilogue) (insert-return)))
   ("List of abbreviations" (make-unnamed-section 'list-of-abbreviations))

--- a/TeXmacs/tests/1254.scm
+++ b/TeXmacs/tests/1254.scm
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : 1254.scm
-;; DESCRIPTION : 集成测试：在 section/subsection/subsubsection 结构内插入同类结构
+;; DESCRIPTION : 集成测试：在 chapter/section/subsection/subsubsection/paragraph 结构内插入同类及跨级结构
 ;; COPYRIGHT   : (C) 2026 Mogan STEM
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -54,70 +54,108 @@
 (define (get-heading-titles tag)
   (let ((st (tree->stree (buffer-tree))))
     (map caddr
-         (filter (lambda (item)
-                   (and (pair? item)
-                        (== (car item) 'concat)
-                        (pair? (cdr item))
-                        (pair? (cadr item))
-                        (== (caadr item) tag)))
-                 (cdr st)))))
+      (filter (lambda (item)
+                (and (pair? item)
+                  (== (car item) 'concat)
+                  (pair? (cdr item))
+                  (pair? (cadr item))
+                  (== (caadr item) tag)
+                ) ;and
+              ) ;lambda
+        (cdr st)
+      ) ;filter
+    ) ;map
+  ) ;let
+) ;define
 
 (tm-define (test_1254)
-  (run-chain (list
-    (cons "new document"
-      (lambda ()
-        (new-document)
-        (init-env "style" "generic")
-      ))
-    (cons "insert first section"
-      (lambda ()
-        (smart-insert-heading 'section)
-        (insert "Section 1")
-        (check (get-heading-titles 'section) => '("Section 1"))
-        (check-true (not (not (current-section-node))))
-      ))
-    (cons "insert section while cursor inside first section"
-      (lambda ()
-        ;; 光标在 Section 1 内部，此时插入 section
-        (smart-insert-heading 'section)
-        (insert "Section 2")
-        (check (get-heading-titles 'section) => '("Section 1" "Section 2"))
-      ))
-    (cons "insert subsection while cursor inside section"
-      (lambda ()
-        ;; 光标在 Section 2 内部，此时插入 subsection
-        (smart-insert-heading 'subsection)
-        (insert "Subsection 2.1")
-        (check (get-heading-titles 'section) => '("Section 1" "Section 2"))
-        (check (get-heading-titles 'subsection) => '("Subsection 2.1"))
-      ))
-    (cons "insert subsection while cursor inside subsection"
-      (lambda ()
-        ;; 光标在 Subsection 2.1 内部，此时插入 subsection
-        (smart-insert-heading 'subsection)
-        (insert "Subsection 2.2")
-        (check (get-heading-titles 'subsection) => '("Subsection 2.1" "Subsection 2.2"))
-      ))
-    (cons "insert subsubsection while cursor inside subsection"
-      (lambda ()
-        ;; 光标在 Subsection 2.2 内部，此时插入 subsubsection
-        (smart-insert-heading 'subsubsection)
-        (insert "Subsubsection 2.2.1")
-        (check (get-heading-titles 'subsection) => '("Subsection 2.1" "Subsection 2.2"))
-        (check (get-heading-titles 'subsubsection) => '("Subsubsection 2.2.1"))
-      ))
-    (cons "insert section while cursor inside subsubsection"
-      (lambda ()
-        ;; 光标在 Subsubsection 2.2.1 内部，此时插入 section
-        (smart-insert-heading 'section)
-        (insert "Section 3")
-        (check (get-heading-titles 'section) => '("Section 1" "Section 2" "Section 3"))
-        (check (get-heading-titles 'subsubsection) => '("Subsubsection 2.2.1"))
-      ))
-    (cons "report + quit"
-      (lambda ()
-        (check-report)
-        (quit-TeXmacs)
-      ))
-  ))
+  (run-chain (list (cons "new document" (lambda () (new-document) (init-env "style" "generic")))
+               (cons "insert chapter"
+                 (lambda ()
+                   (smart-insert-heading 'chapter)
+                   (insert "Chapter 1")
+                   (check (get-heading-titles 'chapter) => '("Chapter 1"))
+                   (check-true (not (not (current-section-node))))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert section while cursor inside chapter"
+                 (lambda ()
+                   ;; 光标在 Chapter 1 内部，此时插入 section
+                   (smart-insert-heading 'section)
+                   (insert "Section 1")
+                   (check (get-heading-titles 'chapter) => '("Chapter 1"))
+                   (check (get-heading-titles 'section) => '("Section 1"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert section while cursor inside first section"
+                 (lambda ()
+                   ;; 光标在 Section 1 内部，此时插入 section
+                   (smart-insert-heading 'section)
+                   (insert "Section 2")
+                   (check (get-heading-titles 'section) => '("Section 1"
+                                                             "Section 2"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert subsection while cursor inside section"
+                 (lambda ()
+                   ;; 光标在 Section 2 内部，此时插入 subsection
+                   (smart-insert-heading 'subsection)
+                   (insert "Subsection 2.1")
+                   (check (get-heading-titles 'section) => '("Section 1"
+                                                             "Section 2"))
+                   (check (get-heading-titles 'subsection) => '("Subsection 2.1"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert subsection while cursor inside subsection"
+                 (lambda ()
+                   ;; 光标在 Subsection 2.1 内部，此时插入 subsection
+                   (smart-insert-heading 'subsection)
+                   (insert "Subsection 2.2")
+                   (check (get-heading-titles 'subsection) => '("Subsection 2.1"
+                                                                "Subsection 2.2"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert subsubsection while cursor inside subsection"
+                 (lambda ()
+                   ;; 光标在 Subsection 2.2 内部，此时插入 subsubsection
+                   (smart-insert-heading 'subsubsection)
+                   (insert "Subsubsection 2.2.1")
+                   (check (get-heading-titles 'subsection) => '("Subsection 2.1"
+                                                                "Subsection 2.2"))
+                   (check (get-heading-titles 'subsubsection) => '("Subsubsection 2.2.1"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert paragraph while cursor inside subsubsection"
+                 (lambda ()
+                   ;; 光标在 Subsubsection 2.2.1 内部，此时插入 paragraph
+                   (smart-insert-heading 'paragraph)
+                   (insert "Paragraph 2.2.1.1")
+                   (check (get-heading-titles 'subsubsection) => '("Subsubsection 2.2.1"))
+                   (check (get-heading-titles 'paragraph) => '("Paragraph 2.2.1.1"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert subparagraph while cursor inside paragraph"
+                 (lambda ()
+                   ;; 光标在 Paragraph 2.2.1.1 内部，此时插入 subparagraph
+                   (smart-insert-heading 'subparagraph)
+                   (insert "Subparagraph 2.2.1.1.1")
+                   (check (get-heading-titles 'paragraph) => '("Paragraph 2.2.1.1"))
+                   (check (get-heading-titles 'subparagraph) => '("Subparagraph 2.2.1.1.1"))
+                 ) ;lambda
+               ) ;cons
+               (cons "insert section while cursor inside subparagraph"
+                 (lambda ()
+                   ;; 光标在 Subparagraph 2.2.1.1.1 内部，此时插入 section
+                   (smart-insert-heading 'section)
+                   (insert "Section 3")
+                   (check (get-heading-titles 'chapter) => '("Chapter 1"))
+                   (check (get-heading-titles 'section) => '("Section 1"
+                                                             "Section 2"
+                                                             "Section 3"))
+                   (check (get-heading-titles 'subparagraph) => '("Subparagraph 2.2.1.1.1"))
+                 ) ;lambda
+               ) ;cons
+               (cons "report + quit" (lambda () (check-report) (quit-TeXmacs)))
+             ) ;list
+  ) ;run-chain
 ) ;tm-define

--- a/TeXmacs/tests/python/1254.py
+++ b/TeXmacs/tests/python/1254.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+| Tester                  | Platform    | Status |
+| ----------------------- | ----------- | ------ |
+| Darcy Shen <da@liii.pro>| Linux (X11) | Passed |
+
+Automated end-to-end UI test for issue 1254:
+Verify that inserting headings (chapter / section / subsection / subsubsection / paragraph / subparagraph)
+via Alt+0..5 shortcuts while cursor is inside an existing heading automatically exits
+the current heading structure, inserts a newline, and creates the new heading without
+breaking, splitting, or improperly nesting inside the existing heading.
+"""
+
+import os
+import sys
+import time
+import re
+import subprocess
+from PIL import ImageGrab
+
+# Fallback: import pynput from ~/git/pynput/lib if not installed system-wide
+try:
+    import pynput
+except ImportError:
+    pynput_path = os.path.expanduser("~/git/pynput/lib")
+    if os.path.exists(pynput_path):
+        sys.path.insert(0, pynput_path)
+    import pynput
+
+from pynput.keyboard import Key, Controller as KeyboardController
+from pynput.mouse import Button, Controller as MouseController
+
+
+def find_repo_root():
+    cur = os.path.abspath(os.path.dirname(__file__))
+    while cur != "/" and cur != os.path.dirname(cur):
+        if os.path.exists(os.path.join(cur, "TeXmacs")) and os.path.exists(os.path.join(cur, "src")):
+            return cur
+        cur = os.path.dirname(cur)
+    return os.path.abspath(".")
+
+
+def find_mogan_binary(repo_root):
+    candidates = [
+        os.path.join(repo_root, "build/linux/x86_64/release/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/debug/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/releasedbg/moganstem"),
+        os.path.join(repo_root, "build/packages/stem/data/bin/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+    ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    raise FileNotFoundError("Mogan binary not found. Please build stem first (xmake b stem).")
+
+
+def find_no_name_dir():
+    candidates = []
+    try:
+        xdg_docs = subprocess.check_output(["xdg-user-dir", "DOCUMENTS"], text=True).strip()
+        if xdg_docs:
+            candidates.append(os.path.join(xdg_docs, "LiiiSTEM", "no_name"))
+    except Exception:
+        pass
+
+    candidates.extend([
+        os.path.expanduser("~/文档/LiiiSTEM/no_name"),
+        os.path.expanduser("~/Documents/LiiiSTEM/no_name"),
+        os.path.expanduser("~/LiiiSTEM/no_name"),
+    ])
+
+    for d in candidates:
+        if os.path.exists(d):
+            return d
+
+    target = os.path.expanduser("~/Documents/LiiiSTEM/no_name")
+    os.makedirs(target, exist_ok=True)
+    return target
+
+
+def focus_mogan_window():
+    """Ensure Mogan window is raised and focused on X11 platform."""
+    try:
+        import Xlib.display
+        import Xlib.X
+        import Xlib.protocol.event
+
+        d = Xlib.display.Display()
+        root = d.screen().root
+
+        def find_mogan(win):
+            try:
+                name = win.get_wm_name()
+                if name and "Liii STEM" in name:
+                    return win
+                for child in win.query_tree().children:
+                    res = find_mogan(child)
+                    if res:
+                        return res
+            except Exception:
+                pass
+            return None
+
+        w = find_mogan(root)
+        if w:
+            net_active = d.intern_atom("_NET_ACTIVE_WINDOW")
+            cm = Xlib.protocol.event.ClientMessage(
+                window=w,
+                client_type=net_active,
+                data=(32, [2, Xlib.X.CurrentTime, 0, 0, 0]),
+            )
+            root.send_event(
+                cm,
+                event_mask=Xlib.X.SubstructureRedirectMask | Xlib.X.SubstructureNotifyMask,
+            )
+            w.set_input_focus(Xlib.X.RevertToParent, Xlib.X.CurrentTime)
+            w.configure(stack_mode=Xlib.X.Above)
+            d.sync()
+    except Exception:
+        pass
+
+
+def terminate_process(proc):
+    if proc:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def extract_headings(tmu_content):
+    """Extract all headings in the body tag."""
+    body_match = re.search(r"<\\body>(.*?)</body>", tmu_content, re.DOTALL)
+    if not body_match:
+        return []
+    body_content = body_match.group(1)
+    pattern = re.compile(r"<(chapter|section|subsection|subsubsection|paragraph|subparagraph)\|([^>]+)>")
+    return pattern.findall(body_content)
+
+
+def run_test():
+    repo_root = find_repo_root()
+    bin_path = find_mogan_binary(repo_root)
+    no_name_dir = find_no_name_dir()
+    print(f"[1254] Using Mogan binary: {bin_path}")
+    print(f"[1254] Monitoring draft directory: {no_name_dir}")
+
+    existing_files = set(os.listdir(no_name_dir)) if os.path.exists(no_name_dir) else set()
+
+    env = os.environ.copy()
+    env["TEXMACS_PATH"] = os.path.join(repo_root, "TeXmacs")
+
+    created_temp_files = []
+
+    print("\n[1254] --- Step 1: Launching Mogan and opening a new document ---")
+    proc = subprocess.Popen([bin_path], env=env)
+    keyboard = KeyboardController()
+    mouse = MouseController()
+
+    try:
+        time.sleep(3.5)
+        focus_mogan_window()
+        time.sleep(0.5)
+
+        # Click window to ensure focus
+        mouse.position = (500, 500)
+        time.sleep(0.3)
+        mouse.click(Button.left)
+        time.sleep(0.5)
+
+        # Create new tab (Ctrl+T)
+        print("[1254] Creating new tab (Ctrl+T)...")
+        with keyboard.pressed(Key.ctrl):
+            keyboard.press("t")
+            keyboard.release("t")
+        time.sleep(2.0)
+
+        # =========================================================================
+        # Step 2: Insert headings using Alt+0..5 while cursor is inside headings
+        # =========================================================================
+        print("\n[1254] --- Step 2: Inserting headings while cursor is inside heading structures ---")
+
+        # 1. Insert Chapter 1 (Alt+0)
+        print("[1254] [1/9] Inserting Chapter 1 (Alt+0 -> 'Chapter 1')...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("0")
+            keyboard.release("0")
+        time.sleep(0.4)
+        keyboard.type("Chapter 1")
+        time.sleep(0.4)
+
+        # 2. While cursor is inside Chapter 1, press Alt+1 to insert Section 1
+        print("[1254] [2/9] Cursor is inside Chapter 1 -> Pressing Alt+1 to insert Section 1...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("1")
+            keyboard.release("1")
+        time.sleep(0.4)
+        keyboard.type("Section 1")
+        time.sleep(0.4)
+
+        # 3. While cursor is inside Section 1, press Alt+1 to insert Section 2
+        print("[1254] [3/9] Cursor is inside Section 1 -> Pressing Alt+1 to insert Section 2...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("1")
+            keyboard.release("1")
+        time.sleep(0.4)
+        keyboard.type("Section 2")
+        time.sleep(0.4)
+
+        # 4. While cursor is inside Section 2, press Alt+2 to insert Subsection 2.1
+        print("[1254] [4/9] Cursor is inside Section 2 -> Pressing Alt+2 to insert Subsection 2.1...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("2")
+            keyboard.release("2")
+        time.sleep(0.4)
+        keyboard.type("Subsection 2.1")
+        time.sleep(0.4)
+
+        # 5. While cursor is inside Subsection 2.1, press Alt+2 to insert Subsection 2.2
+        print("[1254] [5/9] Cursor is inside Subsection 2.1 -> Pressing Alt+2 to insert Subsection 2.2...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("2")
+            keyboard.release("2")
+        time.sleep(0.4)
+        keyboard.type("Subsection 2.2")
+        time.sleep(0.4)
+
+        # 6. While cursor is inside Subsection 2.2, press Alt+3 to insert Subsubsection 2.2.1
+        print("[1254] [6/9] Cursor is inside Subsection 2.2 -> Pressing Alt+3 to insert Subsubsection 2.2.1...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("3")
+            keyboard.release("3")
+        time.sleep(0.4)
+        keyboard.type("Subsubsection 2.2.1")
+        time.sleep(0.4)
+
+        # 7. While cursor is inside Subsubsection 2.2.1, press Alt+4 to insert Paragraph 1
+        print("[1254] [7/9] Cursor is inside Subsubsection 2.2.1 -> Pressing Alt+4 to insert Paragraph 1...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("4")
+            keyboard.release("4")
+        time.sleep(0.4)
+        keyboard.type("Paragraph 1")
+        time.sleep(0.4)
+
+        # 8. While cursor is inside Paragraph 1, press Alt+5 to insert Subparagraph 1.1
+        print("[1254] [8/9] Cursor is inside Paragraph 1 -> Pressing Alt+5 to insert Subparagraph 1.1...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("5")
+            keyboard.release("5")
+        time.sleep(0.4)
+        keyboard.type("Subparagraph 1.1")
+        time.sleep(0.4)
+
+        # 9. While cursor is inside Subparagraph 1.1, press Alt+1 to insert Section 3
+        print("[1254] [9/9] Cursor is inside Subparagraph 1.1 -> Pressing Alt+1 to insert Section 3...")
+        with keyboard.pressed(Key.alt):
+            keyboard.press("1")
+            keyboard.release("1")
+        time.sleep(0.4)
+        keyboard.type("Section 3")
+        time.sleep(0.4)
+
+        # Take screenshot for diagnosis
+        screenshot_path = "/tmp/1254_screenshot.png"
+        img = ImageGrab.grab()
+        img.save(screenshot_path)
+        print(f"[1254] Saved screenshot to {screenshot_path}")
+
+        # Trigger preview (Ctrl+P) to auto-save the draft
+        print("[1254] Triggering preview (Ctrl+P) to auto-save draft...")
+        with keyboard.pressed(Key.ctrl):
+            keyboard.press("p")
+            keyboard.release("p")
+        time.sleep(3.5)
+
+        # Find newly created draft file
+        current_files = set(os.listdir(no_name_dir)) if os.path.exists(no_name_dir) else set()
+        diff_files = current_files - existing_files
+        tmu_files = [f for f in diff_files if f.endswith(".tmu")]
+        for f in diff_files:
+            created_temp_files.append(os.path.join(no_name_dir, f))
+
+        if not tmu_files:
+            print("[1254] ERROR: No .tmu draft file was created after previewing.")
+            return 1
+
+        target_file = os.path.join(no_name_dir, tmu_files[-1])
+        print(f"[1254] Inspecting draft file: {target_file}")
+        with open(target_file, "r", encoding="utf-8") as f:
+            tmu_content = f.read()
+
+        # =========================================================================
+        # Step 3: Validate AST and heading structure
+        # =========================================================================
+        print("\n[1254] --- Step 3: Validating heading structure in saved document ---")
+        headings = extract_headings(tmu_content)
+        print(f"[1254] Extracted headings: {headings}")
+
+        expected_headings = [
+            ("chapter", "Chapter 1"),
+            ("section", "Section 1"),
+            ("section", "Section 2"),
+            ("subsection", "Subsection 2.1"),
+            ("subsection", "Subsection 2.2"),
+            ("subsubsection", "Subsubsection 2.2.1"),
+            ("paragraph", "Paragraph 1"),
+            ("subparagraph", "Subparagraph 1.1"),
+            ("section", "Section 3"),
+        ]
+
+        if headings != expected_headings:
+            print(f"[1254] ERROR: Headings do not match expected structure!")
+            print(f"  Expected: {expected_headings}")
+            print(f"  Actual:   {headings}")
+            return 1
+
+        print("[1254] PASS: All headings were correctly inserted without nesting or structure corruption.")
+
+    finally:
+        print("\n[1254] Terminating Mogan instance...")
+        terminate_process(proc)
+
+        # =========================================================================
+        # Step 4: Cleanup temporary draft files
+        # =========================================================================
+        print("[1254] Cleaning up temporary test files...")
+        for p in created_temp_files:
+            try:
+                if os.path.exists(p):
+                    os.remove(p)
+                    print(f"[1254] Removed temp file: {p}")
+            except Exception as e:
+                print(f"[1254] Warning: Failed to remove {p}: {e}")
+
+    print("\n[1254] ALL TESTS PASSED: Smart heading insertion verified!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/devel/1254.md
+++ b/devel/1254.md
@@ -3,48 +3,89 @@
 ## 1 相关文档
 - [dddd.md](dddd.md) - 任务文档模板
 - [1234.md](1234.md) - Alt+0..3 智能插入有/无编号的标题
+- [1257.md](1257.md) - 草稿文件名用 `_` 分隔日期与时刻
 
 ## 2 任务相关的代码文件
-- `TeXmacs/progs/text/text-edit.scm`
-- `TeXmacs/tests/1254.scm`
+- `TeXmacs/progs/text/text-edit.scm` — 标题插入与移出结构换行逻辑
+- `TeXmacs/progs/text/text-kbd.scm` — Alt+0..6 快捷键绑定统一接入 `smart-insert-heading`
+- `TeXmacs/progs/text/text-menu.scm` — 标题菜单项统一接入 `smart-insert-heading`
+- `TeXmacs/progs/text/smart-heading-test.scm` — 智能插入标题纯逻辑测试
+- `TeXmacs/tests/1254.scm` — GUI Scheme 异步集成测试
+- `TeXmacs/tests/python/1254.py` — 基于 pynput 的端到端 UI 自动化测试脚本
 
 ## 3 如何测试
 
-### 3.1 集成测试
+### 3.1 单元测试（纯逻辑测试）
 
 ```bash
+xmake b smart-heading-test
+xmake r smart-heading-test
+```
+
+### 3.2 集成测试
+
+```bash
+xmake b stem
 xmake r 1254
 MOGAN_TEST_GUI=1 xmake r 1254
 ```
 
-### 3.2 其它回归测试
+### 3.3 端到端测试
+端到端测试既可以手动测试，也可以采用 Python 的 pynput 框架来自动化测试：
 
+- **自动化测试**：
 ```bash
-xmake r smart-heading-test
+python3 TeXmacs/tests/python/1254.py
 ```
 
-### 3.3 手动 GUI 验证
+在 `TeXmacs/tests/python/1254.py` 中的自动化实现流程：
+1. **启动与建档**：利用 `subprocess` 启动 Mogan 进程，聚焦窗口并通过 `Ctrl+T` 新建文档标签；
+2. **模拟键盘快捷键在标题内部连续插入各级标题**：
+   - 按 `Alt+0` 插入 Chapter 1 并键入 `"Chapter 1"`；
+   - 光标停留在 Chapter 1 内部，按 `Alt+1` 插入 Section 1 并键入 `"Section 1"`；
+   - 光标停留在 Section 1 内部，再次按 `Alt+1` 插入 Section 2 并键入 `"Section 2"`；
+   - 光标停留在 Section 2 内部，按 `Alt+2` 插入 Subsection 2.1 并键入 `"Subsection 2.1"`；
+   - 光标停留在 Subsection 2.1 内部，再次按 `Alt+2` 插入 Subsection 2.2 并键入 `"Subsection 2.2"`；
+   - 光标停留在 Subsection 2.2 内部，按 `Alt+3` 插入 Subsubsection 2.2.1 并键入 `"Subsubsection 2.2.1"`；
+   - 光标停留在 Subsubsection 2.2.1 内部，按 `Alt+4` 插入 Paragraph 1 并键入 `"Paragraph 1"`；
+   - 光标停留在 Paragraph 1 内部，按 `Alt+5` 插入 Subparagraph 1.1 并键入 `"Subparagraph 1.1"`；
+   - 光标停留在 Subparagraph 1.1 内部，按 `Alt+1` 插入 Section 3 并键入 `"Section 3"`；
+3. **落盘与文档结构校验**：
+   - 按 `Ctrl+P`（预览）触发文档自动保存到草稿目录；
+   - 读取新生成的 `.tmu` 文档，提取 `body` 内所有的 `chapter` / `section` / `subsection` / `subsubsection` / `paragraph` / `subparagraph` 节点；
+   - 校验标题列表与层级结构完整一致（9 个标题全部独立成顶级节点、文本完好、未发生旧标题被拆散嵌套的损坏）；
+4. **清理测试临时文件**：自动清理测试过程中生成的草稿文件并正常终止 Mogan 进程。
 
-```bash
-xmake b stem && xmake r stem
-```
-
-1. 新建文档，按 `Alt+1` 插入 section，输入 "Section 1"
-2. 光标停留在 "Section 1" 内部，按 `Alt+1` 再次插入 section
-3. 验证：光标移出第一节并自动回车，在下一行成功创建新的 section，原有 "Section 1" 结构完好无损
-4. 在 section / subsection / subsubsection 之间互相嵌套插入，验证均能正常移出并回车创建新标题
+- **手动测试**：
+1. `xmake r stem` 启动 Mogan（Windows 下需先 `xmake i stem`）；
+2. Ctrl+T 新建文档；
+3. 按 `Alt+0` 插入 chapter，输入 "Chapter 1"；
+4. 光标停留在 "Chapter 1" 内部，按 `Alt+1` 插入 section，输入 "Section 1"；
+5. 验证：光标自动移出 Chapter 1 并换行，在下一行成功创建新的 section，原有 "Chapter 1" 完好无损；
+6. 光标停留在 "Section 1" 内部，按 `Alt+1` 再次插入 section，输入 "Section 2"；
+7. 验证：光标自动移出 Section 1 并换行，在下一行创建 Section 2，原有 "Section 1" 完好无损；
+8. 光标停留在 "Section 2" 内部，按 `Alt+2` 插入 subsection，输入 "Subsection 2.1"；
+9. 光标停留在 "Subsection 2.1" 内部，按 `Alt+2` 再次插入 subsection，输入 "Subsection 2.2"；
+10. 光标停留在 "Subsection 2.2" 内部，按 `Alt+3` 插入 subsubsection，输入 "Subsubsection 2.2.1"；
+11. 光标停留在 "Subsubsection 2.2.1" 内部，按 `Alt+4` 插入 paragraph（或通过菜单「插入 -> 标题 -> 段落」），输入 "Paragraph 1"；
+12. 光标停留在 "Paragraph 1" 内部，按 `Alt+5` 插入 subparagraph（或通过菜单「插入 -> 标题 -> 下级段落」），输入 "Subparagraph 1.1"；
+13. 光标停留在 "Subparagraph 1.1" 内部，按 `Alt+1` 插入 section，输入 "Section 3"；
+14. 观察文档或按 Ctrl+P 预览保存，验证各级标题独立成行、层级正确、旧标题内容无破坏与非预期拆分嵌套。
 
 ## 4 如何提交
 
 提交前执行以下最少步骤：
 
 ```bash
+xmake b stem
+xmake b smart-heading-test && xmake r smart-heading-test
+python3 TeXmacs/tests/python/1254.py
 gf fmt --changed-since=main
 ```
 
 ## 5 What
 
-在一个 `section`, `subsection`, `subsubsection` 等同类结构中插入同类标题结构的时候，先把光标移出这个结构并回车，再执行插入。
+在一个 `chapter`, `section`, `subsection`, `subsubsection`, `paragraph`, `subparagraph` 等同类结构中插入同类或跨级标题结构的时候，先把光标移出这个结构并回车，再执行插入。
 
 ## 6 Why
 
@@ -52,6 +93,17 @@ gf fmt --changed-since=main
 
 ## 7 How
 
-1. 在 `TeXmacs/progs/text/text-edit.scm` 中增加 `section-heading-tree?` 与 `current-section-node`，兼顾 `generic` 样式（`concat` 包裹 `(section)` 与标题文本）与 `article` 样式（`section` 直接包裹标题参数）两种 AST 结构，精准识别光标是否处于标题结构内部。
-2. 在 `smart-insert-heading` 入口处，若检测到光标处于标题结构 `t` 内，先通过 `(tree-go-to t :end)` 移出结构，再执行 `(insert-return)` 回车换行，之后正常执行后续同级/变体插入逻辑。
-3. 在 `TeXmacs/tests/1254.scm` 增加自动化集成测试，覆盖从 section、subsection、subsubsection 内部连续插入同类标题的各种场景。
+### 7.1 标题识别与移出换行
+
+1. 在 `TeXmacs/progs/text/text-edit.scm` 中增加 `section-heading-tree?` 与 `current-section-node`，兼顾 `generic` 样式（`concat` 包裹 `(section)` 与标题文本）与 `article` 样式（`section` 直接包裹标题参数）两种 AST 结构，精准识别光标是否处于标题结构内部（涵盖 `chapter`、`section`、`subsection`、`subsubsection`、`paragraph`、`subparagraph`、`appendix` 等全部 sectional tags）。
+2. 在 `text-kbd.scm` 与 `text-menu.scm` 中，将 `Alt+0..6` 快捷键与菜单项统一接入 `smart-insert-heading`，保证各类标题插入均遵循光标移出换行机制。
+3. 在 `smart-insert-heading` 入口处，若检测到光标处于标题结构 `t` 内，先通过 `(tree-go-to t :end)` 移出结构，再执行 `(insert-return)` 回车换行，之后正常执行后续同级/变体插入逻辑。
+4. 在 `TeXmacs/tests/1254.scm` 增加自动化集成测试，覆盖从 chapter、section、subsection、subsubsection、paragraph、subparagraph 内部连续插入同类与跨级标题的各种场景。
+
+### 7.2 端到端自动化测试实现
+
+在 `TeXmacs/tests/python/1254.py` 中：
+- 利用 `subprocess` 启动 Mogan 进程；
+- 利用 `pynput` 控制键盘依次模拟：新建文档 -> `Alt+0`（Chapter）-> 在 Chapter 内 `Alt+1`（Section）-> 在 Section 内 `Alt+1`（Section）-> 在 Section 内 `Alt+2`（Subsection）-> 在 Subsection 内 `Alt+2`（Subsection）-> 在 Subsection 内 `Alt+3`（Subsubsection）-> 在 Subsubsection 内 `Alt+4`（Paragraph）-> 在 Paragraph 内 `Alt+5`（Subparagraph）-> 在 Subparagraph 内 `Alt+1`（Section）；
+- 按 `Ctrl+P` 触发草稿保存，解析生成的 `.tmu` 文档 `body` 结构，断言验证标题节点层级和文本完整性；
+- 测试结束后自动清理临时草稿文件并终止进程。


### PR DESCRIPTION
## 任务简述

关联任务文档：`devel/1254.md`

### 改动内容

1. **端到端自动化测试**：
   - 新增 `TeXmacs/tests/python/1254.py`，基于 `pynput` 模拟键鼠交互，覆盖从 `chapter`、`section`、`subsection`、`subsubsection`、`paragraph`、`subparagraph` 各级标题内部插入同级与跨级标题的完整流程，并校验 AST 树独立性与完整性。
2. **快捷键与菜单支持**：
   - `text-kbd.scm` 与 `text-menu.scm` 中将 `paragraph`、`subparagraph`、`appendix` 接入 `smart-insert-heading`，确保在标题内部触发插入时均能先退出结构并换行。
3. **集成测试增强**：
   - `TeXmacs/tests/1254.scm` 增加 `chapter`、`paragraph`、`subparagraph` 的连续嵌套测试用例。
4. **任务文档更新**：
   - 参照 `1257.md` 更新 `devel/1254.md` 中的手动与自动化测试步骤说明。

### 本地测试

```bash
xmake b smart-heading-test && xmake r smart-heading-test
MOGAN_TEST_GUI=1 xmake r 1254
python3 TeXmacs/tests/python/1254.py
```
所有测试均已本地通过。