### PR TITLE
[1266] 标签页脏标记改为圆点，悬停标签任意位置显示关闭按钮

### DIFF
--- a/devel/1266.md
+++ b/devel/1266.md
@@ -1,0 +1,51 @@
+# 1266 标签页脏标记改为圆点
+
+分支：`da/1266/nice_tab`
+
+## What
+
+标签页的未保存（dirty）提示由文本 `*` 改为小圆点，并调整 ×
+关闭按钮的显示时机：
+
+- 脏标签未悬停：关闭按钮位置画半透明小圆点（直径 6 逻辑像素），不再画 `*`。
+- 悬停标签页任意位置（不再要求精确悬停在关闭按钮上）：圆点被 × 关闭按钮取代。
+- 移开后 × 隐藏，回落为圆点。
+- 干净的活动标签仍常驻 ×（原有行为保留）；关闭确认弹窗期间 × 依旧隐藏。
+
+## Why
+
+`*` 与标题文字混排时视觉噪音大且不直观，用小圆点提示未保存状态、
+悬停时圆点变为 ×，交互更自然。旧逻辑要求鼠标精确悬停在 18px 的关闭按钮
+上才能从 `*` 切到 ×，命中困难。
+
+## How
+
+- `paintEvent`：dirty 且关闭按钮隐藏时，用 `QPainter::drawEllipse` 在关闭
+  按钮几何中心画抗锯齿圆点（`QPalette::ButtonText` + alpha 150，随主题），
+  取代原 `drawItemText("*")`。
+- `updateCloseButtonVisibility`：`m_hoverOnCloseArea`（仅关闭按钮区域）
+  换成 `m_hoverOnTab`（enter/leaveEvent 维护的整标签悬停态），× 的显示
+  条件简化为 `hover || (!dirty && checked)`；新增 `m_suppressCloseBtn`
+  在关闭确认弹窗期间强制隐藏 ×，弹窗关闭后按 `QCursor::pos()` 恢复。
+- 删除随之失效的 `eventFilter`（关闭按钮 Enter/Leave 过滤）与
+  `isPointerOnCloseArea`；`mouseMoveEvent` 不再逐帧刷新悬停态。
+- 测试 `qt_tab_page_test.cpp`：悬停触发由合成 MouseMove 改为合成
+  `QEnterEvent`/`QEvent::Leave`（悬停点取文本区，锁定"任意位置"语义），
+  并断言活动+脏+未悬停时 × 隐藏。
+
+## 验证
+
+- `xmake b qt_tab_page_test && xmake r qt_tab_page_test`：6 通过 / 0 失败。
+- GUI 实测（Linux, HiDPI）：Ctrl+T 新建草稿（天生 dirty）→ 标签显示圆点；
+  键入内容 → 圆点保持；悬停标签文本区 → × 出现；移开 → 圆点恢复（3 轮
+  循环稳定）；点击 × → 弹"保存草稿文档?"确认框，期间 × 隐藏（suppress
+  生效），取消后状态正确恢复。
+- 注意：草稿缓冲会被应用在空闲时静默保存（状态栏出现 "Saved
+  .../draft_*.tmu"），保存后文档变干净，此时活动标签常驻 × 属预期行为，
+  与本次改动无关。
+
+## 涉及文件
+
+- `src/Plugins/Qt/QTMTabPage.hpp`
+- `src/Plugins/Qt/QTMTabPage.cpp`
+- `tests/Plugins/Qt/qt_tab_page_test.cpp`

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -231,7 +231,7 @@ QTMTabPage::syncActionText (const QString& cleanTitle) {
 
 void
 QTMTabPage::syncDisplay (const QString& cleanTitle, bool dirty) {
-  // dirty 变化或标题变化都需要重画：前者改关闭按钮位置的 `*`，后者改文本。
+  // dirty 变化或标题变化都需要重画：前者改关闭按钮位置的脏圆点，后者改文本。
   bool changed= (m_isDirty != dirty) || (text () != cleanTitle);
   m_isDirty   = dirty;
   setText (cleanTitle);
@@ -254,48 +254,24 @@ QTMTabPage::initializeCloseButton (QAction* closeAction) {
   int closeBtnRadius= DpiUtils::scaled (6);
   m_closeBtn->setStyleSheet (
       QString ("border-radius: %1px; padding: 0px;").arg (closeBtnRadius));
-  m_closeBtn->installEventFilter (this);
   if (closeAction) {
     QPointer<QAction> safeAction (closeAction);
     connect (m_closeBtn, &QPushButton::clicked, this, [=] () {
       if (!safeAction) return;
-      // 弹窗期间先隐藏关闭按钮高亮；取消后按鼠标位置恢复。
-      m_hoverOnCloseArea= false;
+      // 弹窗期间先隐藏关闭按钮；弹窗关闭后按光标实际位置恢复 hover 态。
+      m_suppressCloseBtn= true;
       updateCloseButtonVisibility ();
       QPointer<QTMTabPage> guard (this);
       safeAction->trigger ();
       if (guard) {
         QPoint pos               = guard->mapFromGlobal (QCursor::pos ());
-        guard->m_hoverOnCloseArea= guard->isPointerOnCloseArea (pos);
+        guard->m_hoverOnTab      = guard->rect ().contains (pos);
+        guard->m_suppressCloseBtn= false;
         guard->updateCloseButtonVisibility ();
       }
     });
   }
   updateCloseButtonVisibility ();
-}
-
-bool
-QTMTabPage::isPointerOnCloseArea (const QPoint& pos) const {
-  if (!m_closeBtn) return false;
-  return m_closeBtn->geometry ().contains (pos);
-}
-
-bool
-QTMTabPage::eventFilter (QObject* watched, QEvent* event) {
-  if (watched == m_closeBtn) {
-    if (event->type () == QEvent::Enter) {
-      m_hoverOnCloseArea= true;
-      updateCloseButtonVisibility ();
-      return false;
-    }
-    if (event->type () == QEvent::Leave) {
-      QPoint pos        = mapFromGlobal (QCursor::pos ());
-      m_hoverOnCloseArea= isPointerOnCloseArea (pos);
-      updateCloseButtonVisibility ();
-      return false;
-    }
-  }
-  return QToolButton::eventFilter (watched, event);
 }
 
 /* We can't align the text to the left of the button by QSS or other methods,
@@ -350,9 +326,15 @@ QTMTabPage::paintEvent (QPaintEvent*) {
                     isEnabled (), elidedText, QPalette::ButtonText);
 
     if (m_isDirty && m_closeBtn && !m_closeBtn->isVisible ()) {
-      QRect dirtyRect= m_closeBtn->geometry ();
-      p.drawItemText (dirtyRect, Qt::AlignCenter, palette (), isEnabled (), "*",
-                      QPalette::ButtonText);
+      // 未保存的文档在关闭按钮位置画小圆点，悬停时被 × 取代。
+      QColor dotColor= palette ().color (QPalette::ButtonText);
+      dotColor.setAlpha (150);
+      p.setRenderHint (QPainter::Antialiasing, true);
+      p.setPen (Qt::NoPen);
+      p.setBrush (dotColor);
+      qreal dotSize= DpiUtils::scaled (6);
+      p.drawEllipse (QRectF (m_closeBtn->geometry ()).center (), dotSize / 2,
+                     dotSize / 2);
     }
   }
 }
@@ -403,8 +385,6 @@ QTMTabPage::mouseReleaseEvent (QMouseEvent* e) {
 
 void
 QTMTabPage::mouseMoveEvent (QMouseEvent* e) {
-  m_hoverOnCloseArea= isPointerOnCloseArea (e->pos ());
-  updateCloseButtonVisibility ();
   if (is_startup_tab_view (m_viewUrl) || is_chat_tab_view (m_viewUrl)) {
     return QToolButton::mouseMoveEvent (e);
   }
@@ -445,14 +425,14 @@ QTMTabPage::mouseMoveEvent (QMouseEvent* e) {
 
 void
 QTMTabPage::enterEvent (QEnterEvent* e) {
-  m_hoverOnCloseArea= isPointerOnCloseArea (e->position ().toPoint ());
+  m_hoverOnTab= true;
   updateCloseButtonVisibility ();
   QToolButton::enterEvent (e);
 }
 
 void
 QTMTabPage::leaveEvent (QEvent* e) {
-  m_hoverOnCloseArea= false;
+  m_hoverOnTab= false;
   updateCloseButtonVisibility ();
   QToolButton::leaveEvent (e);
 }
@@ -461,10 +441,11 @@ void
 QTMTabPage::updateCloseButtonVisibility () {
   if (!m_closeBtn) return;
   // TODO: 聊天标签页当前不可关闭，后续需支持可删除
+  // 悬停标签页任意位置即显示 ×（脏圆点随之被取代）；未悬停的干净活动标签
+  // 也常驻 ×，脏标签则回落到画圆点。
   bool shouldShow= !is_startup_tab_view (m_viewUrl) &&
-                   !is_chat_tab_view (m_viewUrl) &&
-                   ((!m_isDirty && (underMouse () || isChecked ())) ||
-                    (m_isDirty && m_hoverOnCloseArea));
+                   !is_chat_tab_view (m_viewUrl) && !m_suppressCloseBtn &&
+                   (m_hoverOnTab || (!m_isDirty && isChecked ()));
   bool wasVisible= m_closeBtn->isVisible ();
   m_closeBtn->setVisible (shouldShow);
 

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -37,7 +37,8 @@ class QTMTabPage : public QToolButton {
   QWK::WindowButton* m_closeBtn= nullptr;
   QPoint             m_dragStartPos;
   bool               m_isDirty         = false;
-  bool               m_hoverOnCloseArea= false;
+  bool               m_hoverOnTab      = false;
+  bool               m_suppressCloseBtn= false;
 
 public:
   const url m_viewUrl;
@@ -58,7 +59,7 @@ public:
    * replaceTabPages 复用既有 tab 时调用：srcTab 构造时已 applyDisplayTitle
    * 解析过尾部 `*`，其 text() 是干净标题、isDirty() 是最新脏状态。复用的
    * tab 必须同步这两者，否则 m_isDirty 停留在首次构造的旧值，编辑标脏 /
-   * 保存去脏都不会反映到关闭按钮位置的 `*` 上。
+   * 保存去脏都不会反映到关闭按钮位置的脏圆点上。
    */
   void syncDisplay (const QString& cleanTitle, bool dirty);
 
@@ -66,7 +67,6 @@ public slots:
   void setChecked (bool checked);
 
 protected:
-  virtual bool eventFilter (QObject* watched, QEvent* event) override;
   virtual void resizeEvent (QResizeEvent* e) override;
   virtual void mousePressEvent (QMouseEvent* e) override;
   virtual void mouseReleaseEvent (QMouseEvent* e) override;
@@ -77,7 +77,6 @@ protected:
 private:
   void applyDisplayTitle (const QString& rawTitle);
   void syncActionText (const QString& cleanTitle);
-  bool isPointerOnCloseArea (const QPoint& pos) const;
   void updateCloseButtonVisibility ();
   void initializeCloseButton (QAction* closeAction= nullptr);
 };

--- a/tests/Plugins/Qt/qt_tab_page_test.cpp
+++ b/tests/Plugins/Qt/qt_tab_page_test.cpp
@@ -37,7 +37,9 @@ private slots:
 
   void cleanup () { cleanup_qt_top_level_widgets (); }
 
-  void test_dirty_title_moves_star_to_close_slot () {
+  // 回归（1266）：脏标签悬停任意位置（含远离关闭按钮的文本区）即显示 ×，
+  // × 取代关闭按钮位置的脏圆点；离开后 × 隐藏，回落为脏圆点。
+  void test_dirty_title_shows_close_button_on_hover () {
     QAction    titleAction (QString::fromUtf8 ("very-long-file-name.tm *"),
                             nullptr);
     QAction    closeAction ("Close", nullptr);
@@ -54,15 +56,18 @@ private slots:
     QVERIFY (closeBtn != nullptr);
     QVERIFY (!closeBtn->isVisible ());
 
-    QPoint closeCenter= closeBtn->geometry ().center ();
     // macOS (Cocoa) 的 QTest::mouseMove 不会向未 grab 鼠标的 widget 派发
-    // mouseMoveEvent，因此直接合成一个 MouseMove 事件投递给 tab，触发其
-    // hover 检测逻辑（等价于 Windows 上鼠标移入关闭按钮区域）。
-    QMouseEvent moveEvent (QEvent::MouseMove, closeCenter,
-                           tab.mapToGlobal (closeCenter), Qt::NoButton,
-                           Qt::NoButton, Qt::NoModifier);
-    QApplication::sendEvent (&tab, &moveEvent);
+    // 事件，因此直接合成 Enter/Leave 事件投递给 tab，触发其 hover 检测
+    // 逻辑（等价于 Windows 上鼠标移入/移出标签页）。
+    QPoint      textArea (20, tab.height () / 2);
+    QEnterEvent enterEvent (QPointF (textArea), QPointF (textArea),
+                            tab.mapToGlobal (textArea));
+    QApplication::sendEvent (&tab, &enterEvent);
     QTRY_VERIFY (closeBtn->isVisible ());
+
+    QEvent leaveEvent (QEvent::Leave);
+    QApplication::sendEvent (&tab, &leaveEvent);
+    QTRY_VERIFY (!closeBtn->isVisible ());
   }
 
   void test_clean_title_keeps_close_button_hidden_without_hover () {
@@ -123,6 +128,10 @@ private slots:
     QVERIFY (tab.isDirty ());
     QCOMPARE (tab.text (), QString::fromUtf8 ("no_name_1.tmu"));
     QCOMPARE (titleAction.text (), QString::fromUtf8 ("no_name_1.tmu"));
+    // 活动 + 脏 + 未悬停：关闭按钮隐藏，显示的是脏圆点而非 ×（1266）。
+    auto* closeBtn= tab.findChild<QWK::WindowButton*> ("tabpage-close-button");
+    QVERIFY (closeBtn != nullptr);
+    QVERIFY (!closeBtn->isVisible ());
 
     tab.setChecked (false); // 切走后再切回，回写路径重复触发仍需保持干净
     tab.setChecked (true);


### PR DESCRIPTION
## What

标签页的未保存（dirty）提示由文本 `*` 改为小圆点，并调整 × 关闭按钮的显示时机：

- 脏标签未悬停：关闭按钮位置画半透明小圆点（直径 6 逻辑像素），不再画 `*`。
- 悬停标签页任意位置（不再要求精确悬停在关闭按钮上）：圆点被 × 关闭按钮取代。
- 移开后 × 隐藏，回落为圆点。
- 干净的活动标签仍常驻 ×（原有行为保留）；关闭确认弹窗期间 × 依旧隐藏。

## Why

`*` 与标题文字混排时视觉噪音大且不直观，用小圆点提示未保存状态、悬停时圆点变为 ×，交互更自然。旧逻辑要求鼠标精确悬停在 18px 的关闭按钮上才能从 `*` 切到 ×，命中困难。

## How

- `paintEvent`：dirty 且关闭按钮隐藏时，用 `QPainter::drawEllipse` 在关闭按钮几何中心画抗锯齿圆点（`QPalette::ButtonText` + alpha 150，随主题），取代原 `drawItemText("*")`。
- `updateCloseButtonVisibility`：`m_hoverOnCloseArea`（仅关闭按钮区域）换成 `m_hoverOnTab`（enter/leaveEvent 维护的整标签悬停态），× 的显示条件简化为 `hover || (!dirty && checked)`；新增 `m_suppressCloseBtn` 在关闭确认弹窗期间强制隐藏 ×，弹窗关闭后按 `QCursor::pos()` 恢复。
- 删除随之失效的 `eventFilter`（关闭按钮 Enter/Leave 过滤）与 `isPointerOnCloseArea`；`mouseMoveEvent` 不再逐帧刷新悬停态。
- 测试 `qt_tab_page_test.cpp`：悬停触发由合成 MouseMove 改为合成 `QEnterEvent`/`QEvent::Leave`（悬停点取文本区，锁定“任意位置”语义），并断言活动+脏+未悬停时 × 隐藏。

## 验证

- `xmake b qt_tab_page_test && xmake r qt_tab_page_test`：6 通过 / 0 失败 / 1 跳过。
- GUI 实测（Linux, HiDPI）：新建草稿显示圆点，悬停标签文本区 × 出现，移开恢复圆点；点击 × 弹窗期间 × 隐藏，取消后状态正确恢复。

任务文档：`devel/1266.md`