### PR TITLE
[1275] 历史会话恢复不闪现欢迎页

### DIFF
--- a/devel/1275.md
+++ b/devel/1275.md
@@ -1,0 +1,36 @@
+# 1275 历史会话恢复不闪现欢迎页
+
+## What
+
+点击对话列表中的历史会话时，消息区先闪现「欢迎使用 Liii STEM」欢迎页，再切换到
+对话消息历史缓冲区。期望：历史会话恢复直接显示消息历史，欢迎页只属于新建会话。
+
+## Why
+
+- `ChatConversationPanel` 构造时欢迎页默认可见、消息区隐藏，恢复路径要等
+  `chat-persist-load-session-content` 加载完 message.tmu 才调
+  `enterConversationMode` 切走；
+- `enterConversationMode` 原实现带 220ms 渐隐渐显过渡，欢迎页淡出期间可见；
+- 面板若在内容加载完成前上屏（如 `conversationStack_` 为空时 `addWidget`
+  会立即置为当前页），欢迎页会完整画出一帧。
+
+## How
+
+1. `enterConversationMode` 增加 `animate` 参数（默认 `true` 保持新建会话首次
+   发送的过渡效果）；无动画路径直接 `messageFrame_->show ()` /
+   `welcomeTitle_->hide ()`，不创建 `QGraphicsOpacityEffect` 与动画。
+2. `ChatController::loadSessionContent`（历史会话恢复路径）改调
+   `enterConversationMode (false)`。
+3. 欢迎页默认改为隐藏：`setup_ui` 中 `welcomeTitle_->hide ()`，新增
+   `showWelcomePage ()` 仅供 `ensureNewConversation` 的两条新建会话路径
+   （复用空白会话 / 创建新会话）显式打开。恢复路径无论何种时序上屏，
+   都画不出欢迎页。
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_chat_tab_widget.hpp`：`enterConversationMode (bool animate)`、
+  新增 `showWelcomePage ()` 声明
+- `src/Plugins/Qt/qt_chat_tab_widget.cpp`：`setup_ui` 欢迎页默认隐藏；
+  `enterConversationMode` 支持无动画切换；新增 `showWelcomePage`
+- `src/Plugins/Qt/qt_chat_controller.cpp`：`loadSessionContent` 用无动画切换；
+  `ensureNewConversation` 显式打开欢迎页

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -519,7 +519,9 @@ ChatController::loadSessionContent (ChatConversationPanel* panel) {
   tree msgBody= get_buffer_body (
       ChatSessionManager::messageBufferUrl (panel->sessionId ()));
   if (!ChatConversationPanel::is_empty_document_body (msgBody)) {
-    panel->enterConversationMode ();
+    // 历史会话恢复时面板尚未上屏，无需欢迎页→消息区的渐隐过渡，
+    // 直接切换避免欢迎页先闪现（1275）
+    panel->enterConversationMode (false);
     // ensureMessageWidget 里 texmacs_input_widget 会 set_buffer_tree 整体
     // 覆盖消息 buffer 样式，而此前的 scheme 样式操作发生在无视图阶段、
     // 已被 with-buffer 静默跳过；须在视图就绪后补齐默认样式包，
@@ -621,6 +623,7 @@ ChatController::ensureNewConversation () {
     if (s && s->panel) {
       ChatConversationPanel* p= static_cast<ChatConversationPanel*> (s->panel);
       if (p->sessionTitle ()) p->sessionTitle ()->hide ();
+      p->showWelcomePage ();
     }
     activateSession (reusable);
     view_->sidebar ()->setActiveItem (""); // 未注册会话不在 sidebar，清除高亮
@@ -640,6 +643,7 @@ ChatController::ensureNewConversation () {
   call ("chat-tab-load-input-styles!", sid);
 
   if (panel->sessionTitle ()) panel->sessionTitle ()->hide ();
+  panel->showWelcomePage ();
 
   // 连接 Panel 的信号
   connectPanelSignals (panel);

--- a/src/Plugins/Qt/qt_chat_tab_widget.cpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.cpp
@@ -207,6 +207,10 @@ ChatConversationPanel::setup_ui () {
   welcomeTitle_->setAlignment (Qt::AlignCenter);
   DpiUtils::applyScaledFont (welcomeTitle_, kWelcomeFontPx);
   topLayout->addWidget (welcomeTitle_);
+  // 欢迎页默认隐藏，仅新建会话经 showWelcomePage 显式打开：
+  // 历史会话恢复的面板可能在内容加载完成前上屏（如 conversationStack
+  // 为空时 addWidget 立即置为当前页），默认可见会先画出一帧欢迎页
+  welcomeTitle_->hide ();
 
   // Session title label
   sessionTitle_= new QLabel ("", topPanel);
@@ -387,7 +391,7 @@ ChatConversationPanel::ensureMessageWidget () {
 }
 
 void
-ChatConversationPanel::enterConversationMode () {
+ChatConversationPanel::enterConversationMode (bool animate) {
   if (conversationMode_) return;
 
   ensureMessageWidget ();
@@ -395,35 +399,43 @@ ChatConversationPanel::enterConversationMode () {
   const int endOffset= DpiUtils::scaled (kConversationTopOffsetY);
 
   if (messageFrame_) {
-    QGraphicsOpacityEffect* messageEffect=
-        new QGraphicsOpacityEffect (messageFrame_);
-    messageEffect->setOpacity (0.0);
-    messageFrame_->setGraphicsEffect (messageEffect);
-    messageFrame_->show ();
+    if (animate) {
+      QGraphicsOpacityEffect* messageEffect=
+          new QGraphicsOpacityEffect (messageFrame_);
+      messageEffect->setOpacity (0.0);
+      messageFrame_->setGraphicsEffect (messageEffect);
 
-    QPropertyAnimation* fadeIn=
-        new QPropertyAnimation (messageEffect, "opacity", messageFrame_);
-    fadeIn->setDuration (kTransitionDurationMs);
-    fadeIn->setStartValue (0.0);
-    fadeIn->setEndValue (1.0);
-    fadeIn->start (QAbstractAnimation::DeleteWhenStopped);
+      QPropertyAnimation* fadeIn=
+          new QPropertyAnimation (messageEffect, "opacity", messageFrame_);
+      fadeIn->setDuration (kTransitionDurationMs);
+      fadeIn->setStartValue (0.0);
+      fadeIn->setEndValue (1.0);
+      fadeIn->start (QAbstractAnimation::DeleteWhenStopped);
+    }
+    // 无动画路径（历史会话恢复）：欢迎页从未上屏，直接显示消息区
+    messageFrame_->show ();
   }
 
   if (welcomeTitle_) {
-    QGraphicsOpacityEffect* titleEffect=
-        new QGraphicsOpacityEffect (welcomeTitle_);
-    titleEffect->setOpacity (1.0);
-    welcomeTitle_->setGraphicsEffect (titleEffect);
+    if (animate) {
+      QGraphicsOpacityEffect* titleEffect=
+          new QGraphicsOpacityEffect (welcomeTitle_);
+      titleEffect->setOpacity (1.0);
+      welcomeTitle_->setGraphicsEffect (titleEffect);
 
-    QPropertyAnimation* fadeOut=
-        new QPropertyAnimation (titleEffect, "opacity", welcomeTitle_);
-    fadeOut->setDuration (kTransitionDurationMs);
-    fadeOut->setStartValue (1.0);
-    fadeOut->setEndValue (0.0);
-    connect (fadeOut, &QPropertyAnimation::finished, this, [this] () {
-      if (welcomeTitle_) welcomeTitle_->hide ();
-    });
-    fadeOut->start (QAbstractAnimation::DeleteWhenStopped);
+      QPropertyAnimation* fadeOut=
+          new QPropertyAnimation (titleEffect, "opacity", welcomeTitle_);
+      fadeOut->setDuration (kTransitionDurationMs);
+      fadeOut->setStartValue (1.0);
+      fadeOut->setEndValue (0.0);
+      connect (fadeOut, &QPropertyAnimation::finished, this, [this] () {
+        if (welcomeTitle_) welcomeTitle_->hide ();
+      });
+      fadeOut->start (QAbstractAnimation::DeleteWhenStopped);
+    }
+    else {
+      welcomeTitle_->hide ();
+    }
   }
 
   if (topSpacer_ && layout ()) {
@@ -441,6 +453,13 @@ ChatConversationPanel::enterConversationMode () {
     // 通知父级布局链重新计算
     updateGeometry ();
   }
+}
+
+void
+ChatConversationPanel::showWelcomePage () {
+  // 历史会话恢复路径不调用本函数，欢迎页对恢复面板不可见
+  if (conversationMode_) return;
+  if (welcomeTitle_) welcomeTitle_->show ();
 }
 
 void

--- a/src/Plugins/Qt/qt_chat_tab_widget.hpp
+++ b/src/Plugins/Qt/qt_chat_tab_widget.hpp
@@ -68,8 +68,18 @@ public:
 
   /**
    * @brief 进入对话模式（隐藏欢迎页，显示消息区域）。
+   * @param animate 是否带渐隐过渡。历史会话恢复时消息区尚未上屏，
+   *                无需过渡，直接切换以免欢迎页先闪现一帧
    */
-  void enterConversationMode ();
+  void enterConversationMode (bool animate= true);
+
+  /**
+   * @brief 显示欢迎页（仅新建会话调用）。
+   *
+   * 欢迎页默认隐藏：历史会话恢复的面板可能在消息内容加载完成前上屏，
+   * 默认可见会让恢复路径先画出一帧欢迎页再切到消息区。
+   */
+  void showWelcomePage ();
 
   /**
    * @brief 按需创建消息区嵌入编辑器（幂等）。


### PR DESCRIPTION
## 问题

点击对话列表中的历史会话时，消息区先闪现「欢迎使用 Liii STEM」欢迎页，再切换到对话消息历史缓冲区。

## 原因

- 面板构造时欢迎页默认可见、消息区隐藏，恢复路径要等 `chat-persist-load-session-content` 加载完 message.tmu 才调 `enterConversationMode` 切走；
- `enterConversationMode` 带 220ms 渐隐过渡，欢迎页淡出期间可见；
- 面板若在内容加载完成前上屏（如 `conversationStack_` 为空时 `addWidget` 立即置为当前页），欢迎页会完整画出一帧。

## 方案

1. `enterConversationMode` 增加 `animate` 参数（默认 `true`，保留新建会话首次发送的过渡效果）；无动画路径直接 `show`/`hide`，不创建效果与动画。`loadSessionContent`（恢复路径）改传 `false`。
2. 欢迎页默认隐藏，新增 `showWelcomePage ()` 仅供 `ensureNewConversation` 的两条新建会话路径（复用空白会话 / 创建新会话）显式打开。恢复路径无论何种时序上屏都画不出欢迎页。

## 测试

- 点击历史会话：直接显示消息历史，无欢迎页闪现
- 新建会话：欢迎页正常显示；首次发送：欢迎页渐隐过渡到消息区（原有动效保留）
- 重启后打开 Chat 标签页自动恢复上次会话：不闪欢迎页

🤖 Generated with [Claude Code](https://claude.com/claude-code)