### PR TITLE
[1280] gf stem 构建子命令与共享编译缓存

### DIFF
--- a/devel/1280.md
+++ b/devel/1280.md
@@ -1,0 +1,109 @@
+# [1280] gf stem 构建子命令与共享编译缓存
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1278.md](1278.md) - gf fmt 提交前检查的使用示例
+- 参考实现（本仓库外）：`~/git/liii/tools/stem/liii/stem.scm` 与 `~/git/liii/gfproject.json`
+
+## 2 任务相关的代码文件
+- gfproject.json
+- tools/stem/mogan/stem.scm
+- xmake/targets/stem.lua（`target("stem")`，仅作参考，本任务未改动）
+- xmake/options.lua（`is_community` 选项定义，仅作参考，本任务未改动）
+
+## 3 如何测试
+
+### 3.1 端到端测试（手动）
+
+```bash
+cd ~/git/mogan3
+gf stem --help     # 输出用法，exit 0
+gf stem --bogus    # Error: unknown stem command: --bogus，exit 1
+gf stem --build    # 清理构建产物后 xmake config + xmake build stem
+gf stem --run      # xmake run stem
+```
+
+`--build` 会真实清理 `.xmake`、`build` 与 `3rdparty/<sub>/{.xmake,build}`
+并触发全量重建，耗时较长。config 命令应为：
+
+```
+xmake config -vD --yes --is_community=n --ccache=y --ccachedir=~/.xmake/.build_cache
+```
+
+### 3.2 验证共享缓存
+
+首次 `gf stem --build` 后查看缓存对象数：
+
+```bash
+find ~/.xmake/.build_cache -type f | wc -l
+```
+
+再次 `gf stem --build`（全清理后重建）应大量命中缓存，编译阶段耗时明显缩短；
+在 `~/git/mogan`、`~/git/mogan2` 交替执行同样命中（缓存键与 checkout 绝对路径无关）。
+
+### 3.3 验证 CI 与普通构建不受影响
+
+- `git diff xmake.lua` 为空：共享缓存与商业版开关只由 `gf stem --build`
+  在 config 时传参，不写入仓库配置；
+- CI 工作流的 `xmake config ... --policies=build.ccache` 保持原样，
+  其 `actions/cache` 持久化的仍是 `tmp/build/.build_cache`。
+
+### 3.4 沙箱测试（不触发真实构建）
+
+用桩 `xmake` 验证命令拼装与清理范围：临时目录内放置 `gfproject.json` 与
+`tools/stem/` 副本，伪造 `.xmake`、`build`、`3rdparty/s7/.xmake` 等目录，
+把一个回显参数的 `xmake` 桩脚本放到 `PATH` 最前，执行 `gf stem --build`，
+确认每条 `Cleaning <路径>` 先于删除打印、无产物目录（如 `3rdparty/doctest`）
+不被误删、config/build 命令按序执行且参数完整。
+
+## 4 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+gf fmt --changed-since=main
+gf stem --build
+```
+
+## 5 What
+
+1. 在 `gfproject.json` 注册 `stem` 工具（organization `mogan`，module `stem`），
+   gf 据此从 `tools/stem/mogan/` 加载 `(mogan stem)` 库；
+2. 新增 `tools/stem/mogan/stem.scm`，提供 `gf stem --build`、`gf stem --run`、
+   `gf stem --help`；
+3. `--build` 流程：打印 `WORK_SPACE` → 逐条打印 `Cleaning <路径>` 后用 `trash`
+   清理 `.xmake`、`build`、`3rdparty/.xmake`、`3rdparty/build` 及
+   `3rdparty/<sub>/{.xmake,build}` → `xmake config -vD --yes --is_community=n
+   --ccache=y --ccachedir=~/.xmake/.build_cache` → `xmake build stem`；
+4. 编译缓存位于用户级 `~/.xmake/.build_cache`，mogan / mogan2 / mogan3
+   三个 checkout 共享同一份。
+
+## 6 Why
+
+- 三个姊妹仓库交替开发，且习惯频繁删除 `.xmake` 和 `build`；xmake 默认把
+  编译缓存放在项目内 `build/.build_cache`，删目录即丢缓存，每次全量重编。
+- xmake 的 `--ccache` 实为其内置缓存（并不调用系统 ccache 二进制），
+  支持 `--ccachedir` 指定公共目录；实测缓存键为「编译器 + 编译标志（忽略
+  `-D`）+ 预处理产物内容哈希」，与 checkout 绝对路径无关，跨目录可命中。
+- 共享配置不能写进 `xmake.lua`：CI 工作流已显式 `--policies=build.ccache`
+  并用 `actions/cache` 持久化 `tmp/build/.build_cache`，改动仓库配置会影响
+  CI 的缓存路径与行为；普通 `xmake` 构建也应保持默认。因此配置只由
+  `gf stem --build` 这一构建入口每次显式传入，删 `.xmake` 也不会丢。
+- 商业版开关：仓库默认 `is_community = true`（社区版，见 `xmake/stem.lua`），
+  本机日常构建需要商业版（Liii STEM），故 config 追加 `--is_community=n`。
+
+## 7 How
+
+- 工具解析约定参考 liii 仓库：`gfproject.json` 的 `tools` 声明
+  organization + module，gf 从 `tools/<module>/<organization>/` 加载
+  `(organization module)` 库并调用其 `main`；`--help` / 未知子命令 /
+  非零退出码行为与 liii 一致。
+- 关键操作执行前打印：删除前打印 `Cleaning <路径>`，外部命令执行前打印
+  `$ <命令>`；删除统一走 `trash`（可从回收站找回），`trash` 未安装时
+  明确报错退出，不做静默兜底。
+- 曾评估 `build.ccache.global_storage` 策略（缓存同样落在
+  `~/.xmake/.build_cache`），并在临时工程验证可行，但它必须在
+  `xmake.lua` 中 `set_policy` 才能持久生效，且会连带影响 CI，故弃用，
+  改为 `gf stem --build` 传参方案。
+- 已知取舍：内置缓存无 LRU 淘汰，`~/.xmake/.build_cache` 需要偶尔手动
+  清理；缓存键忽略 `-D` 宏定义（xmake#2425），与共享目录无关。

--- a/gfproject.json
+++ b/gfproject.json
@@ -1,3 +1,12 @@
 {
-  "tools": {}
+  "tools": {
+    "stem": {
+      "organization": "mogan",
+      "module": "stem",
+      "description": {
+        "en_US": "Clean and build STEM in this repository via xmake",
+        "zh_CN": "清理构建缓存后在本仓库内自动执行 xmake config 和 xmake build"
+      }
+    }
+  }
 }

--- a/tools/stem/mogan/stem.scm
+++ b/tools/stem/mogan/stem.scm
@@ -1,15 +1,17 @@
 (define-library (mogan stem)
   (import (liii os)
-          (liii path)
-          (liii subprocess)
-          (scheme base)
-          (scheme process-context)
-          (scheme write))
+    (liii path)
+    (liii subprocess)
+    (scheme base)
+    (scheme process-context)
+    (scheme write)
+  ) ;import
   (export main)
   (begin
     (define (display-line text)
       (display text)
-      (newline))
+      (newline)
+    ) ;define
 
     (define (display-help)
       (display-line "Usage:")
@@ -17,104 +19,137 @@
       (display-line "  gf stem --run")
       (newline)
       (display-line "Commands:")
-      (display-line "  --build  Clean .xmake and build dirs, then xmake config + xmake build stem")
+      (display-line "  --build  Clean .xmake and build dirs, then xmake config + xmake build stem"
+      ) ;display-line
       (display-line "           (compile cache shared at ~/.xmake/.build_cache)")
       (display-line "  --run    Run the built stem binary (xmake run stem)")
       (newline)
       (display-line "Directories cleaned by --build:")
       (display-line "  .xmake, build, 3rdparty/.xmake, 3rdparty/build,")
-      (display-line "  3rdparty/<sub>/.xmake, 3rdparty/<sub>/build"))
+      (display-line "  3rdparty/<sub>/.xmake, 3rdparty/<sub>/build")
+    ) ;define
 
     (define (fail message)
       (display-line (string-append "Error: " message))
-      1)
+      1
+    ) ;define
 
     (define (die message)
       (display-line (string-append "Error: " message))
-      (exit 1))
+      (exit 1)
+    ) ;define
 
     (define (ok)
-      0)
+      0
+    ) ;define
 
     (define (root . parts)
-      (apply path-join (cons (getcwd) parts)))
+      (apply path-join (cons (getcwd) parts))
+    ) ;define
 
     (define (exec command . opts)
       (display-line (string-append "$ " command))
       (let ((status (apply run command opts)))
-        (if (= status 0)
-          status
-          (die (string-append "command failed: " command)))))
+        (if (= status 0) status (die (string-append "command failed: " command)))
+      ) ;let
+    ) ;define
 
     (define (trash-dir rel)
       (when (path-dir? (root rel))
         (display-line (string-append "Cleaning " rel))
         (let ((status (run (string-append "trash " rel))))
           (unless (= status 0)
-            (die (string-append "command failed: trash " rel))))))
+            (die (string-append "command failed: trash " rel))
+          ) ;unless
+        ) ;let
+      ) ;when
+    ) ;define
 
     (define (clean-artifacts)
       (for-each trash-dir '(".xmake" "build" "3rdparty/.xmake" "3rdparty/build"))
       (when (path-dir? (root "3rdparty"))
-        (vector-for-each
-          (lambda (entry)
-            (when (path-dir? (root "3rdparty" entry))
-              (trash-dir (string-append "3rdparty/" entry "/.xmake"))
-              (trash-dir (string-append "3rdparty/" entry "/build"))))
-          (path-list (root "3rdparty")))))
+        (vector-for-each (lambda (entry)
+                           (when (path-dir? (root "3rdparty" entry))
+                             (trash-dir (string-append "3rdparty/" entry "/.xmake"))
+                             (trash-dir (string-append "3rdparty/" entry "/build"))
+                           ) ;when
+                         ) ;lambda
+          (path-list (root "3rdparty"))
+        ) ;vector-for-each
+      ) ;when
+    ) ;define
 
     (define (trash-available?)
       (let-values (((out err code)
-                    (run-values "trash --version"
-                      :stdout 'discard
-                      :stderr 'discard)))
-        (= code 0)))
+                    (run-values "trash --version" :stdout 'discard :stderr 'discard)
+                   ) ;
+                  ) ;
+        (= code 0)
+      ) ;let-values
+    ) ;define
 
     (define (require-trash)
       (if (trash-available?)
         #t
-        (die "trash command not found; please install trash (e.g. 'trash-cli' on Linux, 'brew install trash' on macOS)")))
+        (die "trash command not found; please install trash (e.g. 'trash-cli' on Linux, 'brew install trash' on macOS)"
+        ) ;die
+      ) ;if
+    ) ;define
 
     (define (shared-cache-dir)
       (let ((home (or (getenv "HOME") (getenv "USERPROFILE"))))
         (if home
           (string-append home "/.xmake/.build_cache")
-          (die "cannot determine the home directory (tried HOME and USERPROFILE)"))))
+          (die "cannot determine the home directory (tried HOME and USERPROFILE)")
+        ) ;if
+      ) ;let
+    ) ;define
 
     (define (build-stem)
       (require-trash)
       (display-line (string-append "WORK_SPACE: " (getcwd)))
       (clean-artifacts)
       (exec (string-append "xmake config -vD --yes --is_community=n"
-              " --ccache=y --ccachedir=" (shared-cache-dir)))
+              " --ccache=y --ccachedir="
+              (shared-cache-dir)
+            ) ;string-append
+      ) ;exec
       (exec "xmake build stem")
-      (ok))
+      (ok)
+    ) ;define
 
     (define (run-stem)
       (exec "xmake run stem")
-      (ok))
+      (ok)
+    ) ;define
 
     (define (parse-args)
       (let ((argv (command-line)))
-        (if (and (pair? argv) (pair? (cdr argv)))
-          (cddr argv)
-          '())))
+        (if (and (pair? argv) (pair? (cdr argv))) (cddr argv) '())
+      ) ;let
+    ) ;define
 
     (define (main)
       (let ((args (parse-args)))
-        (cond ((or (null? args)
-                   (member "-h" args)
-                   (member "--help" args))
+        (cond ((or (null? args) (member "-h" args) (member "--help" args))
                (display-help)
-               (ok))
+               (ok)
+              ) ;
               ((string=? (car args) "--build")
                (if (null? (cdr args))
                  (build-stem)
-                 (fail "--build does not accept extra arguments")))
+                 (fail "--build does not accept extra arguments")
+               ) ;if
+              ) ;
               ((string=? (car args) "--run")
                (if (null? (cdr args))
                  (run-stem)
-                 (fail "--run does not accept extra arguments")))
-              (else
-               (fail (string-append "unknown stem command: " (car args)))))))
-  ))
+                 (fail "--run does not accept extra arguments")
+               ) ;if
+              ) ;
+              (else (fail (string-append "unknown stem command: " (car args))))
+        ) ;cond
+      ) ;let
+    ) ;define
+  ) ;begin
+) ;define-library

--- a/tools/stem/mogan/stem.scm
+++ b/tools/stem/mogan/stem.scm
@@ -1,0 +1,120 @@
+(define-library (mogan stem)
+  (import (liii os)
+          (liii path)
+          (liii subprocess)
+          (scheme base)
+          (scheme process-context)
+          (scheme write))
+  (export main)
+  (begin
+    (define (display-line text)
+      (display text)
+      (newline))
+
+    (define (display-help)
+      (display-line "Usage:")
+      (display-line "  gf stem --build")
+      (display-line "  gf stem --run")
+      (newline)
+      (display-line "Commands:")
+      (display-line "  --build  Clean .xmake and build dirs, then xmake config + xmake build stem")
+      (display-line "           (compile cache shared at ~/.xmake/.build_cache)")
+      (display-line "  --run    Run the built stem binary (xmake run stem)")
+      (newline)
+      (display-line "Directories cleaned by --build:")
+      (display-line "  .xmake, build, 3rdparty/.xmake, 3rdparty/build,")
+      (display-line "  3rdparty/<sub>/.xmake, 3rdparty/<sub>/build"))
+
+    (define (fail message)
+      (display-line (string-append "Error: " message))
+      1)
+
+    (define (die message)
+      (display-line (string-append "Error: " message))
+      (exit 1))
+
+    (define (ok)
+      0)
+
+    (define (root . parts)
+      (apply path-join (cons (getcwd) parts)))
+
+    (define (exec command . opts)
+      (display-line (string-append "$ " command))
+      (let ((status (apply run command opts)))
+        (if (= status 0)
+          status
+          (die (string-append "command failed: " command)))))
+
+    (define (trash-dir rel)
+      (when (path-dir? (root rel))
+        (display-line (string-append "Cleaning " rel))
+        (let ((status (run (string-append "trash " rel))))
+          (unless (= status 0)
+            (die (string-append "command failed: trash " rel))))))
+
+    (define (clean-artifacts)
+      (for-each trash-dir '(".xmake" "build" "3rdparty/.xmake" "3rdparty/build"))
+      (when (path-dir? (root "3rdparty"))
+        (vector-for-each
+          (lambda (entry)
+            (when (path-dir? (root "3rdparty" entry))
+              (trash-dir (string-append "3rdparty/" entry "/.xmake"))
+              (trash-dir (string-append "3rdparty/" entry "/build"))))
+          (path-list (root "3rdparty")))))
+
+    (define (trash-available?)
+      (let-values (((out err code)
+                    (run-values "trash --version"
+                      :stdout 'discard
+                      :stderr 'discard)))
+        (= code 0)))
+
+    (define (require-trash)
+      (if (trash-available?)
+        #t
+        (die "trash command not found; please install trash (e.g. 'trash-cli' on Linux, 'brew install trash' on macOS)")))
+
+    (define (shared-cache-dir)
+      (let ((home (or (getenv "HOME") (getenv "USERPROFILE"))))
+        (if home
+          (string-append home "/.xmake/.build_cache")
+          (die "cannot determine the home directory (tried HOME and USERPROFILE)"))))
+
+    (define (build-stem)
+      (require-trash)
+      (display-line (string-append "WORK_SPACE: " (getcwd)))
+      (clean-artifacts)
+      (exec (string-append "xmake config -vD --yes --is_community=n"
+              " --ccache=y --ccachedir=" (shared-cache-dir)))
+      (exec "xmake build stem")
+      (ok))
+
+    (define (run-stem)
+      (exec "xmake run stem")
+      (ok))
+
+    (define (parse-args)
+      (let ((argv (command-line)))
+        (if (and (pair? argv) (pair? (cdr argv)))
+          (cddr argv)
+          '())))
+
+    (define (main)
+      (let ((args (parse-args)))
+        (cond ((or (null? args)
+                   (member "-h" args)
+                   (member "--help" args))
+               (display-help)
+               (ok))
+              ((string=? (car args) "--build")
+               (if (null? (cdr args))
+                 (build-stem)
+                 (fail "--build does not accept extra arguments")))
+              ((string=? (car args) "--run")
+               (if (null? (cdr args))
+                 (run-stem)
+                 (fail "--run does not accept extra arguments")))
+              (else
+               (fail (string-append "unknown stem command: " (car args)))))))
+  ))


### PR DESCRIPTION
## What
- `gfproject.json` 注册 `stem` 工具，新增 `tools/stem/mogan/stem.scm`（`(mogan stem)` 模块），提供 `gf stem --build / --run / --help`
- `gf stem --build`：逐条打印后用 trash 清理 `.xmake`、`build`、`3rdparty/<sub>/{.xmake,build}`，再执行 `xmake config -vD --yes --is_community=n --ccache=y --ccachedir=~/.xmake/.build_cache` 和 `xmake build stem`
- 新增任务文档 `devel/1280.md`

## Why
- 三个姊妹 checkout 交替开发且经常删除 `.xmake` / `build`，xmake 默认的项目内缓存（`build/.build_cache`）随之丢失；内置缓存键为「编译器 + 编译标志 + 预处理内容哈希」，与绝对路径无关，指向共享目录即可跨 checkout 命中
- 共享缓存与商业版开关只由 `gf stem --build` 传参，不进 `xmake.lua`：CI 已有 `--policies=build.ccache` + `actions/cache`（`tmp/build/.build_cache`）体系，保持零改动
- `--is_community=n`：仓库默认 `is_community = true`（社区版），本机日常构建商业版（Liii STEM）

## Test
- 沙箱（桩 xmake）验证：命令拼装完整、`Cleaning <路径>` 先于删除打印、无产物目录不被误删、退出码正确
- 真实仓库冒烟：`gf stem --help` / 未知子命令报错；`gf fix` 格式通过
- 首次真实 `gf stem --build` 后，再次执行（全清理后重建）应大量命中 `~/.xmake/.build_cache`

Closes #1280