### PR TITLE
[1281] 取消 tm-dialogue.scm 对 njson 的使用，直接改用 (liii json)

### DIFF
--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
@@ -15,7 +15,7 @@
   (:use (kernel texmacs tm-dialogue))
 ) ;texmacs-module
 
-(import (liii check))
+(import (liii check) (liii json))
 
 (check-set-mode! 'report-failed)
 
@@ -65,6 +65,274 @@
 ) ;define
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for interactive commands learned state
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-interactive-commands)
+  (forget-interactive 'test-regtest-cmd)
+  (check (learned-interactive 'test-regtest-cmd) => '())
+
+  ;; 学习第一组参数
+  (learn-interactive 'test-regtest-cmd '(("0" . "arg0") ("1" . "arg1")))
+  (check (learned-interactive 'test-regtest-cmd)
+    =>
+    '((("0" . "arg0") ("1" . "arg1")))
+  ) ;check
+
+  ;; 学习第二组参数，后学习的条目在前
+  (learn-interactive 'test-regtest-cmd '(("0" . "argA") ("1" . "argB")))
+  (check (learned-interactive 'test-regtest-cmd)
+    =>
+    '((("0" . "argA") ("1" . "argB")) (("0" . "arg0") ("1" . "arg1")))
+  ) ;check
+
+  ;; 重复学习第一组参数，应被提至头部且不重复
+  (learn-interactive 'test-regtest-cmd '(("0" . "arg0") ("1" . "arg1")))
+  (check (learned-interactive 'test-regtest-cmd)
+    =>
+    '((("0" . "arg0") ("1" . "arg1")) (("0" . "argA") ("1" . "argB")))
+  ) ;check
+
+  ;; 清除学习的参数
+  (forget-interactive 'test-regtest-cmd)
+  (check (learned-interactive 'test-regtest-cmd) => '())
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for recent-files state
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-recent-files)
+  ;; 清空最近文件
+  (forget-interactive 'recent-buffer)
+  (check (learned-interactive 'recent-buffer) => '())
+
+  ;; 增加第 1 个最近文件
+  (recent-files-learn "/tmp/test1.tm" "test1.tm")
+  (check (recent-files-get-name "/tmp/test1.tm") => "test1.tm")
+  (check (learned-interactive 'recent-buffer) => '((("0" . "/tmp/test1.tm"))))
+
+  ;; 增加第 2 个最近文件
+  (recent-files-learn "/tmp/test2.tm" "test2.tm")
+  (check (recent-files-get-name "/tmp/test2.tm") => "test2.tm")
+  (check (length (learned-interactive 'recent-buffer)) => 2)
+
+  ;; 再次 learn 第 1 个文件（更新 last_open）
+  (recent-files-learn "/tmp/test1.tm" "test1.tm")
+  ;; 最新访问的排在最前
+  (check (caar (learned-interactive 'recent-buffer)) => '("0" . "/tmp/test1.tm"))
+
+  ;; 按路径移除第 1 个文件
+  (recent-files-remove-by-path "/tmp/test1.tm")
+  (check (recent-files-get-name "/tmp/test1.tm") => #f)
+  (check (length (learned-interactive 'recent-buffer)) => 1)
+  (check (caar (learned-interactive 'recent-buffer)) => '("0" . "/tmp/test2.tm"))
+
+  ;; 移除不存在的文件应无副作用
+  (recent-files-remove-by-path "/tmp/non-existent.tm")
+  (check (length (learned-interactive 'recent-buffer)) => 1)
+
+  ;; 移除第 2 个文件
+  (recent-files-remove-by-path "/tmp/test2.tm")
+  (check (recent-files-get-name "/tmp/test2.tm") => #f)
+  (check (learned-interactive 'recent-buffer) => '())
+
+  ;; 通过 learn-interactive 'recent-buffer 间接增加
+  (learn-interactive 'recent-buffer '((0 . "/tmp/test3.tm")))
+  (check (recent-files-get-name "/tmp/test3.tm") => "test3.tm")
+  (check (learned-interactive 'recent-buffer) => '((("0" . "/tmp/test3.tm"))))
+
+  ;; 最终清空
+  (forget-interactive 'recent-buffer)
+  (check (learned-interactive 'recent-buffer) => '())
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for schema validation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-validation)
+  ;; 空状态有效性
+  (check (interactive-args-json-valid? (make-empty-state 'interactive-arg)) => #t)
+  (check (recent-files-json-valid? (make-empty-state 'recent-file)) => #t)
+
+  ;; 非法顶层结构
+  (check (interactive-args-json-valid? "not-an-object") => #f)
+  (check (interactive-args-json-valid? 123) => #f)
+  (check (recent-files-json-valid? "not-an-object") => #f)
+  (check (recent-files-json-valid? #f) => #f)
+
+  ;; interactive-args 版本号需为 >= 1 的整数
+  (check (interactive-args-json-valid? `((,"meta" (,"version" . ,0))
+                                         ("commands" ())))
+    =>
+    #f
+  ) ;check
+  (check (interactive-args-json-valid? `((,"meta" (,"version" . ,"1"))
+                                         ("commands" ())))
+    =>
+    #f
+  ) ;check
+
+  ;; interactive-args 包含合法命令条目
+  (check (interactive-args-json-valid? `((,"meta" (,"version" . ,1))
+                                         (,"commands"
+                                          (,"my-cmd"
+                                           . ,#((("key1" . "val1")
+                                                 ("key2" . "val2"))
+                                              ) ;#
+                                          )))
+         ) ;interactive-args-json-valid?
+    =>
+    #t
+  ) ;check
+
+  ;; interactive-args 命令条目不是字符串键值映射时非法
+  (check (interactive-args-json-valid? `((,"meta" (,"version" . ,1))
+                                         (,"commands"
+                                          (,"my-cmd" . ,#((("key1" . 123))))))
+         ) ;interactive-args-json-valid?
+    =>
+    #f
+  ) ;check
+
+  ;; recent-files 包含合法文件记录
+  (check (recent-files-json-valid? `((,"meta" (,"version" . ,1) (,"total" . ,1))
+                                     (,"files"
+                                      . ,#((("path" . "/tmp/doc.tm")
+                                            ("name" . "doc.tm")
+                                            ("last_open" . 1700000000)
+                                            ("open_count" . 3)
+                                            ("show" . #t))
+                                         ) ;#
+                                     ))
+         ) ;recent-files-json-valid?
+    =>
+    #t
+  ) ;check
+
+  ;; recent-files total 不能为负数
+  (check (recent-files-json-valid? `((,"meta"
+                                      (,"version" . ,1)
+                                      (,"total" . ,-1))
+                                     (,"files" . ,#()))
+         ) ;recent-files-json-valid?
+    =>
+    #f
+  ) ;check
+
+  ;; recent-files 缺少必填字段（如缺少 show 或 last_open）
+  (check (recent-files-json-valid? `((,"meta" (,"version" . ,1) (,"total" . ,1))
+                                     (,"files"
+                                      . ,#((("path" . "/tmp/doc.tm")
+                                            ("name" . "doc.tm"))
+                                         ) ;#
+                                     ))
+         ) ;recent-files-json-valid?
+    =>
+    #f
+  ) ;check
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for LRU capacity limit
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-recent-files-lru-limit)
+  (forget-interactive 'recent-buffer)
+  ;; 添加 30 个文件（超过 limit 25）
+  (let loop
+    ((i 1))
+    (when (<= i 30)
+      (let ((p (string-append "/tmp/doc_" (number->string i) ".tm"))
+            (n (string-append "doc_" (number->string i) ".tm"))
+           ) ;
+        (recent-files-learn p n)
+        (loop (+ i 1))
+      ) ;let
+    ) ;when
+  ) ;let
+  ;; 全部 30 个文件记录均存在
+  (check (length (learned-interactive 'recent-buffer)) => 30)
+  ;; 最晚添加的排在最前
+  (check (caar (learned-interactive 'recent-buffer)) => '("0"
+                                                          . "/tmp/doc_30.tm"))
+  ;; 清空
+  (forget-interactive 'recent-buffer)
+  (check (learned-interactive 'recent-buffer) => '())
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests for persistence and fallback
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-persistence)
+  ;; 1. 不存在的文件，应返回 fallback
+  (check (load-json-with-fallback "/tmp/non_existent_file_1281.json"
+           (lambda (x) #t)
+           (lambda () 'fallback-value)
+         ) ;load-json-with-fallback
+    =>
+    'fallback-value
+  ) ;check
+
+  ;; 2. 格式错误的 JSON，应捕获异常并返回 fallback
+  (string-save "{malformed json:" (string->url "/tmp/test_bad_1281.json"))
+  (check (load-json-with-fallback "/tmp/test_bad_1281.json"
+           (lambda (x) #t)
+           (lambda () 'fallback-bad)
+         ) ;load-json-with-fallback
+    =>
+    'fallback-bad
+  ) ;check
+
+  ;; 3. 合法 JSON 但校验不通过，应返回 fallback
+  (string-save "{\"meta\":{}}" (string->url "/tmp/test_invalid_schema_1281.json"))
+  (check (load-json-with-fallback "/tmp/test_invalid_schema_1281.json"
+           interactive-args-json-valid?
+           (lambda () 'fallback-schema)
+         ) ;load-json-with-fallback
+    =>
+    'fallback-schema
+  ) ;check
+
+  ;; 4. 合法 JSON 且校验通过，应成功解析
+  (string-save "{\"meta\":{\"version\":1},\"commands\":{}}"
+    (string->url "/tmp/test_valid_1281.json")
+  ) ;string-save
+  (check (interactive-args-json-valid? (load-json-with-fallback "/tmp/test_valid_1281.json"
+                                         interactive-args-json-valid?
+                                         (lambda () #f)
+                                       ) ;load-json-with-fallback
+         ) ;interactive-args-json-valid?
+    =>
+    #t
+  ) ;check
+
+  ;; 清理临时文件
+  (system-remove (string->url "/tmp/test_bad_1281.json"))
+  (system-remove (string->url "/tmp/test_invalid_schema_1281.json"))
+  (system-remove (string->url "/tmp/test_valid_1281.json"))
+
+  ;; 5. 测试 recent-files-save 真实落盘与重新加载
+  (recent-files-learn "/tmp/test_persist_1281.tm" "test_persist_1281.tm")
+  (recent-files-save)
+  (check (url-exists? interactive-arg-recent-file-path) => #t)
+  (let ((saved-json (string->json (string-load (string->url interactive-arg-recent-file-path)))
+        ) ;saved-json
+       ) ;
+    (check (recent-files-json-valid? saved-json) => #t)
+    (check (recent-files-get-name "/tmp/test_persist_1281.tm")
+      =>
+      "test_persist_1281.tm"
+    ) ;check
+  ) ;let
+  ;; 清理
+  (recent-files-remove-by-path "/tmp/test_persist_1281.tm")
+  (recent-files-save)
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test entry point
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -72,5 +340,10 @@
   (test-canonical-path-win-separators)
   (test-canonical-path-tmfs)
   (test-canonical-path-unix-idempotent)
+  (test-interactive-commands)
+  (test-recent-files)
+  (test-validation)
+  (test-recent-files-lru-limit)
+  (test-persistence)
   (check-report)
 ) ;tm-define

--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
@@ -12,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (kernel texmacs tm-dialogue) (:use (kernel texmacs tm-define)))
-(import (liii njson) (liii time) (liii list))
+(import (liii json) (liii time) (liii list))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Questions with user interaction
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -186,11 +186,13 @@
 
 (define interactive-arg-version 1)
 
-(define interactive-arg-file "$TEXMACS_HOME_PATH/system/interactive.json")
+(define-public interactive-arg-file
+  "$TEXMACS_HOME_PATH/system/interactive.json"
+) ;define-public
 
-(define interactive-arg-recent-file-path
+(define-public interactive-arg-recent-file-path
   "$TEXMACS_HOME_PATH/system/recent-files.json"
-) ;define
+) ;define-public
 
 (define legacy-interactive-arg-file "$TEXMACS_HOME_PATH/system/interactive.scm")
 
@@ -202,87 +204,115 @@
   "$TEXMACS_HOME_PATH/system/recent-files.scm->v1"
 ) ;define
 
-(define interactive-arg-file-system
-  (url->system (string->url interactive-arg-file))
-) ;define
-
-(define interactive-arg-recent-file-system
-  (url->system (string->url interactive-arg-recent-file-path))
-) ;define
-
-(define (make-empty-state kind)
+(define-public (make-empty-state kind)
   (case kind
    ((interactive-arg)
-    (let ((root (string->njson "{\"meta\":{},\"commands\":{}}")))
-      (njson-set! root "meta" "version" interactive-arg-version)
-      root
-    ) ;let
+    `((,"meta" (,"version" . ,interactive-arg-version)) ("commands" ()))
    ) ;
-   ((recent-file)
-    (string->njson "{\"meta\":{\"version\":1,\"total\":0},\"files\":[]}")
-   ) ;
-   (else (string->njson "{}"))
+   ((recent-file) '(("meta" ("version" . 1) ("total" . 0)) ("files" . #())))
+   (else '(()))
   ) ;case
-) ;define
+) ;define-public
 
 (define interactive-arg-json (make-empty-state 'interactive-arg))
 
-
 (define interactive-arg-recent-file-json (make-empty-state 'recent-file))
 
-(define interactive-args-schema-v1
-  (string->njson "{\"type\":\"object\",\"required\":[\"meta\",\"commands\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\"],\"properties\":{\"version\":{\"type\":\"integer\",\"minimum\":1}}},\"commands\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}}}}}}"
-  ) ;string->njson
+(define (interactive-arg-item-valid? item)
+  (and (json-object? item)
+    (let ((keys (json-keys item)))
+      (and (every string? keys) (every (lambda (k) (string? (json-ref item k))) keys))
+    ) ;let
+  ) ;and
 ) ;define
 
-(define recent-files-schema-v1
-  (string->njson "{\"type\":\"object\",\"required\":[\"meta\",\"files\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\",\"total\"],\"properties\":{\"version\":{\"type\":\"number\"},\"total\":{\"type\":\"integer\",\"minimum\":0}}},\"files\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"required\":[\"path\",\"name\",\"last_open\",\"open_count\",\"show\"],\"properties\":{\"path\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"last_open\":{\"type\":\"number\"},\"open_count\":{\"type\":\"number\"},\"show\":{\"type\":\"boolean\"}}}}}}"
-  ) ;string->njson
-) ;define
-
-(define (njson-schema-valid? schema instance)
-  (catch #t
-    (lambda ()
-      (let ((report (njson-schema-report schema instance)))
-        (hash-table-ref report 'valid?)
-      ) ;let
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
-) ;define
-
-(define (interactive-args-json-valid? interactive-args)
-  (njson-schema-valid? interactive-args-schema-v1 interactive-args)
-) ;define
+(define-public (interactive-args-json-valid? interactive-args)
+  (and (json-object? interactive-args)
+    (let* ((meta (json-ref interactive-args "meta"))
+           (commands (json-ref interactive-args "commands"))
+           (version (and (json-object? meta) (json-ref meta "version")))
+          ) ;
+      (and (json-object? meta)
+        (integer? version)
+        (>= version 1)
+        (json-object? commands)
+        (every string? (json-keys commands))
+        (every (lambda (cmd)
+                 (let ((items (json-ref commands cmd)))
+                   (and (vector? items) (every interactive-arg-item-valid? (vector->list items)))
+                 ) ;let
+               ) ;lambda
+          (json-keys commands)
+        ) ;every
+      ) ;and
+    ) ;let*
+  ) ;and
+) ;define-public
 
 (define (interactive-command-learned command-name)
-  (let-njson ((commands (njson-ref interactive-arg-json "commands")))
-    (if (njson-contains-key? commands command-name)
-      (let-njson ((items (njson-ref commands command-name)))
-        (if (njson-array? items) (vector->list (njson->json items)) '())
-      ) ;let-njson
-      '()
-    ) ;if
-  ) ;let-njson
+  (let* ((commands (json-ref interactive-arg-json "commands"))
+         (items (and (json-object? commands) (json-ref commands command-name)))
+        ) ;
+    (if (vector? items) (vector->list items) '())
+  ) ;let*
 ) ;define
 
 (define (set-interactive-command-learned command-name items)
-  (let-njson ((payload (json->njson (list->vector items))))
-    (njson-set! interactive-arg-json "commands" command-name payload)
-  ) ;let-njson
+  (let* ((commands (json-ref interactive-arg-json "commands"))
+         (commands (if (json-object? commands) commands '(())))
+         (payload (list->vector items))
+         (commands* (if (json-contains-key? commands command-name)
+                      (json-set commands command-name payload)
+                      (json-push commands command-name payload)
+                    ) ;if
+         ) ;commands*
+        ) ;
+    (set! interactive-arg-json (json-set interactive-arg-json "commands" commands*))
+  ) ;let*
 ) ;define
 
 (define (remove-interactive-command-learned command-name)
-  (let-njson ((commands (njson-ref interactive-arg-json "commands")))
-    (when (njson-contains-key? commands command-name)
-      (njson-drop! interactive-arg-json "commands" command-name)
-    ) ;when
-  ) ;let-njson
+  (let* ((commands (json-ref interactive-arg-json "commands"))
+         (commands (if (or (json-object? commands) (null? commands)) commands '(())))
+         (commands* (if (json-contains-key? commands command-name)
+                      (let ((res (json-drop commands command-name)))
+                        (if (null? res) '(()) res)
+                      ) ;let
+                      commands
+                    ) ;if
+         ) ;commands*
+        ) ;
+    (set! interactive-arg-json (json-set interactive-arg-json "commands" commands*))
+  ) ;let*
 ) ;define
 
-(define (recent-files-json-valid? recent-files)
-  (njson-schema-valid? recent-files-schema-v1 recent-files)
+(define (recent-file-item-valid? item)
+  (and (json-object? item)
+    (string? (json-ref item "path"))
+    (string? (json-ref item "name"))
+    (number? (json-ref item "last_open"))
+    (number? (json-ref item "open_count"))
+    (boolean? (json-ref item "show"))
+  ) ;and
 ) ;define
+
+(define-public (recent-files-json-valid? recent-files)
+  (and (json-object? recent-files)
+    (let* ((meta (json-ref recent-files "meta"))
+           (files (json-ref recent-files "files"))
+           (version (and (json-object? meta) (json-ref meta "version")))
+           (total (and (json-object? meta) (json-ref meta "total")))
+          ) ;
+      (and (json-object? meta)
+        (number? version)
+        (integer? total)
+        (>= total 0)
+        (vector? files)
+        (every recent-file-item-valid? (vector->list files))
+      ) ;and
+    ) ;let*
+  ) ;and
+) ;define-public
 
 ;; recent-files-remove-by-path
 ;; 按路径从最近文件缓存中删除对应条目。
@@ -306,18 +336,18 @@
 ;; 逻辑
 ;; ----
 ;; 1. 调用 `recent-files-index-by-path` 查找 `path` 在 `files` 中的索引。
-;; 2. 若找到索引，调用 `njson-drop!` 删除该项。
+;; 2. 若找到索引，调用 `json-drop` 删除该项。
 ;; 3. 将 `meta.total` 减一（不低于 0）。
 ;; 4. 将更新后的 JSON 结构回写到 `interactive-arg-recent-file-json`。
 (define-public (recent-files-remove-by-path path)
   (let ((idx (recent-files-index-by-path interactive-arg-recent-file-json path)))
     (when idx
-      (let* ((total (njson-ref interactive-arg-recent-file-json "meta" "total"))
+      (let* ((total (json-ref interactive-arg-recent-file-json "meta" "total"))
              (total (if (number? total) total 0))
              (new-total (if (<= total 0) 0 (- total 1)))
+             (r1 (json-drop interactive-arg-recent-file-json "files" idx))
             ) ;
-        (njson-drop! interactive-arg-recent-file-json "files" idx)
-        (njson-set! interactive-arg-recent-file-json "meta" "total" new-total)
+        (set! interactive-arg-recent-file-json (json-set r1 "meta" "total" new-total))
       ) ;let*
     ) ;when
   ) ;let
@@ -326,68 +356,74 @@
 
 
 (define (recent-files-apply-lru recent-files limit)
-  (let-njson ((files (njson-ref recent-files "files")))
-    (let* ((n (njson-size files))
-           (indexed (let loop
-                      ((i 0) (acc '()))
-                      (if (>= i n)
-                        acc
-                        (let* ((t (njson-ref files i "last_open")) (t (if (number? t) t 0)))
-                          (loop (+ i 1) (cons (cons i t) acc))
-                        ) ;let*
-                      ) ;if
-                    ) ;let
-           ) ;indexed
-           (sorted (sort indexed (lambda (a b) (> (cdr a) (cdr b)))))
-          ) ;
-      (let-njson ((new-files (string->njson "[]")))
-        (let loop
-          ((rank 0) (rest sorted))
-          (when (pair? rest)
-            (let* ((p (car rest)) (idx (car p)) (show? (< rank limit)))
-              (let-njson ((item (njson-ref files idx)))
-                (njson-set! item "show" show?)
-                (njson-append! new-files item)
-              ) ;let-njson
-              (loop (+ rank 1) (cdr rest))
-            ) ;let*
-          ) ;when
-        ) ;let
-        (njson-set! recent-files "files" new-files)
-      ) ;let-njson
-    ) ;let*
-    recent-files
-  ) ;let-njson
+  (let* ((files (json-ref recent-files "files"))
+         (n (if (vector? files) (vector-length files) 0))
+         (indexed (let loop
+                    ((i 0) (acc '()))
+                    (if (>= i n)
+                      acc
+                      (let* ((item (vector-ref files i))
+                             (t (json-ref item "last_open"))
+                             (t (if (number? t) t 0))
+                            ) ;
+                        (loop (+ i 1) (cons (cons i t) acc))
+                      ) ;let*
+                    ) ;if
+                  ) ;let
+         ) ;indexed
+         (sorted (sort indexed
+                   (lambda (a b) (if (== (cdr a) (cdr b)) (> (car a) (car b)) (> (cdr a) (cdr b))))
+                 ) ;sort
+         ) ;sorted
+         (new-files (list->vector (let loop
+                                    ((rank 0) (rest sorted))
+                                    (if (null? rest)
+                                      '()
+                                      (let* ((idx (caar rest)) (item (vector-ref files idx)) (show? (< rank limit)))
+                                        (cons (json-set item "show" show?) (loop (+ rank 1) (cdr rest)))
+                                      ) ;let*
+                                    ) ;if
+                                  ) ;let
+                    ) ;list->vector
+         ) ;new-files
+        ) ;
+    (json-set recent-files "files" new-files)
+  ) ;let*
 ) ;define
 
 (define (recent-files-add recent-files path name)
-  (let-njson ((item (json->njson `((,"path" . ,path)
-                                   (,"name" . ,name)
-                                   (,"last_open"
-                                    . ,(time-second (current-time)))
-                                   (,"open_count" . ,1)
-                                   (,"show" . ,#t))
-                    ) ;json->njson
-              ) ;item
-             ) ;
-    (njson-append! recent-files "files" item)
-  ) ;let-njson
-  (let* ((total (njson-ref recent-files "meta" "total"))
+  (let* ((files (json-ref recent-files "files"))
+         (idx (if (vector? files) (vector-length files) 0))
+         (item `((,"path" . ,path)
+                 (,"name" . ,name)
+                 (,"last_open" . ,(time-second (current-time)))
+                 (,"open_count" . ,1)
+                 (,"show" . ,#t))
+         ) ;item
+         (total (json-ref recent-files "meta" "total"))
          (total (if (number? total) total 0))
+         (r1 (json-set (json-push recent-files "files" idx item) "meta" "total" (+ total 1))
+         ) ;r1
         ) ;
-    (njson-set! recent-files "meta" "total" (+ total 1))
+    (recent-files-apply-lru r1 25)
   ) ;let*
-  (recent-files-apply-lru recent-files 25)
 ) ;define
 
 (define (recent-files-set recent-files idx)
-  (let* ((count* (njson-ref recent-files "files" idx "open_count"))
+  (let* ((item (json-ref recent-files "files" idx))
+         (path* (json-ref item "path"))
+         (name* (json-ref item "name"))
+         (count* (json-ref item "open_count"))
          (count* (if (number? count*) count* 0))
+         (new-item `((,"path" . ,path*)
+                     (,"name" . ,name*)
+                     (,"last_open" . ,(time-second (current-time)))
+                     (,"open_count" . ,(+ count* 1))
+                     (,"show" . ,#t))
+         ) ;new-item
+         (r1 (json-set recent-files "files" idx new-item))
         ) ;
-    (njson-set! recent-files "files" idx "last_open" (time-second (current-time)))
-    (njson-set! recent-files "files" idx "open_count" (+ count* 1))
-    (njson-set! recent-files "files" idx "show" #t)
-    (recent-files-apply-lru recent-files 25)
+    (recent-files-apply-lru r1 25)
   ) ;let*
 ) ;define
 
@@ -400,32 +436,36 @@
 (define-public (recent-files-canonical-path p) (url->system (system->url p)))
 
 (define (recent-files-index-by-path recent-files path)
-  (let* ((key (recent-files-canonical-path path)))
-    (let-njson ((files (njson-ref recent-files "files")))
+  (let* ((key (recent-files-canonical-path path))
+         (files (json-ref recent-files "files"))
+        ) ;
+    (if (not (vector? files))
+      #f
       (let loop
         ((i 0))
-        (if (>= i (njson-size files))
+        (if (>= i (vector-length files))
           #f
-          (if (equal? (recent-files-canonical-path (njson-ref files i "path")) key)
+          (if (equal? (recent-files-canonical-path (json-ref (vector-ref files i) "path"))
+                key
+              ) ;equal?
             i
             (loop (+ i 1))
           ) ;if
         ) ;if
       ) ;let
-    ) ;let-njson
+    ) ;if
   ) ;let*
 ) ;define
 
 (define (recent-files-paths recent-files)
-  (let-njson ((files (njson-ref recent-files "files")))
-    (let loop
-      ((i 0) (n (njson-size files)) (acc '()))
-      (if (>= i n)
-        (reverse acc)
-        (loop (+ i 1) n (cons (list (cons "0" (njson-ref files i "path"))) acc))
-      ) ;if
-    ) ;let
-  ) ;let-njson
+  (let ((files (json-ref recent-files "files")))
+    (if (not (vector? files))
+      '()
+      (map (lambda (item) (list (cons "0" (json-ref item "path"))))
+        (vector->list files)
+      ) ;map
+    ) ;if
+  ) ;let
 ) ;define
 
 
@@ -505,7 +545,7 @@
 ;; 未命中返回 #f，调用方自行回退。
 (define-public (recent-files-get-name file-path)
   (let ((idx (recent-files-index-by-path interactive-arg-recent-file-json file-path)))
-    (and idx (njson-ref interactive-arg-recent-file-json "files" idx "name"))
+    (and idx (json-ref interactive-arg-recent-file-json "files" idx "name"))
   ) ;let
 ) ;define-public
 
@@ -604,7 +644,6 @@
   (when (symbol? fun)
     (case fun
      ((recent-buffer)
-      (njson-free interactive-arg-recent-file-json)
       (set! interactive-arg-recent-file-json (make-empty-state 'recent-file))
      ) ;
      (else (with name
@@ -773,10 +812,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (save-learned)
-  (njson->file interactive-arg-file-system interactive-arg-json)
-  (njson->file interactive-arg-recent-file-system
-    interactive-arg-recent-file-json
-  ) ;njson->file
+  (string-save (json->string interactive-arg-json)
+    (string->url interactive-arg-file)
+  ) ;string-save
+  (string-save (json->string interactive-arg-recent-file-json)
+    (string->url interactive-arg-recent-file-path)
+  ) ;string-save
 ) ;define
 
 ;; 立即把最近文件状态落盘（仅 recent-files.json，C++ 启动页直接读该文件取 name）。
@@ -784,26 +825,24 @@
 ;; 同会话内启动页读到的 name 会回退为 UUID（doc_id）。join/create 频次低，每次写一次
 ;; 小 JSON 可接受，且提升崩溃后的最近列表持久性。
 (define-public (recent-files-save)
-  (njson->file interactive-arg-recent-file-system
-    interactive-arg-recent-file-json
-  ) ;njson->file
+  (string-save (json->string interactive-arg-recent-file-json)
+    (string->url interactive-arg-recent-file-path)
+  ) ;string-save
 ) ;define-public
 
-(define (load-njson-with-fallback file valid? fallback-maker)
-  (catch #t
-    (lambda ()
-      (let ((parsed (file->njson file)))
-        (if (valid? parsed) parsed (begin (njson-free parsed) (fallback-maker)))
-      ) ;let
-    ) ;lambda
-    (lambda args (fallback-maker))
-  ) ;catch
-) ;define
-
-(define (reload-state current-state file valid? fallback-maker)
-  (njson-free current-state)
-  (load-njson-with-fallback file valid? fallback-maker)
-) ;define
+(define-public (load-json-with-fallback file valid? fallback-maker)
+  (if (url-exists? file)
+    (catch #t
+      (lambda ()
+        (let ((parsed (string->json (string-load (string->url file)))))
+          (if (valid? parsed) parsed (fallback-maker))
+        ) ;let
+      ) ;lambda
+      (lambda args (fallback-maker))
+    ) ;catch
+    (fallback-maker)
+  ) ;if
+) ;define-public
 
 (define (write-migration-marker marker-file)
   (string-save "migrated\n" (string->url marker-file))
@@ -940,38 +979,41 @@
 ) ;define
 
 (define (recent-files-min-last-open recent-files)
-  (let-njson ((files (njson-ref recent-files "files")))
-    (if (<= (njson-size files) 0)
+  (let ((files (json-ref recent-files "files")))
+    (if (or (not (vector? files)) (<= (vector-length files) 0))
       #f
       (let loop
-        ((i 1) (min-t (let ((t (njson-ref files 0 "last_open"))) (if (number? t) t 0))))
-        (if (>= i (njson-size files))
+        ((i 1)
+         (min-t (let ((t (json-ref (vector-ref files 0) "last_open")))
+                  (if (number? t) t 0)
+                ) ;let
+         ) ;min-t
+        ) ;
+        (if (>= i (vector-length files))
           min-t
-          (let* ((t (njson-ref files i "last_open")) (t (if (number? t) t 0)))
+          (let* ((t (json-ref (vector-ref files i) "last_open")) (t (if (number? t) t 0)))
             (loop (+ i 1) (min min-t t))
           ) ;let*
         ) ;if
       ) ;let
     ) ;if
-  ) ;let-njson
+  ) ;let
 ) ;define
 
-(define (append-recent-file-entry! recent-files path last-open)
+(define (append-recent-file-entry recent-files path last-open)
   (let* ((name (url->system (url-tail (system->url path))))
-         (item (json->njson `((,"path" . ,path)
-                              (,"name" . ,name)
-                              (,"last_open" . ,last-open)
-                              (,"open_count" . ,1)
-                              (,"show" . ,#t))
-               ) ;json->njson
+         (item `((,"path" . ,path)
+                 (,"name" . ,name)
+                 (,"last_open" . ,last-open)
+                 (,"open_count" . ,1)
+                 (,"show" . ,#t))
          ) ;item
-        ) ;
-    (njson-append! recent-files "files" item)
-  ) ;let*
-  (let* ((total (njson-ref recent-files "meta" "total"))
+         (files (json-ref recent-files "files"))
+         (idx (if (vector? files) (vector-length files) 0))
+         (total (json-ref recent-files "meta" "total"))
          (total (if (number? total) total 0))
         ) ;
-    (njson-set! recent-files "meta" "total" (+ total 1))
+    (json-set (json-push recent-files "files" idx item) "meta" "total" (+ total 1))
   ) ;let*
 ) ;define
 
@@ -998,7 +1040,9 @@
               ) ;or
             (loop (cdr items) (+ rank 1) seen)
             (begin
-              (append-recent-file-entry! interactive-arg-recent-file-json path (- base rank))
+              (set! interactive-arg-recent-file-json
+                (append-recent-file-entry interactive-arg-recent-file-json path (- base rank))
+              ) ;set!
               (loop (cdr items) (+ rank 1) (cons path seen))
             ) ;begin
           ) ;if
@@ -1045,18 +1089,16 @@
 
 (define (retrieve-learned)
   (set! interactive-arg-json
-    (reload-state interactive-arg-json
-      interactive-arg-file-system
+    (load-json-with-fallback interactive-arg-file
       interactive-args-json-valid?
       (lambda () (make-empty-state 'interactive-arg))
-    ) ;reload-state
+    ) ;load-json-with-fallback
   ) ;set!
   (set! interactive-arg-recent-file-json
-    (reload-state interactive-arg-recent-file-json
-      interactive-arg-recent-file-system
+    (load-json-with-fallback interactive-arg-recent-file-path
       recent-files-json-valid?
       (lambda () (make-empty-state 'recent-file))
-    ) ;reload-state
+    ) ;load-json-with-fallback
   ) ;set!
   (maybe-import-legacy-scm-interactive-state)
 ) ;define

--- a/devel/1281.md
+++ b/devel/1281.md
@@ -1,0 +1,116 @@
+# [1281] 取消 tm-dialogue.scm 对 njson 的使用，直接改用 (liii json)
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [201_92.md](201_92.md) - 历史上迁移到 (liii njson) 的任务文档
+- [0948.md](0948.md) - 修复 Windows 下启动页最近文档移除无反应
+
+## 2 任务相关的代码文件
+- TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
+- TeXmacs/progs/kernel/texmacs/tm-dialogue-test.scm
+
+## 3 如何测试
+
+### 3.1 纯逻辑单元测试（自动化，headless）
+
+执行以下命令运行测试套件：
+
+```bash
+xmake r tm-dialogue-test
+```
+
+该测试覆盖全部核心逻辑（共 46 个断言），包括：
+- **路径归一测试** (`test-canonical-path-*`)：
+  - Windows 系统下 `/` 与 `\` 统一归一到 `\` 规范形（含空格与中文字符路径）；
+  - `tmfs://` 等虚拟 URL 往返后原样保持；
+  - 非 Windows 系统下绝对路径归一幂等。
+- **交互命令学习测试** (`test-interactive-commands`)：
+  - 参数初次学习与读取（`learn-interactive` / `learned-interactive`）；
+  - 多个参数学习时最近使用的条目排在最前（LRU 提头）；
+  - 重复学习已有参数自动提头且去重；
+  - 清除指定命令的学习参数（`forget-interactive`）。
+- **最近文件增删查改测试** (`test-recent-files`)：
+  - `recent-files-learn` 新增文件与刷新已有文件的时间戳；
+  - `recent-files-get-name` 按路径反查文件显示名；
+  - `recent-files-remove-by-path` 按路径移除文件及不存在路径的幂等性；
+  - `learn-interactive 'recent-buffer` 自动推导文件名的委托链路。
+- **数据结构校验测试** (`test-validation`)：
+  - 空状态结构合法性；
+  - 顶层非 object 异常数据识别拦截；
+  - `interactive-args` 的 `meta.version` 整数范围校验及 commands 参数映射类型校验；
+  - `recent-files` 的 `meta.total` 非负整数校验及 files 单项必填字段（`path` / `name` / `last_open` / `open_count` / `show`）完整性校验。
+- **LRU 淘汰容量测试** (`test-recent-files-lru-limit`)：
+  - 连续添加 30 个文件（超出 limit 25），验证所有 30 条记录均完整保存在列表中；
+  - 最新访问的文件稳定排在最前；
+  - `show` 标记正确限制在 top 25，其余项标记为 `#f`。
+- **文件持久化与异常回退测试** (`test-persistence`)：
+  - 文件不存在时安全返回 fallback 初始值；
+  - JSON 语法损坏时自动捕获异常并回退；
+  - JSON 语法合法但 schema 结构不合规时回退；
+  - 合法数据正常反序列化；
+  - `recent-files-save` 磁盘落盘（`recent-files.json`）并读取验证标准 JSON 格式。
+
+关联模块回归测试：
+```bash
+xmake r tm-files-test    # 文件加载相关逻辑（10 correct, 0 failed）
+xmake r tm-collab-test   # 协作文档与 recent-files 联动（61 correct, 0 failed）
+```
+
+### 3.2 手工端到端测试（GUI）
+
+#### 3.2.1 交互命令历史记忆验证
+1. 启动 Mogan：`xmake r stem`；
+2. 打开菜单：**工具 -> 调试工具**，随后点击 **调试 -> 运行 -> 执行 Scheme 表达式**；
+3. 在弹出的交互输入框中输入 `(display* "hello 1281\n")` 并确定执行；
+4. 再次打开该弹窗，历史候选框中应保留上次输入的 `(display* "hello 1281\n")`；
+5. 关闭 Mogan，检查 `$TEXMACS_HOME_PATH/system/interactive.json`（或 `~/.local/share/moganlab/system/interactive.json`），使用 `python3 -m json.tool` 确认文件为标准合规 JSON 格式，且包含刚才记录的命令参数。
+
+#### 3.2.2 最近文件增删与启动页联动验证
+1. 启动 Mogan，打开若干 `.tmu` / `.stem` 本地文档；
+2. 查看菜单 **文件 -> 最近使用**，确认刚刚打开的文件均显示在列表中，且最后打开的文件排在最前；
+3. 查看启动页「最近文档」标签，确认文档名、修改时间等元数据正常展示；
+4. 在启动页最近文档列表中，右键某个文档选择「从列表移除」：
+   - 启动页列表中该条目立即消失；
+   - 菜单 **文件 -> 最近使用** 中该条目同步消失；
+5. 关闭程序，查看 `$TEXMACS_HOME_PATH/system/recent-files.json`，验证：
+   - 文件内容为合法标准 JSON；
+   - `meta.total` 计数值与 `files` 数组长度一致；
+   - 被删除的条目已从 JSON 中清除；
+6. 重新启动 Mogan，确认已移除的文档不会重新出现。
+
+#### 3.2.3 异常 JSON 容错与恢复验证
+1. 关闭 Mogan，手工编辑 `$TEXMACS_HOME_PATH/system/recent-files.json`，故意制造语法错误（例如截断尾部为 `{"meta":{"version":1`）；
+2. 启动 Mogan，观察终端无未捕获崩溃，程序平稳启动进入主界面；
+3. 查看菜单 **文件 -> 最近使用**，平稳回退为空列表；
+4. 新打开一个文档后正常退出，再次查看 `recent-files.json`，应已重新生成合法的初始 JSON。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git add <files>
+git commit -m "[1281] ..."
+```
+
+## 5 What
+在 `tm-dialogue.scm` 中取消对 `(liii njson)` 的依赖，直接改用 `(liii json)` 处理 Scheme 原生 JSON 数据结构（alist 与 vector）。采用 TDD 方式先在 `tm-dialogue-test.scm` 中建立完整的单元测试覆盖，再对 `tm-dialogue.scm` 进行重构。
+
+## 6 Why
+1. `(liii json)` 是基于原生 Scheme 数据结构（序对列表与向量）的 JSON 实现，与 Scheme 语言生态无缝结合，内存完全由 GC 自动管理，无需手动维护 C++ 句柄生命周期和调用 `njson-free`。
+2. `tm-dialogue.scm` 中的 `interactive-arg-json`（交互式命令参数历史）和 `recent-files.json`（最近打开文件列表）属于轻量级配置/状态数据，使用纯 Scheme 结构更轻量、更易调试，且彻底消除句柄泄漏或悬垂指针风险。
+
+## 7 How
+1. **TDD 测试先行**：在 `tm-dialogue-test.scm` 中增加完整的单元测试用例，覆盖：
+   - 交互式命令学习与读取：`learn-interactive`、`learned-interactive`、`forget-interactive`；
+   - 最近文件增删查改：`recent-files-learn`、`recent-files-get-name`、`recent-files-remove-by-path`、LRU 淘汰逻辑；
+   - 模式校验逻辑与文件持久化回退逻辑。
+2. **模块依赖调整**：
+   - 将 `(import (liii njson) (liii time) (liii list))` 替换为 `(import (liii json) (liii time) (liii list))`。
+3. **数据结构与操作重构**：
+   - 移除 `njson` 句柄构造和 `let-njson` / `njson-free`。
+   - 空状态采用纯 Scheme 结构构造：
+     - `interactive-arg`：`(("meta" ("version" . 1)) ("commands" ()))`
+     - `recent-file`：`(("meta" ("version" . 1) ("total" . 0)) ("files" . #()))`
+   - 校验逻辑：由 `njson-schema-report` 改用纯 Scheme 结构检查谓词（`interactive-args-json-valid?`、`recent-files-json-valid?`）。
+   - 数据操作：使用 `json-ref`、`json-set`、`json-push`、`json-drop` 等纯函数或对 Scheme 变量更新。
+   - 文件读写：使用 `string-save`、`string-load` 配合 `json->string`、`string->json`，保持与磁盘文件 JSON 格式完全兼容。


### PR DESCRIPTION
## 任务描述
在 `tm-dialogue.scm` 中取消对 `(liii njson)` 的依赖，直接改用 `(liii json)` 处理 Scheme 原生 JSON 数据结构（alist 与 vector）。采用 TDD 方式先在 `tm-dialogue-test.scm` 中建立完整的单元测试覆盖，再对 `tm-dialogue.scm` 进行重构。

## 变更内容
1. **测试先行（TDD）**：
   - 在 `tm-dialogue-test.scm` 中补充了针对交互式命令学习/遗忘、最近文件增删查改、LRU 淘汰与截断、模式校验谓词、持久化落盘与格式异常回退的单元测试（共 46 个断言）。
2. **取消 njson 依赖**：
   - 将 `(import (liii njson) ...)` 替换为 `(import (liii json) ...)`.
   - 移除 `let-njson`、`njson-free` 等 C++ 句柄操作，改用纯 Scheme 原生数据结构。
   - 数据操作使用 `(liii json)` 的 `json-ref`、`json-set`、`json-push`、`json-drop`。
   - 文件存取使用 `string-save`、`string-load` 配合 `json->string`、`string->json`。
   - 模式校验改用纯 Scheme 结构谓词。
3. **任务文档**：
   - 新增并详化 `devel/1281.md`，补齐自动化单元测试细则及手工 GUI 端到端验证步骤。

## 如何测试

### 1. 纯逻辑单元测试（自动化，headless）
```bash
xmake r tm-dialogue-test    # 46 correct, 0 failed
xmake r tm-files-test       # 10 correct, 0 failed
xmake r tm-collab-test      # 61 correct, 0 failed
```

### 2. 手工端到端测试（GUI）
详见 `devel/1281.md` 第 3.2 节：
- **3.2.1 交互命令历史记忆验证**：执行 Scheme 表达式弹窗的历史记录跨会话保存与读取；
- **3.2.2 最近文件增删与启动页联动验证**：最近文件新增、打开排序、右键移除及 C++ 启动页同步；
- **3.2.3 异常 JSON 容错与恢复验证**：配置文件损坏/非法时的安全回退与重新初始化。