### PR TITLE
[1283] 修复启动页按下 Shift+方向键崩溃问题，改用 QShortcut 注册启动页标签快捷键

### DIFF
--- a/TeXmacs/tests/python/1283.py
+++ b/TeXmacs/tests/python/1283.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+| Tester                  | Platform    | Status |
+| ----------------------- | ----------- | ------ |
+| Darcy Shen <da@liii.pro>| Linux (X11) | Passed |
+
+Automated end-to-end UI test for issue 1283:
+1. Pressing Shift + arrow keys (Left, Right, Up, Down) on the Startup page
+   (tmfs://startup-tab) must not crash Mogan STEM.
+2. Tab shortcuts on the startup page (Ctrl+T to create a new tab, Ctrl+1/Ctrl+2
+   to switch between tabs) must work as expected.
+3. Tab shortcuts inside document tabs must continue to work.
+"""
+
+import os
+import sys
+import time
+import subprocess
+
+# Ensure UTF-8 and unbuffered stdout
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True, encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(line_buffering=True, encoding="utf-8")
+
+# DPI awareness on Windows
+if sys.platform == "win32":
+    try:
+        import ctypes
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    except Exception:
+        try:
+            import ctypes
+            ctypes.windll.user32.SetProcessDPIAware()
+        except Exception:
+            pass
+
+# Fallback: import pynput from ~/git/pynput/lib if not installed system-wide
+try:
+    import pynput
+except ImportError:
+    pynput_path = os.path.expanduser("~/git/pynput/lib")
+    if os.path.exists(pynput_path):
+        sys.path.insert(0, pynput_path)
+    import pynput
+
+from pynput.keyboard import Key, Controller as KeyboardController
+from pynput.mouse import Button, Controller as MouseController
+
+IS_WINDOWS = sys.platform == "win32"
+IS_DARWIN = sys.platform == "darwin"
+
+
+def find_repo_root():
+    cur = os.path.abspath(os.path.dirname(__file__))
+    while cur != "/" and cur != os.path.dirname(cur):
+        if os.path.exists(os.path.join(cur, "TeXmacs")) and os.path.exists(os.path.join(cur, "src")):
+            return cur
+        cur = os.path.dirname(cur)
+    return os.path.abspath(".")
+
+
+def find_mogan_binary(repo_root):
+    candidates = [
+        os.path.join(repo_root, "build/linux/x86_64/releasedbg/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/release/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/debug/moganstem"),
+        os.path.join(repo_root, "build/packages/stem/data/bin/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/windows/x64/releasedbg/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/windows/x64/release/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/macosx/arm64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+    ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    raise FileNotFoundError("Mogan binary not found. Please build stem first (xmake b stem).")
+
+
+def focus_mogan_window():
+    """Ensure Mogan window is raised and focused across platforms."""
+    if IS_DARWIN:
+        try:
+            import AppKit
+            for app in AppKit.NSWorkspace.sharedWorkspace().runningApplications():
+                if "Mogan" in (app.localizedName() or ""):
+                    app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
+                    return
+        except Exception:
+            pass
+        subprocess.run(
+            ["osascript", "-e", 'tell application "System Events" to set frontmost of first process whose name contains "Mogan" to true'],
+            capture_output=True,
+        )
+        return
+
+    if IS_WINDOWS:
+        try:
+            import ctypes
+            from ctypes import wintypes
+            user32 = ctypes.windll.user32
+
+            def callback(hwnd, _lparam):
+                if user32.IsWindowVisible(hwnd):
+                    n = user32.GetWindowTextLengthW(hwnd)
+                    buf = ctypes.create_unicode_buffer(n + 1)
+                    user32.GetWindowTextW(hwnd, buf, n + 1)
+                    if "STEM" in buf.value or "Mogan" in buf.value:
+                        user32.ShowWindow(hwnd, 9)  # SW_RESTORE
+                        user32.SetForegroundWindow(hwnd)
+                        return False
+                return True
+
+            EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, wintypes.HWND, wintypes.LPARAM)
+            user32.EnumWindows(EnumWindowsProc(callback), 0)
+        except Exception:
+            pass
+        return
+
+    # Linux (X11)
+    try:
+        import Xlib.display
+        import Xlib.X
+        import Xlib.protocol.event
+
+        d = Xlib.display.Display()
+        root = d.screen().root
+
+        def find_mogan(win):
+            try:
+                cls = win.get_wm_class()
+                if cls and "mogan" in cls[0].lower():
+                    return win
+                name = win.get_wm_name()
+                if name and ("Mogan" in name or "STEM" in name):
+                    return win
+                for child in win.query_tree().children:
+                    res = find_mogan(child)
+                    if res:
+                        return res
+            except Exception:
+                pass
+            return None
+
+        w = find_mogan(root)
+        if w:
+            net_active = d.intern_atom("_NET_ACTIVE_WINDOW")
+            cm = Xlib.protocol.event.ClientMessage(
+                window=w,
+                client_type=net_active,
+                data=(32, [2, Xlib.X.CurrentTime, 0, 0, 0]),
+            )
+            root.send_event(
+                cm,
+                event_mask=Xlib.X.SubstructureRedirectMask | Xlib.X.SubstructureNotifyMask,
+            )
+            w.set_input_focus(Xlib.X.RevertToParent, Xlib.X.CurrentTime)
+            w.configure(stack_mode=Xlib.X.Above)
+            d.sync()
+    except Exception:
+        pass
+
+
+def run_test():
+    repo_root = find_repo_root()
+    bin_path = find_mogan_binary(repo_root)
+    print(f"[1283] Using binary: {bin_path}")
+
+    env = os.environ.copy()
+    env["TEXMACS_PATH"] = os.path.join(repo_root, "TeXmacs")
+
+    print("[1283] Launching Mogan STEM...")
+    proc = subprocess.Popen([bin_path, "-d"], env=env, cwd=repo_root)
+    modifier = Key.cmd if IS_DARWIN else Key.ctrl
+
+    try:
+        time.sleep(3.0)
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1283] ERROR: Mogan exited prematurely with code {ret}")
+            return 1
+
+        print("[1283] Focusing Mogan window...")
+        focus_mogan_window()
+        time.sleep(0.5)
+
+        # Click inside the startup page content area to guarantee keyboard focus
+        mouse = MouseController()
+        mouse.position = (1000, 1000)
+        time.sleep(0.3)
+        mouse.click(Button.left)
+        time.sleep(0.5)
+
+        kb = KeyboardController()
+
+        # Step 1: Verify Shift+Arrow keys on the startup page do NOT crash
+        test_arrows = [
+            (Key.left, "Shift+Left"),
+            (Key.right, "Shift+Right"),
+            (Key.up, "Shift+Up"),
+            (Key.down, "Shift+Down"),
+        ]
+
+        for key, name in test_arrows:
+            print(f"[1283] Pressing {name} on startup page...")
+            with kb.pressed(Key.shift):
+                kb.press(key)
+                kb.release(key)
+
+            time.sleep(0.5)
+            ret = proc.poll()
+            if ret is not None:
+                print(f"[1283] CRASH REPRODUCED: Mogan crashed on {name} with exit code {ret}!")
+                return 1
+            print(f"[1283] {name} passed (no crash).")
+
+        # Step 2: Verify Ctrl+T creates a new tab from the startup page
+        print("[1283] Pressing Ctrl+T on startup page to create a new tab...")
+        with kb.pressed(modifier):
+            kb.press("t")
+            kb.release("t")
+        time.sleep(1.5)
+
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1283] CRASH: Mogan crashed after Ctrl+T with exit code {ret}!")
+            return 1
+
+        # Step 3: Switch back to startup tab (Ctrl+1) and to second tab (Ctrl+2)
+        print("[1283] Pressing Ctrl+1 to switch to first tab (startup page)...")
+        with kb.pressed(modifier):
+            kb.press("1")
+            kb.release("1")
+        time.sleep(1.0)
+
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1283] CRASH: Mogan crashed after Ctrl+1 with exit code {ret}!")
+            return 1
+
+        print("[1283] Pressing Ctrl+2 to switch to second tab...")
+        with kb.pressed(modifier):
+            kb.press("2")
+            kb.release("2")
+        time.sleep(1.0)
+
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1283] CRASH: Mogan crashed after Ctrl+2 with exit code {ret}!")
+            return 1
+
+        # Step 4: Press Ctrl+T inside the second tab to create a third tab
+        print("[1283] Pressing Ctrl+T in second tab to create third tab...")
+        with kb.pressed(modifier):
+            kb.press("t")
+            kb.release("t")
+        time.sleep(1.5)
+
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1283] CRASH: Mogan crashed after Ctrl+T in tab with exit code {ret}!")
+            return 1
+
+        # Step 5: Switch among tabs using Ctrl+1 and Ctrl+3
+        print("[1283] Pressing Ctrl+1 then Ctrl+3...")
+        with kb.pressed(modifier):
+            kb.press("1")
+            kb.release("1")
+        time.sleep(0.8)
+
+        with kb.pressed(modifier):
+            kb.press("3")
+            kb.release("3")
+        time.sleep(0.8)
+
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1283] CRASH: Mogan crashed during tab switching with exit code {ret}!")
+            return 1
+
+        print("[1283] TEST PASSED: All Shift+Arrow keys and tab shortcuts work properly.")
+        return 0
+
+    finally:
+        if proc.poll() is None:
+            print("[1283] Terminating Mogan...")
+            proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(run_test())

--- a/devel/1283.md
+++ b/devel/1283.md
@@ -1,0 +1,52 @@
+# [1283] 修复启动页按下 Shift+方向键崩溃问题
+
+## 1 相关文档
+- [216_14.md](216_14.md) - 启动页通用键盘桥接（历史变更）
+
+## 2 任务相关的代码文件
+- `src/Plugins/Qt/QTMStartupTabWidget.hpp` — 移除 keyPressEvent / keyReleaseEvent 声明，增加 setup_shortcuts
+- `src/Plugins/Qt/QTMStartupTabWidget.cpp` — 移除通用 key-press 转发，改用 Qt 原生 QShortcut 注册标签页快捷键（Ctrl+T / Ctrl+1~9）
+- `src/Typeset/Boxes/Basic/boxes.cpp` — `find_innermost_scroll` 增加防御性判空 `if (is_nil (b)) return path ();`
+- `TeXmacs/tests/python/1283.py` — 基于 pynput 的端到端自动化测试脚本
+
+## 3 如何测试
+
+### 3.1 端到端自动化测试
+```bash
+xmake b stem
+python3 TeXmacs/tests/python/1283.py
+```
+
+测试流程：
+1. 启动 Mogan STEM，聚焦到启动页；
+2. 依次按下 `Shift+Left`、`Shift+Right`、`Shift+Up`、`Shift+Down`，验证进程未崩溃；
+3. 在启动页按下 `Ctrl+T` 新建标签页，验证标签页创建成功；
+4. 按 `Ctrl+1` 切回启动页，按 `Ctrl+2` 切到新建标签页；
+5. 在新建标签页中再次按 `Ctrl+T` 新建第 3 个标签页，按 `Ctrl+1` 和 `Ctrl+3` 验证标签页切换正常。
+
+### 3.2 手动测试
+1. 启动 Mogan STEM，保持在启动页；
+2. 按 `Shift + 左/右/上/下` 箭头键，确认程序不崩溃；
+3. 按 `Ctrl + T`，确认新建标签页打开；
+4. 按 `Ctrl + 1`，切回启动页；
+5. 按 `Ctrl + 2`，切回文档页。
+
+## 4 What
+启动页（`tmfs://startup-tab`）处于焦点状态时，按下 `Shift + 任意方向键`，程序直接崩溃（`SIGSEGV`，信号 11）。
+
+## 5 Why
+1. 历史改动（`216_14`）为了让 `Ctrl+T` 和 `Ctrl+1..6` 在启动页生效，在 `QTMStartupTabWidget` 中实现了 `keyPressEvent` / `keyReleaseEvent`，将所有键盘事件通过 `eval_scheme("(key-press ...)")` 转发到 Scheme 侧文本编辑器。
+2. Scheme 侧 `generic-kbd.scm` 中将 `Shift+方向键`（`S-left`, `S-right`, `S-up`, `S-down`）绑定为选区移动操作 `(kbd-select kbd-*)`，最终调用当前编辑器的 `go_left()` / `go_right()` / `cursor_move_sub()`。
+3. 启动页由纯 Qt 控件承载，没有文档排版盒，其 `get_box()` 为空（`is_nil(b)`）。`cursor_move_sub` 中调用 `find_innermost_scroll(get_box(), ...)`，未对 `b` 进行判空就直接解引用 `b->find_box_path(...)`，引发空指针解引用崩溃（`SIGSEGV`）。
+4. 启动页是纯 Qt 控件界面，不应该复用 Scheme 文本编辑器的 `key-press` 机制。
+
+## 6 How
+1. **移除启动页对 Scheme `key-press` 的无差别转发**：
+   从 `QTMStartupTabWidget` 中移除 `keyPressEvent` 与 `keyReleaseEvent` 覆盖，让 Qt 原生子控件自然处理键盘事件（列表选择、按钮切换等），不再误触发文档编辑器的光标与选区移动。
+2. **使用 Qt 原生 `QShortcut` 注册启动页快捷键**：
+   在 `QTMStartupTabWidget::setup_shortcuts()` 中通过 `QShortcut` 直接注册启动页所需的标签页快捷键：
+   - `QKeySequence::AddTab`（`Ctrl+T` / `Cmd+T`）：触发 `(new-document)`；
+   - `Qt::CTRL | (Qt::Key_1 + i)`（`Ctrl+1` ~ `Ctrl+9`）：触发 `(switch-to-view-index i)`。
+   由于 `QShortcut` 附着于 `QTMStartupTabWidget`，在切换到文档视图导致启动页隐藏时，这些快捷键由 Qt 机制自动休眠，文档视图原有的 Scheme 快捷键机制正常接管。
+3. **防御性编程**：
+   在 `src/Typeset/Boxes/Basic/boxes.cpp` 的 `find_innermost_scroll` 函数开头增加 `if (is_nil (b)) return path ();` 判空保护，防止任何空盒调用导致崩溃。

--- a/src/Plugins/Qt/QTMStartupTabWidget.cpp
+++ b/src/Plugins/Qt/QTMStartupTabWidget.cpp
@@ -19,8 +19,10 @@
 #include <QButtonGroup>
 #include <QHBoxLayout>
 #include <QKeyEvent>
+#include <QKeySequence>
 #include <QLabel>
 #include <QPushButton>
+#include <QShortcut>
 #include <QStackedWidget>
 #include <QVBoxLayout>
 
@@ -93,6 +95,8 @@ QTMStartupTabWidget::QTMStartupTabWidget (QWidget* parent)
   stackedWidget->setObjectName ("startup-tab-content"); // 样式在主题CSS中定义
   setup_right_content (stackedWidget);
   mainLayout->addWidget (stackedWidget, 1);
+
+  setup_shortcuts ();
 }
 
 QTMStartupTabWidget::Entry
@@ -361,19 +365,16 @@ QTMStartupTabWidget::on_app_quit () {
 }
 
 void
-QTMStartupTabWidget::keyPressEvent (QKeyEvent* event) {
-  string key= from_key_press_event (event);
-  if (is_empty (key)) return QWidget::keyPressEvent (event);
+QTMStartupTabWidget::setup_shortcuts () {
+  QShortcut* scNewTab= new QShortcut (QKeySequence::AddTab, this);
+  connect (scNewTab, &QShortcut::activated, this,
+           [] () { eval_scheme ("(new-document)"); });
 
-  eval_scheme ("(key-press " * qt_scheme_quote (to_qstring (key)) * ")");
-  event->accept ();
-}
-
-void
-QTMStartupTabWidget::keyReleaseEvent (QKeyEvent* event) {
-  string key= from_key_release_event (event);
-  if (is_empty (key)) return QWidget::keyReleaseEvent (event);
-
-  eval_scheme ("(key-press " * qt_scheme_quote (to_qstring (key)) * ")");
-  event->accept ();
+  for (int i= 0; i < 9; ++i) {
+    QShortcut* scTab=
+        new QShortcut (QKeySequence (Qt::CTRL | (Qt::Key_1 + i)), this);
+    connect (scTab, &QShortcut::activated, this, [i] () {
+      eval_scheme ("(switch-to-view-index " * as_string (i) * ")");
+    });
+  }
 }

--- a/src/Plugins/Qt/QTMStartupTabWidget.hpp
+++ b/src/Plugins/Qt/QTMStartupTabWidget.hpp
@@ -47,10 +47,6 @@ private slots:
   void onCategoryClicked ();
   void onCategoriesLoaded ();
 
-protected:
-  void keyPressEvent (QKeyEvent* event) override;
-  void keyReleaseEvent (QKeyEvent* event) override;
-
 private:
   // 界面构建辅助函数
   void         setup_left_sidebar (QVBoxLayout* sidebarLayout);
@@ -66,6 +62,7 @@ private:
   // 导航按钮状态管理
   void set_active_nav_button (Entry entry);
   void refresh_recent_docs_on_file_entry (Entry entry);
+  void setup_shortcuts ();
 
 private:
   Entry   currentEntry_;

--- a/src/Typeset/Boxes/Basic/boxes.cpp
+++ b/src/Typeset/Boxes/Basic/boxes.cpp
@@ -324,6 +324,7 @@ path
 find_innermost_scroll (box b, path p) {
   // Given a box b and a logical path p, this routine returns
   // the longest box path sp such that b[sp] is a scroll node
+  if (is_nil (b)) return path ();
   path bp;
   while (true) {
     bool found= false;


### PR DESCRIPTION
## What
修复启动页处于焦点时按下 Shift+方向键导致程序崩溃（SIGSEGV）的问题。

## Why
1. `QTMStartupTabWidget` 之前将键盘事件无差别转发给 Scheme 文本编辑器的 `key-press`。
2. `Shift+方向键` 触发文本选区移动，但启动页没有文档排版盒，`get_box()` 为空导致 `find_innermost_scroll` 空指针解引用崩溃。
3. 启动页为纯 Qt 控件界面，不应走 Scheme 文本编辑器的 `key-press` 机制。

## How
1. 移除 `QTMStartupTabWidget` 的 `keyPressEvent` / `keyReleaseEvent` Scheme 桥接。
2. 改用 Qt 原生 `QShortcut` 注册启动页所需的标签页快捷键（`Ctrl+T` 新建标签页、`Ctrl+1` ~ `Ctrl+9` 切换标签页）。
3. 在 `find_innermost_scroll` 中增加防御性判空。
4. 新增 `TeXmacs/tests/python/1283.py` 端到端自动化测试。