### PR TITLE
[0955] LLM 模型选择菜单与会话级切换

### DIFF
--- a/devel/0955.md
+++ b/devel/0955.md
@@ -1,0 +1,105 @@
+# [0955] LLM 聊天模型菜单与切换（PR-M3）
+
+## 1 相关文档
+- 任务包：`llm-design/tasks/PR-M3-模型菜单与切换.md`（外部设计仓库，自包含任务说明）
+- 前置：0954（Model 按钮与占位菜单，本分支基于其分支开发）
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/qt_chat_model.hpp`（新增）— `ChatModelInfo` 值类型、
+  `ChatModelProvider` 抽象、`BuiltinModelProvider` 声明、
+  `chat_model_parse_list` 自由函数声明
+- `src/Plugins/Qt/qt_chat_model.cpp`（新增）— 上述实现：JSON 解析、
+  内置清单（仅 Kimi-VLM）、`MOGAN_LLM_MODELS_FILE` 调试通道
+- `src/Plugins/Qt/qt_chat_controller.hpp` / `.cpp` — 持有 Provider；
+  删除 `currentModel_`（G7 修正）；`onModelMenuRequested` 改为真实菜单；
+  新增 `onModelSelected`；`activateSession` 清单外模型内存回退
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp` / `.cpp` —
+  `ChatConversationPanel::showModelMenu`（QMenu + QWidgetAction 自定义行）；
+  `modelSelected` 信号；Model 按钮胶囊描边样式
+- `tests/Plugins/Qt/qt_chat_model_test.cpp`（新增）— Provider/解析纯逻辑测试
+- `devel/0955.md`（本文件）
+
+## 3 如何测试
+
+### 3.1 单元测试
+```bash
+xmake b qt_chat_model_test && xmake r qt_chat_model_test
+```
+
+### 3.2 编译验证
+```bash
+xmake build --yes stem
+```
+
+### 3.3 手工验证（GUI）
+1. 不设环境变量：菜单仅 `K3` 一项且为选中态；发送、持久化、恢复与 main 一致；
+2. 新建会话（含复用空白会话）模型恒为 `Kimi-VLM`，不继承最近激活会话；
+3. 设 `MOGAN_LLM_MODELS_FILE` 指向含 kimi+deepseek 两条目的 JSON，
+   重开 Chat 标签页：菜单双条目、logo、徽标、选中态正确；切换后
+   `ChatSession.model` 变化并写入 manifest；chat 标签页与 dock 侧边栏一致。
+
+调试通道 JSON 示例：
+```json
+{ "default": "Kimi-VLM",
+  "models": [ { "key": "Kimi-VLM", "name": "K3", "icon": "kimi",
+                "description": "订阅优先", "dsc_color": "orange" },
+              { "key": "DeepSeek", "name": "R1", "icon": "deepseek",
+                "description": "推理", "dsc_color": "red" } ] }
+```
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+xmake build --yes stem
+```
+
+## 5 What
+1. 新增 `ChatModelInfo` 值类型与 `ChatModelProvider` 抽象，本期实现
+   `BuiltinModelProvider`（内置清单仅 `Kimi-VLM`，行为与现状一致）；
+   预留调试通道 `MOGAN_LLM_MODELS_FILE`（环境变量指向 JSON 文件时从文件
+   读清单，用于本地联调多条目 UI）。
+2. 占位菜单升级为完整模型选择菜单：logo + 名称 + 描述徽标 + 选中项背景加深；
+   菜单每次打开重建并按当前会话刷新选中态。
+3. 会话级模型切换：`onModelSelected` 写 `ChatSession.model` + 落 manifest。
+4. G7 修正：新会话固定为默认模型 `Kimi-VLM`，不再继承最近激活会话的模型。
+
+## 6 Why
+- 模型清单来源需要抽象，liii 插件重构完成后可平滑接入 `LiiiModelProvider`，
+  本期先用内置清单把 View/切换/持久化链路一次打通；
+- G7：继承最近激活会话的模型会让"新会话"的模型随操作历史漂移，语义混乱；
+- 发送路径本就实时读 `session->model`，会话级写回即可，无需触碰发送链路。
+
+## 7 How
+- **Provider**（`qt_chat_model.*`）：`chat_model_parse_list` 用
+  `QJsonDocument` 解析（本组件已大量用 Qt 类；与 `string` 互转用
+  `utf8_to_qstring`/`from_qstring_utf8`），字段缺省规则与 unknown
+  `dsc_color`→orange 归一均在解析期完成；`BuiltinModelProvider` 构造时
+  读 `MOGAN_LLM_MODELS_FILE`，失败回落内置清单。`contains`/`find` 为非虚
+  遍历实现，`find` 找不到时返回 key 兜底构造的 Info。
+- **Controller**：值语义持有 `BuiltinModelProvider`，`createView` 早期重建
+  （调试通道改文件后重开标签页即生效）；`onModelSelected` 先校验 key 在
+  清单内，再 `setModel` + `updateManifest`（未注册会话的 manifest 由首次
+  发送时的既有路径落盘）；`activateSession` 开头把清单外模型内存回退为
+  默认模型（不写 manifest）。G7：删除 `currentModel_`，
+  `ensureNewConversation` 两处 `setModel` 改用 `defaultModelKey()`。
+- **View**（`showModelMenu`）：`QMenu`（`WA_TranslucentBackground` +
+  objectName qss，圆角/边框/选中加深）+ 每项 `QWidgetAction` 自定义行
+  `[logo][name][badge]`；logo 为空或 `QIcon::isNull()` 时画占位圆点；
+  徽标按 `dscColor` 取 red/orange 预设背景，description 为空不创建；
+  配色沿用会话项 hover/选中色值（light `#f0f0f0`/`#e8eefc`，dark
+  `#444444`/`#1a3a5a`），暗色判定与 QML 弹窗一致（`tm_style_sheet`）；
+  点击发射 `modelSelected(sessionId, key)` 信号，由 Controller 槽处理。
+- 不新增/修改任何 C++→Scheme 调用；发送路径不变。
+
+## 8 本次改动记录
+
+### 2026-09-03 初版实现
+- What：模型 Provider 抽象 + 完整模型菜单 + 会话级切换 + G7 默认模型修正
+- Why：见第 6 节
+- How：见第 7 节
+- 涉及文件：见第 2 节
+- 验证：`xmake build --yes stem` 通过；`qt_chat_model_test` 16/16 通过；
+  用户手工 GUI 验证通过（菜单观感、选中态、切换、发送/持久化与 main 一致）。
+  多条目 UI（`MOGAN_LLM_MODELS_FILE` 调试通道）暂未实机验证，待后续 liii
+  插件重构完成后随真实清单一并验证。

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -25,7 +25,6 @@
 #include <QDockWidget>
 #include <QFileDialog>
 #include <QLabel>
