### PR TITLE
[1273] 点击历史会话恢复后自动补齐 llm 样式包

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-style.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-style.scm
@@ -68,22 +68,22 @@
   ) ;let
 ) ;tm-define
 
-(tm-define (chat-tab-sync-dark-style! session-id)
-  ;; C++ 侧创建 panel 后调用，同步暗色样式包
-  (when (== (get-preference "gui theme") "liii-night")
-    (let ((msg-buf (chat-tab-session->message-buffer session-id))
-          (in-buf (chat-tab-session->input-buffer session-id))
-         ) ;
-      (chat-tab-with-buffer msg-buf
-        (when (and chat-tab-focus-ok? (not (has-style-package? "dark")))
-          (add-style-package "dark")
-        ) ;when
-      ) ;chat-tab-with-buffer
-      (with-buffer in-buf
-        (when (not (has-style-package? "dark"))
-          (add-style-package "dark")
-        ) ;when
-      ) ;with-buffer
-    ) ;let
-  ) ;when
+(tm-define (chat-tab-sync-session-styles! session-id)
+  ;; C++ 侧在消息嵌入编辑器建立（含 set_buffer_tree 覆盖）后调用。
+  ;; 无视图阶段 with-buffer 会静默跳过样式操作，而 texmacs_input_widget
+  ;; 对已有 buffer 会整体覆盖样式，故须在视图就绪后按当前 buffer 补齐
+  ;; 默认样式包，点击历史会话恢复后 llm 等插件包才不缺失。
+  ;; set-style-list 归一化去重，包已齐时重复调用不触发样式树重建。
+  (let ((msg-buf (chat-tab-session->message-buffer session-id))
+        (in-buf (chat-tab-session->input-buffer session-id))
+       ) ;
+    (chat-tab-with-buffer msg-buf
+      (when chat-tab-focus-ok?
+        (chat-tab-add-default-style-packages! chat-tab-session-name)
+      ) ;when
+    ) ;chat-tab-with-buffer
+    (with-buffer in-buf
+      (chat-tab-add-default-style-packages! chat-tab-session-name)
+    ) ;with-buffer
+  ) ;let
 ) ;tm-define

--- a/devel/1273.md
+++ b/devel/1273.md
@@ -1,0 +1,46 @@
+# 1273 点击历史会话恢复后 llm 样式包未自动加载
+
+## What
+
+点击历史 AI 会话恢复消息区时，llm 样式包未自动加载：消息按裸 markup
+渲染（全宽、无 ornament 输入框）；新建对话发送首条消息则正常加载 llm
+样式。`%chat` 协议行外露属社区版设计，不在本问题范围内。
+
+## Why
+
+- 历史路径时序：`chat-persist-load-session-content`（scheme 侧补样式）
+  先于 `ensureMessageWidget`（C++）。前者执行时消息 buffer 尚无视图，
+  社区版 `with-buffer`（cursor.scm）对无视图 buffer 静默跳过 body，
+  llm 包从未加上（chat-tree-ops.scm 对该语义有注释说明）。
+- 随后 `ensureMessageWidget` 里 `texmacs_input_widget` 对已有 buffer 会
+  `set_buffer_tree` 整体覆盖，样式被重置为 `chat_embedded_style()`
+  （generic+dark），即使此前加过 llm 也会被抹掉。视图就绪后无人补加。
+- 发送路径正常，恰因 `onSendRequested` 先 `ensureMessageWidget` 再
+  `chat-tab-send`，`chat-tab-session-send` 的样式操作发生在视图就绪
+  之后（qt_chat_controller.cpp 同位置有 1230 的时序注释）。
+
+## How
+
+- scheme（chat-style.scm）：`chat-tab-sync-dark-style!` 泛化为
+  `chat-tab-sync-session-styles!`，按 `chat-tab-add-default-style-packages!`
+  的完整包列表（number-europe/语言包/插件包/dark）同步消息区
+  （`chat-tab-focus-ok?` 守卫，须有视图）与输入区。包已齐时
+  `set-style-list` 归一化去重（document-style.scm
+  `normalize-style-list`），重复调用不触发样式树重建，幂等。
+- C++（qt_chat_controller.cpp）：`loadSessionContent` 在
+  `enterConversationMode()`（消息视图建好、`set_buffer_tree` 覆盖完成）
+  之后补调 `chat-tab-sync-session-styles!`；`ensureNewConversation` /
+  `getOrCreatePanel` 两处既有调用点同步改名。
+
+## 测试
+
+- 修复前现象以 GUI 探索截图确认：历史会话消息区全宽裸 markup，
+  `llm>` 提示与消息文本按灰色普通文本渲染。
+- 手动验证（Linux GUI）：点击历史会话，消息区带 llm 样式（宽度变窄、
+  ornament 输入框）；新建对话发送首条消息 llm 样式不回退、样式包不重复
+  叠加；liii-night 下恢复的会话画布保持深色（1272 不回退）。
+
+## 涉及文件
+
+- `TeXmacs/plugins/llm/progs/llm/chat-style.scm`
+- `src/Plugins/Qt/qt_chat_controller.cpp`

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -520,6 +520,11 @@ ChatController::loadSessionContent (ChatConversationPanel* panel) {
       ChatSessionManager::messageBufferUrl (panel->sessionId ()));
   if (!ChatConversationPanel::is_empty_document_body (msgBody)) {
     panel->enterConversationMode ();
+    // ensureMessageWidget 里 texmacs_input_widget 会 set_buffer_tree 整体
+    // 覆盖消息 buffer 样式，而此前的 scheme 样式操作发生在无视图阶段、
+    // 已被 with-buffer 静默跳过；须在视图就绪后补齐默认样式包，
+    // 历史会话恢复才能带上 llm 等插件包
+    call ("chat-tab-sync-session-styles!", panel->sessionId ());
     QTimer::singleShot (3000, this, [this, sid= panel->sessionId ()] () {
       if (!sessionManager_.getSession (sid)) return;
       call ("chat-scroll-message-to-end", sid);
@@ -631,7 +636,7 @@ ChatController::ensureNewConversation () {
   sessionManager_.setModel (sid, currentModel_);
 
   eval ("(use-modules (llm chat-style))");
-  call ("chat-tab-sync-dark-style!", sid);
+  call ("chat-tab-sync-session-styles!", sid);
   call ("chat-tab-load-input-styles!", sid);
 
   if (panel->sessionTitle ()) panel->sessionTitle ()->hide ();
@@ -664,7 +669,7 @@ ChatController::getOrCreatePanel (const string& sessionId) {
   sessionManager_.setPanel (sessionId, panel);
 
   eval ("(use-modules (llm chat-style) (llm chat-protocol))");
-  call ("chat-tab-sync-dark-style!", sessionId);
+  call ("chat-tab-sync-session-styles!", sessionId);
   call ("chat-tab-init-session!", sessionId, s->model);
 
   // 连接 Panel 的信号


### PR DESCRIPTION
## 问题

点击历史 AI 会话恢复消息区时，llm 样式包未自动加载：消息按裸 markup 渲染（全宽、无 ornament 输入框）。新建对话发送首条消息则正常加载 llm 样式。

## 根因

历史路径时序：`chat-persist-load-session-content`（scheme 补样式）先于 `ensureMessageWidget`（C++）。前者执行时消息 buffer 尚无视图，社区版 `with-buffer` 对无视图 buffer 静默跳过 body，llm 从未加上；随后 `texmacs_input_widget` 又对已有 buffer `set_buffer_tree` 整体覆盖样式（generic+dark）。视图就绪后无人补加。

发送路径正常，恰因 `onSendRequested` 先 `ensureMessageWidget` 再 `chat-tab-send`，样式操作发生在视图就绪之后。

## 改动

- **chat-style.scm**：`chat-tab-sync-dark-style!` 泛化为 `chat-tab-sync-session-styles!`，按 `chat-tab-add-default-style-packages!` 完整包列表（number-europe/语言包/插件包/dark）同步消息区（`chat-tab-focus-ok?` 守卫）与输入区；`set-style-list` 归一化去重，幂等。
- **qt_chat_controller.cpp**：`loadSessionContent` 在 `enterConversationMode()`（视图建好、覆盖完成）之后补调 `chat-tab-sync-session-styles!`；两处既有调用点同步改名。

## 测试

- 手动验证：点击历史会话，消息区带 llm 样式（宽度变窄、ornament 输入框）；新建对话首发消息不回退；liii-night 深色画布不回退（1272 不回退）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)