### PR TITLE
[0954] LLM 聊天输入区按钮布局调整与 Model 占位菜单

### DIFF
--- a/devel/0954.md
+++ b/devel/0954.md
@@ -1,0 +1,71 @@
+# [0954] LLM 聊天输入区按钮布局调整 + Model 按钮占位菜单
+
+## 1 相关文档
+- 任务包：`llm-design/tasks/PR-M2-按钮布局.md`（外部设计仓库，自包含任务说明）
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp` — `ChatConversationPanel` 新增
+  `modelButton()` 访问器、`modelMenuRequested` 信号、`modelButton_` 成员
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp` — `setup_ui()` 按钮行重排，
+  新增 Model 按钮创建与信号发射
+- `src/Plugins/Qt/qt_chat_controller.hpp` — 新增 `onModelMenuRequested` 声明
+- `src/Plugins/Qt/qt_chat_controller.cpp` — 连接 `modelMenuRequested`，
+  实现只读占位菜单
+
+## 3 如何测试
+
+### 3.1 单元测试
+暂无（纯 View 布局 + Controller 占位菜单，无纯逻辑可抽）。
+
+### 3.2 编译验证
+```bash
+xmake build --yes stem
+```
+
+### 3.3 手工验证（GUI）
+1. 打开 Chat 标签页与 dock 侧边栏两处入口，确认按钮行布局为
+   `[深度思考] [联网搜索] ... [Model] [发送]`；
+2. 深度思考、联网搜索开关与发送/取消功能与 main 一致；
+3. 点击 Model 按钮弹出只读菜单，仅显示当前模型名（不可点选），
+   点击空白处菜单消失，会话状态无任何变化。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+xmake build --yes stem
+```
+
+## 5 What
+调整 LLM 聊天面板输入区底部按钮行：
+
+- 深度思考、联网搜索按钮从发送按钮左侧移到按钮行最左侧（输入框左边）；
+- 发送按钮左侧新增 `Model` 按钮（文字固定），点击弹出占位菜单——
+  仅含一个禁用的 QAction 显示当前会话模型名，不可切换。
+
+目标布局：`[深度思考] [联网搜索] [stretch] [Model] [发送]`。
+
+## 6 Why
+为后续模型选择菜单（PR-M3）做布局与交互占位：按钮位置、信号通路
+（View 发 `modelMenuRequested(sessionId, globalPos)` → Controller 弹菜单）
+本任务一次到位，后续只需把占位菜单替换为真实模型清单。
+
+## 7 How
+- View（`ChatConversationPanel::setup_ui()`）：调整 `addWidget`/`addStretch`
+  顺序；Model 按钮为普通 `QToolButton`（objectName `chat-tab-model-btn`），
+  `clicked` 时发射 `modelMenuRequested`，附带按钮左上角的全局坐标供菜单
+  向上弹出。
+- Controller（`ChatController::connectPanelSignals`）：连接该信号到新槽
+  `onModelMenuRequested`，用栈上 `QMenu` + `exec`（文件内既有惯例）弹出
+  只读菜单；模型名取 `sessionManager_.getModel(sessionId)`，为空时回落
+  `"Kimi-VLM"`。
+- 不引入模型清单、切换逻辑与任何 Scheme 调用变化；chat 标签页与 dock
+  侧边栏共用同一面板，布局改动自动生效于两处。
+
+## 8 本次改动记录
+
+### 2026-09-03 初版实现
+- What：按钮行重排 + Model 占位按钮 + 只读占位菜单
+- Why：见第 6 节
+- How：见第 7 节
+- 涉及文件：见第 2 节

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -25,6 +25,7 @@
 #include <QDockWidget>
 #include <QFileDialog>
 #include <QLabel>
+#include <QMenu>
 #include <QPushButton>
 #include <QStandardPaths>
 #include <QStyle>
@@ -254,6 +255,19 @@ void
 ChatController::onSearchToggled (const string& sessionId, bool enabled) {
   sessionManager_.setSearch (sessionId, enabled);
   updateManifest (sessionId);
+}
+
+void
+ChatController::onModelMenuRequested (const string& sessionId,
+                                      const QPoint& globalPos) {
+  string model= sessionManager_.getModel (sessionId);
+  if (is_empty (model)) model= "Kimi-VLM";
+
+  // 占位菜单：仅展示当前模型名，不可切换（模型清单在后续任务接入）
+  QMenu    menu;
+  QAction* current= menu.addAction (to_qstring (model));
+  current->setEnabled (false);
+  menu.exec (globalPos);
 }
 
 void
@@ -579,6 +593,8 @@ ChatController::connectPanelSignals (ChatConversationPanel* panel) {
            &ChatController::onThinkingToggled);
   connect (panel, &ChatConversationPanel::searchToggled, this,
            &ChatController::onSearchToggled);
+  connect (panel, &ChatConversationPanel::modelMenuRequested, this,
+           &ChatController::onModelMenuRequested);
   connect (panel, &ChatConversationPanel::closeSidebarInDockModeRequested, this,
            [this] () {
              if (!view_) return;

--- a/src/Plugins/Qt/qt_chat_controller.hpp
+++ b/src/Plugins/Qt/qt_chat_controller.hpp
@@ -122,6 +122,13 @@ public:
   void onSearchToggled (const string& sessionId, bool enabled);
 
   /**
+   * @brief Model 按钮点击时触发：弹出只读占位菜单（仅显示当前模型名）。
+   * @param sessionId 目标会话 ID
+   * @param globalPos 菜单弹出位置（全局坐标）
+   */
+  void onModelMenuRequested (const string& sessionId, const QPoint& globalPos);
+
+  /**
    * @brief Scheme→C++ 回调：通知状态变更。
    */
   void notifyStateChanged (const string& sessionId, const string& stateStr);

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -262,15 +262,6 @@ ChatConversationPanel::setup_ui () {
     }
   }
   QHBoxLayout* btnLayout= new QHBoxLayout ();
-  btnLayout->addStretch ();
-
-  // Search toggle button
-  searchButton_= make_toggle_btn (inputFrame, "chat-tab-search-btn",
-                                  qt_translate ("Internet Search"));
-  connect (searchButton_, &QToolButton::toggled, this,
-           [this] (bool checked) { emit searchToggled (sessionId_, checked); });
-  btnLayout->addWidget (searchButton_);
-  btnLayout->addSpacing (DpiUtils::scaled (kSidebarSpacing));
 
   // Thinking toggle button
   thinkingButton_= make_toggle_btn (inputFrame, "chat-tab-thinking-btn",
@@ -279,6 +270,29 @@ ChatConversationPanel::setup_ui () {
     emit thinkingToggled (sessionId_, checked);
   });
   btnLayout->addWidget (thinkingButton_);
+  btnLayout->addSpacing (DpiUtils::scaled (kSidebarSpacing));
+
+  // Search toggle button
+  searchButton_= make_toggle_btn (inputFrame, "chat-tab-search-btn",
+                                  qt_translate ("Internet Search"));
+  connect (searchButton_, &QToolButton::toggled, this,
+           [this] (bool checked) { emit searchToggled (sessionId_, checked); });
+  btnLayout->addWidget (searchButton_);
+  btnLayout->addStretch ();
+
+  // Model button（占位：弹出只读菜单，不含切换逻辑）
+  modelButton_= new QToolButton (inputFrame);
+  modelButton_->setObjectName ("chat-tab-model-btn");
+  modelButton_->setText (qt_translate ("Model"));
+  modelButton_->setFocusPolicy (Qt::NoFocus);
+  modelButton_->setCursor (Qt::PointingHandCursor);
+  modelButton_->setFixedHeight (DpiUtils::scaled (kSendButtonSize));
+  connect (modelButton_, &QToolButton::clicked, this, [this] () {
+    // 菜单向上弹出：携带按钮左上角上方的全局坐标
+    emit modelMenuRequested (sessionId_, modelButton_->mapToGlobal (QPoint (
+                                             0, -modelButton_->height ())));
+  });
+  btnLayout->addWidget (modelButton_);
   btnLayout->addSpacing (DpiUtils::scaled (kSidebarSpacing));
 
   // Send button

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -94,6 +94,7 @@ public:
   QToolButton*  sendButton () const { return sendButton_; }
   QToolButton*  thinkingButton () const { return thinkingButton_; }
   QToolButton*  searchButton () const { return searchButton_; }
+  QToolButton*  modelButton () const { return modelButton_; }
   QLabel*       sessionTitle () const { return sessionTitle_; }
   const string& sessionId () const { return sessionId_; }
   bool          conversationMode () const { return conversationMode_; }
@@ -138,6 +139,8 @@ signals:
   void sendRequested (const string& sessionId);
   void thinkingToggled (const string& sessionId, bool enabled);
   void searchToggled (const string& sessionId, bool enabled);
+  /// 请求弹出模型选择菜单；globalPos 为建议弹出位置
+  void modelMenuRequested (const string& sessionId, const QPoint& globalPos);
   void inputHeightChanged ();
   void closeSidebarInDockModeRequested ();
 
@@ -157,22 +160,23 @@ private:
   /// 根据内容动态调整输入区高度
   void adjust_input_height ();
 
-  string       sessionId_;                     ///< 所属会话 ID
-  url          msgBufferUrl_;                  ///< 消息缓冲区 URL（外部注入）
-  url          inputBufferUrl_;                ///< 输入缓冲区 URL（外部注入）
-  bool         conversationMode_ = false;      ///< 是否已进入对话模式
-  QLabel*      welcomeTitle_     = nullptr;    ///< 欢迎页标题
-  QLabel*      sessionTitle_     = nullptr;    ///< 会话标题标签
-  QWidget*     messageFrame_     = nullptr;    ///< 消息区域容器
-  QWidget*     inputEditorWidget_= nullptr;    ///< 输入编辑器容器
-  QTMWidget*   inputQTMWidget_   = nullptr;    ///< 输入区 QTMWidget
-  QToolButton* sendButton_       = nullptr;    ///< 发送/停止按钮
-  QToolButton* thinkingButton_   = nullptr;    ///< 推理模式开关
-  QToolButton* searchButton_     = nullptr;    ///< 网络搜索开关
-  QSpacerItem* topSpacer_        = nullptr;    ///< 欢迎页顶部弹性空间
-  widget       messageWidget_;                 ///< 消息区 TeXmacs widget
-  widget       inputWidget;                    ///< 输入区 TeXmacs widget
-  int          fixedFrameExtra_           = 0; ///< 输入框额外高度（边框等）
+  string       sessionId_;                  ///< 所属会话 ID
+  url          msgBufferUrl_;               ///< 消息缓冲区 URL（外部注入）
+  url          inputBufferUrl_;             ///< 输入缓冲区 URL（外部注入）
+  bool         conversationMode_ = false;   ///< 是否已进入对话模式
+  QLabel*      welcomeTitle_     = nullptr; ///< 欢迎页标题
+  QLabel*      sessionTitle_     = nullptr; ///< 会话标题标签
+  QWidget*     messageFrame_     = nullptr; ///< 消息区域容器
+  QWidget*     inputEditorWidget_= nullptr; ///< 输入编辑器容器
+  QTMWidget*   inputQTMWidget_   = nullptr; ///< 输入区 QTMWidget
+  QToolButton* sendButton_       = nullptr; ///< 发送/停止按钮
+  QToolButton* thinkingButton_   = nullptr; ///< 推理模式开关
+  QToolButton* searchButton_     = nullptr; ///< 网络搜索开关
+  QToolButton* modelButton_      = nullptr; ///< 模型选择按钮（文字固定 Model）
+  QSpacerItem* topSpacer_        = nullptr; ///< 欢迎页顶部弹性空间
+  widget       messageWidget_;              ///< 消息区 TeXmacs widget
+  widget       inputWidget;                 ///< 输入区 TeXmacs widget
+  int          fixedFrameExtra_           = 0;     ///< 输入框额外高度（边框等）
   bool         inputHeightAdjustScheduled_= false; ///< 是否已有待执行的高度更新
 };
 


### PR DESCRIPTION
## What

调整 LLM 聊天面板输入区底部按钮行：

- 深度思考、联网搜索按钮从发送按钮左侧移到按钮行**最左侧**（输入框左边）
- 发送按钮左侧新增 `Model` 按钮（文字固定为 `Model`），点击弹出**占位菜单**：仅含一个禁用的菜单项显示当前会话模型名，不可切换
- 目标布局：`[深度思考] [联网搜索] [stretch] [Model] [发送]`

## Why

为后续模型选择菜单（PR-M3）做布局与交互占位：按钮位置与信号通路
（View 发 `modelMenuRequested(sessionId, globalPos)` → Controller 弹菜单）
本 PR 一次到位，后续只需把占位菜单替换为真实模型清单。

## How

- **View**（`ChatConversationPanel::setup_ui()`，`qt_chat_tab_widget.cpp`）：
  调整 `addWidget`/`addStretch` 顺序；新增 Model 按钮
  （`QToolButton`，objectName `chat-tab-model-btn`，固定高度与既有按钮一致），
  `clicked` 时发射 `modelMenuRequested`，携带按钮上方的全局坐标（菜单向上弹出）。
- **Controller**（`qt_chat_controller.cpp`）：`connectPanelSignals` 连接该信号到新槽
  `onModelMenuRequested`，用栈上 `QMenu` + `exec`（文件内既有惯例）弹出只读菜单；
  模型名取 `sessionManager_.getModel(sessionId)`，为空时回落 `"Kimi-VLM"`。
- 不引入模型清单、切换逻辑与任何 Scheme 调用变化；chat 标签页与 dock 侧边栏
  共用同一面板，布局改动自动生效于两处。

## 显式不做

- 菜单不做 logo、描述徽标、选中高亮（后续 PR-M3）
- Model 按钮在 Generating 状态不做置灰（保持可用，是目标语义）

## 验证

- [x] `xmake build --yes stem` 通过
- [x] `gf fmt --changed-since=main` 已运行，无遗留无关改动
- [x] **GUI 手工验证（用户已执行，通过）**：
  - Chat 标签页与 dock 侧边栏两处按钮行布局一致：
    `[深度思考] [联网搜索] ... [Model] [发送]`
  - 发送/取消、深度思考开关、联网搜索开关功能与 main 一致（仅位置变化）
  - 点击 Model 按钮弹出只读占位菜单，显示当前模型名，不产生任何状态变化

## 涉及文件

- `devel/0954.md`（任务文档）
- `src/Plugins/Qt/qt_chat_tab_widget.hpp` / `.cpp`
- `src/Plugins/Qt/qt_chat_controller.hpp` / `.cpp`
