### PR TITLE
[1266] 修复 TestQTMTabPage 对环境光标的依赖，恢复 Debian/macOS CI

### DIFF
--- a/devel/1266.md
+++ b/devel/1266.md
@@ -1,6 +1,6 @@
 # 1266 标签页脏标记改为圆点
 
-分支：`da/1266/nice_tab`
+分支：`da/1266/nice_tab`（CI 修复分支：`da/1266/fix_ci`）
 
 ## What
 
@@ -48,4 +48,39 @@
 
 - `src/Plugins/Qt/QTMTabPage.hpp`
 - `src/Plugins/Qt/QTMTabPage.cpp`
+- `tests/Plugins/Qt/qt_tab_page_test.cpp`
+
+## 2026-09-05 CI 修复：Debian/macOS 上 TestQTMTabPage 挂
+
+### What
+
+`test_dirty_title_shows_close_button_on_hover` 与
+`test_checked_state_sync_keeps_title_clean` 在 Debian 13（QT_QPA_PLATFORM=
+offscreen）和 macOS runner 上失败：脏标签未悬停时断言关闭按钮隐藏
+（`!closeBtn->isVisible ()`）不成立——按钮在断言前就已可见。Windows CI 与
+本地开发机均通过。
+
+### Why
+
+测试假设「顶层窗口弹出时鼠标不在其内」。offscreen 平台的虚拟光标恒在
+(0,0)，窗口也恰好映射在 (0,0)，`show ()` 时 Qt 的合成 Enter 事件把
+`m_hoverOnTab` 置 true，`updateCloseButtonVisibility` 据此显示 ×；macOS
+runner 的窗口默认级联位置同样可能压在真实光标下。产品行为本身正确，
+属测试对环境光标的隐式依赖。
+
+### How
+
+- 测试新增 `moveAwayFromCursor`：按 `QCursor::pos ()` 从屏幕四角挑一个
+  不含光标的位置 `move` 过去，再补投一个 `QEvent::Leave` 把 hover 归零；
+  移动后真实光标不在窗口内，后续不会再收到 Enter。两处未悬停断言前调用。
+- 悬停切换仍走原有合成 `QEnterEvent`/`Leave`，语义不变。
+
+### 验证
+
+- `QT_QPA_PLATFORM=offscreen xmake r qt_tab_page_test`：修复前精确复现
+  CI 的 2 处失败，修复后 6 通过 / 0 失败。
+- 原生显示（X11）`xmake r qt_tab_page_test`：6 通过 / 0 失败。
+
+### 涉及文件
+
 - `tests/Plugins/Qt/qt_tab_page_test.cpp`

--- a/tests/Plugins/Qt/qt_tab_page_test.cpp
+++ b/tests/Plugins/Qt/qt_tab_page_test.cpp
@@ -8,8 +8,10 @@
 #include "Qt/qt_utilities.hpp"
 #include "base.hpp"
 #include <QApplication>
+#include <QCursor>
 #include <QList>
 #include <QMouseEvent>
+#include <QScreen>
 #include <QtTest/QtTest>
 
 namespace {
@@ -26,6 +28,28 @@ makeCarrierList (const QList<QPair<QString, QString>>& urlTitlePairs) {
     list->append (new QTMTabPageAction (tab));
   }
   return list;
+}
+
+// 断言「未悬停」状态前调用。QT_QPA_PLATFORM=offscreen（Debian CI）下虚拟
+// 光标恒在 (0,0)，顶层窗口也映射在 (0,0)，show() 的合成 Enter 事件会把
+// m_hoverOnTab 置 true，导致未悬停断言随环境翻转；macOS runner 的窗口默认
+// 位置同样可能压在真实光标下。把窗口挪到不含光标的屏幕角落并补一个 Leave
+// 事件，使 hover 状态归零且后续不再受真实/合成光标影响。
+void
+moveAwayFromCursor (QWidget& w) {
+  const QRect         avail= w.screen ()->availableGeometry ();
+  const QList<QPoint> corners{
+      {avail.left () + 16, avail.top () + 16},
+      {avail.right () - w.width () - 16, avail.top () + 16},
+      {avail.left () + 16, avail.bottom () - w.height () - 16},
+      {avail.right () - w.width () - 16, avail.bottom () - w.height () - 16}};
+  for (const QPoint& c : corners)
+    if (!QRect (c, w.size ()).contains (QCursor::pos ())) {
+      w.move (c);
+      break;
+    }
+  QEvent leave (QEvent::Leave);
+  QApplication::sendEvent (&w, &leave);
 }
 } // namespace
 
@@ -54,6 +78,7 @@ private slots:
 
     auto* closeBtn= tab.findChild<QWK::WindowButton*> ("tabpage-close-button");
     QVERIFY (closeBtn != nullptr);
+    moveAwayFromCursor (tab);
     QVERIFY (!closeBtn->isVisible ());
 
     // macOS (Cocoa) 的 QTest::mouseMove 不会向未 grab 鼠标的 widget 派发
@@ -131,6 +156,7 @@ private slots:
     // 活动 + 脏 + 未悬停：关闭按钮隐藏，显示的是脏圆点而非 ×（1266）。
     auto* closeBtn= tab.findChild<QWK::WindowButton*> ("tabpage-close-button");
     QVERIFY (closeBtn != nullptr);
+    moveAwayFromCursor (tab);
     QVERIFY (!closeBtn->isVisible ());
 
     tab.setChecked (false); // 切走后再切回，回写路径重复触发仍需保持干净


### PR DESCRIPTION
## 问题

#4493 合入后，`Build on Debian 13` 与 `Build and Test on macOS arm64` 挂在
`TestQTMTabPage` 的两处断言（`qt_tab_page_test.cpp:57`/`:134`）：

```
FAIL!  : TestQTMTabPage::test_dirty_title_shows_close_button_on_hover() '!closeBtn->isVisible ()' returned FALSE
FAIL!  : TestQTMTabPage::test_checked_state_sync_keeps_title_clean()   '!closeBtn->isVisible ()' returned FALSE
```

Windows CI 与本地均通过。

## 根因

测试假设顶层窗口弹出时鼠标不在其内。Debian CI 跑在
`QT_QPA_PLATFORM=offscreen` 下，虚拟光标恒在 (0,0)、窗口也恰好映射在
(0,0)，`show ()` 时 Qt 的合成 Enter 事件把 `m_hoverOnTab` 置 true，
`updateCloseButtonVisibility` 据此提前显示 ×；macOS runner 的窗口默认
级联位置同样可能压在真实光标下。产品行为正确，属测试对环境光标的隐式依赖。

## 修复

测试内新增 `moveAwayFromCursor`：按 `QCursor::pos ()` 从屏幕四角挑一个
不含光标的位置 `move` 过去，再补投 `QEvent::Leave` 把 hover 归零；两处
未悬停断言前调用。悬停切换仍走原合成 `QEnterEvent`/`Leave`，语义不变。

## 验证

- 本机 Debian 13 复现：`QT_QPA_PLATFORM=offscreen xmake r qt_tab_page_test`
  修复前精确复现 CI 的 2 处失败；修复后 **6 通过 / 0 失败**
- 原生显示（X11）：**6 通过 / 0 失败**
- 已跑 `gf fmt --changed-since=main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)