### PR TITLE
[1261] 修复 llm 插件忙碌提示解码崩溃

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -108,7 +108,7 @@
     (let* ((msg-buf (chat-tab-session->message-buffer session-id))
            (in-buf (chat-tab-session->input-buffer session-id))
           ) ;
-      (with-buffer msg-buf
+      (chat-tab-with-buffer msg-buf
         (let ((body (buffer-get-body msg-buf)))
           (when (chat-tab-buffer-empty? body)
             (buffer-set-body msg-buf
@@ -118,7 +118,7 @@
           ) ;when
         ) ;let
         (chat-tab-add-default-style-packages! chat-tab-session-name)
-      ) ;with-buffer
+      ) ;chat-tab-with-buffer
       (with-buffer in-buf
         (chat-tab-add-default-style-packages! chat-tab-session-name)
       ) ;with-buffer
@@ -174,7 +174,7 @@
       (with (input session-id out opts)
         (chat-tab-session-decode (car l))
         (let ((msg-buf (chat-tab-session->message-buffer session-id)))
-          (with-buffer msg-buf
+          (chat-tab-with-buffer msg-buf
             (when (and (tm-func? out 'document)
                     (> (tree-arity out) 0)
                     (tm-func? (tree-ref out :last) 'script-busy)
@@ -182,7 +182,7 @@
               (tree-remove! out (- (tree-arity out) 1) 1)
             ) ;when
             (buffer-pretend-saved msg-buf)
-          ) ;with-buffer
+          ) ;chat-tab-with-buffer
         ) ;let
         (chat-tab-session-detach (car l))
         ;; 通知 C++ 生成结束
@@ -206,7 +206,7 @@
                    ;; t 包含 reasoning-delta → 提取并追加到 unfolded-explain
                    ;; 注意：t 可能同时包含 fold-explain-reasoning，需要一并处理
                    ((tree-contains-label? t 'reasoning-delta)
-                    (with-buffer msg-buf
+                    (chat-tab-with-buffer msg-buf
                       (let* ((text (tree-extract-reasoning-delta! t))
                              (has-fold? (tree-contains-label? t 'fold-explain-reasoning))
                             ) ;
@@ -225,28 +225,34 @@
                         ) ;when
                       ) ;let*
                       (buffer-pretend-saved msg-buf)
-                    ) ;with-buffer
+                    ) ;chat-tab-with-buffer
                    ) ;
                    ;; t 仅包含 fold-explain-reasoning → 直接折叠
                    ((tree-contains-label? t 'fold-explain-reasoning)
-                    (with-buffer msg-buf
+                    (chat-tab-with-buffer msg-buf
                       (chat-tab-fold-last-explain! out)
                       (buffer-pretend-saved msg-buf)
-                    ) ;with-buffer
+                    ) ;chat-tab-with-buffer
                    ) ;
                    ;; 正常输出
-                   (else (with-buffer msg-buf (chat-tab-output out t) (buffer-pretend-saved msg-buf))
+                   (else (chat-tab-with-buffer msg-buf
+                           (chat-tab-output out t)
+                           (buffer-pretend-saved msg-buf)
+                         ) ;chat-tab-with-buffer
                    ) ;else
                  ) ;cond
                 ) ;
                 ((== ch "error")
-                 (with-buffer msg-buf (chat-tab-errput out t) (buffer-pretend-saved msg-buf))
+                 (chat-tab-with-buffer msg-buf
+                   (chat-tab-errput out t)
+                   (buffer-pretend-saved msg-buf)
+                 ) ;chat-tab-with-buffer
                 ) ;
                 ((== ch "prompt")
-                 (with-buffer msg-buf
+                 (chat-tab-with-buffer msg-buf
                    (tree-set out :up 0 (tree-copy t))
                    (buffer-pretend-saved msg-buf)
-                 ) ;with-buffer
+                 ) ;chat-tab-with-buffer
                 ) ;
                 ((and (== ch "input") (null? (cdr l))) (chat-tab-set-input-body! in-buf t))
           ) ;cond
@@ -256,6 +262,38 @@
   ) ;with
 ) ;define
 
+(tm-define (chat-tab-busy-message msg)
+  (:synopsis "Update script-busy node for pending chat-tab rounds")
+  ;; goldfish 会话经 flush-command 在 message buffer 上下文中调用。
+  ;; 不能用通用 session-busy-message：它以 generic session-decode 解码
+  ;; pending 队列，而 chat-tab 条目第三位是 session-id 字符串，
+  ;; 会被误当作 tree-pointer 求值导致 "is a string" 错误。
+  (let* ((lan (get-env "prog-language")) (ses (get-env "prog-session")))
+    (when (and (== lan chat-tab-session-name)
+            (>= (string-length ses) 9)
+            (== (substring ses 0 9) "chat-tab:")
+          ) ;and
+      (let ((l (pending-ref lan ses)))
+        (for-each (lambda (entry)
+                    (with (input entry-session-id out opts)
+                      (chat-tab-session-decode entry)
+                      (chat-tab-with-buffer (chat-tab-session->message-buffer entry-session-id)
+                        (when (and (tm-func? out 'document)
+                                (> (tree-arity out) 0)
+                                (tm-func? (tree-ref out :last) 'script-busy)
+                              ) ;and
+                          (tree-assign (tree-ref out :last) `(script-busy ,msg))
+                        ) ;when
+                      ) ;chat-tab-with-buffer
+                    ) ;with
+                  ) ;lambda
+          l
+        ) ;for-each
+      ) ;let
+    ) ;when
+  ) ;let*
+) ;tm-define
+
 (define (chat-tab-session-cancel lan ses dead?)
   (with l
     (pending-ref lan ses)
@@ -263,7 +301,7 @@
       (with (input session-id out opts)
         (chat-tab-session-decode (car l))
         (let ((msg-buf (chat-tab-session->message-buffer session-id)))
-          (with-buffer msg-buf
+          (chat-tab-with-buffer msg-buf
             (when (and (tm-func? out 'document)
                     (> (tree-arity out) 0)
                     (tm-func? (tree-ref out :last) 'script-busy)
@@ -271,7 +309,7 @@
               (tree-assign (tree-ref out :last) '(script-interrupted))
             ) ;when
             (buffer-pretend-saved msg-buf)
-          ) ;with-buffer
+          ) ;chat-tab-with-buffer
         ) ;let
         (chat-tab-session-detach (car l))
         ;; 通知 C++ 生成结束
@@ -401,9 +439,9 @@
         (session-id (chat-input-session-id ctx))
        ) ;
     (set! input (plugin-preprocess lan ses input opts))
-    (with-buffer (chat-tab-session->message-buffer session-id)
+    (chat-tab-with-buffer (chat-tab-session->message-buffer session-id)
       (tree-assign! out '(document (script-busy)))
-    ) ;with-buffer
+    ) ;chat-tab-with-buffer
     ;; 通知 C++ 进入 Generating 状态，切换按钮为 Stop
     (chat-tab-notify-state session-id "generating")
     (with x
@@ -441,7 +479,7 @@
             (buffer-set-body msg-buf '(document ""))
           ) ;when
           (view-passive msg-buf)
-          (with-buffer msg-buf
+          (chat-tab-with-buffer msg-buf
             (let ((msg-body (buffer-get-body msg-buf)))
               (when (chat-tab-buffer-empty? msg-body)
                 (session-enable-text-input chat-tab-session-name plugin-ses)
@@ -452,7 +490,7 @@
                 (chat-tab-add-default-style-packages! chat-tab-session-name)
               ) ;when
             ) ;let
-          ) ;with-buffer
+          ) ;chat-tab-with-buffer
           (let* ((out (chat-tab-append-round! msg-buf input model)))
             (if (not out)
               #f
@@ -460,7 +498,10 @@
                 (chat-tab-clear-input! in-buf)
                 (if (not (connection-defined? chat-tab-session-name))
                   (begin
-                    (with-buffer msg-buf (chat-tab-output out input) (buffer-pretend-saved msg-buf))
+                    (chat-tab-with-buffer msg-buf
+                      (chat-tab-output out input)
+                      (buffer-pretend-saved msg-buf)
+                    ) ;chat-tab-with-buffer
                     #t
                   ) ;begin
                   (begin

--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -117,7 +117,9 @@
             (buffer-pretend-saved msg-buf)
           ) ;when
         ) ;let
-        (chat-tab-add-default-style-packages! chat-tab-session-name)
+        (when chat-tab-focus-ok?
+          (chat-tab-add-default-style-packages! chat-tab-session-name)
+        ) ;when
       ) ;chat-tab-with-buffer
       (with-buffer in-buf
         (chat-tab-add-default-style-packages! chat-tab-session-name)
@@ -487,7 +489,11 @@
                   `(session ,chat-tab-session-name ,plugin-ses (document))
                 ) ;buffer-set-body
                 (buffer-pretend-saved msg-buf)
-                (chat-tab-add-default-style-packages! chat-tab-session-name)
+                ;; 样式包操作依赖当前 buffer；无视图时跳过，
+                ;; C++ 侧 ensureMessageWidget 会以嵌入样式初始化
+                (when chat-tab-focus-ok?
+                  (chat-tab-add-default-style-packages! chat-tab-session-name)
+                ) ;when
               ) ;when
             ) ;let
           ) ;chat-tab-with-buffer

--- a/TeXmacs/plugins/llm/progs/llm/chat-style.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-style.scm
@@ -66,11 +66,11 @@
     (let ((msg-buf (chat-tab-session->message-buffer session-id))
           (in-buf (chat-tab-session->input-buffer session-id))
          ) ;
-      (with-buffer msg-buf
+      (chat-tab-with-buffer msg-buf
         (when (not (has-style-package? "dark"))
           (add-style-package "dark")
         ) ;when
-      ) ;with-buffer
+      ) ;chat-tab-with-buffer
       (with-buffer in-buf
         (when (not (has-style-package? "dark"))
           (add-style-package "dark")

--- a/TeXmacs/plugins/llm/progs/llm/chat-style.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-style.scm
@@ -67,7 +67,7 @@
           (in-buf (chat-tab-session->input-buffer session-id))
          ) ;
       (chat-tab-with-buffer msg-buf
-        (when (not (has-style-package? "dark"))
+        (when (and chat-tab-focus-ok? (not (has-style-package? "dark")))
           (add-style-package "dark")
         ) ;when
       ) ;chat-tab-with-buffer

--- a/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm
@@ -19,6 +19,34 @@
   ) ;:use
 ) ;texmacs-module
 
+
+;;; ---------- 视图无关的 with-buffer 变体 ----------
+
+;; 社区版 with-buffer（cursor.scm）要求目标 buffer 有关联视图：
+;; (buffer-focus name #f) 返回 #f 时整个 and 链短路，body 被静默跳过。
+;; 新会话的 message buffer 嵌入编辑器由 C++ 侧懒创建（首次发送成功后
+;; enterConversationMode 才建立视图），发送时必然无视图。
+;; 此变体在 focus 失败时仍执行 body；body 内可通过 chat-tab-focus-ok?
+;; 判断是否需要执行依赖当前视图的操作（如 tree-go-to、add-style-package）。
+
+(define chat-tab-focus-ok? #f)
+
+(define-public-macro (chat-tab-with-buffer name . body)
+  (let* ((old (gensym)) (res (gensym)))
+    `(if (== ,name (current-buffer))
+       (begin ,@body)
+       (let* ((,old (current-buffer)))
+         (with chat-tab-focus-ok?
+           (and (or (url? ,name) (string? ,name))
+             (buffer-exists? ,name)
+             (buffer-focus ,name ,#f))
+           (with ,res
+             (begin ,@body)
+             (when chat-tab-focus-ok? (buffer-focus ,old ,#f))
+             ,res))))
+  ) ;let*
+) ;define-public-macro
+
 ;;; ---------- 文档处理工具 ----------
 
 (tm-define (chat-tab-normalize-document body)
@@ -279,7 +307,9 @@
       (if (and (> i 0) (tm-func? (tree-ref t (- i 1)) 'errput)) (set! i (- i 1)))
       (when (tm-func? u 'document)
         (tree-insert! t i (var-tree-children u))
-        (tree-go-to t :end)
+        (when chat-tab-focus-ok?
+          (tree-go-to t :end)
+        ) ;when
       ) ;when
     ) ;with
   ) ;when
@@ -333,7 +363,7 @@
 ) ;define
 
 (tm-define (chat-tab-message-document message-buffer)
-  (with-buffer message-buffer
+  (chat-tab-with-buffer message-buffer
     (let ((doc (buffer-get-body message-buffer)))
       (cond ((tree-is? doc 'session)
              (with d (tree-ref doc 2) (if (tree-is? d 'document) d doc))
@@ -350,7 +380,7 @@
             ) ;else
       ) ;cond
     ) ;let
-  ) ;with-buffer
+  ) ;chat-tab-with-buffer
 ) ;tm-define
 
 ;;; ---------- 输入操作 ----------
@@ -389,7 +419,7 @@
 ;;; ---------- 追加对话轮次 ----------
 
 (tm-define (chat-tab-append-round! message-buffer body model)
-  (with-buffer message-buffer
+  (chat-tab-with-buffer message-buffer
     (let* ((doc (chat-tab-message-document message-buffer))
            (prompt (chat-tab-model-prompt model))
            (input-children (chat-tab-body-children body))
@@ -401,11 +431,13 @@
            ) ;io-node
           ) ;
       (tree-insert! doc (tree-arity doc) (list io-node))
-      (tree-go-to doc :end)
+      (when chat-tab-focus-ok?
+        (tree-go-to doc :end)
+      ) ;when
       (buffer-pretend-saved message-buffer)
       (let ((last-node (tree-ref doc :last)))
         (and (tree-is? last-node 'unfolded-io-text) (tree-ref last-node 2))
       ) ;let
     ) ;let*
-  ) ;with-buffer
+  ) ;chat-tab-with-buffer
 ) ;tm-define

--- a/devel/1261.md
+++ b/devel/1261.md
@@ -12,6 +12,9 @@
 - `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 新增视图无关的
   `chat-tab-with-buffer` 宏与 `chat-tab-focus-ok?` 标志；`chat-tab-output` /
   `chat-tab-append-round!` 中依赖视图的 `tree-go-to` 加 `chat-tab-focus-ok?` 守卫
+- `TeXmacs/plugins/llm/progs/llm/chat-style.scm` — `chat-tab-sync-dark-style!`
+  的 message buffer 调用点 `with-buffer` → `chat-tab-with-buffer`，
+  `add-style-package "dark"` 加 `chat-tab-focus-ok?` 守卫
 - `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 新增
   `chat-tab-busy-message`，按 chat-tab 布局解码 pending 队列；message buffer
   相关调用点 `with-buffer` → `chat-tab-with-buffer`
@@ -55,9 +58,10 @@ is a string but should be some other thing
   遍历 pending 队列，把各轮次 `out` 末尾的 `script-busy` 节点更新为新的
   忙碌提示（行为与核心通用版本等价）。message buffer 的调用点
   `with-buffer` → `chat-tab-with-buffer`（输入区 buffer 保持社区版
-  `with-buffer`，与 liii 一致）。
+  `with-buffer`，与 liii 一致）；`chat-tab-init-session!` 与发送路径的
+  `chat-tab-add-default-style-packages!` 加 `chat-tab-focus-ok?` 守卫。
 - `chat-style.scm`：`chat-tab-sync-dark-style!` 的 message buffer 调用点
-  同步切换。
+  同步切换，`add-style-package "dark"` 加守卫。
 
 ### Why
 

--- a/devel/1261.md
+++ b/devel/1261.md
@@ -1,0 +1,87 @@
+# [1261] 修复 llm 插件忙碌提示解码崩溃
+
+迁移 liii 仓库 [0511]（3a5ca8a9）的 `llm/progs` 部分，附带迁移其依赖的
+`chat-tab-with-buffer` 宏与 `tree-go-to` 守卫（源自 liii [0507]，02580479）。
+
+## 相关文档
+
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+
+- `TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm` — 新增视图无关的
+  `chat-tab-with-buffer` 宏与 `chat-tab-focus-ok?` 标志；`chat-tab-output` /
+  `chat-tab-append-round!` 中依赖视图的 `tree-go-to` 加 `chat-tab-focus-ok?` 守卫
+- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` — 新增
+  `chat-tab-busy-message`，按 chat-tab 布局解码 pending 队列；message buffer
+  相关调用点 `with-buffer` → `chat-tab-with-buffer`
+- `TeXmacs/plugins/llm/progs/llm/chat-style.scm` — `chat-tab-sync-dark-style!`
+  的 message buffer 调用点 `with-buffer` → `chat-tab-with-buffer`
+
+## 根因
+
+AI 聊天生成过程中（连接/思考/搜索等忙碌阶段切换时）goldfish 侧经
+`flush-command` 发出 `(session-busy-message ...)`，该命令在 message buffer
+上下文中求值，命中核心 `session-busy-message`
+（`TeXmacs/progs/dynamic/session-edit.scm:726`）。核心版本用**通用**
+`session-decode` 遍历会话的整个 `plugin-pending` 队列，而两种 pending
+条目的编码布局不同：
+
+- 通用 `session-encode`：`(callbacks in out-pointer next-pointer opts)`
+- chat-tab `chat-tab-session-encode`：`(callbacks input session-id out-pointer opts)`
+
+通用 decode 执行 `(tree-pointer->tree (third l))`，chat-tab 条目第三位是
+session-id 字符串（UUID），于是 `tree-pointer->tree` 收到字符串报错：
+
+```
+;tree-pointer->tree first argument, "6090CFF7-...",
+is a string but should be some other thing
+```
+
+`session-busy-message` 是全代码库唯一按约定（而非 pending 条目自带回调）
+解码队列的入口，因此只有它踩中该不兼容。
+
+## 2026/09/04 迁移 liii [0511] 的 llm/progs 部分
+
+### What
+
+- `chat-tree-ops.scm`：新增 `chat-tab-with-buffer` 宏与 `chat-tab-focus-ok?`。
+  社区版 `with-buffer`（cursor.scm）在 `buffer-focus` 失败（buffer 无视图）
+  时短路跳过 body；此变体 focus 失败仍执行 body，body 内可用
+  `chat-tab-focus-ok?` 区分是否执行依赖视图的操作。`chat-tab-output` /
+  `chat-tab-append-round!` 的 `tree-go-to` 是依赖视图的操作，加守卫。
+- `chat-protocol.scm`：新增 `chat-tab-busy-message`，校验 `prog-session`
+  以 `chat-tab:` 开头后，用 chat-tab 自己的 `chat-tab-session-decode`
+  遍历 pending 队列，把各轮次 `out` 末尾的 `script-busy` 节点更新为新的
+  忙碌提示（行为与核心通用版本等价）。message buffer 的调用点
+  `with-buffer` → `chat-tab-with-buffer`（输入区 buffer 保持社区版
+  `with-buffer`，与 liii 一致）。
+- `chat-style.scm`：`chat-tab-sync-dark-style!` 的 message buffer 调用点
+  同步切换。
+
+### Why
+
+- 插件若采用自定义 pending 条目布局（chat-tab 额外携带 session-id），
+  不能复用核心中按通用布局解码队列的 `session-busy-message`，必须提供
+  与自家 encode 配套的解码函数。
+- 忙碌提示更新发生在 message buffer 可能尚无视图的时机（新会话的嵌入
+  编辑器由 C++ 侧懒创建），社区版 `with-buffer` 会静默短路跳过 body。
+
+### How
+
+- 核心的 `session-busy-message` 保持原样，使用通用编码的其他插件
+  （gnuplot 等）不受影响。
+- goldfish 侧 `flush-command` 改调 `chat-tab-busy-message` 的改动在 liii
+  仓库（`llm/goldfish/liii/llm-chat.scm`），不在本仓库。
+
+## 如何测试
+
+```bash
+gf fix TeXmacs/plugins/llm/progs/llm/chat-protocol.scm \
+      TeXmacs/plugins/llm/progs/llm/chat-tree-ops.scm \
+      TeXmacs/plugins/llm/progs/llm/chat-style.scm
+```
+
+GUI 手工验证（与 liii [0511] 一致）：发起一次 AI 对话，连接/思考/搜索等
+忙碌阶段提示正常显示且不再报
+`tree-pointer->tree ... is a string` 错。


### PR DESCRIPTION
## 改动

迁移 liii 仓库 [0511]（3a5ca8a9）的 `llm/progs` 部分：

- `chat-protocol.scm`：新增 `chat-tab-busy-message`，校验 `prog-session` 以 `chat-tab:` 开头后，用 chat-tab 自己的 `chat-tab-session-decode` 遍历 pending 队列，把各轮次 `out` 末尾的 `script-busy` 节点更新为新的忙碌提示
- `chat-tree-ops.scm`：迁移 `chat-tab-with-buffer` 宏与 `chat-tab-focus-ok?`（liii [0507]）；`chat-tab-output` / `chat-tab-append-round!` 的 `tree-go-to` 加守卫
- `chat-style.scm` / `chat-protocol.scm`：message buffer 相关调用点 `with-buffer` → `chat-tab-with-buffer`（输入区 buffer 保持社区版 `with-buffer`，与 liii 一致）

## 背景

AI 聊天生成过程中（连接/思考/搜索等忙碌阶段切换时），核心 `session-busy-message` 用通用 `session-decode` 遍历 `plugin-pending` 队列，而 chat-tab 条目布局为 `(callbacks input session-id out-pointer opts)`，第三位是 session-id 字符串，被误当 tree-pointer 求值报错：

```
;tree-pointer->tree first argument, "6090CFF7-...", is a string but should be some other thing
```

核心 `session-busy-message` 保持原样，使用通用编码的其他插件（gnuplot 等）不受影响。goldfish 侧 `flush-command` 改调 `chat-tab-busy-message` 的改动在 liii 仓库。

## 测试

- `gf fix` / `gf fmt --changed-since=main` 通过
- GUI 手工验证：发起一次 AI 对话，忙碌阶段提示正常显示且不再报错（待验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)