-#include <QMenu>
 #include <QPushButton>
 #include <QStandardPaths>
 #include <QStyle>
@@ -56,6 +55,10 @@ ChatController::destroyView () {
 
 QWidget*
 ChatController::createView (QWidget* parent, qt_tm_widget_rep* tm) {
+  // 每次创建 View 时重建 Provider：调试通道（MOGAN_LLM_MODELS_FILE）
+  // 修改后重开 Chat 标签页即可生效
+  modelProvider_= BuiltinModelProvider ();
+
   // 1. Load session metadata
   // llm 插件按 idle 延迟初始化，新建 Chat 标签页时其 scheme 模块可能尚未加载
   bool benching= QTChatTabWidget::isInitBenchPending ();
@@ -142,15 +145,7 @@ ChatController::createView (QWidget* parent, qt_tm_widget_rep* tm) {
   }
   if (benching) bench_end ("chat_init: activate session");
 
-  // 5. 恢复当前模型（使用激活的会话）
-  if (!is_empty (initialId)) {
-    ChatSession* s= sessionManager_.getSession (initialId);
-    if (s && !is_empty (s->model)) {
-      currentModel_= s->model;
-    }
-  }
-
-  // 6. 注册浮动搜索栏的 parent provider
+  // 5. 注册浮动搜索栏的 parent provider
   qt_floating_search_set_parent_provider ([this] () -> QWidget* {
     if (!view_) return nullptr;
     return view_->contentWidget ();
@@ -260,14 +255,21 @@ ChatController::onSearchToggled (const string& sessionId, bool enabled) {
 void
 ChatController::onModelMenuRequested (const string& sessionId,
                                       const QPoint& globalPos) {
-  string model= sessionManager_.getModel (sessionId);
-  if (is_empty (model)) model= "Kimi-VLM";
+  ChatSession* s= sessionManager_.getSession (sessionId);
+  if (!s || !s->panel) return;
+  ChatConversationPanel* panel= static_cast<ChatConversationPanel*> (s->panel);
 
-  // 占位菜单：仅展示当前模型名，不可切换（模型清单在后续任务接入）
-  QMenu    menu;
-  QAction* current= menu.addAction (to_qstring (model));
-  current->setEnabled (false);
-  menu.exec (globalPos);
+  string current= s->model;
+  if (!modelProvider_.contains (current))
+    current= modelProvider_.defaultModelKey ();
+  panel->showModelMenu (modelProvider_.models (), current, globalPos);
+}
+
+void
+ChatController::onModelSelected (const string& sessionId, const string& key) {
+  if (!modelProvider_.contains (key)) return;
+  sessionManager_.setModel (sessionId, key);
+  updateManifest (sessionId);
 }
 
 void
@@ -478,6 +480,13 @@ void
 ChatController::activateSession (const string& sessionId) {
   if (!view_) return;
 
+  // 清单外模型（如清单更新后恢复的旧会话）：内存回退为默认模型，
+  // 不写 manifest，下次发送经既有路径自然落盘
+  ChatSession* session= sessionManager_.getSession (sessionId);
+  if (session && !modelProvider_.contains (session->model)) {
+    sessionManager_.setModel (sessionId, modelProvider_.defaultModelKey ());
+  }
+
   // 切换 session 时隐藏悬浮搜索栏
   qt_floating_search_bar_show (view_->contentWidget (), false);
 
@@ -595,6 +604,8 @@ ChatController::connectPanelSignals (ChatConversationPanel* panel) {
            &ChatController::onSearchToggled);
   connect (panel, &ChatConversationPanel::modelMenuRequested, this,
            &ChatController::onModelMenuRequested);
+  connect (panel, &ChatConversationPanel::modelSelected, this,
+           &ChatController::onModelSelected);
   connect (panel, &ChatConversationPanel::closeSidebarInDockModeRequested, this,
            [this] () {
              if (!view_) return;
@@ -611,7 +622,7 @@ ChatController::ensureNewConversation () {
   // 复用无标题的空白会话（面板和输入内容保持不变）
   string reusable= sessionManager_.findReusableSession ();
   if (!is_empty (reusable)) {
-    sessionManager_.setModel (reusable, currentModel_);
+    sessionManager_.setModel (reusable, modelProvider_.defaultModelKey ());
     ChatSession* s= sessionManager_.getSession (reusable);
     if (s && s->panel) {
       ChatConversationPanel* p= static_cast<ChatConversationPanel*> (s->panel);
@@ -628,7 +639,7 @@ ChatController::ensureNewConversation () {
   if (!panel) return;
 
   sessionManager_.setPanel (sid, panel);
-  sessionManager_.setModel (sid, currentModel_);
+  sessionManager_.setModel (sid, modelProvider_.defaultModelKey ());
 
   eval ("(use-modules (llm chat-style))");
   call ("chat-tab-sync-dark-style!", sid);

--- a/src/Plugins/Qt/qt_chat_controller.hpp
+++ b/src/Plugins/Qt/qt_chat_controller.hpp
@@ -12,6 +12,7 @@
 #ifndef QT_CHAT_CONTROLLER_HPP
 #define QT_CHAT_CONTROLLER_HPP
 
+#include "qt_chat_model.hpp"
 #include "qt_chat_tab_widget.hpp"
 #include <QObject>
 
@@ -122,11 +123,20 @@ public:
   void onSearchToggled (const string& sessionId, bool enabled);
 
   /**
-   * @brief Model 按钮点击时触发：弹出只读占位菜单（仅显示当前模型名）。
+   * @brief Model 按钮点击时触发：弹出模型选择菜单。
    * @param sessionId 目标会话 ID
    * @param globalPos 菜单弹出位置（全局坐标）
    */
   void onModelMenuRequested (const string& sessionId, const QPoint& globalPos);
+
+  /**
+   * @brief 模型菜单项被选中时触发：会话级切换模型并落 manifest。
+   *
+   * key 不在 Provider 清单内时忽略；不触碰 thinking/search 开关。
+   * @param sessionId 目标会话 ID
+   * @param key       选中的模型键名
+   */
+  void onModelSelected (const string& sessionId, const string& key);
 
   /**
    * @brief Scheme→C++ 回调：通知状态变更。
@@ -153,10 +163,10 @@ public:
   static QString sanitizeExportFileName (const QString& rawName);
 
 private:
-  QTChatTabWidget*   view_= nullptr;   ///< View 指针，由 createView 创建
-  ChatSessionManager sessionManager_;  ///< 会话管理器
-  bool               firstOpen_= true; ///< 是否首次打开（首次时切换到新会话）
-  string             currentModel_= "Kimi-VLM"; ///< 当前选择的模型（C++ 管理）
+  QTChatTabWidget*     view_= nullptr;   ///< View 指针，由 createView 创建
+  ChatSessionManager   sessionManager_;  ///< 会话管理器
+  bool                 firstOpen_= true; ///< 是否首次打开（首次时切换到新会话）
+  BuiltinModelProvider modelProvider_;   ///< 模型清单来源（含调试通道）
 
   /**
    * @brief 激活指定会话：按需创建面板，按需加载内容。

--- a/src/Plugins/Qt/qt_chat_model.cpp
+++ b/src/Plugins/Qt/qt_chat_model.cpp
@@ -1,0 +1,141 @@
+
+/******************************************************************************
+ * MODULE     : qt_chat_model.cpp
+ * DESCRIPTION: LLM 聊天模型清单：值类型、来源抽象与内置实现
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ ******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "qt_chat_model.hpp"
+#include "qt_utilities.hpp"
+#include "sys_utils.hpp" // get_env
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+/******************************************************************************
+ * ChatModelProvider
+ ******************************************************************************/
+
+bool
+ChatModelProvider::contains (const string& key) const {
+  QList<ChatModelInfo> all= models ();
+  for (int i= 0; i < all.size (); ++i) {
+    if (all[i].key == key) return true;
+  }
+  return false;
+}
+
+ChatModelInfo
+ChatModelProvider::find (const string& key) const {
+  QList<ChatModelInfo> all= models ();
+  for (int i= 0; i < all.size (); ++i) {
+    if (all[i].key == key) return all[i];
+  }
+  // 清单外键名兜底：保证菜单/会话仍能展示一个可读的条目
+  ChatModelInfo fallback;
+  fallback.key          = key;
+  fallback.name         = key;
+  fallback.icon         = "";
+  fallback.description  = "";
+  fallback.dscColor     = "orange";
+  fallback.allowThinking= true;
+  fallback.allowSearch  = true;
+  return fallback;
+}
+
+/******************************************************************************
+ * JSON 解析
+ ******************************************************************************/
+
+bool
+chat_model_parse_list (const string& jsonText, QList<ChatModelInfo>& outModels,
+                       string& outDefaultKey) {
+  QJsonParseError err;
+  QJsonDocument   doc=
+      QJsonDocument::fromJson (utf8_to_qstring (jsonText).toUtf8 (), &err);
+  if (err.error != QJsonParseError::NoError || !doc.isObject ()) return false;
+
+  QJsonArray arr= doc.object ().value ("models").toArray ();
+  if (arr.isEmpty ()) return false;
+
+  QList<ChatModelInfo> models;
+  for (const QJsonValue& v : arr) {
+    if (!v.isObject ()) return false;
+    QJsonObject   o= v.toObject ();
+    ChatModelInfo info;
+    info.key= from_qstring_utf8 (o.value ("key").toString ());
+    // key 是协议与 manifest 的唯一标识，缺失则整条清单不可用
+    if (is_empty (info.key)) return false;
+    QString name    = o.value ("name").toString ();
+    info.name       = name.isEmpty () ? info.key : from_qstring_utf8 (name);
+    info.icon       = from_qstring_utf8 (o.value ("icon").toString ());
+    info.description= from_qstring_utf8 (o.value ("description").toString ());
+    string color    = from_qstring_utf8 (o.value ("dsc_color").toString ());
+    info.dscColor   = (color == "red" || color == "orange") ? color : "orange";
+    info.allowThinking= o.value ("allow_thinking").toBool (true);
+    info.allowSearch  = o.value ("allow_search").toBool (true);
+    models.append (info);
+  }
+
+  string def= from_qstring_utf8 (doc.object ().value ("default").toString ());
+  if (is_empty (def)) def= "Kimi-VLM";
+  bool inList= false;
+  for (int i= 0; i < models.size (); ++i) {
+    if (models[i].key == def) inList= true;
+  }
+  if (!inList) def= models.first ().key;
+
+  outModels    = models;
+  outDefaultKey= def;
+  return true;
+}
+
+/******************************************************************************
+ * BuiltinModelProvider
+ ******************************************************************************/
+
+BuiltinModelProvider::BuiltinModelProvider () {
+  // 调试通道：环境变量指向 JSON 文件时从文件读清单，便于本地联调多条目 UI
+  string path= get_env ("MOGAN_LLM_MODELS_FILE");
+  if (!is_empty (path)) {
+    QFile file (to_qstring (path));
+    if (file.open (QIODevice::ReadOnly)) {
+      string content= from_qstring_utf8 (QString::fromUtf8 (file.readAll ()));
+      QList<ChatModelInfo> fileModels;
+      string               fileDefault;
+      if (chat_model_parse_list (content, fileModels, fileDefault)) {
+        models_    = fileModels;
+        defaultKey_= fileDefault;
+        return;
+      }
+    }
+  }
+
+  ChatModelInfo kimi;
+  kimi.key          = "Kimi-VLM";
+  kimi.name         = "K3";
+  kimi.icon         = "kimi";
+  kimi.description  = "";
+  kimi.dscColor     = "orange";
+  kimi.allowThinking= true;
+  kimi.allowSearch  = true;
+  models_.append (kimi);
+  defaultKey_= "Kimi-VLM";
+}
+
+QList<ChatModelInfo>
+BuiltinModelProvider::models () const {
+  return models_;
+}
+
+string
+BuiltinModelProvider::defaultModelKey () const {
+  return defaultKey_;
+}

--- a/src/Plugins/Qt/qt_chat_model.hpp
+++ b/src/Plugins/Qt/qt_chat_model.hpp
@@ -1,0 +1,73 @@
+
+/******************************************************************************
+ * MODULE     : qt_chat_model.hpp
+ * DESCRIPTION: LLM 聊天模型清单：值类型、来源抽象与内置实现
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ ******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#ifndef QT_CHAT_MODEL_HPP
+#define QT_CHAT_MODEL_HPP
+
+#include "string.hpp"
+#include <QList>
+
+/**
+ * @brief 模型菜单项的显示与能力数据（值类型）。
+ */
+struct ChatModelInfo {
+  string key;           ///< 模型键名：%chat 协议与 manifest 的唯一标识
+  string name;          ///< 菜单显示名（如 "K3"）
+  string icon;          ///< 图标名，空串显示占位圆点
+  string description;   ///< 描述徽标文字，空串不渲染徽标
+  string dscColor;      ///< 徽标背景色："red" | "orange"，未知值按 orange
+  bool   allowThinking; ///< false 时隐藏深度思考按钮（本期数据恒 true）
+  bool   allowSearch;   ///< false 时隐藏联网搜索按钮（本期数据恒 true）
+};
+
+/**
+ * @brief 模型清单来源抽象。本期仅 BuiltinModelProvider；
+ * liii 插件重构完成后新增 LiiiModelProvider 桥接实现。
+ */
+class ChatModelProvider {
+public:
+  virtual ~ChatModelProvider ()               = default;
+  virtual QList<ChatModelInfo> models () const= 0; ///< 返回顺序即菜单展示顺序
+  virtual string               defaultModelKey () const= 0;
+  bool          contains (const string& key) const; ///< 非虚，遍历 models()
+  ChatModelInfo find (const string& key) const;     ///< 找不到返回 key 兜底构造
+};
+
+/**
+ * @brief 内置清单：仅 Kimi-VLM，行为与现状一致。
+ *
+ * 环境变量 MOGAN_LLM_MODELS_FILE 存在且可读时改从该 JSON 文件读取
+ * （调试通道，用于本地联调多条目 UI）。
+ */
+class BuiltinModelProvider : public ChatModelProvider {
+public:
+  BuiltinModelProvider ();
+  QList<ChatModelInfo> models () const override;
+  string               defaultModelKey () const override;
+
+private:
+  QList<ChatModelInfo> models_;
+  string               defaultKey_;
+};
+
+/**
+ * @brief 解析模型清单 JSON；字段缺失按既定规则补默认。
+ * @param jsonText      JSON 文本
+ * @param outModels     输出模型列表（解析失败时不变）
+ * @param outDefaultKey 输出默认模型键名（解析失败时不变）
+ * @return 解析成功返回 true；非法 JSON、models 缺失/为空、条目缺 key
+ *         时返回 false
+ */
+bool chat_model_parse_list (const string&         jsonText,
+                            QList<ChatModelInfo>& outModels,
+                            string&               outDefaultKey);
+
+#endif // QT_CHAT_MODEL_HPP

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -14,6 +14,8 @@
 #include "QTMStateToolButton.hpp"
 #include "QTMStyle.hpp"
 #include "QTMWidget.hpp"
+#include "analyze.hpp"
+#include "gui.hpp" // tm_style_sheet
 #include "new_buffer.hpp"
 #include "new_view.hpp"
 #include "qt_dpi_utils.hpp"
@@ -37,6 +39,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
+#include <QPainter>
 #include <QPropertyAnimation>
 #include <QPushButton>
 #include <QResizeEvent>
@@ -47,6 +50,7 @@
 #include <QToolButton>
 #include <QVBoxLayout>
 #include <QVariantAnimation>
+#include <QWidgetAction>
 
 using namespace moebius;
 
@@ -120,6 +124,26 @@ constexpr int kSendIconSize          = 30;
 constexpr int kSendButtonSize        = 36;
 constexpr int kSendButtonRadius      = 18;
 constexpr int kConversationBtnRadius = 6;
+
+// ---- 模型菜单常量 ----
+constexpr int kModelMenuIconSize   = 18; ///< 模型 logo 边长
+constexpr int kModelMenuRadius     = 8;  ///< 菜单圆角
+constexpr int kModelMenuItemRadius = 6;  ///< 菜单项圆角
+constexpr int kModelMenuPad        = 4;  ///< 菜单内边距
+constexpr int kModelMenuItemPadX   = 10; ///< 菜单项水平内边距
+constexpr int kModelMenuItemPadY   = 6;  ///< 菜单项垂直内边距
+constexpr int kModelMenuItemSpacing= 8;  ///< 菜单项内元素间距
+constexpr int kModelMenuFontPx     = 13; ///< 模型名字号
+constexpr int kModelBadgeFontPx    = 10; ///< 描述徽标字号
+constexpr int kModelBadgeRadius    = 8;  ///< 描述徽标圆角
+constexpr int kModelDotSize        = 8;  ///< 占位圆点直径
+
+/// 暗色判定与 QML 弹窗一致：liii-night / *-dark 视为深色
+static bool
+chat_is_dark_mode () {
+  return occurs ("dark", tm_style_sheet) ||
+         occurs ("liii-night", tm_style_sheet);
+}
 
 //---- dock 模式 常量 ----
 constexpr int kCloseSidebarBtnMarginY= 12;
@@ -280,7 +304,7 @@ ChatConversationPanel::setup_ui () {
   btnLayout->addWidget (searchButton_);
   btnLayout->addStretch ();
 
-  // Model button（占位：弹出只读菜单，不含切换逻辑）
+  // Model button（点击弹出模型选择菜单）
   modelButton_= new QToolButton (inputFrame);
   modelButton_->setObjectName ("chat-tab-model-btn");
   modelButton_->setText (qt_translate ("Model"));
@@ -672,6 +696,108 @@ ChatConversationPanel::adjust_input_height () {
     frame->setFixedHeight (targetFrameH);
     emit inputHeightChanged ();
   }
+}
+
+void
+ChatConversationPanel::showModelMenu (const QList<ChatModelInfo>& models,
+                                      const string&               currentKey,
+                                      const QPoint&               globalPos) {
+  bool isDark= chat_is_dark_mode ();
+
+  // 配色沿用会话项的 hover/选中色值（liii.css / liii-night.css）
+  const QString menuBg    = isDark ? "#404040" : "#ffffff";
+  const QString menuBorder= isDark ? "#4c4c4c" : "#e0e0e0";
+  const QString itemHover = isDark ? "#444444" : "#f0f0f0";
+  const QString itemSel   = isDark ? "#1a3a5a" : "#e8eefc";
+  const QString nameFg    = isDark ? "#ffffff" : "#000000";
+
+  QMenu menu (this);
+  menu.setObjectName ("chat-model-menu");
+  // 透明背景使圆角生效；item 行通过 objectName 选择器着色
+  menu.setAttribute (Qt::WA_TranslucentBackground);
+  menu.setStyleSheet (
+      QString ("QMenu#chat-model-menu { background-color: %1; border: 1px "
+               "solid %2; border-radius: %3px; padding: %4px; }"
+               "QWidget#chat-model-menu-item { background: transparent; "
+               "border-radius: %5px; }"
+               "QWidget#chat-model-menu-item:hover { background: %6; }"
+               "QWidget#chat-model-menu-item[selected=\"true\"] { "
+               "background: %7; }"
+               "QWidget#chat-model-menu-item QLabel#chat-model-name { "
+               "background: transparent; color: %8; }")
+          .arg (menuBg, menuBorder)
+          .arg (DpiUtils::scaled (kModelMenuRadius))
+          .arg (DpiUtils::scaled (kModelMenuPad))
+          .arg (DpiUtils::scaled (kModelMenuItemRadius))
+          .arg (itemHover, itemSel, nameFg));
+
+  const int iconPx= DpiUtils::scaled (kModelMenuIconSize);
+  for (int i= 0; i < models.size (); ++i) {
+    const ChatModelInfo& info= models[i];
+
+    QWidget* row= new QWidget ();
+    row->setObjectName ("chat-model-menu-item");
+    row->setAttribute (Qt::WA_Hover);
+    row->setCursor (Qt::PointingHandCursor);
+    if (info.key == currentKey) row->setProperty ("selected", true);
+
+    QHBoxLayout* rowLayout= new QHBoxLayout (row);
+    rowLayout->setContentsMargins (DpiUtils::scaled (kModelMenuItemPadX),
+                                   DpiUtils::scaled (kModelMenuItemPadY),
+                                   DpiUtils::scaled (kModelMenuItemPadX),
+                                   DpiUtils::scaled (kModelMenuItemPadY));
+    rowLayout->setSpacing (DpiUtils::scaled (kModelMenuItemSpacing));
+
+    QLabel* iconLabel= new QLabel (row);
+    iconLabel->setFixedSize (iconPx, iconPx);
+    QIcon icon;
+    if (!is_empty (info.icon))
+      icon= QIcon (":llm-chat/models/" + to_qstring (info.icon) + ".svg");
+    if (icon.isNull ()) {
+      // 图标缺失时画占位圆点，不留错位
+      QPixmap pm (iconPx, iconPx);
+      pm.fill (Qt::transparent);
+      QPainter p (&pm);
+      p.setRenderHint (QPainter::Antialiasing);
+      p.setPen (Qt::NoPen);
+      p.setBrush (QColor (isDark ? "#7a7a7a" : "#c8c8c8"));
+      int d= DpiUtils::scaled (kModelDotSize);
+      p.drawEllipse ((iconPx - d) / 2, (iconPx - d) / 2, d, d);
+      iconLabel->setPixmap (pm);
+    }
+    else {
+      iconLabel->setPixmap (icon.pixmap (iconPx, iconPx));
+    }
+    rowLayout->addWidget (iconLabel);
+
+    QLabel* nameLabel= new QLabel (utf8_to_qstring (info.name), row);
+    nameLabel->setObjectName ("chat-model-name");
+    DpiUtils::applyScaledFont (nameLabel, kModelMenuFontPx);
+    rowLayout->addWidget (nameLabel, 1);
+
+    if (!is_empty (info.description)) {
+      QLabel* badge= new QLabel (utf8_to_qstring (info.description), row);
+      // 未知 dscColor 已在解析期归一为 red/orange
+      QString badgeBg= (info.dscColor == "red") ? "#e05d5d" : "#f2994a";
+      badge->setStyleSheet (
+          QString ("QLabel { background: %1; color: #ffffff; border-radius: "
+                   "%2px; padding: 1px %3px; font-size: %4px; }")
+              .arg (badgeBg)
+              .arg (DpiUtils::scaled (kModelBadgeRadius))
+              .arg (DpiUtils::scaled (6))
+              .arg (DpiUtils::scaled (kModelBadgeFontPx)));
+      rowLayout->addWidget (badge);
+    }
+
+    QWidgetAction* act= new QWidgetAction (&menu);
+    act->setDefaultWidget (row);
+    string key= info.key;
+    connect (act, &QAction::triggered, this,
+             [this, key] () { emit modelSelected (sessionId_, key); });
+    menu.addAction (act);
+  }
+
+  menu.exec (globalPos);
 }
 
 /******************************************************************************

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -12,6 +12,7 @@
 #ifndef QT_CHAT_TAB_WIDGET_HPP
 #define QT_CHAT_TAB_WIDGET_HPP
 
+#include "qt_chat_model.hpp"
 #include "qt_chat_session.hpp"
 #include <QList>
 #include <QMap>
@@ -135,12 +136,26 @@ public:
                                        bool hasActiveCompletionPopup,
                                        bool isInHybrid= false);
 
+  /**
+   * @brief 弹出模型选择菜单（每次打开重建，按当前会话刷新选中态）。
+   *
+   * 每行为自定义 widget：logo 图标 + 名称 + 描述徽标，选中项背景加深。
+   * 点击后发射 modelSelected 信号。
+   * @param models     模型清单（展示顺序即列表顺序）
+   * @param currentKey 当前会话的模型键名（用于选中态）
+   * @param globalPos  菜单弹出位置（全局坐标）
+   */
+  void showModelMenu (const QList<ChatModelInfo>& models,
+                      const string& currentKey, const QPoint& globalPos);
+
 signals:
   void sendRequested (const string& sessionId);
   void thinkingToggled (const string& sessionId, bool enabled);
   void searchToggled (const string& sessionId, bool enabled);
   /// 请求弹出模型选择菜单；globalPos 为建议弹出位置
   void modelMenuRequested (const string& sessionId, const QPoint& globalPos);
+  /// 模型菜单项被选中；key 为模型键名
+  void modelSelected (const string& sessionId, const string& key);
   void inputHeightChanged ();
   void closeSidebarInDockModeRequested ();
 

--- a/tests/Plugins/Qt/qt_chat_model_test.cpp
+++ b/tests/Plugins/Qt/qt_chat_model_test.cpp
@@ -1,0 +1,266 @@
+
+/******************************************************************************
+ * MODULE     : qt_chat_model_test.cpp
+ * DESCRIPTION: Tests for ChatModelProvider / chat_model_parse_list
+ * COPYRIGHT  : (C) 2026 Mogan STEM
+ ******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include "Qt/qt_chat_model.hpp"
+#include "base.hpp"
+#include <QTemporaryFile>
+#include <QtTest/QtTest>
+
+class TestChatModel : public QObject {
+  Q_OBJECT
+
+private slots:
+  void init () { init_lolly (); }
+
+  // === chat_model_parse_list ===
+  void test_parse_full_fields ();
+  void test_parse_keeps_order ();
+  void test_parse_default_key ();
+  void test_parse_missing_fields_use_defaults ();
+  void test_parse_default_missing_falls_back ();
+  void test_parse_default_not_in_list_uses_first ();
+  void test_parse_unknown_dsc_color_becomes_orange ();
+  void test_parse_invalid_json_returns_false ();
+  void test_parse_empty_models_returns_false ();
+  void test_parse_missing_key_returns_false ();
+
+  // === ChatModelProvider::contains / find ===
+  void test_contains ();
+  void test_find_fallback ();
+
+  // === BuiltinModelProvider ===
+  void test_builtin_without_env ();
+  void test_builtin_with_env_file ();
+};
+
+void
+TestChatModel::test_parse_full_fields () {
+  string               json= string (R"({
+    "default": "DeepSeek",
+    "models": [
+      { "key": "Kimi-VLM", "name": "K3", "icon": "kimi",
+        "description": "订阅优先", "dsc_color": "orange",
+        "allow_thinking": true, "allow_search": true },
+      { "key": "DeepSeek", "name": "R1", "icon": "deepseek",
+        "description": "推理", "dsc_color": "red",
+        "allow_thinking": false, "allow_search": false }
+    ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  QCOMPARE (models.size (), 2);
+  qcompare (models[0].key, "Kimi-VLM");
+  qcompare (models[0].name, "K3");
+  qcompare (models[0].icon, "kimi");
+  qcompare (models[0].description, "订阅优先");
+  qcompare (models[0].dscColor, "orange");
+  QVERIFY (models[0].allowThinking);
+  QVERIFY (models[0].allowSearch);
+  qcompare (models[1].key, "DeepSeek");
+  qcompare (models[1].dscColor, "red");
+  QVERIFY (!models[1].allowThinking);
+  QVERIFY (!models[1].allowSearch);
+  qcompare (def, "DeepSeek");
+}
+
+void
+TestChatModel::test_parse_keeps_order () {
+  string               json= string (R"({
+    "models": [
+      { "key": "A" }, { "key": "B" }, { "key": "C" }
+    ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  QCOMPARE (models.size (), 3);
+  qcompare (models[0].key, "A");
+  qcompare (models[1].key, "B");
+  qcompare (models[2].key, "C");
+}
+
+void
+TestChatModel::test_parse_default_key () {
+  string               json= string (R"({
+    "default": "B",
+    "models": [ { "key": "A" }, { "key": "B" } ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  qcompare (def, "B");
+}
+
+void
+TestChatModel::test_parse_missing_fields_use_defaults () {
+  string               json= string (R"({
+    "models": [ { "key": "Kimi-VLM" } ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  QCOMPARE (models.size (), 1);
+  qcompare (models[0].name, "Kimi-VLM"); // name 缺省回落为 key
+  qcompare (models[0].icon, "");
+  qcompare (models[0].description, "");
+  qcompare (models[0].dscColor, "orange");
+  QVERIFY (models[0].allowThinking);
+  QVERIFY (models[0].allowSearch);
+}
+
+void
+TestChatModel::test_parse_default_missing_falls_back () {
+  // 顶层 default 缺失且清单无 Kimi-VLM 时，回落为第一个模型
+  string               json= string (R"({
+    "models": [ { "key": "A" }, { "key": "B" } ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  qcompare (def, "A");
+}
+
+void
+TestChatModel::test_parse_default_not_in_list_uses_first () {
+  string               json= string (R"({
+    "default": "NOT-EXIST",
+    "models": [ { "key": "A" }, { "key": "B" } ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  qcompare (def, "A");
+}
+
+void
+TestChatModel::test_parse_unknown_dsc_color_becomes_orange () {
+  string               json= string (R"({
+    "models": [ { "key": "A", "dsc_color": "blue" } ]
+  })");
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (chat_model_parse_list (json, models, def));
+  qcompare (models[0].dscColor, "orange");
+}
+
+void
+TestChatModel::test_parse_invalid_json_returns_false () {
+  QList<ChatModelInfo> models;
+  ChatModelInfo        sentinel;
+  sentinel.key= "sentinel";
+  models.append (sentinel);
+  string def= "sentinel-default";
+  QVERIFY (!chat_model_parse_list (string ("not a json"), models, def));
+  // 解析失败时 out 参数不变
+  QCOMPARE (models.size (), 1);
+  qcompare (models[0].key, "sentinel");
+  qcompare (def, "sentinel-default");
+}
+
+void
+TestChatModel::test_parse_empty_models_returns_false () {
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (
+      !chat_model_parse_list (string (R"({ "models": [] })"), models, def));
+  QVERIFY (!chat_model_parse_list (string (R"({})"), models, def));
+}
+
+void
+TestChatModel::test_parse_missing_key_returns_false () {
+  QList<ChatModelInfo> models;
+  string               def;
+  QVERIFY (!chat_model_parse_list (
+      string (R"({ "models": [ { "name": "K3" } ] })"), models, def));
+}
+
+void
+TestChatModel::test_contains () {
+  BuiltinModelProvider provider;
+  QVERIFY (provider.contains (string ("Kimi-VLM")));
+  QVERIFY (!provider.contains (string ("DeepSeek")));
+  QVERIFY (!provider.contains (string ("")));
+}
+
+void
+TestChatModel::test_find_fallback () {
+  BuiltinModelProvider provider;
+  ChatModelInfo        found= provider.find (string ("Kimi-VLM"));
+  qcompare (found.key, "Kimi-VLM");
+  qcompare (found.name, "K3");
+
+  // 清单外键名：兜底构造，name 回落为 key
+  ChatModelInfo fallback= provider.find (string ("Ghost"));
+  qcompare (fallback.key, "Ghost");
+  qcompare (fallback.name, "Ghost");
+  qcompare (fallback.icon, "");
+  qcompare (fallback.description, "");
+  qcompare (fallback.dscColor, "orange");
+  QVERIFY (fallback.allowThinking);
+  QVERIFY (fallback.allowSearch);
+}
+
+void
+TestChatModel::test_builtin_without_env () {
+  qunsetenv ("MOGAN_LLM_MODELS_FILE");
+  BuiltinModelProvider provider;
+  QList<ChatModelInfo> models= provider.models ();
+  QCOMPARE (models.size (), 1);
+  qcompare (models[0].key, "Kimi-VLM");
+  qcompare (models[0].name, "K3");
+  qcompare (models[0].icon, "kimi");
+  qcompare (models[0].description, "");
+  qcompare (models[0].dscColor, "orange");
+  QVERIFY (models[0].allowThinking);
+  QVERIFY (models[0].allowSearch);
+  qcompare (provider.defaultModelKey (), "Kimi-VLM");
+}
+
+void
+TestChatModel::test_builtin_with_env_file () {
+  QTemporaryFile file;
+  QVERIFY (file.open ());
+  file.write (R"({
+    "default": "DeepSeek",
+    "models": [
+      { "key": "Kimi-VLM", "name": "K3", "icon": "kimi" },
+      { "key": "DeepSeek", "name": "R1", "icon": "deepseek",
+        "description": "推理", "dsc_color": "red" }
+    ]
+  })");
+  file.flush ();
+  qputenv ("MOGAN_LLM_MODELS_FILE", file.fileName ().toUtf8 ());
+
+  BuiltinModelProvider provider;
+  QList<ChatModelInfo> models= provider.models ();
+  QCOMPARE (models.size (), 2);
+  qcompare (models[1].key, "DeepSeek");
+  qcompare (provider.defaultModelKey (), "DeepSeek");
+
+  // 文件不可读时回落内置清单
+  qputenv ("MOGAN_LLM_MODELS_FILE", "/nonexistent/path/models.json");
+  BuiltinModelProvider fallback;
+  QCOMPARE (fallback.models ().size (), 1);
+  qcompare (fallback.defaultModelKey (), "Kimi-VLM");
+
+  qunsetenv ("MOGAN_LLM_MODELS_FILE");
+}
+
+#ifdef QTTEXMACS
+QTEST_MAIN (TestChatModel)
+#else
+int
+main () {
+  return 0;
+}
+#endif
+#include "qt_chat_model_test.moc"


### PR DESCRIPTION
## What

实现 LLM 聊天的模型菜单与会话级切换（PR-M3）：

1. 新增 `ChatModelInfo` 值类型与 `ChatModelProvider` 抽象，本期实现
   `BuiltinModelProvider`（内置清单仅 `Kimi-VLM`，行为与现状一致）；
   预留调试通道 `MOGAN_LLM_MODELS_FILE`（环境变量指向 JSON 文件时从文件
   读清单，用于本地联调多条目 UI）。
2. 占位菜单升级为完整模型选择菜单：logo + 名称 + 描述徽标 + 选中项背景加深；
   菜单每次打开重建并按当前会话刷新选中态，明暗双主题配色。
3. 会话级模型切换：`onModelSelected` 写 `ChatSession.model` + 落 manifest。
4. G7 修正：新会话（含复用空白会话）固定为默认模型 `Kimi-VLM`，
   不再继承最近激活会话的模型；激活会话时清单外模型内存回退为默认模型。

## Why

- 模型清单来源需要抽象，liii 插件重构完成后可平滑接入 `LiiiModelProvider`，
  本期先用内置清单把 View/切换/持久化链路一次打通；
- G7：继承最近激活会话的模型会让"新会话"的模型随操作历史漂移，语义混乱；
- 发送路径本就实时读 `session->model`，会话级写回即可，无需触碰发送链路。

## How

- `qt_chat_model.*`：`chat_model_parse_list` 用 `QJsonDocument` 解析，
  字段缺省与 unknown `dsc_color`→orange 归一均在解析期完成；
  `BuiltinModelProvider` 构造时读 `MOGAN_LLM_MODELS_FILE`，失败回落内置清单。
- Controller：值语义持有 Provider，`createView` 早期重建；`onModelSelected`
  先校验 key 在清单内，再 `setModel` + `updateManifest`；`activateSession`
  开头把清单外模型内存回退为默认模型（不写 manifest）。
- View：`ChatConversationPanel::showModelMenu` 用 `QMenu` + `QWidgetAction`
  自定义行渲染，点击发射 `modelSelected(sessionId, key)` 信号；
  图标缺失时画占位圆点；配色沿用会话项 hover/选中色值。
- 不新增/修改任何 C++→Scheme 调用；发送路径不变。

## 验证

- [x] `xmake build --yes stem` 通过
- [x] `xmake b qt_chat_model_test && xmake r qt_chat_model_test`：16/16 通过
- [x] `gf fmt --changed-since=main` 已运行，无无关改动
- [x] 手工 GUI 验证通过（菜单观感、选中态、切换、发送/持久化与 main 一致）
- [ ] 多条目 UI（`MOGAN_LLM_MODELS_FILE` 调试通道）暂未实机验证，
      待后续 liii 插件重构完成后随真实清单一并验证

任务文档：`devel/0955.md`（含调试通道 JSON 示例与手工验证步骤）。
