### PR TITLE
[1269] 导出PDF默认目录：tmu 在 texmacs 路径外用所在目录，否则落 Documents/LiiiSTEM

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tests/export-pdf-default-dir-test.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tests/export-pdf-default-dir-test.scm
@@ -1,0 +1,79 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : export-pdf-default-dir-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：导出 PDF 缺省目录策略（Issue #1268）——
+;;               tmu 位于 texmacs_path / texmacs_home_path 之外时用 tmu 所在
+;;               目录，其余（内置/帮助文档、scratch 草稿、tmfs 云文档）落
+;;               Documents/LiiiSTEM。不弹任何 GUI，headless 可跑。
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r export-pdf-default-dir-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/texmacs/texmacs/tm-print.scm")
+
+;; 本地 tmu 在 texmacs 路径之外：默认导出到 tmu 所在目录。
+
+(define (test-local-tmu-uses-own-dir)
+  (check (url->system (export-pdf-default-dir (system->url "/tmp/1268/demo.tmu")))
+    =>
+    "/tmp/1268"
+  ) ;check
+) ;define
+
+;; 内置/帮助文档（texmacs_path 下）：不写安装目录，落 Documents/LiiiSTEM。
+
+(define (test-below-texmacs-path-goes-to-documents)
+  (let ((master (url-append (get-texmacs-path) "doc/tmdoc/manual.tmu"))
+        (doc-dir (url->system (url-append (get-documents-path) "LiiiSTEM")))
+       ) ;
+    (check (url->system (export-pdf-default-dir master)) => doc-dir)
+  ) ;let
+) ;define
+
+;; 用户配置目录（texmacs_home_path）下的文档同样落 Documents/LiiiSTEM。
+
+(define (test-below-texmacs-home-path-goes-to-documents)
+  (let ((master (url-append (get-texmacs-home-path) "system/no_name/demo.tmu"))
+        (doc-dir (url->system (url-append (get-documents-path) "LiiiSTEM")))
+       ) ;
+    (check (url->system (export-pdf-default-dir master)) => doc-dir)
+  ) ;let
+) ;define
+
+;; scratch 草稿无本地 tmu 位置，不落 no_name 暂存目录，落 Documents/LiiiSTEM。
+
+(define (test-scratch-goes-to-documents)
+  (let ((master (url-append (get-documents-path) "LiiiSTEM/no_name/draft_20260905_120000.tmu"))
+        (doc-dir (url->system (url-append (get-documents-path) "LiiiSTEM")))
+       ) ;
+    (check (url-scratch? master) => #t)
+    (check (url->system (export-pdf-default-dir master)) => doc-dir)
+  ) ;let
+) ;define
+
+;; tmfs（云/帮助文档）master 非本地路径，落 Documents/LiiiSTEM。
+
+(define (test-tmfs-goes-to-documents)
+  (let ((master (system->url "tmfs://help/index.tmu"))
+        (doc-dir (url->system (url-append (get-documents-path) "LiiiSTEM")))
+       ) ;
+    (check (url->system (export-pdf-default-dir master)) => doc-dir)
+  ) ;let
+) ;define
+
+(tm-define (regtest-export-pdf-default-dir)
+  (test-local-tmu-uses-own-dir)
+  (test-below-texmacs-path-goes-to-documents)
+  (test-below-texmacs-home-path-goes-to-documents)
+  (test-scratch-goes-to-documents)
+  (test-tmfs-goes-to-documents)
+  (check-report)
+) ;tm-define

--- a/TeXmacs/progs/texmacs/texmacs/tm-print.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-print.scm
@@ -207,26 +207,22 @@
   ) ;with
 ) ;define
 
