### PR TITLE
[1263] 同步内部仓库 llm 协议改动并清理 1185 的 view-passive 补丁

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
@@ -1,4 +1,3 @@
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : chat-protocol.scm
@@ -104,7 +103,11 @@
   (let ((plugin-ses (string-append "chat-tab:" session-id)))
     ;; Step 1: 注册 text-input 模式
     (session-enable-text-input chat-tab-session-name plugin-ses)
-    ;; Step 2: 初始化 buffer
+    ;; Step 2: 初始化 buffer（message buffer 可能尚未创建，
+    ;; with-buffer 对不存在的 buffer 静默返回 #f，需先创建）
+    (when (not (buffer-exists? (chat-tab-session->message-buffer session-id)))
+      (buffer-set (chat-tab-session->message-buffer session-id) '(document ""))
+    ) ;when
     (let* ((msg-buf (chat-tab-session->message-buffer session-id))
            (in-buf (chat-tab-session->input-buffer session-id))
           ) ;
@@ -428,7 +431,9 @@
     (let ((json-str (njson->string obj)))
       (njson-free params)
       (njson-free obj)
-      (stree->tree `(document ,(string-append "%chat " json-str)))
+      (let ((cork-json (utf8->cork json-str)))
+        (stree->tree `(document ,(string-append "%chat " cork-json)))
+      ) ;let
     ) ;let
   ) ;let*
 ) ;define
