### PR TITLE
[1258] 适配 macOS 端到端 UI 自动化测试

### DIFF
--- a/TeXmacs/tests/python/1258.py
+++ b/TeXmacs/tests/python/1258.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-| Tester                  | Platform    | Status |
-| ----------------------- | ----------- | ------ |
-| Darcy Shen <da@liii.pro>| Linux (X11) | Passed |
+| Tester                           | Platform      | Status |
+| -------------------------------- | ------------- | ------ |
+| Darcy Shen <da@liii.pro>         | Linux (X11)   | Passed |
+| ShuLi Zheng <2831850183@qq.com>  | macOS (arm64) | Passed |
 
 Automated end-to-end UI test for issue 1258:
 Verify that the underscore in 'draft_YYYYMMDDHHMMSS.tmu' is visible in
@@ -46,7 +47,11 @@ def find_mogan_binary(repo_root):
         os.path.join(repo_root, "build/linux/x86_64/releasedbg/moganstem"),
         os.path.join(repo_root, "build/packages/stem/data/bin/MoganSTEM.exe"),
         os.path.join(repo_root, "build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/arm64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/arm64/debug/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
         os.path.join(repo_root, "build/macosx/x86_64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/debug/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
     ]
     for c in candidates:
         if os.path.exists(c):
@@ -55,7 +60,22 @@ def find_mogan_binary(repo_root):
 
 
 def focus_mogan_window():
-    """Ensure Mogan window is raised and focused on X11 platform."""
+    """Ensure Mogan window is raised and focused across platforms."""
+    if sys.platform == "darwin":
+        try:
+            import AppKit
+            for app in AppKit.NSWorkspace.sharedWorkspace().runningApplications():
+                if "Mogan" in (app.localizedName() or ""):
+                    app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
+                    return
+        except Exception:
+            pass
+        subprocess.run(
+            ["osascript", "-e", 'tell application "System Events" to set frontmost of first process whose name contains "Mogan" to true'],
+            capture_output=True,
+        )
+        return
+
     try:
         import Xlib.display
         import Xlib.X
@@ -140,13 +160,17 @@ def check_underscore_visible(screenshot_path):
     print(f"[1258] Detected {len(lines)} line clusters in recent documents area")
 
     # Check for the underscore stroke rendered below the baseline of 'draft'
+    scale = 2 if w > 2000 else 1
+    max_stroke_h = 6 * scale
+    max_gap = 6 * scale
+
     for idx, (r1, r2) in enumerate(lines):
         cluster_h = r2 - r1
-        # The underscore stroke has a small height (1-6px) directly under the main text line
-        if cluster_h <= 6 and idx > 0:
+        # The underscore stroke has a small height directly under the main text line
+        if cluster_h <= max_stroke_h and idx > 0:
             prev_r1, prev_r2 = lines[idx - 1]
             gap = r1 - prev_r2
-            if gap <= 6:
+            if gap <= max_gap:
                 line_binary = binary[r1:r2, :]
                 cols = np.where(line_binary.sum(axis=0) > 0)[0]
                 if len(cols) > 0:
@@ -162,6 +186,12 @@ def run_test():
     bin_path = find_mogan_binary(repo_root)
     print(f"[1258] Using Mogan binary: {bin_path}")
 
+    # On macOS, ensure .app bundle is ad-hoc signed so AMFI allows execution
+    if sys.platform == "darwin":
+        app_dir = os.path.dirname(os.path.dirname(os.path.dirname(bin_path)))
+        if app_dir.endswith(".app"):
+            subprocess.run(["codesign", "--force", "--deep", "--sign", "-", app_dir], capture_output=True)
+
     env = os.environ.copy()
     env["TEXMACS_PATH"] = os.path.join(repo_root, "TeXmacs")
 
@@ -169,6 +199,7 @@ def run_test():
     proc = subprocess.Popen([bin_path], env=env)
     keyboard = KeyboardController()
     mouse = MouseController()
+    mod_key = Key.cmd if sys.platform == "darwin" else Key.ctrl
 
     try:
         # 1. Wait for Mogan window to open and raise to front
@@ -182,34 +213,38 @@ def run_test():
         mouse.click(Button.left)
         time.sleep(0.5)
 
-        # 3. Create a new document / tab (Ctrl+T)
-        print("[1258] Creating new tab (Ctrl+T)...")
-        with keyboard.pressed(Key.ctrl):
+        # 3. Create a new document / tab (Cmd+T / Ctrl+T)
+        print("[1258] Creating new tab...")
+        with keyboard.pressed(mod_key):
             keyboard.press("t")
             keyboard.release("t")
         time.sleep(2.0)
 
-        # 4. Type 'hello'
+        # 4. Type 'hello' and commit (Enter avoids IME composition on macOS)
         print("[1258] Typing 'hello'...")
         keyboard.type("hello")
+        time.sleep(0.3)
+        keyboard.press(Key.enter)
+        keyboard.release(Key.enter)
         time.sleep(1.0)
 
-        # 5. Preview document (Ctrl+P) -> triggers auto-save draft and opens PDF tab
-        print("[1258] Triggering preview (Ctrl+P)...")
-        with keyboard.pressed(Key.ctrl):
+        # 5. Preview document (Cmd+P / Ctrl+P) -> triggers auto-save draft and opens PDF tab
+        print("[1258] Triggering preview...")
+        with keyboard.pressed(mod_key):
             keyboard.press("p")
             keyboard.release("p")
         time.sleep(3.5)
 
-        # 6. Return to Home page: click first tab / press Ctrl+1
-        print("[1258] Returning to Home page (Ctrl+1 / click first tab)...")
+        # 6. Return to Home page: click first tab / press Cmd+1 or Ctrl+1
+        print("[1258] Returning to Home page...")
         focus_mogan_window()
         time.sleep(0.2)
-        mouse.position = (80, 40)
+        tab_click_pos = (130, 42) if sys.platform == "darwin" else (80, 40)
+        mouse.position = tab_click_pos
         time.sleep(0.3)
         mouse.click(Button.left)
         time.sleep(0.3)
-        with keyboard.pressed(Key.ctrl):
+        with keyboard.pressed(mod_key):
             keyboard.press("1")
             keyboard.release("1")
         time.sleep(2.0)

--- a/devel/1258.md
+++ b/devel/1258.md
@@ -24,15 +24,15 @@ python3 TeXmacs/tests/python/1258.py
 ```
 测试流程：
 1. 自动启动 MoganSTEM；
-2. 自动新建标签页（Ctrl+T）；
-3. 在文档中输入 `hello` 并按下 Ctrl+P 预览，触发文档自动保存（生成 `draft_YYYYMMDDHHMMSS.tmu` 及对应预览 `.pdf`）；
-4. 切换回首页（Ctrl+1 或点击第一个标签页）；
+2. 自动新建标签页（Cmd+T / Ctrl+T）；
+3. 在文档中输入 `hello` 并按下 Cmd+P / Ctrl+P 预览，触发文档自动保存（生成 `draft_YYYYMMDDHHMMSS.tmu` 及对应预览 `.pdf`）；
+4. 切换回首页（Cmd+1 / Ctrl+1 或点击第一个标签页）；
 5. 截屏并自动分析「最近文档」列表中的像素，验证 `draft` 后面的下划线 `_` 完整可见且未被裁剪。
 
 - **手动测试**：
 1. `xmake r stem` 启动 Mogan（Windows 下需先 `xmake i stem`）；
-2. Ctrl+T 新建标签页，输入 `hello`，按 Ctrl+P 触发预览；
-3. 点击第一个标签页（或按 Ctrl+1）回到首页；
+2. Cmd+T / Ctrl+T 新建标签页，输入 `hello`，按 Cmd+P / Ctrl+P 触发预览；
+3. 点击第一个标签页（或按 Cmd+1 / Ctrl+1）回到首页；
 4. 观察首页「最近文档」列表中新生成的 `draft_xxxxxxxxxxxxxx.tmu`，下划线清晰可见，未被裁剪成空格。
 
 ## 4 如何提交
@@ -75,6 +75,9 @@ python3 TeXmacs/tests/python/1258.py
 
 在 `TeXmacs/tests/python/1258.py` 中：
 - 利用 `subprocess` 启动 Mogan 进程；
-- 利用 `pynput` 控制鼠标与键盘依次执行：聚焦窗口 -> Ctrl+T 新建标签页 -> 键入 `hello` -> Ctrl+P 预览保存 -> Ctrl+1 / 鼠标点击切回首页；
-- 通过 `PIL.ImageGrab` 抓取主页界面截图并分析最近文档区域像素投影，校验下划线墨迹；
+- 适配跨平台窗口激活（macOS 下通过 AppKit / osascript 激活，Linux 下通过 X11 事件）；
+- 适配跨平台修饰键（macOS 下使用 Command 键，Linux/Windows 下使用 Control 键）；
+- 输入后模拟 Enter 提交输入，避免 macOS 中文输入法残留组合候选框；
+- 利用 `pynput` 控制鼠标与键盘依次执行：聚焦窗口 -> Cmd+T/Ctrl+T 新建标签页 -> 键入 `hello` -> Cmd+P/Ctrl+P 预览保存 -> Cmd+1/Ctrl+1 或鼠标点击切回首页；
+- 通过 `PIL.ImageGrab` 抓取主页界面截图（自动适配 Retina 高分屏缩放比例）并分析最近文档区域像素投影，校验下划线墨迹；
 - 测试结束后自动清理并关闭进程。


### PR DESCRIPTION
## 任务简述
- 适配 `TeXmacs/tests/python/1258.py` 端到端 UI 自动化测试脚本在 macOS 平台的兼容性：
  1. 窗口激活：新增通过 `AppKit.NSWorkspace` 及 AppleScript (`osascript`) 将 Mogan 窗口置顶聚焦；
  2. 修饰键：macOS 下使用 `Cmd`（`Key.cmd`），Linux/Windows 下使用 `Ctrl`；
  3. 输入法兼容：在键入 `hello` 后模拟回车提交输入，避免输入法处于组合候选框状态截断后续快捷键；
  4. 坐标与高分屏适配：适配 macOS 标题栏下的 Tab 点击坐标以及 Retina（2x 缩放）下截图与下划线墨迹高度阈值；
  5. 可执行文件与签名：补齐 macOS 各构建模式路径并在执行前自动进行 ad-hoc 签名。
- 在 `1258.py` 测试人员表格中补充 macOS (arm64) 测试通过信息。
- 更新 `devel/1258.md` 任务文档中的相关说明。

## 测试验证
- 在 macOS (arm64) 上运行 `python3 TeXmacs/tests/python/1258.py`，测试顺利通过（`TEST PASSED: Underscore '_' in recent documents is visible!`）。
