### PR TITLE
[1277] 修复 moganstem -h 帮助信息被写入日志文件

### DIFF
--- a/devel/1277.md
+++ b/devel/1277.md
@@ -1,0 +1,52 @@
+# [1277] moganstem -h 无法正确展示帮助信息
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2 任务相关的代码文件
+- src/Mogan/Research/research.cpp
+- src/System/Boot/init_texmacs.cpp
+
+## 3 如何测试
+
+### 3.1 端到端测试（手动）
+
+```bash
+xmake b stem
+TEXMACS_PATH=$(pwd)/TeXmacs ./build/linux/x86_64/release/moganstem -h
+```
+
+帮助信息应直接打印到终端并退出，而不是写入日志文件。
+
+同类选项一并验证：
+
+```bash
+TEXMACS_PATH=$(pwd)/TeXmacs ./build/linux/x86_64/release/moganstem -v   # 版本信息到终端
+TEXMACS_PATH=$(pwd)/TeXmacs ./build/linux/x86_64/release/moganstem -p   # TeXmacs 路径到终端
+TEXMACS_PATH=$(pwd)/TeXmacs ./build/linux/x86_64/release/moganstem -headless -q   # 普通启动仍写日志文件
+```
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+xmake b stem
+```
+
+## 5 What
+
+修复 `moganstem -h`（以及 `-v`/`-p`/`-bp`）输出被重定向进日志文件、终端看不到帮助信息的问题。
+
+## 6 Why
+
+`immediate_options` 默认把 `cout`/`cerr` 重定向到
+`$TEXMACS_HOME_PATH/system/<时间戳>.log`，只有 `-d` 会关闭。而 `-h`（帮助）、
+`-v`（版本）、`-p`/`-bp`（路径）这些打印到 `cout` 后立即退出的终端查询选项，
+其输出全部被吞进日志文件，用户在终端看不到任何内容。
+
+## 7 How
+
+在 `immediate_options`（research.cpp）的参数预扫描中，把 `-h`/`-help`、
+`-v`/`-version`、`-p`/`-path`、`-bp`/`-binpath` 与 `-d` 一样处理：
+置 `enale_logging= false`，跳过重定向，输出留在终端。普通启动的日志
+行为不变。

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -141,6 +141,12 @@ immediate_options (int argc, char** argv) {
     else if ((s == "-d") || (s == "-debug")) {
       enale_logging= false;
     }
+    // -h/-v/-p/-bp 打印到 cout 后立即退出，输出需留在终端
+    else if ((s == "-h") || (s == "-help") || (s == "-v") ||
+             (s == "-version") || (s == "-p") || (s == "-path") ||
+             (s == "-bp") || (s == "-binpath")) {
+      enale_logging= false;
+    }
   }
 
   url u= url_system (string ("$TEXMACS_HOME_PATH/system/") *


### PR DESCRIPTION
## 问题

`moganstem -h` 无法在终端展示帮助信息——输出被重定向进了 `$TEXMACS_HOME_PATH/system/<时间戳>.log`。

## 原因

`main()` 启动时 `immediate_options()`（`src/Mogan/Research/research.cpp`）默认把 `cout`/`cerr` 重定向到日志文件，只有 `-d` 会关闭。而 `-h`（帮助）、`-v`（版本）、`-p`/`-bp`（路径）这些打印到 `cout` 后立即退出的终端查询选项，输出全被吞进日志文件。

## 修复

在 `immediate_options` 的参数预扫描中，把 `-h`/`-help`、`-v`/`-version`、`-p`/`-path`、`-bp`/`-binpath` 与 `-d` 同等处理：置 `enale_logging = false`，输出留在终端。普通启动的日志重定向行为不变。

## 测试

- `moganstem -h`：帮助信息完整打印到终端，exit 0
- `moganstem -v`：版本信息到终端；`-p`：TeXmacs 路径到终端
- `moganstem -headless -q`：普通启动仍写日志文件，行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)