### PR TITLE
[1228] 修复 raw_insert/raw_remove memmove 块移动的引用计数泄漏

### DIFF
--- a/devel/1228.md
+++ b/devel/1228.md
@@ -192,3 +192,49 @@ Totals: 5 passed, 1 failed, 0 skipped, 0 blacklisted, 6ms
 - `devel/1228.md`：记录缺陷机制与复现
 - `tests/Data/tree_observer_test.cpp`：新增 `test_raw_remove_releases_ownership` 复现用例
 
+## 第十项：修复 raw_insert/raw_remove 引用计数泄漏
+
+### What
+
+修复第八项 memmove 块移动引入的引用计数记账错误（第九项复现）。
+
+### Why
+
+`tm_new_array` 按容量构造全部槽位、`tm_delete_array` 析构全部槽位，
+因此不变量是「容量内每个槽位恒为持有一份所有权的有效句柄」。
+原 memmove 实现两处破坏该不变量：
+
+- `raw_remove`：被删槽位的句柄被 memmove 按位覆盖，数组对它们的
+  所有权引用被遗弃（`tmp` 只释放自己拷贝 +1 的那份，净账为零），
+  被删子树泄漏；同时 `[n, n+nr)` 留下无所有权的 stale 位，数组销毁时
+  会被 `tm_delete_array` 再析构一次（重复减计数）。
+- `raw_insert`：memmove 按位覆盖 `[n, n+nr)` 的默认句柄，
+  这些槽位的 rep 直接泄漏。
+
+### How
+
+memmove 前后用显式析构 / placement-new 把账目补齐：
+
+- `raw_remove`：先 `a[pos+i].~tree()` 显式析构被删槽位（释放数组的
+  唯一所有权），memmove 尾部下移，再对 `[n, n+nr)` 的 stale 位
+  placement-new 默认句柄恢复有效性，最后 resize 收缩。
+  同时省掉了原 `tmp` 临时数组的分配与 +1/-1 往返。
+- `raw_insert`：resize 腾位后先显式析构 `[n, n+nr)` 的默认句柄，
+  memmove 尾部上移，洞内 stale 位直接 placement-new 拷贝构造
+  `tree (t[i])`（+1 接管插入孩子），省去原先「默认构造 + 赋值」的
+  分配与减计数往返。
+
+### 验证
+
+- `tree_observer_test` 6/6 通过（含原 FAIL 的
+  `test_raw_remove_releases_ownership`，转为回归断言）
+- `xmake test "moebius_tests/*"` 18/18 通过
+- `tree_observer_bench`：头部插入+删除 ×1000 约 0.63 ms，
+  与参考分支 0.56 ms 相当，块移动收益保持
+
+### 涉及文件
+
+- `moebius/Data/Tree/tree_observer.cpp`：raw_insert/raw_remove 记账修复
+- `tests/Data/tree_observer_test.cpp`：复现用例注释改为回归断言说明
+
+

--- a/devel/1228.md
+++ b/devel/1228.md
@@ -151,3 +151,44 @@ O(n) 次引用计数操作，memmove 后为纯内存搬运。表格编辑、文�
 通过。`tree_observer_test` 本机因 Qt 安装缺 `Qt6Bodymovin.lib` 无法链接
 （存量问题，`tree_helper_test` 同样失败），测试与 bench 以参考分支
 CI 为准。
+
+## 第九项：复现 raw_remove 引用计数泄漏（bug 复现）
+
+### What
+
+参考 `da/1265/stage` 分支，在 `tests/Data/tree_observer_test.cpp` 中新增
+单元测试用例 `test_raw_remove_releases_ownership`，确定性复现 [1228]
+第八项 memmove 块移动优化引入的子树引用计数遗弃与内存泄漏缺陷。
+
+### Why
+
+`moebius/Data/Tree/tree_observer.cpp` 的 `raw_remove` 中：
+`tmp` 仅通过拷贝构造接管了被删孩子的引用（+1）；随后的
+`memmove (a + pos, a + pos + nr, ...)` 将尾部元素下移覆盖被删槽位，
+原槽位持有的树句柄被按位覆盖，没有经过析构或 `operator=` 减引用计数。
+`tmp` 析构时仅释放了拷贝增加的那一份引用，原数组槽位持有的所有权被静默遗弃。
+若无其他持有者，整棵被删子树将永久泄漏。
+（`raw_insert` 亦存在 memmove 覆盖新分配槽位导致默认句柄未减计数的同类机制）。
+
+### 复现
+
+构造包含复合子树 `victim` 的文档 `doc`，记录其初始引用计数 `rc0`，
+执行 `raw_remove (doc, 0, 1)` 后断言其引用计数减 1 回落为 `rc0 - 1`：
+
+```bash
+xmake b tree_observer_test && \
+TEXMACS_PATH=$PWD/TeXmacs xmake r tree_observer_test
+```
+
+实测：新用例断言失败（FAIL），泄漏被确定性复现：
+```text
+FAIL!  : TestTreeObserver::test_raw_remove_releases_ownership() '((concrete_struct*) (victim.operator->()))->ref_count == rc0 - 1' returned FALSE. (raw_remove did not release the array's ownership reference to the removed child (memory leak, [1228] 2e628771e3))
+   Loc: [tests/Data/tree_observer_test.cpp(116)]
+Totals: 5 passed, 1 failed, 0 skipped, 0 blacklisted, 6ms
+```
+
+### 涉及文件
+
+- `devel/1228.md`：记录缺陷机制与复现
+- `tests/Data/tree_observer_test.cpp`：新增 `test_raw_remove_releases_ownership` 复现用例
+

