### PR TITLE
[1274] 修复会话列表多选勾选框昼夜主题下看不清

### DIFF
--- a/TeXmacs/misc/images/images.qrc
+++ b/TeXmacs/misc/images/images.qrc
@@ -31,6 +31,7 @@
         <file>llm-chat/thinking-white.svg</file>
         <file>llm-chat/search.svg</file>
         <file>llm-chat/search-white.svg</file>
+        <file>llm-chat/check-white.svg</file>
         <file>llm-chat/models/kimi.svg</file>
         <file>llm-chat/models/deepseek.svg</file>
 

--- a/TeXmacs/misc/images/llm-chat/check-white.svg
+++ b/TeXmacs/misc/images/llm-chat/check-white.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+	<path style="fill:none;stroke:#ffffff;stroke-width:7;stroke-linecap:round;stroke-linejoin:round;" d="M10,25 L20,35 L38,14"/>
+</svg>

--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -1565,12 +1565,31 @@ QWidget#centralWidget QToolButton#chat-tab-send-btn:pressed {
   background-color: #8e8e8e;
 }
 
-/* 选择复选框 */
-QWidget#centralWidget QCheckBox#chat-tab-select-checkbox::indicator:checked {
-  background-color: #4a90d9;
+/* 选择复选框（多选模式）：深色侧边栏上未勾选需靠边框辨认，勾选需有勾选图形 */
+QWidget#centralWidget QCheckBox#chat-tab-select-checkbox,
+QCheckBox#chat-tab-select-checkbox {
+  background: transparent;
 }
-QWidget#centralWidget QCheckBox#chat-tab-select-checkbox::indicator:unchecked {
+QWidget#centralWidget QCheckBox#chat-tab-select-checkbox::indicator,
+QCheckBox#chat-tab-select-checkbox::indicator {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+}
+QWidget#centralWidget QCheckBox#chat-tab-select-checkbox::indicator:checked,
+QCheckBox#chat-tab-select-checkbox::indicator:checked {
+  background-color: #2791ad;
+  border: 1px solid #2791ad;
+  image: url(":/llm-chat/check-white.svg");
+}
+QWidget#centralWidget QCheckBox#chat-tab-select-checkbox::indicator:unchecked,
+QCheckBox#chat-tab-select-checkbox::indicator:unchecked {
   background-color: #2c2c2c;
+  border: 1px solid #7a7a7a;
+}
+QWidget#centralWidget QCheckBox#chat-tab-select-checkbox::indicator:unchecked:hover,
+QCheckBox#chat-tab-select-checkbox::indicator:unchecked:hover {
+  border: 1px solid #2791ad;
 }
 
 /* 会话项容器 */

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -1453,12 +1453,26 @@ QToolButton#chat-tab-send-btn:pressed {
   background-color: #d3d3d3;
 }
 
-/* 选择复选框 */
+/* 选择复选框（多选模式）：浅色侧边栏上未勾选需靠边框辨认，勾选需有勾选图形 */
+QCheckBox#chat-tab-select-checkbox {
+  background: transparent;
+}
+QCheckBox#chat-tab-select-checkbox::indicator {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+}
 QCheckBox#chat-tab-select-checkbox::indicator:checked {
-  background-color: #4a90d9;
+  background-color: #215a6a;
+  border: 1px solid #215a6a;
+  image: url(":/llm-chat/check-white.svg");
 }
 QCheckBox#chat-tab-select-checkbox::indicator:unchecked {
   background-color: #ffffff;
+  border: 1px solid #cccccc;
+}
+QCheckBox#chat-tab-select-checkbox::indicator:unchecked:hover {
+  border: 1px solid #215a6a;
 }
 
 /* 会话项容器 */

