### PR TITLE
[1270] QML 弹窗 scene graph 固定 software 后端，规避 GPU 驱动问题

### DIFF
--- a/devel/1270.md
+++ b/devel/1270.md
@@ -1,0 +1,45 @@
+# [1270] QML 弹窗 scene graph 固定 software 后端，规避 GPU 驱动问题
+
+## What
+
+QML 弹窗底座（`QTMQmlDialog`）将 scene graph 后端固定为 software（
+`QQuickWindow::setGraphicsApi (QSGRendererInterface::Software)`），全部 QML
+弹窗（调色盘、Version、导出 PDF、字体选择器、段落格式等）不再走
+GL/Vulkan/Metal 驱动渲染。
+
+## Why
+
+0928 取色崩溃（X11 + NVIDIA 下 `QRhi::endOffscreenFrame` 段错误）虽已用异步
+取色修复，但 RHI 路径对各类 GPU 驱动仍有残留风险。QML 弹窗均为简单静态 UI，
+软件渲染开销可忽略（实测响应速度尚快），直接切 software 后端可整类规避驱动
+问题。Qt 6 起 software 后端与 QQuickWidget 兼容（Qt 5 时代不兼容的限制已
+解除，Qt 6.8 文档 Graphics API Support 节明示）。
+
+## How
+
+1. `setup_frameless_qml_host` 是全部 QML 弹窗 QQuickWidget 的唯一构造卡点
+   （阻塞 `run_qml_dialog` 与非阻塞 `run_modal_qml_dialog` 都经它），在此以
+   static 守卫一次性声明 graphics API。图形 API 是进程级全局选择，须赶在
+   首个 QQuickWidget 构造前设定，之后不可再改，故不能按单个弹窗选择。
+2. 局限说明：真实 app 中弹窗是唯一 Quick 内容，守卫必然先于一切生效；测试
+   进程里有用例绕开该函数直接建 QQuickWidget，此时声明会被忽略并告警
+   （`Scenegraph already initialized, setBackend() request ignored`），仅是
+   测试内噪音。
+
+## 如何测试
+
+1. `xmake b stem && xmake r stem` 启动 Mogan（已人工验证：软件渲染正常且快）
+2. 打开 Format / Color -> Palette、Document -> Background color 等弹窗：
+   预期渲染、交互、屏幕取色均正常，`QT_LOGGING_RULES="qt.quick.*=true"` 下
+   可确认 renderer 为 software
+3. `xmake b qml_load_test && xmake r qml_load_test`：19 通过 1 失败
+   （`test_version_dialog_focuses_on_open`，无头环境下焦点类用例固有抖动，
+   不含本改动的主分支基线同样失败且连 `test_version_escape_cancels` 也超时
+   失败；本改动后 escape 用例恢复通过、整体耗时 14s -> 4s）
+4. `xmake b color_picker_bridge_test && xmake r color_picker_bridge_test`：
+   5 通过 0 失败
+
+## 涉及文件
+
+- `src/Plugins/Qt/QTMQmlDialog.cpp`
+- `devel/1270.md`

--- a/src/Plugins/Qt/QTMQmlDialog.cpp
+++ b/src/Plugins/Qt/QTMQmlDialog.cpp
@@ -34,6 +34,8 @@ using moebius::data::tree_to_scheme_tree;
 #include <QQmlError>
 #include <QQuickItem>
 #include <QQuickWidget>
+#include <QQuickWindow>
+#include <QSGRendererInterface>
 #include <QString>
 #include <QStringList>
 #include <QTimer>
@@ -104,12 +106,21 @@ kv_map_to_tree (const QVariantMap& res) {
  * - setClearColor（QQuickWidget 专属）而非 WA_TranslucentBackground（对它不完全
  *   生效，默认白色 clear color 会盖住透明、露方角）。
  * - objectName + 样式反制 liii.css 的通用 QDialog 规则，避免圆角外露方块。
+ * - scene graph 固定走 software 后端：弹窗均为简单静态 UI，软件渲染开销可忽略，
+ *   却不再依赖 GL/Vulkan/Metal 驱动，规避 X11+NVIDIA 下 QRhi::endOffscreenFrame
+ *   崩溃一类驱动问题。Qt 6 起该后端与 QQuickWidget 兼容；图形 API 是进程级全局
+ *   选择，须赶在首个 QQuickWidget 构造前设定，故在本函数（唯一构造卡点）声明。
  *
  * @param d 由调用方栈分配、生命期覆盖 exec() 的宿主 QDialog。
  * @return 挂到 d 上、待 setSource / 注入 context property 的 QQuickWidget。
  */
 static QQuickWidget*
 setup_frameless_qml_host (QDialog& d) {
+  static const bool sgApiInitialized= [] () {
+    QQuickWindow::setGraphicsApi (QSGRendererInterface::Software);
+    return true;
+  }();
+  (void) sgApiInitialized;
   d.setAttribute (Qt::WA_TranslucentBackground);
   d.setAttribute (Qt::WA_NativeWindow);
   d.setObjectName ("QTMQmlDialog");


### PR DESCRIPTION
## What
QML 弹窗底座（`QTMQmlDialog`）将 scene graph 后端固定为 software（`QQuickWindow::setGraphicsApi(QSGRendererInterface::Software)`），全部 QML 弹窗（调色盘、Version、导出 PDF、字体选择器、段落格式等）不再走 GL/Vulkan/Metal 驱动渲染。

## Why
0928 取色崩溃（X11 + NVIDIA `QRhi::endOffscreenFrame`）虽已用异步取色修复，但 RHI 路径对各类 GPU 驱动仍有残留风险。QML 弹窗均为简单静态 UI，软件渲染开销可忽略，直接切 software 整类规避驱动问题。Qt 6 起 software 后端与 QQuickWidget 兼容（Qt 5 时代的不兼容限制已解除）。

## How
`setup_frameless_qml_host` 是全部 QML 弹窗 QQuickWidget 的唯一构造卡点（阻塞 `run_qml_dialog` 与非阻塞 `run_modal_qml_dialog` 都经它），在此以 static 守卫一次性声明 graphics API。图形 API 是进程级全局选择，须赶在首个 QQuickWidget 构造前设定，之后不可再改，故无法按单个弹窗选择。

## 测试
- `xmake b color_picker_bridge_test && xmake r color_picker_bridge_test`：5 通过 0 失败
- `xmake b qml_load_test && xmake r qml_load_test`：19 通过 1 失败（`test_version_dialog_focuses_on_open` 为无头环境焦点类用例固有抖动，main 基线同样失败且连 `test_version_escape_cancels` 也超时；本改动后 escape 恢复通过、整体耗时 14s → 4s）
- 人工 GUI 验证：软件渲染正常、弹窗响应快

任务文档：`devel/1270.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)