### PR TITLE
[1228] 修复 tm_resize_array 收缩时不析构截断槽位导致的句柄泄漏

### DIFF
--- a/devel/1228.md
+++ b/devel/1228.md
@@ -238,3 +238,48 @@ memmove 前后用显式析构 / placement-new 把账目补齐：
 - `tests/Data/tree_observer_test.cpp`：复现用例注释改为回归断言说明
 
 
+## 第十一项：tm_resize_array 跨容量桶收缩泄漏——复现测试与修复
+
+### What
+
+复现：`lolly/tests/System/Memory/fast_alloc_test.cpp` 新增两个 TEST_CASE，
+用静态存活计数器类型 `CountedSlot`（构造 +1、析构 -1）直接验证
+`tm_resize_array` 的构造/析构账目：
+
+- grow：4 → 8，新槽位被构造（live == 8），删除后归零。
+- shrink：8 → 3，断言 `[3, 8)` 被截断槽位析构（live == 3）。
+  修复前 FAIL：`CHECK_EQ(8, 3)`，收缩后 5 个槽位的析构从未发生，
+  `tm_delete_array` 只按新计数析构 3 个，剩余 5 个句柄泄漏
+  （`CHECK_EQ(5, 0)`）。
+
+修复：`fast_alloc.hpp` 的 `tm_resize_array` 在 `new_num < old_num` 时，
+realloc 之前先析构 `[new_num, old_num)` 槽位（realloc 后这些槽位不再
+可达，必须先析构）。平凡类型析构为空操作，循环零开销。
+
+### Why
+
+`fast_alloc.hpp` 原 `tm_resize_array` 增长时构造新槽，收缩时
+`[new_num, old_num)` 既不析构也不再可达（头部改写为 new_num），
+引用计数类型在此泄漏。触发面：`array<T>::resize` 跨桶收缩
+（`array.ipp:43`，小数组容量桶为精确值，每次收缩都触发）、
+typeset 的 box 句柄 resize（`concat_text.cpp`、`columns_breaker.cpp`）。
+此为存量 bug，非 memmove 优化引入；memmove 修复依赖的
+「头部计数 == 存活槽位数」不变量正被它破坏。一处修复同时补上
+raw_remove 残留泄漏与 typeset box 句柄泄漏。
+
+### 涉及文件
+
+- `lolly/System/Memory/fast_alloc.hpp`（tm_resize_array 收缩析构）
+- `lolly/tests/System/Memory/fast_alloc_test.cpp`（新增 CountedSlot +
+  两个 TEST_CASE）
+
+### 本机构建 / 测试
+
+lolly 子工程需 `xmake f -c --yes --enable_tests=true` 清缓存并开启测试
+（缓存里 `enable_tests=false` 时无 lolly_tests 目标）。
+
+- 修复前 `xmake test lolly_tests/fast_alloc_test`：grow 通过、shrink
+  FAIL（确定性复现）。
+- 修复后：`fast_alloc_test` 全部通过；`xmake test` 全套 53 个目标
+  52 通过，唯一失败 `shared_lib_test` 经 stash 验证为存量问题
+  （与本改动无关）。

