### PR TITLE
[1268] 修复 PDF 附件中文名乱码：附件名以 UTF-16BE+BOM 写入

### DIFF
--- a/TeXmacs/tests/1268.scm
+++ b/TeXmacs/tests/1268.scm
@@ -1,0 +1,55 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1268.scm
+;; DESCRIPTION : PDF 附件（内嵌 tmu）中文文件名编码回归测试
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; PURPOSE
+;;   [1268] 导出 PDF 并内嵌 tmu 后，okular（poppler）里附件文件名乱码。
+;;   根因：写侧把 UTF-8 文件名原样写进 PDF text string，而 PDF 规范约定
+;;   text string 不带 UTF-16BE BOM（FE FF）时按 PDFDocEncoding 解码，
+;;   中文于是变乱码。本测试钉死两条契约：
+;;     1. 写侧：附件名以 UTF-16BE + BOM 写入（字面量里是转义序列
+;;        \376\377\000...，okular/poppler 据此按 UTF-16BE 解码）。
+;;     2. 读侧：extract-attachments 回读时识别 BOM 并还原 UTF-8 文件名，
+;;        解出的文件名与内容都和原 tmu 一致（mogan 自身的往返不回归）。
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r 1268
+;;
+;; 本测试全部为同步断言（无 exec-delayed-at 异步链），headless 即可跑完。
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY whatsoever. For details see LICENSE.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(tm-define (test_1268)
+  (define tmu-url "$TEXMACS_PATH/tests/tmu/1268_中文文件名.tmu")
+  (define tmp-dir (url-temp-dir))
+  ;; 基础 PDF 用仓库现成样例，避免依赖 headless 导出 PDF。
+  (define base-pdf "$TEXMACS_PATH/tests/PDF/pdf_1_4_sample.pdf")
+  (define out-pdf (url-append tmp-dir "1268_attach.pdf"))
+  (define extracted (url-append tmp-dir "1268_中文文件名.tmu"))
+
+  ;; 1 嵌入 tmu 附件。
+  (check (pdf-make-attachments base-pdf (list tmu-url) out-pdf) => #t)
+  (check (url-exists? out-pdf) => #t)
+
+  ;; 2 写侧编码：附件名必须以 UTF-16BE BOM 开头。PDFHummus 会把
+  ;;    0xFE/0xFF/0x00 转义成八进制 \376\377\000，故在原始字节流里查转义
+  ;;    形式；修复前写的是 UTF-8 原文，不含 BOM，此断言红。
+  (check (string-contains? (string-load out-pdf) "\\376\\377\\000") => #t)
+
+  ;; 3 读侧往返：extract-attachments 解出 BOM'ed UTF-16BE 文件名后须还原
+  ;;    成 UTF-8，落盘文件名与内容均与原 tmu 一致。
+  (check (extract-attachments out-pdf) => #t)
+  (check (url-exists? extracted) => #t)
+  (check (string-load extracted) => (string-load tmu-url))
+
+  (check-report)) ;tm-define

--- a/TeXmacs/tests/tmu/1268_中文文件名.tmu
+++ b/TeXmacs/tests/tmu/1268_中文文件名.tmu
@@ -1,0 +1,14 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  测试中文文件名
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/1268.md
+++ b/devel/1268.md
@@ -1,0 +1,45 @@
+# 1268 PDF 内嵌 tmu 附件中文文件名乱码
+
+## What
+
+`TeXmacs/tests/tmu/1268_中文文件名.tmu` 打开后导出 PDF（勾选内嵌 tmu），
+在 okular 中打开，附件面板里的文件名显示乱码。
+
+## Why
+
+写侧把 UTF-8 文件名原样写进 PDF text string。PDF 规范（ISO 32000-1
+§7.9.2.2）规定 text string 不以 UTF-16BE BOM（`FE FF`）开头时按
+PDFDocEncoding 解码，okular/poppler 据此把 UTF-8 字节当 PDFDocEncoding，
+于是乱码（`pdfdetach -list` 可复现：`1268_ä¸­æ–‡...`）。
+
+## How
+
+按 PDF text string 规则补上编码，读写两侧对称：
+
+- 写侧 `pdf_hummus_make_attachment.cpp`：附件名统一转成 BOM'ed UTF-16BE
+  再写入（lolly 的 `utf8_to_utf16`，tbox `TB_CHARSET_TYPE_UTF16` 缺省即
+  BE，BOM 手动前置）。随之 UTF-16BE 字节含 NUL（ASCII 字符高字节），
+  `as_charp` 隐式转 `std::string` 走 strlen 会在首个 NUL 截断，故新增
+  `as_pdf_string` 带长度构造，四处写入点（Names 数组键 + filespec /F）
+  统一换用。
+- 读侧 `pdf_hummus_extract_attachment.cpp`：`extract_attachments_from_pdf`
+  读到 BOM 开头的名字时用 `utf16_to_utf8` 还原成 UTF-8；无 BOM 的旧 PDF
+  （历史版本导出）保持原字节，向后兼容。
+
+## 测试
+
+- `TeXmacs/tests/1268.scm`（`xmake r 1268`，headless 同步断言）：
+  1. `pdf-make-attachments` 嵌入 `$TEXMACS_PATH/tests/tmu/1268_中文文件名.tmu`
+     到仓库现成 `tests/PDF/pdf_1_4_sample.pdf`；
+  2. 原始字节流里查写侧编码（PDFHummus 把 `FE FF 00` 转义成
+     `\376\377\000`，修复前为 UTF-8 原文，此断言红）；
+  3. `extract-attachments` 回读，落盘文件名与内容均与原 tmu 一致。
+- poppler 交叉验证（okular 同引擎）：修复后 `pdfdetach -list` 显示
+  `1268_中文文件名.tmu`。
+
+## 涉及文件
+
+- `src/Plugins/Pdf/pdf_hummus_make_attachment.cpp`
+- `src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp`
+- `TeXmacs/tests/1268.scm`（新增）
+- `TeXmacs/tests/tmu/1268_中文文件名.tmu`（新增，测试夹具）

--- a/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
@@ -31,6 +31,7 @@
 #include "PDFWriter/PDFWriter.h"
 #include "PDFWriter/SafeBufferMacrosDefs.h"
 #include "PDFWriter/Trace.h"
+#include "lolly/data/unicode.hpp"
 #include "url.hpp"
 using namespace PDFHummus;
 using namespace IOBasicTypes;
@@ -137,8 +138,16 @@ extract_attachments_from_pdf (url pdf_path, list<url>& names) {
         break;
       }
 
-      url attachment_path=
-          relative (pdf_path, url (string (name->GetValue ().c_str ())));
+      // 写侧按 PDF text string 规则以 UTF-16BE + BOM 写文件名，读回时还原
+      // 成 UTF-8；无 BOM 的旧 PDF（历史版本导出）保持原字节，不受影响。
+      std::string raw_name= name->GetValue ();
+      string      attachment_name (raw_name.data (), (int) raw_name.length ());
+      if (N (attachment_name) > 2 &&
+          (unsigned char) attachment_name[0] == 0xFE &&
+          (unsigned char) attachment_name[1] == 0xFF)
+        attachment_name= lolly::data::utf16_to_utf8 (
+            attachment_name (2, N (attachment_name)));
+      url        attachment_path= relative (pdf_path, url (attachment_name));
       OutputFile attachment_file;
       status= attachment_file.OpenFile (
           std::string (as_charp (as_string (attachment_path))));

--- a/src/Plugins/Pdf/pdf_hummus_make_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_make_attachment.cpp
@@ -19,12 +19,20 @@
 #include "PDFWriter/SafeBufferMacrosDefs.h"
 #include "PDFWriter/Trace.h"
 #include "file.hpp"
+#include "lolly/data/unicode.hpp"
 #include "tm_debug.hpp"
 #include "tmfs_url.hpp"
 #include "tree_helper.hpp"
 
 using namespace PDFHummus;
 using namespace IOBasicTypes;
+
+// PDFHummus 的字符串写入接口收 std::string；UTF-16BE 名字含 NUL 字节，
+// as_charp 隐式转 std::string 走 strlen 会在首个 NUL 截断，须带长度构造。
+static std::string
+as_pdf_string (string s) {
+  return std::string (as_charp (s), N (s));
+}
 
 class PDFAttachment {
 public:
@@ -118,7 +126,11 @@ pdf_hummus_make_attachments (url pdf_path, array<url> attachment_paths,
       Byte* file_content= new Byte[file_size + 16];
       tm_file_stream.Read (file_content, file_size);
 
-      string attachment_name= as_string (tail (attachment_paths[i]));
+      // PDF text string 不带 UTF-16BE BOM 时按 PDFDocEncoding 解码，中文
+      // 文件名须转成 BOM'ed UTF-16BE，否则 okular 等阅读器显示乱码。
+      string attachment_name=
+          string ("\xfe\xff") *
+          lolly::data::utf8_to_utf16 (as_string (tail (attachment_paths[i])));
 
       PDFAttachment* aAttachment=
           new PDFAttachment (file_content, file_size, attachment_name);
@@ -238,7 +250,8 @@ PDFAttachmentWriter::OnCatalogWrite (
     }
   }
   if (the_main_tm != NULL) {
-    inPDFWriterObjectContext->WriteLiteralString (as_charp (the_main_tm->name));
+    inPDFWriterObjectContext->WriteLiteralString (
+        as_pdf_string (the_main_tm->name));
     DictionaryContext* dictionaryContext_2=
         inPDFWriterObjectContext->StartDictionary ();
     dictionaryContext_2->WriteKey ("EF");
@@ -249,7 +262,8 @@ PDFAttachmentWriter::OnCatalogWrite (
         mAttachment[the_main_tm]);
     inPDFWriterObjectContext->EndDictionary (dictionaryContext_3);
     dictionaryContext_2->WriteKey ("F");
-    dictionaryContext_2->WriteLiteralStringValue (as_charp (the_main_tm->name));
+    dictionaryContext_2->WriteLiteralStringValue (
+        as_pdf_string (the_main_tm->name));
     dictionaryContext_2->WriteKey ("Type");
     dictionaryContext_2->WriteNameValue ("F");
     inPDFWriterObjectContext->EndDictionary (dictionaryContext_2);
@@ -260,7 +274,7 @@ PDFAttachmentWriter::OnCatalogWrite (
     PDFAttachment* cur_attachment= it->next ();
     if (cur_attachment == the_main_tm) continue;
     inPDFWriterObjectContext->WriteLiteralString (
-        as_charp (cur_attachment->name));
+        as_pdf_string (cur_attachment->name));
     DictionaryContext* dictionaryContext_2=
         inPDFWriterObjectContext->StartDictionary ();
     dictionaryContext_2->WriteKey ("EF");
@@ -272,7 +286,7 @@ PDFAttachmentWriter::OnCatalogWrite (
     inPDFWriterObjectContext->EndDictionary (dictionaryContext_3);
     dictionaryContext_2->WriteKey ("F");
     dictionaryContext_2->WriteLiteralStringValue (
-        as_charp (cur_attachment->name));
+        as_pdf_string (cur_attachment->name));
     dictionaryContext_2->WriteKey ("Type");
     dictionaryContext_2->WriteNameValue ("F");
     inPDFWriterObjectContext->EndDictionary (dictionaryContext_2);


### PR DESCRIPTION
## 问题

`TeXmacs/tests/tmu/1268_中文文件名.tmu` 打开后导出 PDF（内嵌 tmu），在 okular 中附件文件名显示乱码。

## 根因

附件名以 UTF-8 原样写进 PDF text string。PDF 规范（ISO 32000-1 §7.9.2.2）规定 text string 不以 UTF-16BE BOM（`FE FF`）开头时按 PDFDocEncoding 解码，poppler/okular 把 UTF-8 字节当 PDFDocEncoding，于是乱码。

## 修复

- **写侧** `pdf_hummus_make_attachment.cpp`：附件名转 BOM'ed UTF-16BE（lolly `utf8_to_utf16`，tbox UTF-16 缺省即 BE，BOM 手动前置）。UTF-16BE 字节含 NUL（ASCII 字符高字节），`as_charp` 隐式转 `std::string` 走 strlen 会在首个 NUL 截断，故新增 `as_pdf_string` 带长度构造，4 个写入点（Names 数组键 + filespec /F）统一换用。
- **读侧** `pdf_hummus_extract_attachment.cpp`：`extract_attachments_from_pdf` 读到 BOM 开头的名字时用 `utf16_to_utf8` 还原；无 BOM 的旧 PDF（历史版本导出）保持原字节，向后兼容。

## 测试

- 新增集成测试 `TeXmacs/tests/1268.scm`（`xmake r 1268`，headless 同步断言）：嵌入 + 写侧 BOM 编码断言 + `extract-attachments` 回读文件名/内容一致；修复前 5 过 1 挂（编码断言），修复后 6 correct, 0 failed。
- poppler 交叉验证（okular 同引擎）：`pdfdetach -list` 修复前 `1268_ä¸­æŒ⁄...`，修复后 `1268_中文文件名.tmu`。
- okular 手动验证通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)