--- a/moebius/Data/Tree/tree_observer.cpp
+++ b/moebius/Data/Tree/tree_observer.cpp
@@ -252,16 +252,18 @@ raw_insert (tree& ref, int pos, tree t) {
   else {
     int n= N (ref), nr= N (t);
     // 块移动代替逐元素赋值：每个被移动孩子的引用计数加减一次都省去。
-    // 记账：memmove 把 [pos, n) 的句柄位原样搬到 [pos+nr, n+nr)，
-    // 数组对其所有权引用随位移动转移；洞里的 stale 位用 placement-new
-    // 默认句柄覆盖（不减计数），随后被赋值语句正常接管
+    // 记账：容量内每个槽位恒为持有一份所有权的有效句柄
+    // （tm_delete_array 会析构整个容量）。memmove 将按位覆盖 [n, n+nr)
+    // 的默认句柄，故先显式析构释放；[pos, n) 的所有权随位移动转移到
+    // [pos+nr, n+nr)；洞内 stale 位（无所有权）用 placement-new 拷贝
+    // 构造直接接管插入孩子（+1）
     AR (ref)->resize (n + nr);
     tree* a= A (AR (ref));
+    for (int i= n; i < n + nr; i++)
+      a[i].~tree ();
     memmove (a + pos + nr, a + pos, (size_t) (n - pos) * sizeof (tree));
     for (int i= 0; i < nr; i++)
-      new ((void*) (a + pos + i)) tree ();
-    for (int i= 0; i < nr; i++)
-      a[pos + i]= t[i];
+      new ((void*) (a + pos + i)) tree (t[i]);
   }
   if (!is_nil (ref->data)) {
     ref->data->notify_insert (ref, pos, is_atomic (t) ? N (t->label) : N (t));
@@ -296,12 +298,16 @@ raw_remove (tree& ref, int pos, int nr) {
     ref->label= ref->label (0, pos) * ref->label (pos + nr, N (ref->label));
   else {
     int n= N (ref) - nr;
-    // 先把被删孩子拷出（引用计数 +1，接管数组的所有权），memmove 尾部
-    // 下移（计数随位移动转移，超出新长度的重复位直接丢弃），
-    // 最后 tmp 析构时统一释放被删孩子的所有权
-    array<tree> tmp (A (AR (ref)) + pos, nr);
-    tree*       a= A (AR (ref));
+    // 记账：容量内每个槽位恒为持有一份所有权的有效句柄
+    // （tm_delete_array 会析构整个容量）。先显式析构被删槽位，释放数组
+    // 对它们的唯一所有权；memmove 尾部下移后 [n, n+nr) 为无所有权的
+    // stale 位，用 placement-new 默认句柄覆盖恢复有效性
+    tree* a= A (AR (ref));
+    for (int i= 0; i < nr; i++)
+      a[pos + i].~tree ();
     memmove (a + pos, a + pos + nr, (size_t) (n - pos) * sizeof (tree));
+    for (int i= n; i < n + nr; i++)
+      new ((void*) (a + i)) tree ();
     AR (ref)->resize (n);
   }
   if (!is_nil (ref->data)) ref->data->done (ref, mod);

--- a/tests/Data/tree_observer_test.cpp
+++ b/tests/Data/tree_observer_test.cpp
@@ -25,6 +25,7 @@ private slots:
   void test_raw_insert ();
   void test_raw_remove ();
   void test_insert_remove_refcount ();
+  void test_raw_remove_releases_ownership ();
 };
 
 void
@@ -97,6 +98,24 @@ TestTreeObserver::test_insert_remove_refcount () {
   raw_remove (big, 500, 40);
   QVERIFY (N (big) == 1000);
   QVERIFY (big[500] == tree ("p500"));
+}
+
+void
+TestTreeObserver::test_raw_remove_releases_ownership () {
+  // [1265] 复现 [1228] 2e628771e3 引入的引用计数泄漏：
+  // raw_remove 用 memmove 位搬移代替逐元素赋值后，数组槽位里持有的
+  // 「被删孩子所有权句柄」被按位覆盖，没有经过 operator= 的减计数路径，
+  // 数组对被删子树的引用被静默遗弃——若无其他持有者，整棵子树泄漏。
+  tree victim (CONCAT, tree ("s1"), tree ("s2"));
+  tree doc (DOCUMENT, victim, tree ("a"), tree ("b"));
+  // rep/ref_count 因私有继承不可直接访问，C 风格上转绕过访问控制
+  const int rc0= ((concrete_struct*) (victim.operator->()))->ref_count;
+  raw_remove (doc, 0, 1);
+  // 正确记账：doc 数组放弃所有权（-1），只剩局部句柄 → rc0 - 1。
+  // 当前实现：计数遗弃 → 保持 rc0，此断言失败即为泄漏复现。
+  QVERIFY2 (((concrete_struct*) (victim.operator->()))->ref_count == rc0 - 1,
+            "raw_remove did not release the array's ownership reference "
+            "to the removed child (memory leak, [1228] 2e628771e3)");
 }
 
 #ifdef QTTEXMACS

--- a/tests/Data/tree_observer_test.cpp
+++ b/tests/Data/tree_observer_test.cpp
@@ -102,7 +102,7 @@ TestTreeObserver::test_insert_remove_refcount () {
 
 void
 TestTreeObserver::test_raw_remove_releases_ownership () {
-  // [1265] 复现 [1228] 2e628771e3 引入的引用计数泄漏：
+  // [1228] 2e628771e3 曾引入的引用计数泄漏（回归断言）：
   // raw_remove 用 memmove 位搬移代替逐元素赋值后，数组槽位里持有的
   // 「被删孩子所有权句柄」被按位覆盖，没有经过 operator= 的减计数路径，
   // 数组对被删子树的引用被静默遗弃——若无其他持有者，整棵子树泄漏。
@@ -111,8 +111,7 @@ TestTreeObserver::test_raw_remove_releases_ownership () {
   // rep/ref_count 因私有继承不可直接访问，C 风格上转绕过访问控制
   const int rc0= ((concrete_struct*) (victim.operator->()))->ref_count;
   raw_remove (doc, 0, 1);
-  // 正确记账：doc 数组放弃所有权（-1），只剩局部句柄 → rc0 - 1。
-  // 当前实现：计数遗弃 → 保持 rc0，此断言失败即为泄漏复现。
+  // 正确记账：doc 数组放弃所有权（-1），只剩局部句柄 → rc0 - 1
   QVERIFY2 (((concrete_struct*) (victim.operator->()))->ref_count == rc0 - 1,
             "raw_remove did not release the array's ownership reference "
             "to the removed child (memory leak, [1228] 2e628771e3)");


### PR DESCRIPTION
## 问题

[1228] 第八项的 raw_insert/raw_remove memmove 块移动优化破坏了 lolly array 的记账不变量（容量内每个槽位恒为持有一份所有权的有效句柄）：

- \`raw_remove\`：被删槽位句柄被 memmove 按位覆盖，数组持有的所有权引用被遗弃（tmp 拷贝 +1、析构 -1，净账为零），被删子树泄漏；\`[n, n+nr)\` 留下无所有权 stale 位，数组销毁时会被 \`tm_delete_array\` 重复析构。
- \`raw_insert\`：memmove 覆盖 \`[n, n+nr)\` 默认句柄，其 rep 直接泄漏。

分支上前两个 commit 为缺陷机制记录与确定性复现用例（断言引用计数不回落即泄漏）。

## 修复

memmove 前后用显式析构 / placement-new 补齐账目：

- \`raw_remove\`：先 \`a[pos+i].~tree()\` 释放被删槽位所有权，下移后对 stale 位 placement-new 默认句柄；省掉 tmp 临时数组的 +1/-1 往返。
- \`raw_insert\`：先析构将被覆盖的 \`[n, n+nr)\` 默认句柄，洞内直接 placement-new \`tree (t[i])\` 拷贝构造接管。

## 验证

- \`tree_observer_test\` 6/6 通过，原 FAIL 的 \`test_raw_remove_releases_ownership\` 转为回归断言
- \`moebius_tests/*\` 18/18 通过
- \`tree_observer_bench\` 头部插删 ×1000 约 0.63 ms，与优化参考分支 0.56 ms 相当，块移动收益保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)