@@ -471,16 +476,11 @@
             ) ;
         ;; 延迟初始化：首次发送时设置 session body 并加载样式包
         (let ((plugin-ses (string-append "chat-tab:" session-id)))
-          ;; 消息编辑器懒创建（#4258）后，新会话首次发送时 message buffer
-          ;; 既不存在也无 view：with-buffer 经 buffer-focus 切视图，任一
-          ;; 不满足都会短路返回 #f，初始化代码因此永不执行。
-          ;; 先 buffer-set-body 直接建 buffer（不得用 view-passive 单独建，
-          ;; 其内部 buffer_load 对 tmfs://chat/* 会产出 Invalid tmfs
-          ;; document 错误文档），再 view-passive 补挂 passive view。
+          ;; 新会话的 message buffer 尚不存在（with-buffer 对不存在的
+          ;; buffer 静默返回 #f），必须先创建
           (when (not (buffer-exists? msg-buf))
-            (buffer-set-body msg-buf '(document ""))
+            (buffer-set msg-buf '(document ""))
           ) ;when
-          (view-passive msg-buf)
           (chat-tab-with-buffer msg-buf
             (let ((msg-body (buffer-get-body msg-buf)))
               (when (chat-tab-buffer-empty? msg-body)

--- a/devel/1263.md
+++ b/devel/1263.md
@@ -1,0 +1,107 @@
+# [1263] 同步内部仓库的一些更改
+
+同步内部仓库（liii）在 LLM 插件协议层的若干改动，并清理因引入 `chat-tab-with-buffer` 后不再需要的临时补丁。
+
+## 1 相关文档
+
+- [1185.md](1185.md) - Chat 标签页初始化性能热点定位及新会话首次发送失败修复
+- [1261.md](1261.md) - 修复 llm 插件忙碌提示解码崩溃（引入视图无关的 `chat-tab-with-buffer`）
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+
+- `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm`
+
+## 3 如何测试
+
+### 3.1 格式化与静态检查
+```bash
+gf fix TeXmacs/plugins/llm/progs/llm/chat-protocol.scm
+```
+
+### 3.2 运行回归测试
+```bash
+xmake b stem && xmake r 2044
+```
+
+### 3.3 手动测试
+1. 启动 Mogan，点击打开 Chat 标签页进入欢迎页；
+2. 在新会话输入框中输入包含中文字符的提示词（如“你好”），按 Enter 或点击发送按钮；
+3. 验证：
+   - 界面正常从欢迎页切换至对话模式；
+   - 消息正常发送给 LLM，没有无响应或欢迎页卡死现象；
+   - 中文内容正常传输和显示，没有乱码。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git add devel/1263.md
+git commit -m "[1263] 添加任务文档"
+```
+
+## 5 What
+
+1. **移除 `view-passive` 视图依赖补丁**：在 `chat-tab-session-send` 中移除 `(view-passive msg-buf)` 及其冗余说明注释，恢复更简洁的 buffer 存在性初始化逻辑。
+2. **提前保证 message buffer 存在**：在 `chat-tab-init-session!` 中增加对 message buffer 存在性的检查与创建（若不存在则调用 `buffer-set` 初始化为 `'(document "")`）；在发送路径中统一改用 `buffer-set`。
+3. **协议消息 Cork 编码同步**：在 `chat-tab-build-context-input` 中，通过 `(utf8->cork json-str)` 将 JSON 文本转换为 Cork 编码表示后再嵌入 `(document ...)` 树中，与内部仓库保持对齐。
+
+## 6 Why
+
+### 为什么有了 1261.md 之后 1185.md 的改动不需要了？
+
+在 1185.md 中，为了解决在消息编辑器懒创建（#4258）之后新会话首次发送界面停在欢迎页的问题，引入了如下补丁：
+```scheme
+(when (not (buffer-exists? msg-buf))
+  (buffer-set-body msg-buf '(document "")))
+(view-passive msg-buf)
+```
+当时必须调用 `view-passive` 的根本原因在于：
+- 当时使用的是核心通用宏 `with-buffer`（`TeXmacs/progs/utils/library/cursor.scm`）；
+- `with-buffer` 宏展开时会调用 `(buffer-focus new #f)`；
+- 新会话首次发送时，消息区嵌入编辑器尚未创建，message buffer 既不存在也没有挂载视图。`buffer-focus` 在 buffer 无 view 时直接返回 `#f`，导致整个 `with-buffer` **静默短路返回 `#f`**，函数体中的初始化和发送代码完全不执行；
+- 当时为了让 `buffer-focus` 能够成功返回，通过 `view-passive` 给 buffer 强行挂载了一个被动视图作为权宜之计。
+
+而在 1261.md 中，从内部仓库迁移了专为 Chat 场景设计的 `chat-tab-with-buffer` 宏（定义在 `chat-tree-ops.scm`）：
+- `chat-tab-with-buffer` 采用**视图无关**的执行语义：即使 `buffer-focus` 失败（即 buffer 尚无视图），依然会继续执行 body 内容，仅通过局部变量 `chat-tab-focus-ok?` 标识视图状态；
+- 因此，`chat-tab-session-send` 内的代码在没有 view 的情况下也能正常执行，不再依赖 `buffer-focus` 的返回值。
+- 这使得 1185.md 中为迎合 `with-buffer` 而额外调用的 `(view-passive msg-buf)` 彻底失去了存在的意义，属于多余的临时副作用，应当回退清理。
+
+### 为什么需要同步 `utf8->cork`？
+
+- 在 `chat-tab-build-context-input` 构建 `%chat` 消息协议时，`json-str` 是纯 UTF-8 字符串；
+- TeXmacs/Mogan 内部的树节点字符串默认遵循 Cork 编码。经由 `utf8->cork` 转义后，非 ASCII 字符（如中文）会被编码为 `<#XXXX>` 转义序列；
+- 与内部仓库保持一致，确保数据在传递给底层 connection 序列化通道时符合标准编码契约，避免二次解释产生乱码。
+
+## 7 How
+
+在 `TeXmacs/plugins/llm/progs/llm/chat-protocol.scm` 中进行以下调整：
+
+1. **`chat-tab-init-session!`**：
+   在 Step 2 前增加对 message buffer 是否存在的检测，若不存在则调用 `buffer-set` 初始化：
+   ```scheme
+   (when (not (buffer-exists? (chat-tab-session->message-buffer session-id)))
+     (buffer-set (chat-tab-session->message-buffer session-id) '(document ""))
+   ) ;when
+   ```
+
+2. **`chat-tab-build-context-input`**：
+   在生成文档树节点时引入 `utf8->cork` 转换：
+   ```scheme
+   (let ((cork-json (utf8->cork json-str)))
+     (stree->tree `(document ,(string-append "%chat " cork-json)))
+   ) ;let
+   ```
+
+3. **`chat-tab-session-send`**：
+   - 移除 `(view-passive msg-buf)` 及其冗长注释；
+   - 对未创建的 buffer 改用 `(buffer-set msg-buf '(document ""))`，保留简明的存在性保障：
+   ```scheme
+   ;; 新会话的 message buffer 尚不存在（with-buffer 对不存在的
+   ;; buffer 静默返回 #f），必须先创建
+   (when (not (buffer-exists? msg-buf))
+     (buffer-set msg-buf '(document ""))
+   ) ;when
+   (chat-tab-with-buffer msg-buf
+   ...
+   ```


### PR DESCRIPTION
详见 `devel/1263.md`。

- 回退 1185 中引入的 `view-passive` 视图依赖补丁（1261 引入 `chat-tab-with-buffer` 后已不再需要视图守卫）；
- 在 `chat-tab-init-session!` 中补齐 message buffer 存在性检查与 `buffer-set` 初始化；
- 在 `chat-tab-build-context-input` 中对协议 JSON 补齐 `utf8->cork` 编码转换。