### PR TITLE
[1262] 修复 chat-style 中插件样式包检测路径并添加 chat-tree-ops 依赖

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-style.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-style.scm
@@ -11,7 +11,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (llm chat-style)
-  (:use (utils library cursor) (generic document-style))
+  (:use (utils library cursor) (generic document-style) (llm chat-tree-ops))
 ) ;texmacs-module
 
 ;;; ---------- 全局常量 ----------
@@ -41,8 +41,12 @@
         (set! packs (append packs (list "table-captions-above")))
       ) ;when
     ) ;when
-    ;; 插件样式包：动态检测，参考 session-edit 的 make-session
-    (when (url-exists? (url-unix "$TEXMACS_STYLE_PATH" (string-append session-name ".ts"))
+    ;; 插件样式包：动态检测
+    (when (url-exists? (url-append (get-texmacs-path)
+                         (string-append "plugins/" session-name
+                           "/packages/session/" session-name ".stem"
+                         ) ;string-append
+                       ) ;url-append
           ) ;url-exists?
       (set! packs (append packs (list session-name)))
     ) ;when

--- a/devel/1262.md
+++ b/devel/1262.md
@@ -1,0 +1,38 @@
+# [1262] 修复 chat-style 中插件样式包检测路径并添加 chat-tree-ops 依赖
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1184.md](1184.md) - chat-tab 样式包加载优化
+- [1261.md](1261.md) - 修复 llm 插件忙碌提示解码崩溃
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/llm/progs/llm/chat-style.scm` — 模块声明引入 `(llm chat-tree-ops)` 依赖；样式包检测路径改为 `get-texmacs-path` 下的 `plugins/<session-name>/packages/session/<session-name>.stem`
+
+## 3 如何测试
+
+### 3.1 手动测试
+1. 启动 Mogan STEM 打开 AI 对话侧边栏。
+2. 发起对话，检查会话 buffer 是否正常应用 `llm` 样式包（如样式属性及输入输出渲染）。
+3. 切换深色主题，验证 `dark` 主题包正常同步且无未绑定符号报错。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git commit -m "[1262] 更新任务文档"
+# ... 代码改动 ...
+git commit -m "[1262] 修复 chat-style 中插件样式包检测路径并添加 chat-tree-ops 依赖"
+```
+
+## 5 What
+1. 在 `TeXmacs/plugins/llm/progs/llm/chat-style.scm` 模块声明中添加 `(:use (llm chat-tree-ops))` 依赖。
+2. 修复 `chat-tab-add-default-style-packages!` 中的插件样式包存在性判断，从查找 `$TEXMACS_STYLE_PATH/<session-name>.ts` 改为查找 `(get-texmacs-path)` 路径下的 `plugins/<session-name>/packages/session/<session-name>.stem`。
+
+## 6 Why
+1. `chat-style.scm` 中的 `chat-tab-sync-dark-style!` 使用了 `chat-tab-with-buffer` 和 `chat-tab-focus-ok?`，这两个符号定义在 `(llm chat-tree-ops)` 模块中，缺少模块依赖可能导致在未提前加载 `chat-tree-ops` 时出现未绑定符号错误。
+2. Mogan 已全面切换为 `.stem` 格式包，插件的 session 样式包位于 `plugins/<session-name>/packages/session/<session-name>.stem`（如 `plugins/llm/packages/session/llm.stem`），原先在 `$TEXMACS_STYLE_PATH` 下查找 `<session-name>.ts` 必定失败，导致 LLM 会话 buffer 无法正确挂载对应的 `llm` 样式包。
+
+## 7 How
+- 使用 `(url-append (get-texmacs-path) (string-append "plugins/" session-name "/packages/session/" session-name ".stem"))` 拼接固定的插件样式包文件路径。
+- 用 `url-exists?` 检测文件是否存在，若存在则把 `session-name` 追加到 `packs` 列表中。
+- 在 `(texmacs-module (llm chat-style) ...)` 的 `:use` 声明中加入 `(llm chat-tree-ops)`。


### PR DESCRIPTION
## What
- 在 `TeXmacs/plugins/llm/progs/llm/chat-style.scm` 模块声明中添加 `(:use (llm chat-tree-ops))` 依赖。
- 修复 `chat-tab-add-default-style-packages!` 中的插件样式包存在性判断，从查找 `$TEXMACS_STYLE_PATH/<session-name>.ts` 改为查找 `(get-texmacs-path)` 路径下的 `plugins/<session-name>/packages/session/<session-name>.stem`。
- 更新任务文档 `devel/1262.md`。

## Why
- `chat-style.scm` 中的 `chat-tab-sync-dark-style!` 使用了 `chat-tab-with-buffer` 和 `chat-tab-focus-ok?`，缺少模块依赖可能导致在未提前加载 `chat-tree-ops` 时报错。
- Mogan 已全面切换为 `.stem` 格式包，插件的 session 样式包位于 `plugins/<session-name>/packages/session/<session-name>.stem`，原先在 `$TEXMACS_STYLE_PATH` 下查找 `<session-name>.ts` 必定失败。

## Test
手动测试验证。