--- a/lolly/System/Memory/fast_alloc.hpp
+++ b/lolly/System/Memory/fast_alloc.hpp
@@ -417,9 +417,15 @@ tm_new_array (int n) {
 template <typename C>
 inline C*
 tm_resize_array (int new_num, C* Ptr) {
-  void* old_arr    = (void*) Ptr;
-  old_arr          = (void*) (((char*) old_arr) - WORD_LENGTH);
-  int   old_num    = *((int*) old_arr);
+  void* old_arr= (void*) Ptr;
+  old_arr      = (void*) (((char*) old_arr) - WORD_LENGTH);
+  int old_num  = *((int*) old_arr);
+  // 收缩时先析构被截断的槽位释放其所有权，realloc 后这些槽位不再可达
+  if (new_num < old_num) {
+    C* ctr= Ptr + new_num;
+    for (int i= new_num; i < old_num; i++, ctr++)
+      ctr->~C ();
+  }
   void* new_arr    = fast_realloc (old_arr, old_num * sizeof (C) + WORD_LENGTH,
                                    new_num * sizeof (C) + WORD_LENGTH);
   *((int*) new_arr)= new_num;

--- a/lolly/tests/System/Memory/fast_alloc_test.cpp
+++ b/lolly/tests/System/Memory/fast_alloc_test.cpp
@@ -97,4 +97,37 @@ TEST_CASE ("test large bunch of tm_*_array with class") {
   }
 }
 
+namespace {
+// 存活计数类型：构造 +1、析构 -1，用于断言槽位析构是否发生
+struct CountedSlot {
+  static int live;
+  int        dummy;
+  CountedSlot () : dummy (0) { live++; }
+  CountedSlot (const CountedSlot& other) : dummy (other.dummy) { live++; }
+  ~CountedSlot () { live--; }
+};
+int CountedSlot::live= 0;
+} // namespace
+
+TEST_CASE ("tm_resize_array: grow constructs new slots") {
+  CountedSlot::live= 0;
+  CountedSlot* a   = tm_new_array<CountedSlot> (4);
+  CHECK_EQ (CountedSlot::live, 4);
+  a= tm_resize_array<CountedSlot> (8, a);
+  CHECK_EQ (CountedSlot::live, 8);
+  tm_delete_array (a);
+  CHECK_EQ (CountedSlot::live, 0);
+}
+
+TEST_CASE ("tm_resize_array: shrink destructs truncated slots") {
+  CountedSlot::live= 0;
+  CountedSlot* a   = tm_new_array<CountedSlot> (8);
+  CHECK_EQ (CountedSlot::live, 8);
+  a= tm_resize_array<CountedSlot> (3, a);
+  // [3, 8) 被截断的槽位必须析构，否则引用计数句柄在此泄漏
+  CHECK_EQ (CountedSlot::live, 3);
+  tm_delete_array (a);
+  CHECK_EQ (CountedSlot::live, 0);
+}
+
 TEST_MEMORY_LEAK_ALL


### PR DESCRIPTION
## What

修复 lolly `tm_resize_array` 跨容量桶收缩时的引用计数句柄泄漏（存量 bug，非 memmove 优化引入）：

- **根因**：`tm_resize_array` 增长时构造新槽，但收缩时 `[new_num, old_num)` 的槽位既不析构也不再可达（头部改写为 new_num，`tm_delete_array` 只按新计数析构），引用计数类型被截断槽位的句柄全部泄漏。
- **修复**：`new_num < old_num` 时，realloc 之前先析构 `[new_num, old_num)` 槽位（realloc 后这些槽位不再可达，顺序不能反）。平凡类型析构为空操作，循环零开销。

触发面：`array<T>::resize` 跨桶收缩（`array.ipp:43`，小数组容量桶为精确值，**每次收缩都触发**）、typeset 的 box 句柄 resize（`concat_text.cpp:518`、`columns_breaker.cpp:81`）。一处修复同时补上 raw_remove 残留泄漏与 typeset box 句柄泄漏，并使「头部计数 == 存活槽位数」不变量全局成立（memmove 块移动优化依赖该不变量）。

详见 `devel/1228.md` 第十项。

## 测试

新增复现测试 `lolly/tests/System/Memory/fast_alloc_test.cpp`：静态存活计数器类型 `CountedSlot` 验证 `tm_resize_array` 构造/析构账目。

- 修复前：shrink 用例确定性 FAIL（`CHECK_EQ(8, 3)`、`CHECK_EQ(5, 0)`，5 个截断槽位句柄泄漏）
- 修复后：`fast_alloc_test` 全部通过；lolly 全套 `xmake test` 53 个目标 52 通过（唯一失败 `shared_lib_test` 经 stash 验证为存量问题，与本改动无关）

注：lolly 为独立子工程，合并后需同步上游 lolly 仓库。

🤖 Generated with [Claude Code](https://claude.com/claude-code)