### PR TITLE
[1264] check 标签默认 utf8->herk，修复编号样式菜单乱码

### DIFF
--- a/TeXmacs/progs/kernel/gui/gui-markup.scm
+++ b/TeXmacs/progs/kernel/gui/gui-markup.scm
@@ -313,7 +313,16 @@
 (tm-define-macro ($check text check pred?)
   (:synopsis "Make check")
   (if developer-mode? (ahash-set! all-translations text #t))
-  `(list 'check ,text ,check (lambda ,() ,pred?))
+  ;; 标签约定按裸 UTF-8 书写,仅 check 在此统一 utf8->herk(QTMAction::set_text
+  ;; 按 herk 解码);ASCII/已是 herk 者不变,verbatim 标签取内层串转换,
+  ;; 其余形态(balloon 等)原样透传
+  `(list 'check
+    (let ((l ,text))
+      (cond ((string? l) (utf8->herk l))
+            ((func? l 'verbatim 1)
+             (list 'verbatim (utf8->herk (cadr l))))
+            (else l)))
+    ,check (lambda ,() ,pred?))
 ) ;tm-define-macro
 
 (tm-define-macro ($shortcut* text sh)

--- a/TeXmacs/progs/kernel/gui/gui-markup.scm
+++ b/TeXmacs/progs/kernel/gui/gui-markup.scm
@@ -317,12 +317,12 @@
   ;; 按 herk 解码);ASCII/已是 herk 者不变,verbatim 标签取内层串转换,
   ;; 其余形态(balloon 等)原样透传
   `(list 'check
-    (let ((l ,text))
-      (cond ((string? l) (utf8->herk l))
-            ((func? l 'verbatim 1)
-             (list 'verbatim (utf8->herk (cadr l))))
-            (else l)))
-    ,check (lambda ,() ,pred?))
+     (let ((l ,text))
+       (cond ((string? l) (utf8->herk l))
+             ((func? l 'verbatim 1) (list 'verbatim (utf8->herk (cadr l))))
+             (else l)))
+     ,check
+     (lambda ,() ,pred?))
 ) ;tm-define-macro
 
 (tm-define-macro ($shortcut* text sh)

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -1170,7 +1170,10 @@
       ((check "Arabic (1, 2, 3)" "v" (== (safe-init-env num-var) "arabic"))
        (init-env num-var "arabic")
       ) ;
-      ((check (verbatim "Hanzi (一, 二, 三)") "v" (== (safe-init-env num-var) "hanzi"))
+      ((check (verbatim "Hanzi (一, 二, 三)")
+         "v"
+         (== (safe-init-env num-var) "hanzi")
+       ) ;check
        (init-env num-var "hanzi")
       ) ;
       ((check "Roman (I, II, III)" "v" (== (safe-init-env num-var) "Roman"))

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -1170,7 +1170,7 @@
       ((check "Arabic (1, 2, 3)" "v" (== (safe-init-env num-var) "arabic"))
        (init-env num-var "arabic")
       ) ;
-      ((check "Hanzi (一, 二, 三)" "v" (== (safe-init-env num-var) "hanzi"))
+      ((check (verbatim "Hanzi (一, 二, 三)") "v" (== (safe-init-env num-var) "hanzi"))
        (init-env num-var "hanzi")
       ) ;
       ((check "Roman (I, II, III)" "v" (== (safe-init-env num-var) "Roman"))
@@ -1200,7 +1200,7 @@
     (section-sep-var (focus-tree))
     (when sep-var
       ((check "." "v" (== (safe-init-env sep-var) ".")) (init-env sep-var "."))
-      ((check "、" "v" (== (safe-init-env sep-var) "<#3001>"))
+      ((check (verbatim "、") "v" (== (safe-init-env sep-var) "<#3001>"))
        (init-env sep-var "<#3001>")
       ) ;
       ((check "-" "v" (== (safe-init-env sep-var) "-")) (init-env sep-var "-"))
@@ -1216,7 +1216,7 @@
       ((check "." "v" (== (safe-init-env prefix-sep-var) "."))
        (init-env prefix-sep-var ".")
       ) ;
-      ((check "、" "v" (== (safe-init-env prefix-sep-var) "<#3001>"))
+      ((check (verbatim "、") "v" (== (safe-init-env prefix-sep-var) "<#3001>"))
        (init-env prefix-sep-var "<#3001>")
       ) ;
       ((check "-" "v" (== (safe-init-env prefix-sep-var) "-"))

--- a/devel/1264.md
+++ b/devel/1264.md
@@ -1,0 +1,71 @@
+# [1264] check 标签默认 utf8->herk，修复编号样式菜单乱码
+
+焦点偏好菜单的编号样式（Number style）等 check 条目出现乱码：`Circle (①, ②, ③)`、`Hanzi (一, 二, 三)`、`、` 等含非 ASCII 字符的标签被显示为拉丁乱码。本任务在 `$check` 宏统一对标签做 `utf8->herk`，使 check 标签默认按裸 UTF-8 书写，恢复确定性的编码契约。
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1240.md](1240.md) - 引入 `QTMAction::set_text` 按 herk 解码的任务（2f744e4c）
+- 0939（内部仓库分支）：导出菜单乱码的针对性修复（409a0d9b、88a66ef），本任务是其通用化
+
+## 2 任务相关的代码文件
+- `TeXmacs/progs/kernel/gui/gui-markup.scm` - `$check` 宏，标签统一 utf8->herk
+- `TeXmacs/progs/text/text-menu.scm` - 编号样式/分隔符 check 标签包 verbatim
+
+## 3 如何测试
+
+### 3.1 单元测试
+```bash
+xmake b stem
+xmake r menu-expand-test
+xmake r menu-entry-test
+```
+
+### 3.2 集成测试
+无新增自动化用例。可在 headless 下求值验证标签转换：
+```bash
+build/linux/x86_64/release/moganstem -headless -d \
+  -b TeXmacs/progs/kernel/gui/menu-expand-test.scm \
+  -x '(display* (utf8->herk "①"))'
+```
+预期输出 `<#2460>`。
+
+### 3.3 端到端测试
+手动测试：
+1. 启动 Mogan，光标置于章节标题，打开焦点偏好菜单（Focus → Number style）；
+2. 验证 `Hanzi (一, 二, 三)`、`Circle (①, ②, ③)` 等条目正常显示，无乱码；
+3. 验证编号分隔符条目（`、`）正常显示；
+4. 切换中/英文界面重复检查，确认既有带译文条目（如 Centered 等）的翻译与显示不受影响。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git add TeXmacs/progs/kernel/gui/gui-markup.scm TeXmacs/progs/text/text-menu.scm devel/1264.md
+git commit -m "[1264] check 标签默认 utf8->herk，修复编号样式菜单乱码"
+```
+
+## 5 What
+1. `$check` 宏（`TeXmacs/progs/kernel/gui/gui-markup.scm`）：展开产物中的标签统一经 `utf8->herk`——字符串标签直接转换；`(verbatim s)` 取内层 `s` 转换；其余形态（balloon 等）原样透传。仅 check 语法生效，其余菜单条目标签行为不变。
+2. `TeXmacs/progs/text/text-menu.scm`：为含非 ASCII 字符的 check 标签手动包 verbatim——`Hanzi (一, 二, 三)` 与编号分隔符的两个 `、` 条目，与既有的 `Circle (①, ②, ③)` 写法一致；verbatim 标签同时不会进入 translate 查找。
+
+## 6 Why
+- 2f744e4c（[1240]）把 `QTMAction::set_text` 从 `to_qstring` 改为确定性的 `utf8_to_qstring(herk_to_utf8(s))`。方向正确：`to_qstring` 按字节内容猜编码（`looks_utf8` 启发式），有不确定性，应当避免。此后菜单标签在 C++ 侧的契约是 herk（ASCII + `<#XXXX>` 转义）。
+- 但 scheme 源码里的 check 标签常以裸 UTF-8 书写。带译文的标签不受影响——词典加载时译文已 `utf8_to_cork`（`dictionary.cpp`），到达 `set_text` 的是 ASCII；而无译文的裸 UTF-8 标签直接进入 `set_text`，被逐字节按 herk 单字节表映射成拉丁字符，即乱码（英文界面 from==to 时 `translate` 原样返回，同样乱码）。
+- 修复点选在 `$check` 宏，而非 0939 那样逐调用点手写 `utf8->herk`，也不是恢复 `to_qstring` 启发式：一处修改覆盖全部 check 条目；`utf8->herk` 对纯 ASCII/已是 herk 的串是恒等变换（幂等），既有英文标签、词典命中、`all-translations` 注册（使用未求值的 text）均不受影响。
+
+## 7 How
+`$check` 宏改动：
+```scheme
+`(list 'check
+  (let ((l ,text))
+    (cond ((string? l) (utf8->herk l))
+          ((func? l 'verbatim 1)
+           (list 'verbatim (utf8->herk (cadr l))))
+          (else l)))
+  ,check (lambda ,() ,pred?))
+```
+- `let` 绑定保证标签表达式只求值一次；
+- 转换发生在菜单展开求值时，先于 `make-menu-label` 的 `translate`：ASCII 标签恒等，translate 的键不变；译文值本身是 cork/herk ASCII，不会经过二次转换；
+- `utf8->herk` 为 L2 glue（`lolly::data::utf8_to_herk`），菜单定义模块可见；
+- C++ 侧零改动，`set_text` 契约不变；
+- 已知边界：`=>` 子菜单标题等非 check 位置的裸 UTF-8 标签仍需按 0939 的方式在调用点转换（如 `file-menu.scm` 的 recent 文件名条目）。


### PR DESCRIPTION
## 摘要
- `` 宏（`TeXmacs/progs/kernel/gui/gui-markup.scm`）：标签统一 `utf8->herk`——字符串直接转换、`(verbatim s)` 转内层、其余形态透传，仅 check 生效。check 标签从此默认按裸 UTF-8 书写。
- `TeXmacs/progs/text/text-menu.scm`：为 `Hanzi (一, 二, 三)` 与分隔符 `、` 条目补上 verbatim 标记，与 `Circle (①, ②, ③)` 写法一致。

## 背景
[1240] 把 `QTMAction::set_text` 改为确定性 `herk_to_utf8` 解码（废弃 `to_qstring` 的启发式判别）后，无译文的裸 UTF-8 check 标签被逐字节按 herk 解码成乱码。修复放在宏层，一处覆盖全部 check 条目；`utf8->herk` 对 ASCII/已是 herk 的串幂等，既有翻译不受影响。C++ 侧零改动。

详见 `devel/1264.md`。

## 测试
- `xmake r menu-expand-test`：24 correct, 0 failed
- headless 求值验证：`"Circle (①, ②, ③)"` → `"Circle (<#2460>, <#2461>, <#2462>)"`、`(verbatim "、")` → `(verbatim "<#3001>")`、ASCII 恒等、balloon 透传
- GUI 手动验证 Number style / 分隔符条目显示正常