-(define (export-pdf-default-dir)
-  ;; 与 choose-file 缺省目录逻辑同源（Issue #327）：scratch 优先用上次文件
-  ;; 对话框目录，其次文档目录下的 LiiiSTEM；tmfs（云/帮助文档）落系统下载
-  ;; 目录；本地文档用其所在目录。
-  (let* ((master (buffer-get-master (current-buffer)))
-         (last-dir (and (url-scratch? master)
-                     (defined? 'get-last-file-dialog-directory)
-                     (get-last-file-dialog-directory)
-                   ) ;and
-         ) ;last-dir
-        ) ;
-    (cond ((and last-dir (string? last-dir) (not (string-null? last-dir)))
-           (system->url last-dir)
+(tm-define (export-pdf-default-dir master)
+  ;; 缺省导出目录（Issue #1268）：buffer 对应的 tmu 位于 texmacs_path 与
+  ;; texmacs_home_path 之外时，导出到 tmu 所在目录；否则——内置/帮助文档
+  ;; （位于安装或用户目录下），以及 scratch 草稿、tmfs 云文档（无本地
+  ;; tmu 位置，草稿不落 no_name 暂存目录）——统一落 Documents/LiiiSTEM。
+  (let ((doc-dir (url-append (get-documents-path) "LiiiSTEM")))
+    (cond ((or (url-scratch? master) (url-rooted-tmfs? master)) doc-dir)
+          ((or (url-descends? master (get-texmacs-path))
+             (url-descends? master (get-texmacs-home-path))
+           ) ;or
+           doc-dir
           ) ;
-          ((url-scratch? master) (url-append (get-documents-path) "LiiiSTEM"))
-          ((url-rooted-tmfs? master) (get-downloads-path))
           (else (url-head master))
     ) ;cond
-  ) ;let*
-) ;define
+  ) ;let
+) ;tm-define
 
 (tm-define (export-as-pdf)
   (:synopsis "Export as PDF, optionally embedding the source document")
@@ -255,7 +251,7 @@
             "Save pdf file"
             "pdf"
             "Save as:"
-            (url-append (export-pdf-default-dir)
+            (url-append (export-pdf-default-dir (buffer-get-master (current-buffer)))
               (system->url (propose-export-pdf-name embed))
             ) ;url-append
           ) ;choose-file

--- a/devel/1268.md
+++ b/devel/1268.md
@@ -1,0 +1,50 @@
+# [1268] 导出 PDF 默认路径策略
+
+## 如何测试
+
+1. `xmake b stem && xmake r stem` 启动 Mogan
+2. 打开一个普通本地目录（texmacs_path / texmacs_home_path 之外）的 tmu，
+   `文件 -> 导出为PDF...`，确认后看文件选择框：
+   - 预期：默认目录为该 tmu 所在目录
+3. 打开内置文档（texmacs_path 下，如帮助/示例）或用户目录（texmacs_home_path）
+   下的 tmu，导出 PDF：
+   - 预期：默认目录为 `Documents/LiiiSTEM`（不写安装/用户配置目录）
+4. 未保存的草稿（scratch）导出 PDF：
+   - 预期：默认目录为 `Documents/LiiiSTEM`（不落 `no_name` 暂存目录）
+5. `xmake b stem && xmake r export-pdf-default-dir-test`：5 组用例全过
+
+## 2026/09/05
+
+### 导出 PDF 默认目录策略
+
+#### What
+
+`export-as-pdf` 的 `choose-file` 缺省目录改为：buffer 对应的 tmu 位于
+`texmacs_path` 与 `texmacs_home_path` 之外时，用 tmu 所在目录；否则
+（内置/帮助文档、scratch 草稿、tmfs 云文档）统一用 `Documents/LiiiSTEM`。
+
+#### Why
+
+上一版 `export-pdf-default-dir`（1267）与 `choose-file` 的缺省目录逻辑同源：
+scratch 优先用上次文件对话框目录，本地文档直接取所在目录。问题在于打开
+texmacs_path（安装目录）或 texmacs_home_path（用户配置目录）下的文档导出
+PDF 时，会默认写进程序安装/配置目录，不合理。改为按「tmu 是否在 texmacs
+自有路径下」二分：用户自己的文档就近导出，其余一律落文档目录下的
+`LiiiSTEM`。
+
+#### How
+
+- `TeXmacs/progs/texmacs/texmacs/tm-print.scm`：`export-pdf-default-dir`
+  改为接收 master url 参数（便于测试），用 `url-descends?` 判断 master 是否
+  位于 `get-texmacs-path` / `get-texmacs-home-path` 之下；`url-scratch?` /
+  `url-rooted-tmfs?` 的 master（无本地 tmu 位置）一并归入 `Documents/LiiiSTEM`
+  兜底分支，`url-head master` 之外的分支全部移除。调用点显式传
+  `(buffer-get-master (current-buffer))`。
+- `TeXmacs/progs/texmacs/texmacs/tests/export-pdf-default-dir-test.scm`（新增）：
+  纯逻辑 regtest，覆盖本地 tmu 用所在目录、texmacs_path 下、texmacs_home_path
+  下、scratch、tmfs 五种输入。
+
+### 涉及文件
+
+- `TeXmacs/progs/texmacs/texmacs/tm-print.scm`
+- `TeXmacs/progs/texmacs/texmacs/tests/export-pdf-default-dir-test.scm`（新增）


### PR DESCRIPTION
## 改动

`export-as-pdf` 的 choose-file 缺省目录策略改为（devel/1269.md）：

- buffer 对应的 tmu 位于 `texmacs_path` 与 `texmacs_home_path` **之外**：默认导出到 tmu 所在目录
- 否则（内置/帮助文档、scratch 草稿、tmfs 云文档）：统一落 `Documents/LiiiSTEM`

不再把安装/用户配置目录下的文档默认导出到程序目录内。

## 测试

- 新增纯逻辑 regtest `export-pdf-default-dir-test`（5 种输入：本地 tmu / texmacs_path 下 / texmacs_home_path 下 / scratch / tmfs），`xmake r export-pdf-default-dir-test` 6 checks 全过
- 已运行 `gf fmt --changed-since=main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)