### PR TITLE
[1276] 修复光标移入定理类环境导致标题被正文背景遮挡

### DIFF
--- a/devel/1276.md
+++ b/devel/1276.md
@@ -24,3 +24,10 @@
 
 - `src/Typeset/Boxes/Modifier/highlight_boxes.cpp`
 - `devel/1276.md`
+
+## 修复 debian13 CI 偶发失败（test_version_dialog_focuses_on_open）
+
+- 现象：debian13 的 `build` job 中 `TestQmlLoad::test_version_dialog_focuses_on_open` 报 `'hadFocus' returned FALSE`。
+- 根因：该用例在弹窗 `exec()` 后固定 200ms 时刻一次性断言 QML 焦点。debian13 冷缓存全量构建（约 44 分钟）后机器高负载，offscreen 平台下焦点事件可能晚于该时刻，导致误报。main 上同用例稳定通过、fedora 同 commit 通过，属既有 flaky，与 1276 的渲染改动无关。
+- 修复：改为 50ms 轮询等待 `hasActiveFocus`，焦点到达后再发 ESC 验证取消链路；8 秒仍无焦点则兜底 reject 弹窗，保证不遗留阻塞模态窗口。本地 offscreen 全量 21 项通过，4 核忙负载下复测仍稳定通过。
+- 涉及文件：`tests/Plugins/Qt/qml_load_test.cpp`

--- a/devel/1276.md
+++ b/devel/1276.md
@@ -1,0 +1,26 @@
+# [1276] 修复光标移入定理类环境导致标题被正文背景遮挡
+
+## 如何测试
+
+在首页找到 ElegantBook 模板，进入 1.4.2 的定理类环境，然后把光标移入 定义1.1 这个结构里面，可以看到渲染是正常的。
+
+## What
+
+在 ElegantBook 等带有标题装饰盒（titled ornament）的定理类环境中，光标移入「定义 1.1」等结构内时，标题文字可能被正文背景遮挡或渲染异常。期望：光标移入或在结构内编辑时，标题始终正常渲染在正文背景之上。
+
+## Why
+
+带标题装饰盒（titled ornament）的标题盒（title）与主体盒（body）是相互重叠的兄弟 box。由于布局上标题与主体重叠，标题必须在主体之后绘制，否则主体背景色会覆盖掉标题的下半部分。
+
+而基类 `box_rep::redraw` 会将包含光标的子 box（child containing the cursor）放在最后重绘，这会导致当光标处于正文或进入该结构重绘时，绘制顺序发生倒错，进而使主体背景遮挡住标题。
+
+## How
+
+1. 在 `src/Typeset/Boxes/Modifier/highlight_boxes.cpp` 中新增 `title_composite_box_rep`，继承自 `concrete_composite_box_rep`。
+2. 重写其 `redraw` 方法，忽略传入的光标路径 `p`，转调 `box_rep::redraw (ren, path (), l)`，从而固定子 box 的绘制顺序，使标题盒始终在主体盒之后绘制，避免因光标位置改变绘制层级。
+3. 将 `title_box` 中的返回值由普通 `composite_box` 替换为 `tm_new<title_composite_box_rep> (ip, bs, x, y)`。
+
+## 涉及文件
+
+- `src/Typeset/Boxes/Modifier/highlight_boxes.cpp`
+- `devel/1276.md`