--- a/devel/1274.md
+++ b/devel/1274.md
@@ -1,0 +1,41 @@
+# 1274 对话列表多选勾选框看不清
+
+## 问题
+
+会话侧边栏多选模式下，条目左侧表示选中的勾选框在白天/黑夜主题下都看不清楚：
+
+- 未勾选态只有一块背景色（浅色 `#ffffff`、深色 `#2c2c2c`），与侧边栏/会话按钮
+  背景（`#f5f5f5`/`#ffffff`/`#2c2c2c`/`#3a3a3a`）几乎同色，且无边框；
+- 勾选态只是一块纯色方块，没有勾选图形，无法直观确认已选中。
+
+### 根因
+
+提交 933aa12c1（[1028] chat tab css 优化）把配色迁到主题 CSS 时：
+
+1. `createItem` 里给 `QCheckBox` 留了局部 stylesheet，且强制 `border: none`——
+   Qt 中 widget 局部 stylesheet 优先级高于应用级主题 CSS，主题里的边框规则会被覆盖；
+2. 主题 CSS（`liii.css` / `liii-night.css`）只写了 `::indicator` 的
+   `background-color`，没有边框，也没有 `image` 勾选图形。
+
+## 改动（What/How）
+
+1. **`src/Plugins/Qt/qt_chat_tab_widget.cpp`**：删除 `createItem` 中勾选框的局部
+   stylesheet，外观完全交给主题 CSS 提供。
+2. **`TeXmacs/misc/images/llm-chat/check-white.svg`**（新增）+ `images.qrc` 注册：
+   白色勾选图形，两种主题的勾选态通用（浅色主题勾选底 `#215a6a`、深色 `#2791ad`
+   均为深色底，白勾清晰）。
+3. **`TeXmacs/misc/themes/liii.css` / `liii-night.css`**：补全 `#chat-tab-select-checkbox`
+   的指示器规则——
+   - 基础：`14px × 14px`、圆角 3px、checkbox 本体背景透明（避免夜主题通用
+     `QCheckBox { background: #6a6a6a; }` 透出灰底）；
+   - 勾选：主题强调色底 + 白色勾选图形（`:/llm-chat/check-white.svg`）；
+   - 未勾选：白/深底 + 可见边框（浅色 `#cccccc`、深色 `#7a7a7a`），
+     hover 时边框变强调色。
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`
+- `TeXmacs/misc/images/llm-chat/check-white.svg`（新增）
+- `TeXmacs/misc/images/images.qrc`
+- `TeXmacs/misc/themes/liii.css`
+- `TeXmacs/misc/themes/liii-night.css`

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -1145,12 +1145,8 @@ ChatSidebar::createItem (const string& sessionId) {
   item.selectCheckBox= new QCheckBox (item.itemWidget);
   item.selectCheckBox->setObjectName ("chat-tab-select-checkbox");
   item.selectCheckBox->setFocusPolicy (Qt::NoFocus);
-  item.selectCheckBox->setStyleSheet ("QCheckBox::indicator:checked { "
-                                      "  border: none; "
-                                      "  border-radius: 3px; }"
-                                      "QCheckBox::indicator:unchecked { "
-                                      "  border: none; "
-                                      "  border-radius: 3px; }");
+  // 勾选框外观（勾选图形/边框/配色）统一由 liii.css / liii-night.css 提供，
+  // 此处不再设置局部 stylesheet，避免覆盖主题规则导致选中态看不清
   item.selectCheckBox->hide ();
   itemLayout->addWidget (item.selectCheckBox);
 


### PR DESCRIPTION
## 问题

会话侧边栏多选模式下，条目左侧表示选中的勾选框在白天/黑夜主题下都看不清楚：

- 未勾选态只有一块背景色（浅色 `#ffffff`、深色 `#2c2c2c`），与侧边栏/会话按钮背景几乎同色，且无边框；
- 勾选态只是一块纯色方块，没有勾选图形，无法直观确认已选中。

### 根因

933aa12c1（[1028] chat tab css 优化）把配色迁到主题 CSS 时：

1. `createItem` 给 `QCheckBox` 留了局部 stylesheet 且强制 `border: none`——Qt 中 widget 局部 stylesheet 优先级高于应用级主题 CSS，主题边框规则被覆盖；
2. 主题 CSS（`liii.css` / `liii-night.css`）只写了 `::indicator` 的 `background-color`，无边框、无勾选图形。

## 改动

1. `qt_chat_tab_widget.cpp`：删除勾选框的局部 stylesheet，外观完全交给主题 CSS；
2. 新增 `llm-chat/check-white.svg` 并注册进 `images.qrc`：白色勾选图形，两种主题勾选态通用；
3. `liii.css` / `liii-night.css`：补全指示器规则——
   - 勾选态：主题强调色底（浅 `#215a6a` / 深 `#2791ad`）+ 白色勾选图形；
   - 未勾选态：可见边框（浅 `#cccccc` / 深 `#7a7a7a`），hover 边框变强调色；
   - checkbox 本体背景透明，规避夜主题通用 `QCheckBox { background: #6a6a6a; }` 透出灰底。

## 测试

- `gf fmt --changed-since=main` 通过（无格式改动）
- 昼/夜主题下手动验证多选模式勾选框的可见性

🤖 Generated with [Claude Code](https://claude.com/claude-code)