### PR TITLE
[1282] 将 shortcut-edit.scm 的 JSON 库从 njson 迁移至 (liii json)

### DIFF
--- a/TeXmacs/progs/source/shortcut-edit.scm
+++ b/TeXmacs/progs/source/shortcut-edit.scm
@@ -12,17 +12,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (source shortcut-edit) (:use (source macro-edit)))
-(import (liii njson))
+(import (liii json))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Management of the list of user keyboard shortcuts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define user-shortcuts-file "$TEXMACS_HOME_PATH/system/shortcuts.json")
-
-(define user-shortcuts-file-system
-  (url->system (string->url user-shortcuts-file))
-) ;define
 
 (define legacy-user-shortcuts-file "$TEXMACS_HOME_PATH/system/shortcuts.scm")
 
@@ -37,52 +33,51 @@
 ) ;define
 
 (define (shortcut-entry-shortcut entry)
-  (assoc-ref entry "shortcut")
+  (and (json-object? entry) (json-ref-string entry "shortcut" #f))
 ) ;define
 
 (define (shortcut-entry-command entry)
-  (assoc-ref entry "command")
+  (and (json-object? entry) (json-ref-string entry "command" #f))
 ) ;define
 
 (define (shortcut-entry-valid? entry)
-  (and (pair? entry)
+  (and (json-object? entry)
     (string? (shortcut-entry-shortcut entry))
     (string? (shortcut-entry-command entry))
   ) ;and
 ) ;define
 
-(define user-shortcuts-schema-v1
-  (string->njson "{\"type\":\"object\",\"required\":[\"meta\",\"shortcuts\"],\"properties\":{\"meta\":{\"type\":\"object\",\"required\":[\"version\",\"total\"],\"properties\":{\"version\":{\"type\":\"integer\"},\"total\":{\"type\":\"integer\",\"minimum\":0}}},\"shortcuts\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"required\":[\"shortcut\",\"command\"],\"properties\":{\"shortcut\":{\"type\":\"string\"},\"command\":{\"type\":\"string\"}}}}}}"
-  ) ;string->njson
-) ;define
-
-(define (njson-schema-valid? schema instance)
-  (catch #t
-    (lambda ()
-      (let ((report (njson-schema-report schema instance)))
-        (hash-table-ref report 'valid?)
-      ) ;let
-    ) ;lambda
-    (lambda args #f)
-  ) ;catch
+(define (shortcut-entries-valid? entries)
+  (or (null? entries)
+    (and (shortcut-entry-valid? (car entries))
+      (shortcut-entries-valid? (cdr entries))
+    ) ;and
+  ) ;or
 ) ;define
 
 (define (user-shortcuts-json-valid? data)
-  (and (njson-schema-valid? user-shortcuts-schema-v1 data)
-    (let-njson ((shortcuts (njson-ref data "shortcuts"))
-                (total (njson-ref data "meta" "total"))
-               ) ;
-      (and (integer? total) (== total (njson-size shortcuts)))
-    ) ;let-njson
+  (and (json-object? data)
+    (let ((meta (json-ref data "meta")) (shortcuts (json-ref data "shortcuts")))
+      (and (json-object? meta)
+        (integer? (json-ref meta "version"))
+        (let ((total (json-ref meta "total")))
+          (and (integer? total)
+            (>= total 0)
+            (vector? shortcuts)
+            (== total (vector-length shortcuts))
+            (shortcut-entries-valid? (vector->list shortcuts))
+          ) ;and
+        ) ;let
+      ) ;and
+    ) ;let
   ) ;and
 ) ;define
 
 (define (make-user-shortcuts-json entries)
-  (json->njson `((,"meta"
-                  (,"version" . ,user-shortcuts-version)
-                  (,"total" . ,(length entries)))
-                 (,"shortcuts" . ,(list->vector entries)))
-  ) ;json->njson
+  `((,"meta"
+     (,"version" . ,user-shortcuts-version)
+     (,"total" . ,(length entries)))
+    (,"shortcuts" . ,(list->vector entries)))
 ) ;define
 
 (define (make-empty-user-shortcuts-json)
@@ -92,16 +87,15 @@
 (define current-user-shortcuts (make-empty-user-shortcuts-json))
 
 (define (replace-current-user-shortcuts! next)
-  (njson-free current-user-shortcuts)
   (set! current-user-shortcuts next)
 ) ;define
 
 (define (current-user-shortcuts-vector)
   (catch #t
     (lambda ()
-      (let-njson ((shortcuts (njson-ref current-user-shortcuts "shortcuts")))
-        (if (njson-array? shortcuts) (njson->json shortcuts) #())
-      ) ;let-njson
+      (let ((shortcuts (json-ref current-user-shortcuts "shortcuts")))
+        (if (vector? shortcuts) shortcuts #())
+      ) ;let
     ) ;lambda
     (lambda args #())
   ) ;catch
@@ -216,15 +210,15 @@
 (define (load-user-shortcuts)
   (replace-current-user-shortcuts! (make-empty-user-shortcuts-json))
   (when (url-exists? user-shortcuts-file)
-    (let ((loaded (catch #t (lambda () (file->njson user-shortcuts-file-system)) (lambda args #f))
+    (let ((loaded (catch #t
+                    (lambda () (string->json (string-load user-shortcuts-file)))
+                    (lambda args #f)
+                  ) ;catch
           ) ;loaded
          ) ;
       (if (user-shortcuts-json-valid? loaded)
         (replace-current-user-shortcuts! loaded)
-        (begin
-          (catch #t (lambda () (njson-free loaded)) (lambda args #f))
-          (reset-user-shortcuts)
-        ) ;begin
+        (reset-user-shortcuts)
       ) ;if
     ) ;let
   ) ;when
@@ -237,7 +231,7 @@
 ) ;define
 
 (define (save-user-shortcuts)
-  (njson->file user-shortcuts-file-system current-user-shortcuts)
+  (string-save (json->string current-user-shortcuts) user-shortcuts-file)
 ) ;define
 
 (tm-define (init-user-shortcuts) (load-user-shortcuts))

--- a/TeXmacs/progs/source/tests/shortcut-edit-test.scm
+++ b/TeXmacs/progs/source/tests/shortcut-edit-test.scm
@@ -1,0 +1,263 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : shortcut-edit-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：快捷键数据的构建、校验、增删查改及 JSON 序列化
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r shortcut-edit-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(import (liii json))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/progs/source/shortcut-edit.scm")
+
+;; 1. 条目构造与访问器
+
+(define (test-make-shortcut-entry)
+  (let ((entry (make-shortcut-entry "C-a" "(noop)")))
+    (check (shortcut-entry-shortcut entry) => "C-a")
+    (check (shortcut-entry-command entry) => "(noop)")
+    (check (shortcut-entry-valid? entry) => #t)
+  ) ;let
+) ;define
+
+;; 2. 非法条目校验
+
+(define (test-shortcut-entry-valid-failures)
+  (check (shortcut-entry-valid? '()) => #f)
+  (check (shortcut-entry-valid? "not-an-entry") => #f)
+  (check (shortcut-entry-valid? '(("shortcut" . "C-a"))) => #f)
+  (check (shortcut-entry-valid? '(("command" . "(noop)"))) => #f)
+  (check (shortcut-entry-valid? '(("shortcut" . 123) ("command" . "(noop)")))
+    =>
+    #f
+  ) ;check
+  (check (shortcut-entry-valid? '(("shortcut" . "C-a") ("command" . 456))) => #f)
+) ;define
+
+;; 3. 空 JSON 构造与序列化
+
+(define (test-empty-user-shortcuts-json)
+  (let ((empty-json (make-empty-user-shortcuts-json)))
+    (check (user-shortcuts-json-valid? empty-json) => #t)
+    (check (json->string empty-json)
+      =>
+      "{\"meta\":{\"version\":1,\"total\":0},\"shortcuts\":[]}"
+    ) ;check
+  ) ;let
+) ;define
+
+;; 4. 非空条目构造与序列化
+
+(define (test-make-user-shortcuts-json)
+  (let* ((entries (list (make-shortcut-entry "C-x C-f" "(find-file)")
+                    (make-shortcut-entry "C-x C-s" "(save-buffer)")
+                  ) ;list
+         ) ;entries
+         (data (make-user-shortcuts-json entries))
+         (json-str (json->string data))
+         (parsed (string->json json-str))
+        ) ;
+    (check (user-shortcuts-json-valid? data) => #t)
+    (check (user-shortcuts-json-valid? parsed) => #t)
+    (check json-str
+      =>
+      "{\"meta\":{\"version\":1,\"total\":2},\"shortcuts\":[{\"shortcut\":\"C-x C-f\",\"command\":\"(find-file)\"},{\"shortcut\":\"C-x C-s\",\"command\":\"(save-buffer)\"}]}"
+    ) ;check
+  ) ;let*
+) ;define
+
+;; 5. user-shortcuts-json-valid? 边界与非法结构检测
+
+(define (test-user-shortcuts-json-valid-failures)
+  ;; 非 json-object
+  (check (user-shortcuts-json-valid? "string") => #f)
+  (check (user-shortcuts-json-valid? 123) => #f)
+  (check (user-shortcuts-json-valid? #()) => #f)
+  (check (user-shortcuts-json-valid? '()) => #f)
+  ;; 缺少 meta
+  (check (user-shortcuts-json-valid? (string->json "{\"shortcuts\":[]}")) => #f)
+  ;; 缺少 shortcuts
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":1,\"total\":0}}")
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+  ;; meta version 非整数
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":\"1\",\"total\":0},\"shortcuts\":[]}")
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+  ;; meta total 负数
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":1,\"total\":-1},\"shortcuts\":[]}")
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+  ;; meta total 与 shortcuts 长度不一致
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":1,\"total\":1},\"shortcuts\":[]}")
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+  ;; shortcuts 非数组
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":1,\"total\":0},\"shortcuts\":{}}")
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+  ;; shortcuts 中含非法条目
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":1,\"total\":1},\"shortcuts\":[{\"shortcut\":\"C-a\"}]}"
+                                     ) ;string->json
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+  (check (user-shortcuts-json-valid? (string->json "{\"meta\":{\"version\":1,\"total\":1},\"shortcuts\":[\"bad\"]}")
+         ) ;user-shortcuts-json-valid?
+    =>
+    #f
+  ) ;check
+) ;define
+
+;; 6. 内存状态与 CRUD
+
+(define (test-shortcuts-crud)
+  (let ((saved current-user-shortcuts))
+    (set-current-user-shortcuts-list (list (make-shortcut-entry "C-x C-f" "(find-file)")
+                                       (make-shortcut-entry "C-x C-s" "(save-buffer)")
+                                     ) ;list
+    ) ;set-current-user-shortcuts-list
+    (check (length (current-user-shortcuts-list)) => 2)
+    (check (find-user-shortcut-entry "C-x C-f")
+      =>
+      (make-shortcut-entry "C-x C-f" "(find-file)")
+    ) ;check
+    (check (find-user-shortcut-entry "non-existent") => #f)
+    ;; 恢复原状态
+    (replace-current-user-shortcuts! saved)
+  ) ;let
+) ;define
+
+;; 7. 快捷键查询与列表排序
+
+(define (test-shortcuts-query-and-sort)
+  (let ((saved current-user-shortcuts))
+    (set-current-user-shortcuts-list (list (make-shortcut-entry "C-b" "(prev)") (make-shortcut-entry "C-a" "(next)"))
+    ) ;set-current-user-shortcuts-list
+    (check (has-user-shortcut? "(prev)") => #t)
+    (check (has-user-shortcut? "(non-existent)") => #f)
+    (check (get-user-shortcut "C-b") => "(prev)")
+    (check (get-user-shortcut "C-c") => #f)
+    (check (user-shortcuts-list) => '("C-a" "C-b"))
+    ;; 恢复原状态
+    (replace-current-user-shortcuts! saved)
+  ) ;let
+) ;define
+
+;; 8. 旧版 scm 条目迁移与合并
+
+(define (test-legacy-scm-migration)
+  (check (legacy-scm-user-shortcut-entry->json '("C-f" "(find)"))
+    =>
+    (make-shortcut-entry "C-f" "(find)")
+  ) ;check
+  (check (legacy-scm-user-shortcut-entry->json '("bad")) => #f)
+  (check (legacy-scm-user-shortcut-entry->json 123) => #f)
+
+  (let* ((existing (list (make-shortcut-entry "C-a" "(cmd-a)")))
+         (legacy-to-merge (list (make-shortcut-entry "C-a" "(cmd-a-old)")
+                            (make-shortcut-entry "C-b" "(cmd-b)")
+                          ) ;list
+         ) ;legacy-to-merge
+         (merged (merge-legacy-scm-user-shortcuts existing legacy-to-merge))
+        ) ;
+    (check (length merged) => 2)
+    (check (assoc-ref (car merged) "shortcut") => "C-a")
+    (check (assoc-ref (car merged) "command") => "(cmd-a)")
+    (check (assoc-ref (cadr merged) "shortcut") => "C-b")
+    (check (assoc-ref (cadr merged) "command") => "(cmd-b)")
+  ) ;let*
+) ;define
+
+;; 9. 快捷键字符串规范化
+
+(define (test-normalize-shortcut-string)
+  (check (normalize-shortcut-string "<less>   <gtr>") => "< >")
+  (check (normalize-shortcut-string "C-x   C-s") => "C-x C-s")
+  (check (normalize-shortcut-string 123) => 123)
+) ;define
+
+;; 10. 文件持久化读写与异常恢复
+
+(define (test-save-and-load-user-shortcuts)
+  (let* ((orig-file user-shortcuts-file)
+         (orig-shortcuts current-user-shortcuts)
+         (tmp-path (url->string (url-append (url-temp) "shortcuts.json")))
+        ) ;
+    (set! user-shortcuts-file tmp-path)
+    (set-current-user-shortcuts-list (list (make-shortcut-entry "C-1" "(insert-1)")
+                                       (make-shortcut-entry "C-2" "(insert-2)")
+                                     ) ;list
+    ) ;set-current-user-shortcuts-list
+    (save-user-shortcuts)
+    (check (url-exists? tmp-path) => #t)
+
+    ;; 验证保存出的 JSON 文件内容可由 (liii json) 正常解析
+    (let ((file-content (string->json (string-load tmp-path))))
+      (check (user-shortcuts-json-valid? file-content) => #t)
+    ) ;let
+
+    ;; 清空内存，重新从文件 load
+    (replace-current-user-shortcuts! (make-empty-user-shortcuts-json))
+    (check (length (current-user-shortcuts-list)) => 0)
+    (load-user-shortcuts)
+    (check (length (current-user-shortcuts-list)) => 2)
+    (check (get-user-shortcut "C-1") => "(insert-1)")
+    (check (get-user-shortcut "C-2") => "(insert-2)")
+
+    ;; 写入损坏的 JSON，load-user-shortcuts 应重置为有效空状态
+    (string-save "corrupted-json-data{{{" tmp-path)
+    (load-user-shortcuts)
+    (check (length (current-user-shortcuts-list)) => 0)
+    (check (user-shortcuts-json-valid? current-user-shortcuts) => #t)
+
+    ;; 清理临时文件并恢复现场
+    (catch #t (lambda () (url-remove tmp-path)) (lambda args #f))
+    (set! user-shortcuts-file orig-file)
+    (replace-current-user-shortcuts! orig-shortcuts)
+  ) ;let*
+) ;define
+
+;; 11. decode-shortcut 映射
+
+(define (test-decode-shortcut)
+  (let ((saved current-user-shortcuts))
+    (set-current-user-shortcuts-list (list (make-shortcut-entry "C-a" "(insert-a)"))
+    ) ;set-current-user-shortcuts-list
+    (check (decode-shortcut (encode-shortcut "C-a")) => "C-a")
+    (replace-current-user-shortcuts! saved)
+  ) ;let
+) ;define
+
+(tm-define (regtest-shortcut-edit)
+  (test-make-shortcut-entry)
+  (test-shortcut-entry-valid-failures)
+  (test-empty-user-shortcuts-json)
+  (test-make-user-shortcuts-json)
+  (test-user-shortcuts-json-valid-failures)
+  (test-shortcuts-crud)
+  (test-shortcuts-query-and-sort)
+  (test-legacy-scm-migration)
+  (test-normalize-shortcut-string)
+  (test-save-and-load-user-shortcuts)
+  (test-decode-shortcut)
+  (check-report)
+) ;tm-define

--- a/devel/1282.md
+++ b/devel/1282.md
@@ -1,0 +1,80 @@
+# [1282] 将 shortcut-edit.scm 的 JSON 库从 njson 迁移至 (liii json)
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [201_76.md](201_76.md) - 自定义快捷键使用 JSON 保存
+- [201_92.md](201_92.md) - 历史迁移至 njson
+- [216_26.md](216_26.md) - 旧版 scm 向 json 的迁移层
+
+## 2 任务相关的代码文件
+- TeXmacs/progs/source/shortcut-edit.scm
+- TeXmacs/progs/source/tests/shortcut-edit-test.scm
+
+## 3 如何测试
+
+### 3.1 单元测试
+```bash
+xmake b stem && xmake r shortcut-edit-test
+```
+
+### 3.2 手动测试
+`$TEXMACS_HOME_PATH` 默认系统路径：
+- Linux: `~/.local/share/moganlab`
+- macOS: `~/Library/Application Support/moganlab`
+- Windows: `%APPDATA%\moganlab`
+
+1. 启动程序：
+   ```bash
+   xmake r stem
+   ```
+2. 打开快捷键编辑器：
+   点击菜单栏 `工具 -> 键盘 -> 编辑键盘快捷键`（英文界面：`Tools -> Keyboard -> Edit keyboard shortcuts`）。
+3. 添加并测试新快捷键：
+   - 将光标置于 `Shortcut` 预览输入框，按下按键（如 `F6` 或 `< < 1`）；
+   - 在 `Command` 输入框填入命令（如 `(display "hello\n")` 或 `"test"`）；
+   - 点击 `New` 保存；
+   - 在主文档编辑器中按下对应的快捷键，验证命令是否正常触发生效。
+4. 验证 JSON 持久化存储格式：
+   - 打开 `$TEXMACS_HOME_PATH/system/shortcuts.json`；
+   - 验证内容为由 `(liii json)` 序列化的标准 JSON 格式，结构完整：
+     ```json
+     {"meta":{"version":1,"total":1},"shortcuts":[{"shortcut":"F6","command":"(display \"hello\\n\")"}]}
+     ```
+5. 重启持久性测试：
+   - 退出软件并重新启动 `xmake r stem`；
+   - 再次打开快捷键编辑器，确认此前保存的自定义快捷键依然存在；
+   - 在编辑器内触发该快捷键，依然生效。
+6. 删除快捷键：
+   - 在快捷键列表选中该条目，点击 `Clear`，确认条目被清除；
+   - 重启软件，确认快捷键已彻底移除。
+7. 异常容错测试：
+   - 关闭软件，故意损坏 `$TEXMACS_HOME_PATH/system/shortcuts.json` 内容（如写入非法 JSON 片段 `{"meta":{"version":1...`）；
+   - 启动软件并打开快捷键编辑器，软件不崩溃，自动将损坏配置重置为合法的空结构并正常使用。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git add devel/1282.md
+git commit -m "[1282] 更新任务文档"
+# 代码修改后：
+git add TeXmacs/progs/source/shortcut-edit.scm TeXmacs/progs/source/tests/shortcut-edit-test.scm
+git commit -m "[1282] 把 shortcut-edit.scm 迁移到 (liii json)"
+```
+
+## 5 What
+- 将 `TeXmacs/progs/source/shortcut-edit.scm` 对 `(liii njson)` 的依赖完全迁移为 `(liii json)`；
+- 采用 TDD 方式，新增 `TeXmacs/progs/source/tests/shortcut-edit-test.scm` 纯逻辑单元测试，覆盖条目结构、模式校验、增删查改、旧格式合并迁移与序列化；
+- 移除 `njson-free`、`njson-schema-report`、`file->njson`、`njson->file` 等 C++ handle 绑定调用，改为基于标准 Scheme 容器与 `(liii json)` 读写。
+
+## 6 Why
+- `(liii njson)` 是包装 C++ nlohmann-json handle 的不透明指针，需要调用端手动 `njson-free` 释放资源，容易引起内存泄漏或悬空句柄；
+- `(liii json)` 使用 Scheme 原生结构（对象为 alist，数组为 vector），生命周期由 GC 自动管理，读写轻量安全；
+- `shortcuts.json` 数据量小、层级浅，无需复杂 schema 引擎，通过原生谓词校验更清晰、更易维护。
+
+## 7 How
+- 将 `(import (liii njson))` 替换为 `(import (liii json))`；
+- 使用 `(liii json)` 谓词（`json-object?`、`vector?`、`json-ref`、`json-ref-string`）重写 `shortcut-entry-shortcut`、`shortcut-entry-command` 与 `user-shortcuts-json-valid?`；
+- 文件读写统一采用 `string-load` + `string->json` 与 `json->string` + `string-save`，移除仅供 C++ handle 文件访问使用的 `user-shortcuts-file-system`；
+- 内存状态 `current-user-shortcuts` 维护标准 JSON alist，更新时直接重置指针，无需调用 `njson-free`；
+- 先编写单测 `shortcut-edit-test.scm`，验证红绿重构周期。


### PR DESCRIPTION
## 任务描述
在 `shortcut-edit.scm` 中取消对 `(liii njson)` 的依赖，直接改用 `(liii json)` 处理 Scheme 原生 JSON 数据结构（alist 与 vector）。采用 TDD 方式新增 `shortcut-edit-test.scm` 单元测试，驱动并验证重构。

## 变更内容
1. **测试先行（TDD）**：
   - 新增 `TeXmacs/progs/source/tests/shortcut-edit-test.scm`，全面覆盖快捷键条目结构校验、合法/非法 JSON 模式验证、CRUD 操作、排序查询、旧版 `.scm` 兼容迁移合并以及文件持久化与异常回退（共 54 个断言）。
2. **取消 njson 依赖**：
   - 将 `(import (liii njson))` 替换为 `(import (liii json))`.
   - 移除 `njson-free`、`njson-schema-report`、`file->njson`、`njson->file` 等 C++ 句柄操作与 schema 校验，改用纯 Scheme 原生数据结构与 `(liii json)` 谓词校验。
   - 文件存取使用 `string-save`、`string-load` 配合 `json->string`、`string->json`，移除仅供 C++ handle 访问使用的 `user-shortcuts-file-system`。
3. **任务文档**：
   - 新增 `devel/1282.md`，记录 What/Why/How 及自动化单元测试与手工 GUI 测试步骤。

## 如何测试

### 1. 纯逻辑单元测试（自动化，headless）
```bash
xmake b stem && xmake r shortcut-edit-test    # 54 correct, 0 failed
```

### 2. 手动测试（GUI）
详见 `devel/1282.md` 第 3.2 节：
- 通过菜单 `工具 -> 键盘 -> 编辑键盘快捷键` 打开快捷键编辑器；
- 新增快捷键并在文档中测试触发；
- 检查 `$TEXMACS_HOME_PATH/system/shortcuts.json` 的标准 JSON 格式；
- 重启验证快捷键持久化有效；
- 删除快捷键并验证移除；
- 模拟非法/损坏 JSON 配置，验证异常容错与安全重置。