--- a/src/Typeset/Boxes/Modifier/highlight_boxes.cpp
+++ b/src/Typeset/Boxes/Modifier/highlight_boxes.cpp
@@ -416,6 +416,21 @@ highlight_box_rep::display_rounded (renderer& ren, int style) {
  * Putting titles by superposing several highlight boxes
  ******************************************************************************/
 
+// The title and the body of a titled ornament are sibling boxes which
+// overlap.  The title must always be painted last, otherwise the body
+// background covers the lower half of the title.  box_rep::redraw however
+// paints the child containing the cursor last, so that editing the title
+// would hide it behind the body.
+struct title_composite_box_rep : public concrete_composite_box_rep {
+  title_composite_box_rep (path ip2, array<box> bs2, array<SI> x2, array<SI> y2)
+      : concrete_composite_box_rep (ip2, bs2, x2, y2, false) {}
+  operator tree () { return tree (TUPLE, "title", (tree) bs[0]); }
+  void redraw (renderer ren, path p, rectangles& l) {
+    (void) p;
+    box_rep::redraw (ren, path (), l);
+  }
+};
+
 box
 title_box (path ip, box b, box xb, ornament_parameters ps) {
   string tst      = ps->tst->label;
@@ -448,9 +463,7 @@ title_box (path ip, box b, box xb, ornament_parameters ps) {
   bs << bb << tit;
   x << 0 << tx;
   y << 0 << ty;
-  return composite_box (ip, bs, x, y, false);
-  // FIXME: we should force redrawing the title box,
-  // whenever redrawing the body box.
+  return tm_new<title_composite_box_rep> (ip, bs, x, y);
 }
 
 /******************************************************************************

--- a/tests/Plugins/Qt/qml_load_test.cpp
+++ b/tests/Plugins/Qt/qml_load_test.cpp
@@ -591,29 +591,36 @@ void
 TestQmlLoad::test_version_dialog_focuses_on_open () {
   // 0927：必须经真实 run_qml_dialog + exec() 路径验证。弹窗显示后检查 QML
   // 场景焦点并发 ESC，确认正常 QML 取消链路生效。
-  bool sawDialog = false;
-  bool hadFocus  = false;
-  bool sentEscape= false;
-  QTimer::singleShot (200, [&] () {
+  // CI（offscreen、高负载）下焦点事件可能晚到，固定时刻检查一次会误报，
+  // 故轮询等待焦点到达后再发 ESC。
+  bool   sawDialog = false;
+  bool   hadFocus  = false;
+  bool   sentEscape= false;
+  QTimer focusPoll;
+  focusPoll.setInterval (50);
+  QObject::connect (&focusPoll, &QTimer::timeout, [&] () {
     for (QWidget* topLevel : QApplication::topLevelWidgets ())
       if (topLevel->objectName () == "QTMQmlDialog") {
         sawDialog       = true;
         QQuickWidget* qw= topLevel->findChild<QQuickWidget*> ();
-        hadFocus        = qw && qw->rootObject ()->hasActiveFocus ();
-        if (qw) {
+        if (qw && qw->rootObject () && qw->rootObject ()->hasActiveFocus ()) {
+          hadFocus= true;
           QTest::keyClick (qw, Qt::Key_Escape);
           sentEscape= true;
+          focusPoll.stop ();
         }
         return;
       }
   });
-  // 运行时加载失败等异常不能让测试遗留一个阻塞模态窗口。
-  QTimer::singleShot (2000, [] () {
+  // 运行时加载失败或焦点始终未到达，都不能让测试遗留一个阻塞模态窗口。
+  QTimer::singleShot (8000, [] () {
     for (QWidget* topLevel : QApplication::topLevelWidgets ())
       if (topLevel->objectName () == "QTMQmlDialog")
         static_cast<QDialog*> (topLevel)->reject ();
   });
+  focusPoll.start ();
   QVERIFY (!cpp_version_dialog ("Version", "Version information"));
+  focusPoll.stop ();
   QVERIFY (sawDialog);
   QVERIFY (hadFocus);
   QVERIFY (sentEscape);


### PR DESCRIPTION
# [1276] 修复光标移入定理类环境导致标题被正文背景遮挡

## 如何测试

在首页找到 ElegantBook 模板，进入 1.4.2 的定理类环境，然后把光标移入 定义1.1 这个结构里面，可以看到渲染是正常的。

## What

在 ElegantBook 等带有标题装饰盒（titled ornament）的定理类环境中，光标移入「定义 1.1」等结构内时，标题文字可能被正文背景遮挡或渲染异常。期望：光标移入或在结构内编辑时，标题始终正常渲染在正文背景之上。

## Why

带标题装饰盒（titled ornament）的标题盒（title）与主体盒（body）是相互重叠的兄弟 box。由于布局上标题与主体重叠，标题必须在主体之后绘制，否则主体背景色会覆盖掉标题的下半部分。

而基类 `box_rep::redraw` 会将包含光标的子 box（child containing the cursor）放在最后重绘，这会导致当光标处于正文或进入该结构重绘时，绘制顺序发生倒错，进而使主体背景遮挡住标题。

## How

1. 在 `src/Typeset/Boxes/Modifier/highlight_boxes.cpp` 中新增 `title_composite_box_rep`，继承自 `concrete_composite_box_rep`。
2. 重写其 `redraw` 方法，忽略传入的光标路径 `p`，转调 `box_rep::redraw (ren, path (), l)`，从而固定子 box 的绘制顺序，使标题盒始终在主体盒之后绘制，避免因光标位置改变绘制层级。
3. 将 `title_box` 中的返回值由普通 `composite_box` 替换为 `tm_new<title_composite_box_rep> (ip, bs, x, y)`。

## 涉及文件

- `src/Typeset/Boxes/Modifier/highlight_boxes.cpp`
- `devel/1276.md`