### PR TITLE
[1267] 隐藏 文件->打印 和 文件->页面设置

### DIFF
--- a/TeXmacs/progs/texmacs/menus/file-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/file-menu.scm
@@ -323,16 +323,7 @@
   ("Print page selection to file" (print-page-selection-to-file))
 ) ;menu-bind
 
-(menu-bind print-menu
- ("Preview" (preview-buffer))
- (if (use-print-dialog?)
-   (if (has-printing-cmd?) ("Print" (print-buffer)))
-   ("Print to file" (choose-file print-to-file "Print all to file" "postscript"))
- ) ;if
- (if (not (use-print-dialog?)) (-> "Print" (link print-menu-sub)))
- (if (use-menus?) (-> "Page setup" (link page-setup-menu)))
- (if (use-popups?) ("Page setup" (open-page-setup)))
-) ;menu-bind
+(menu-bind print-menu ("Preview" (preview-buffer)))
 
 (menu-bind print-menu-inline
  ("Preview" (preview-buffer))

--- a/devel/1267.md
+++ b/devel/1267.md
@@ -1,0 +1,34 @@
+# [1267] 隐藏 文件->打印 和 文件->页面设置
+
+## 如何测试
+
+1. `xmake b stem && xmake r stem` 启动 Mogan
+2. 点开 `文件` 菜单：
+   - 预期：不再出现 `打印`（Print）和 `页面设置`（Page setup）入口
+   - `预览`（Preview）保留
+3. 工具栏打印图标菜单（`print-menu-inline`）不受影响
+
+## 2026/09/05
+
+### What
+
+隐藏 `文件->打印` 和 `文件->页面设置` 两个菜单项。
+
+### Why
+
+打印/页面设置入口当前不可用（本任务属于 PDF 导出改造，导出统一走
+`文件->导出->Pdf`），保留失效入口会误导用户。
+
+### How
+
+`TeXmacs/progs/texmacs/menus/file-menu.scm` 的 `print-menu`（仅被 `file-menu`
+链接，是文件菜单里的打印区块）中，直接移除 `Print`（含打印对话框 / 打印为文件
+两种形态）与 `Page setup`（菜单形态 + 弹窗形态）各条目，保留 `Preview`；
+打印相关函数与 `print-menu-sub` 定义不动。
+
+不动 `print-menu-sub`：它仍被 `print-menu-inline`（工具栏打印图标）引用；
+也不动 `print-menu-inline`：本任务只针对文件菜单。
+
+### 涉及文件
+
+- `TeXmacs/progs/texmacs/menus/file-menu.scm`


### PR DESCRIPTION
## What
- 移除 `文件->打印`（Print，含打印对话框/打印为文件两种形态）与 `文件->页面设置`（Page setup，菜单/弹窗两种形态）菜单入口，`预览` 保留
- 打印相关函数与 `print-menu-sub` 定义不动（仍被工具栏 `print-menu-inline` 引用）

## Why
打印/页面设置入口当前不可用（导出统一走 `文件->导出->Pdf`），保留失效入口会误导用户

## How
`print-menu` 仅被 `file-menu` 链接（工具栏打印图标用 `print-menu-inline`），直接删除其中除 `Preview` 外的条目即可，不影响工具栏

## 测试
- headless 加载 `(texmacs menus file-menu)` 模块无报错
- `xmake r print-widgets-test`：23 correct, 0 failed
- GUI 菜单显示请人工验证

## 任务文档
devel/1267.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)