### PR TITLE
[0956] 按模型能力显隐深度思考/联网搜索按钮 + 切换受限模型重置开关

### DIFF
--- a/devel/0956.md
+++ b/devel/0956.md
@@ -1,0 +1,80 @@
+# 0956 allow_thinking / allow_search 按钮显隐联动
+
+## What
+
+1. 新增 `ChatController::applyModelCapabilities (sessionId)`：按当前会话
+   模型在清单中的 `allowThinking` / `allowSearch` 控制面板上深度思考、
+   联网搜索按钮的显隐——模型不允许的能力对应按钮隐藏。
+2. `onModelSelected` 补充开关重置：切换到不允许某能力的模型时，若对应
+   开关为开，则重置为关（会话状态 `setThinking/setSearch(false)` +
+   按钮取消勾选），随后统一 `updateManifest` 落盘，避免"隐藏的开"
+   泄漏到下一轮请求。
+3. 面板创建路径接入显隐刷新：`getOrCreatePanel` 恢复勾选态之后、
+   `ensureNewConversation` 新建会话路径末尾（该路径不经
+   `getOrCreatePanel`，默认模型本身可能不允许某能力）。
+
+## Why
+
+- 产品约定：模型不允许设置的功能，对应按钮需要隐藏。M3 已落地
+  `ChatModelInfo{allowThinking, allowSearch}` 与 `ChatModelStore`，
+  数据源就绪，本任务让机制真实生效（内置清单 deepseek 两条目
+  `allow_search: false`，切过去即隐藏联网搜索按钮——预期产品行为）。
+- 仅隐藏不够：若切换前开关为开，隐藏后的会话状态仍是开，会随
+  `chat-tab-send` 发出与模型能力不符的请求参数；故切换时必须同步
+  重置并落 manifest。
+- 模型允许时用户开关状态不被触碰（重置只在"切到不允许该能力的
+  模型"时发生）。
+
+## How
+
+1. **`qt_chat_controller.hpp`**
+   - 私有区新增 `applyModelCapabilities (sessionId)` 声明（Doxygen 注明
+     key 兜底语义：模型不在清单内时 `find` 以 key 兜底构造 Info，
+     allow 标志缺省 true，按钮保持可见）。
+   - 更新 `onModelSelected` 的过时注释（原"不触碰 thinking/search"
+     已不成立）。
+2. **`qt_chat_controller.cpp`**
+   - `applyModelCapabilities`：`getSession` 判空 → `find (s->model)`
+     → `panel` 判空 → `thinkingButton()/searchButton()` 判空后
+     `setVisible (info.allow*)`。逐级判空，任一缺失即忽略。
+   - `onModelSelected`：`setModel` 之后、`updateManifest` 之前执行
+     开关重置（`!info.allowThinking && s->thinking` 时
+     `setThinking(false)` + `setChecked(false)`，search 同理；
+     `setChecked` 经既有 toggled 信号链触发 `onThinkingToggled` 等，
+     manifest 最终以末尾统一一次 `updateManifest` 为准）；末尾调用
+     `applyModelCapabilities`。
+   - `getOrCreatePanel`：恢复推理/搜索勾选态代码块之后调用
+     `applyModelCapabilities`——覆盖面板延迟创建、会话恢复激活
+     （`activateSession` → `getOrCreatePanel`）等路径。
+   - `ensureNewConversation` 新建会话路径：`updateModelButtonDisplay`
+     之后补一次 `applyModelCapabilities`。
+3. **布局**：按钮隐藏后 stretch 自然吸收空间，M2 按钮顺序不动，
+   本任务未改 `qt_chat_tab_widget.*`。隐藏思考按钮时行首残留
+   `kSidebarSpacing`(8px) 固定间距，待 GUI 手工验证确认是否需要
+   View 侧微调。
+
+不新增/不改变任何 C++→Scheme 调用；不改 `qt_chat_model.*`、
+`qt_chat_session.*`、发送路径与清单 JSON。
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_chat_controller.hpp`：`applyModelCapabilities`
+  声明；`onModelSelected` 注释更新
+- `src/Plugins/Qt/qt_chat_controller.cpp`：新方法实现；`onModelSelected`
+  开关重置；`getOrCreatePanel`、`ensureNewConversation` 接入调用
+- `devel/0956.md`（新增）
+
+## 测试
+
+- `xmake b stem` 编译通过；`xmake r qt_chat_model_test`（未改动，
+  作回归，19 passed / 0 failed）。
+- GUI 验证（用户手工，两方向，**已通过**，2026-09-07）：
+  1. 内置清单：切到 deepseek-v4-pro → 联网搜索按钮隐藏；切换前
+     search 为开时自动关闭且 manifest 中 `search: "disabled"`；切回
+     kimi 按钮恢复可见、kimi 开关状态不受污染。
+  2. 在 `$TEXMACS_HOME_PATH/plugins/llm/data/liii_llm_menu.json` 放
+     `allow_thinking: false` 调试条目 → 深度思考按钮隐藏；切换前
+     thinking 为开时自动关闭且 manifest 中 `thinking: "disabled"`；
+     切回后恢复。
+  3. chat 标签页与 dock 侧边栏两入口下隐藏/显示无布局错位
+     （8px 残留间距未构成可见错位，View 侧无需微调）。

--- a/src/Plugins/Qt/qt_chat_controller.cpp
+++ b/src/Plugins/Qt/qt_chat_controller.cpp
@@ -279,8 +279,28 @@ void
 ChatController::onModelSelected (const string& sessionId, const string& key) {
   if (!modelStore_.contains (key)) return;
   sessionManager_.setModel (sessionId, key);
-  updateManifest (sessionId); // 仅元数据变更，不导出 buffer
+
+  // 切到不允许某能力的模型时重置对应开关为关：隐藏的开会泄漏到下一轮请求
+  ChatSession* s= sessionManager_.getSession (sessionId);
+  if (s) {
+    ChatModelInfo          info= modelStore_.find (key);
+    ChatConversationPanel* panel=
+        static_cast<ChatConversationPanel*> (s->panel);
+    if (!info.allowThinking && s->thinking) {
+      sessionManager_.setThinking (sessionId, false);
+      if (panel && panel->thinkingButton ())
+        panel->thinkingButton ()->setChecked (false);
+    }
+    if (!info.allowSearch && s->search) {
+      sessionManager_.setSearch (sessionId, false);
+      if (panel && panel->searchButton ())
+        panel->searchButton ()->setChecked (false);
+    }
+  }
+
+  updateManifest (sessionId); // 仅元数据变更，不导出 buffer（含重置后的开关）
   updateModelButtonDisplay (sessionId);
+  applyModelCapabilities (sessionId);
 }
 
 void
@@ -530,6 +550,18 @@ ChatController::updateModelButtonDisplay (const string& sessionId,
       info.name, info.icon, menuOpen);
 }
 
+void
+ChatController::applyModelCapabilities (const string& sessionId) {
+  ChatSession* s= sessionManager_.getSession (sessionId);
+  if (!s || !s->panel) return;
+  ChatModelInfo info= modelStore_.find (s->model); // find 自带 key 兜底
+  ChatConversationPanel* panel= static_cast<ChatConversationPanel*> (s->panel);
+  if (panel->thinkingButton ())
+    panel->thinkingButton ()->setVisible (info.allowThinking);
+  if (panel->searchButton ())
+    panel->searchButton ()->setVisible (info.allowSearch);
+}
+
 /**
  * @brief 按需加载会话的消息内容到面板。
  *
@@ -686,6 +718,8 @@ ChatController::ensureNewConversation () {
   view_->sidebar ()->setActiveItem ("");
 
   updateModelButtonDisplay (sid);
+  // 此路径不经 getOrCreatePanel，默认模型可能不允许某能力，需单独应用
+  applyModelCapabilities (sid);
 }
 
 /**
@@ -724,6 +758,9 @@ ChatController::getOrCreatePanel (const string& sessionId) {
   if (panel->searchButton () && s->search) {
     panel->searchButton ()->setChecked (true);
   }
+
+  // 恢复的会话模型可能不允许推理/搜索，按能力隐藏对应按钮
+  applyModelCapabilities (sessionId);
 
   return panel;
 }

--- a/src/Plugins/Qt/qt_chat_controller.hpp
+++ b/src/Plugins/Qt/qt_chat_controller.hpp
@@ -135,8 +135,9 @@ public:
   /**
    * @brief 模型菜单项被选择时触发。
    *
-   * key 不在清单内忽略；写回 ChatSession.model 并落 manifest，
-   * 不触碰 thinking/search。
+   * key 不在清单内忽略；写回 ChatSession.model 并落 manifest。
+   * 切换到不允许推理/搜索的模型时，对应开关重置为关（会话状态 +
+   * manifest + 按钮取消勾选），避免隐藏的开泄漏到下一轮请求。
    * @param sessionId 目标会话 ID
    * @param key       模型 key（清单条目的 model 字段）
    */
@@ -255,6 +256,16 @@ private:
    * @param menuOpen  模型菜单是否打开（箭头朝上/下）
    */
   void updateModelButtonDisplay (const string& sessionId, bool menuOpen= false);
+
+  /**
+   * @brief 按当前会话模型的能力（allowThinking/allowSearch）刷新深度
+   * 思考、联网搜索按钮的显隐。
+   *
+   * 模型不允许的能力对应按钮隐藏；模型不在清单内时按 find 的 key 兜底
+   * （允许全部，按钮保持可见）。面板未创建时忽略。
+   * @param sessionId 目标会话 ID
+   */
+  void applyModelCapabilities (const string& sessionId);
 
   friend void qt_chat_tab_set_state (string sessionId, string stateStr);
   friend void qt_chat_tab_restore_session (string sessionId, string title,


### PR DESCRIPTION
## 任务

[0956]（PR-M4）allow_thinking / allow_search 按钮显隐联动：模型不允许的功能，对应按钮隐藏；切到受限模型时对应开关自动重置为关并落盘，避免「隐藏的开」泄漏到下一轮请求。

前置：[0955]/#4511（`ChatModelStore`、模型菜单、`onModelSelected`）已合入，本任务让能力数据真实生效。

## 实现要点

1. 新增 `ChatController::applyModelCapabilities (sessionId)`：按 `ChatModelStore::find (s->model)` 的 `allowThinking` / `allowSearch` 控制 `thinkingButton()` / `searchButton()` 的 `setVisible`；session / panel / button 逐级判空；模型不在清单内时按 `find` 的 key 兜底（允许全部，按钮保持可见）。
2. `onModelSelected`：`setModel` 之后，对模型不允许且当前为开的能力执行 `setThinking / setSearch (false)` + 按钮取消勾选，随后统一一次 `updateManifest` 落盘；末尾调用 `applyModelCapabilities`。模型允许时用户开关状态不被触碰（重置只在切到受限模型时发生）。
3. 调用点：`getOrCreatePanel` 恢复勾选态代码块之后（覆盖面板延迟创建与会话恢复激活路径）；`ensureNewConversation` 新建会话路径末尾（该路径不经 `getOrCreatePanel`，默认模型本身可能受限）。

产品语义：kimi 全允许；内置清单 deepseek 两条目 `allow_search: false`，切过去联网搜索按钮隐藏——预期产品行为。

## 涉及文件

- `src/Plugins/Qt/qt_chat_controller.hpp` / `.cpp`
- `devel/0956.md`（新增）

## 验证

- `xmake build --yes stem` ✅
- `xmake r qt_chat_model_test` ✅ 19 passed / 0 failed（回归，未改动该文件）
- `gf fmt --changed-since=main` ✅ 无无关改动
- 人工 GUI 验证（2026-09-07，用户手工执行，已通过）：
  1. 内置清单：切到 deepseek-v4-pro → 联网搜索按钮隐藏；切换前 search 为开时自动关闭且 manifest 中 `search: "disabled"`；切回 kimi 按钮恢复可见、kimi 开关状态不受污染
  2. 在 `$TEXMACS_HOME_PATH/plugins/llm/data/liii_llm_menu.json` 放 `allow_thinking: false` 调试条目 → 深度思考按钮隐藏；切换前 thinking 为开时自动关闭且 manifest 中 `thinking: "disabled"`；切回后恢复
  3. chat 标签页与 dock 侧边栏两入口下隐藏/显示无布局错位

## 说明

- 未新增/未修改任何 C++→Scheme 调用；未改 `qt_chat_model.*` Store 接口与清单解析规则、`qt_chat_session.*` 既有方法签名、发送路径（`onSendRequested` / `chat-tab-send`）与清单 JSON。
- 隐藏深度思考按钮时行首残留 8px 固定间距（`addSpacing` 项不随按钮隐藏消失），人工验证确认不构成可见错位，未动 View 侧布局与 M2 按钮顺序。
