### PR TITLE
[1284] 将 chat-list.scm 的 JSON 库从 njson 迁移至 (liii json)

### DIFF
--- a/TeXmacs/plugins/llm/progs/llm/chat-list.scm
+++ b/TeXmacs/plugins/llm/progs/llm/chat-list.scm
@@ -12,7 +12,7 @@
 
 (texmacs-module (llm chat-list))
 
-(import (liii njson))
+(import (liii json))
 
 ;;; ---------- 路径工具 ----------
 
@@ -56,22 +56,19 @@
          (search (if (and (pair? opts2) (car opts2)) (car opts2) "disabled"))
          (updated-at (if (and (pair? opts2) (pair? (cdr opts2)) (cadr opts2)) (cadr opts2) #f)
          ) ;updated-at
-         (entry (string->njson "{}"))
+         (archived-str (if (or (not archived) (== archived "false")) "false" "true"))
+         (actual-created-at (or created-at ""))
+         (actual-updated-at (or updated-at created-at ""))
         ) ;
-    (njson-set! entry "sessionId" sid)
-    (njson-set! entry "title" title)
-    (njson-set! entry "model" model)
-    (njson-set! entry
-      "archived"
-      (if (or (not archived) (== archived "false")) "false" "true")
-    ) ;njson-set!
-    (njson-set! entry "createdAt" (or created-at ""))
-    (njson-set! entry "defaultExpandCount" 5)
-    (njson-set! entry "thinking" thinking)
-    (njson-set! entry "search" search)
-    ;; updateAt: 最近活跃时间戳，用于排序索引；缺失时回退到 createdAt
-    (njson-set! entry "updateAt" (or updated-at created-at ""))
-    entry
+    `((,"sessionId" . ,sid)
+      (,"title" . ,title)
+      (,"model" . ,model)
+      (,"archived" . ,archived-str)
+      (,"createdAt" . ,actual-created-at)
+      (,"defaultExpandCount" . ,5)
+      (,"thinking" . ,thinking)
+      (,"search" . ,search)
+      (,"updateAt" . ,actual-updated-at))
   ) ;let*
 ) ;tm-define
 
@@ -79,29 +76,26 @@
 
 (tm-define (chat-persist-load-all)
   (let ((manifest-path (chat-persist-manifest-path)))
-    (if (not (file-exists? manifest-path))
-      (noop)
-      (let* ((manifest (file->njson manifest-path))
-             (sessions-json (njson-ref manifest "sessions"))
-             (entries (njson-array->list sessions-json))
+    (when (file-exists? manifest-path)
+      (let* ((manifest (catch #t
+                         (lambda () (string->json (string-load (system->url manifest-path))))
+                         (lambda args #f)
+                       ) ;catch
+             ) ;manifest
+             (sessions-vec (and (json-object? manifest) (json-ref manifest "sessions")))
+             (entries (if (vector? sessions-vec) (vector->list sessions-vec) '()))
             ) ;
         (for-each (lambda (entry)
-                    ;; njson-array->list 返回 alist，用 assoc 访问字段
-                    (let* ((sid (cdr (assoc "sessionId" entry)))
-                           (title (cdr (assoc "title" entry)))
-                           (model (cdr (assoc "model" entry)))
-                           (archived-str (cdr (assoc "archived" entry)))
-                           (created-at-pair (assoc "createdAt" entry))
-                           (created-at (if created-at-pair (cdr created-at-pair) ""))
-                           (updated-at-pair (assoc "updateAt" entry))
+                    (let* ((sid (json-ref-string entry "sessionId" ""))
+                           (title (json-ref-string entry "title" ""))
+                           (model (json-ref-string entry "model" ""))
+                           (archived-str (json-ref-string entry "archived" "false"))
+                           (created-at (json-ref-string entry "createdAt" ""))
                            ;; updateAt 缺失时回退到 createdAt（兼容旧 manifest）
-                           (updated-at (if updated-at-pair (cdr updated-at-pair) created-at))
-                           (expand-count-pair (assoc "defaultExpandCount" entry))
-                           (expand-count (if expand-count-pair (cdr expand-count-pair) 5))
-                           (thinking-pair (assoc "thinking" entry))
-                           (thinking (if thinking-pair (cdr thinking-pair) "disabled"))
-                           (search-pair (assoc "search" entry))
-                           (search (if search-pair (cdr search-pair) "disabled"))
+                           (updated-at (json-ref-string entry "updateAt" created-at))
+                           (expand-count (json-ref-integer entry "defaultExpandCount" 5))
+                           (thinking (json-ref-string entry "thinking" "disabled"))
+                           (search (json-ref-string entry "search" "disabled"))
                           ) ;
                       ;; 只传元数据给 C++，不加载 buffer 内容
                       (qt-chat-tab-restore-session sid title model archived-str
@@ -111,9 +105,8 @@
                   ) ;lambda
           entries
         ) ;for-each
-        (njson-free manifest)
       ) ;let*
-    ) ;if
+    ) ;when
   ) ;let
 ) ;tm-define
 
@@ -135,48 +128,37 @@
          ) ;entry
         ) ;
     (chat-persist-ensure-dir! (chat-persist-base-dir))
-    (if (not (file-exists? manifest-path))
-      ;; manifest 不存在：创建新的，直接构建包含 entry 的数组
-      (let* ((manifest (string->njson "{\"version\":1,\"sessions\":[]}"))
-             (new-arr (string->njson "[]"))
-            ) ;
-        (njson-append! new-arr entry)
-        (njson-set! manifest "sessions" new-arr)
-        (njson->file manifest-path manifest)
-        (njson-free new-arr)
-        (njson-free manifest)
-      ) ;let*
-      ;; manifest 存在：读取，查找并更新或追加
-      (let* ((manifest (file->njson manifest-path))
-             (sessions-arr (njson-ref manifest "sessions"))
-             (entries (njson-array->list sessions-arr))
-            ) ;
-        (let ((new-arr (string->njson "[]")) (found #f))
-          (for-each (lambda (e)
-                      (let ((sid-pair (assoc "sessionId" e)))
-                        (if (and sid-pair (== (cdr sid-pair) session-id))
-                          (begin
-                            (njson-append! new-arr entry)
-                            (set! found #t)
-                          ) ;begin
-                          (njson-append! new-arr (json->njson e))
-                        ) ;if
-                      ) ;let
-                    ) ;lambda
-            entries
-          ) ;for-each
-          (when (not found)
-            (njson-append! new-arr entry)
-          ) ;when
-          (njson-drop! manifest "sessions")
-          (njson-set! manifest "sessions" new-arr)
-          (njson->file manifest-path manifest)
-          (njson-free new-arr)
-          (njson-free manifest)
-        ) ;let
-      ) ;let*
-    ) ;if
-    (njson-free entry)
+    (let* ((manifest (if (file-exists? manifest-path)
+                       (catch #t
+                         (lambda () (string->json (string-load (system->url manifest-path))))
+                         (lambda args #f)
+                       ) ;catch
+                       #f
+                     ) ;if
+           ) ;manifest
+           (version (if (json-object? manifest) (json-ref-integer manifest "version" 1) 1))
+           (sessions-vec (and (json-object? manifest) (json-ref manifest "sessions")))
+           (entries (if (vector? sessions-vec) (vector->list sessions-vec) '()))
+           (found #f)
+           (updated-entries (map (lambda (e)
+                                   (if (equal? (json-ref-string e "sessionId" "") session-id)
+                                     (begin
+                                       (set! found #t)
+                                       entry
+                                     ) ;begin
+                                     e
+                                   ) ;if
+                                 ) ;lambda
+                              entries
+                            ) ;map
+           ) ;updated-entries
+           (final-entries (if found updated-entries (append updated-entries (list entry))))
+           (new-manifest `((,"version" . ,version)
+                           (,"sessions" . ,(list->vector final-entries)))
+           ) ;new-manifest
+          ) ;
+      (string-save (json->string new-manifest) (system->url manifest-path))
+    ) ;let*
   ) ;let*
 ) ;tm-define
 
@@ -199,26 +181,23 @@
   ;; 2. 从 manifest 中移除条目
   (let ((manifest-path (chat-persist-manifest-path)))
     (when (file-exists? manifest-path)
-      (let* ((manifest (file->njson manifest-path))
-             (sessions-arr (njson-ref manifest "sessions"))
-             (entries (njson-array->list sessions-arr))
+      (let* ((manifest (catch #t
+                         (lambda () (string->json (string-load (system->url manifest-path))))
+                         (lambda args #f)
+                       ) ;catch
+             ) ;manifest
+             (version (if (json-object? manifest) (json-ref-integer manifest "version" 1) 1))
+             (sessions-vec (and (json-object? manifest) (json-ref manifest "sessions")))
+             (entries (if (vector? sessions-vec) (vector->list sessions-vec) '()))
+             (remaining (filter (lambda (e) (not (equal? (json-ref-string e "sessionId" "") session-id)))
+                          entries
+                        ) ;filter
+             ) ;remaining
+             (new-manifest `((,"version" . ,version)
+                             (,"sessions" . ,(list->vector remaining)))
+             ) ;new-manifest
             ) ;
-        (let ((new-arr (string->njson "[]")))
-          (for-each (lambda (e)
-                      (let ((sid-pair (assoc "sessionId" e)))
-                        (when (not (and sid-pair (== (cdr sid-pair) session-id)))
-                          (njson-append! new-arr (json->njson e))
-                        ) ;when
-                      ) ;let
-                    ) ;lambda
-            entries
-          ) ;for-each
-          (njson-drop! manifest "sessions")
-          (njson-set! manifest "sessions" new-arr)
-          (njson->file manifest-path manifest)
-          (njson-free new-arr)
-          (njson-free manifest)
-        ) ;let
+        (string-save (json->string new-manifest) (system->url manifest-path))
       ) ;let*
     ) ;when
   ) ;let

--- a/TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm
+++ b/TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm
@@ -1,0 +1,328 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : chat-list-test.scm
+;; DESCRIPTION : 纯逻辑单元测试：Chat 会话列表持久化（条目构造、增量保存、会话加载与删除）
+;; COPYRIGHT   : (C) 2026 Mogan STEM
+;;
+;; USAGE
+;;   xmake b stem
+;;   xmake r chat-list-test
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+(import (liii json))
+
+(check-set-mode! 'report-failed)
+
+(load "./TeXmacs/plugins/llm/progs/llm/chat-list.scm")
+
+;;; ---------- 测试环境隔离（沙箱目录） ----------
+
+(define test-sandbox-dir
+  (url->system (url-append (url-temp) "test-ai-chat-sessions"))
+) ;define
+
+(tm-define (chat-persist-base-dir) test-sandbox-dir)
+
+(define (clean-test-sandbox!)
+  (let ((manifest-url (system->url (chat-persist-manifest-path))))
+    (when (url-exists? manifest-url)
+      (system-remove manifest-url)
+    ) ;when
+  ) ;let
+  (let ((msg-url-2 (system->url (chat-persist-message-path "del-2"))))
+    (when (url-exists? msg-url-2)
+      (system-remove msg-url-2)
+    ) ;when
+  ) ;let
+  (let ((session-dir-2 (system->url (string-append test-sandbox-dir "/del-2"))))
+    (when (url-exists? session-dir-2)
+      (system-rmdir session-dir-2)
+    ) ;when
+  ) ;let
+) ;define
+
+;;; ---------- 1. 条目构造测试 ----------
+
+(define (test-make-entry-defaults)
+  (let ((entry (chat-persist-make-entry "sid-001" "Title 1" "gpt-4o" #f)))
+    (check (json-object? entry) => #t)
+    (check (json-ref-string entry "sessionId" #f) => "sid-001")
+    (check (json-ref-string entry "title" #f) => "Title 1")
+    (check (json-ref-string entry "model" #f) => "gpt-4o")
+    (check (json-ref-string entry "archived" #f) => "false")
+    (check (string? (json-ref-string entry "createdAt" #f)) => #t)
+    (check (json-ref-integer entry "defaultExpandCount" 0) => 5)
+    (check (json-ref-string entry "thinking" #f) => "disabled")
+    (check (json-ref-string entry "search" #f) => "disabled")
+    ;; updateAt 缺省时回退到 createdAt
+    (check (json-ref-string entry "updateAt" #f)
+      =>
+      (json-ref-string entry "createdAt" #f)
+    ) ;check
+  ) ;let
+) ;define
+
+(define (test-make-entry-archived-variants)
+  (let ((e1 (chat-persist-make-entry "sid-1" "T1" "M1" #t))
+        (e2 (chat-persist-make-entry "sid-2" "T2" "M2" "true"))
+        (e3 (chat-persist-make-entry "sid-3" "T3" "M3" "false"))
+        (e4 (chat-persist-make-entry "sid-4" "T4" "M4" #f))
+       ) ;
+    (check (json-ref-string e1 "archived" #f) => "true")
+    (check (json-ref-string e2 "archived" #f) => "true")
+    (check (json-ref-string e3 "archived" #f) => "false")
+    (check (json-ref-string e4 "archived" #f) => "false")
+  ) ;let
+) ;define
+
+(define (test-make-entry-with-options)
+  ;; 传入 rest 参数: created-at thinking search updated-at
+  (let ((entry (chat-persist-make-entry "sid-opt" "Deep Thinking" "deepseek-r1"
+                 #f "1700000000" "enabled" "enabled" "1800000000"
+               ) ;chat-persist-make-entry
+        ) ;entry
+       ) ;
+    (check (json-object? entry) => #t)
+    (check (json-ref-string entry "sessionId" #f) => "sid-opt")
+    (check (json-ref-string entry "createdAt" #f) => "1700000000")
+    (check (json-ref-string entry "thinking" #f) => "enabled")
+    (check (json-ref-string entry "search" #f) => "enabled")
+    (check (json-ref-string entry "updateAt" #f) => "1800000000")
+  ) ;let
+) ;define
+
+(define (test-make-entry-json-serialization)
+  (let* ((entry (chat-persist-make-entry "sid-json" "Serial Test" "model-x" #f
+                  "1700000000" "disabled" "disabled" "1700000000"
+                ) ;chat-persist-make-entry
+         ) ;entry
+         (json-str (json->string entry))
+         (parsed (string->json json-str))
+        ) ;
+    (check (json-object? parsed) => #t)
+    (check (json-ref-string parsed "sessionId" #f) => "sid-json")
+    (check (json-ref-string parsed "title" #f) => "Serial Test")
+    (check (json-ref-string parsed "model" #f) => "model-x")
+    (check (json-ref-integer parsed "defaultExpandCount" 0) => 5)
+  ) ;let*
+) ;define
+
+;;; ---------- 2. 增量保存与更新测试 ----------
+
+(define (test-manifest-create-and-update)
+  (clean-test-sandbox!)
+  (let ((manifest-path (chat-persist-manifest-path)))
+    ;; 1. 初次写入：manifest 不存在，应自动创建新文件
+    (chat-persist-update-manifest "sid-1" "Title 1" "model-a" #f "100"
+      "disabled" "disabled" "100"
+    ) ;chat-persist-update-manifest
+    (check (file-exists? manifest-path) => #t)
+
+    (let* ((parsed (string->json (string-load (system->url manifest-path))))
+           (sessions (and (json-object? parsed) (json-ref parsed "sessions")))
+          ) ;
+      (check (json-ref-integer parsed "version" 0) => 1)
+      (check (vector? sessions) => #t)
+      (check (vector-length sessions) => 1)
+      (let ((s0 (vector-ref sessions 0)))
+        (check (json-ref-string s0 "sessionId" #f) => "sid-1")
+        (check (json-ref-string s0 "title" #f) => "Title 1")
+      ) ;let
+    ) ;let*
+
+    ;; 2. 追加第二条记录：sessions 长度应变为 2
+    (chat-persist-update-manifest "sid-2" "Title 2" "model-b" #t "200" "enabled"
+      "disabled" "200"
+    ) ;chat-persist-update-manifest
+    (let* ((parsed (string->json (string-load (system->url manifest-path))))
+           (sessions (json-ref parsed "sessions"))
+          ) ;
+      (check (vector-length sessions) => 2)
+      (let ((s0 (vector-ref sessions 0)) (s1 (vector-ref sessions 1)))
+        (check (json-ref-string s0 "sessionId" #f) => "sid-1")
+        (check (json-ref-string s1 "sessionId" #f) => "sid-2")
+        (check (json-ref-string s1 "archived" #f) => "true")
+        (check (json-ref-string s1 "thinking" #f) => "enabled")
+      ) ;let
+    ) ;let*
+
+    ;; 3. 更新第一条记录：同 sessionId，原地更新，总数保持 2
+    (chat-persist-update-manifest "sid-1" "Title 1 Updated" "model-a" #f "100"
+      "disabled" "disabled" "300"
+    ) ;chat-persist-update-manifest
+    (let* ((parsed (string->json (string-load (system->url manifest-path))))
+           (sessions (json-ref parsed "sessions"))
+          ) ;
+      (check (vector-length sessions) => 2)
+      (let ((s0 (vector-ref sessions 0)) (s1 (vector-ref sessions 1)))
+        (check (json-ref-string s0 "sessionId" #f) => "sid-1")
+        (check (json-ref-string s0 "title" #f) => "Title 1 Updated")
+        (check (json-ref-string s0 "updateAt" #f) => "300")
+        (check (json-ref-string s1 "sessionId" #f) => "sid-2")
+      ) ;let
+    ) ;let*
+  ) ;let
+  (clean-test-sandbox!)
+) ;define
+
+;;; ---------- 3. 会话恢复与读取测试 ----------
+
+(define restored-sessions '())
+
+(tm-define (qt-chat-tab-restore-session sid title model archived createdAt
+             updateAt expandCount thinking search
+           ) ;qt-chat-tab-restore-session
+  (set! restored-sessions
+    (cons (list sid title model archived createdAt updateAt expandCount thinking search)
+      restored-sessions
+    ) ;cons
+  ) ;set!
+) ;tm-define
+
+(define (test-load-all-normal)
+  (clean-test-sandbox!)
+  (set! restored-sessions '())
+  ;; 保存两条会话
+  (chat-persist-update-manifest "load-sid-1" "LTitle 1" "gpt" #f "1000"
+    "disabled" "disabled" "1000"
+  ) ;chat-persist-update-manifest
+  (chat-persist-update-manifest "load-sid-2" "LTitle 2" "claude" #t "2000"
+    "enabled" "enabled" "3000"
+  ) ;chat-persist-update-manifest
+
+  (chat-persist-load-all)
+
+  (check (length restored-sessions) => 2)
+  ;; sessions 在 load-all 中按原序遍历调用
+  (let ((s2 (assoc "load-sid-2" restored-sessions))
+        (s1 (assoc "load-sid-1" restored-sessions))
+       ) ;
+    (check (pair? s1) => #t)
+    (check (pair? s2) => #t)
+    (check (list-ref s1 1) => "LTitle 1")
+    (check (list-ref s1 2) => "gpt")
+    (check (list-ref s1 3) => "false")
+    (check (list-ref s1 4) => "1000")
+    (check (list-ref s1 5) => "1000")
+    (check (list-ref s1 6) => 5)
+    (check (list-ref s1 7) => "disabled")
+    (check (list-ref s1 8) => "disabled")
+
+    (check (list-ref s2 1) => "LTitle 2")
+    (check (list-ref s2 2) => "claude")
+    (check (list-ref s2 3) => "true")
+    (check (list-ref s2 4) => "2000")
+    (check (list-ref s2 5) => "3000")
+    (check (list-ref s2 7) => "enabled")
+    (check (list-ref s2 8) => "enabled")
+  ) ;let
+  (clean-test-sandbox!)
+) ;define
+
+(define (test-load-all-legacy-compatibility)
+  ;; 验证对缺少 updateAt / defaultExpandCount / thinking / search 的历史 manifest 的兼容回退
+  (clean-test-sandbox!)
+  (chat-persist-ensure-dir! test-sandbox-dir)
+  (set! restored-sessions '())
+
+  (let ((legacy-manifest-str "{\"version\":1,\"sessions\":[{\"sessionId\":\"legacy-1\",\"title\":\"Old Session\",\"model\":\"gpt-3.5\",\"archived\":\"false\",\"createdAt\":\"500\"}]}"
+        ) ;legacy-manifest-str
+       ) ;
+    (string-save legacy-manifest-str (system->url (chat-persist-manifest-path)))
+  ) ;let
+
+  (chat-persist-load-all)
+
+  (check (length restored-sessions) => 1)
+  (let ((s (car restored-sessions)))
+    (check (list-ref s 0) => "legacy-1")
+    (check (list-ref s 1) => "Old Session")
+    ;; updateAt 缺失时应回退到 createdAt
+    (check (list-ref s 5) => "500")
+    ;; defaultExpandCount 缺失时缺省为 5
+    (check (list-ref s 6) => 5)
+    ;; thinking / search 缺失时缺省为 "disabled"
+    (check (list-ref s 7) => "disabled")
+    (check (list-ref s 8) => "disabled")
+  ) ;let
+  (clean-test-sandbox!)
+) ;define
+
+(define (test-load-all-missing-and-corrupted)
+  (clean-test-sandbox!)
+  (set! restored-sessions '())
+  ;; 1. manifest 文件不存在时，安全返回且不崩溃
+  (chat-persist-load-all)
+  (check (length restored-sessions) => 0)
+
+  ;; 2. manifest 内容损坏时，安全捕获且不崩溃
+  (chat-persist-ensure-dir! test-sandbox-dir)
+  (string-save "{invalid-json-content..."
+    (system->url (chat-persist-manifest-path))
+  ) ;string-save
+  (chat-persist-load-all)
+  (check (length restored-sessions) => 0)
+  (clean-test-sandbox!)
+) ;define
+
+;;; ---------- 4. 会话删除测试 ----------
+
+(define (test-delete-one)
+  (clean-test-sandbox!)
+  (let ((manifest-path (chat-persist-manifest-path)))
+    (chat-persist-update-manifest "del-1" "To Delete" "m1" #f)
+    (chat-persist-update-manifest "del-2" "To Keep" "m2" #f)
+
+    ;; 模拟创建会话目录及 message.tmu 文件
+    (let ((msg-path-1 (chat-persist-message-path "del-1"))
+          (msg-path-2 (chat-persist-message-path "del-2"))
+         ) ;
+      (chat-persist-ensure-dir! (chat-persist-parent-dir msg-path-1))
+      (chat-persist-ensure-dir! (chat-persist-parent-dir msg-path-2))
+      (string-save "test message 1" (system->url msg-path-1))
+      (string-save "test message 2" (system->url msg-path-2))
+
+      (check (file-exists? msg-path-1) => #t)
+      (check (file-exists? msg-path-2) => #t)
+
+      ;; 执行删除 del-1
+      (chat-persist-delete-one "del-1")
+
+      ;; 验证 del-1 的文件被删除，del-2 依然存在
+      (check (file-exists? msg-path-1) => #f)
+      (check (file-exists? msg-path-2) => #t)
+
+      ;; 验证 manifest 中 del-1 被移除，del-2 保留
+      (let* ((parsed (string->json (string-load (system->url manifest-path))))
+             (sessions (json-ref parsed "sessions"))
+            ) ;
+        (check (vector-length sessions) => 1)
+        (let ((s0 (vector-ref sessions 0)))
+          (check (json-ref-string s0 "sessionId" #f) => "del-2")
+        ) ;let
+      ) ;let*
+
+      ;; 幂等性：重复删除已删除的 session 不报错
+      (chat-persist-delete-one "del-1")
+      (chat-persist-delete-one "non-existent-sid")
+    ) ;let
+  ) ;let
+  (clean-test-sandbox!)
+) ;define
+
+;;; ---------- 测试套件入口 ----------
+
+(tm-define (regtest-chat-list)
+  (test-make-entry-defaults)
+  (test-make-entry-archived-variants)
+  (test-make-entry-with-options)
+  (test-make-entry-json-serialization)
+  (test-manifest-create-and-update)
+  (test-load-all-normal)
+  (test-load-all-legacy-compatibility)
+  (test-load-all-missing-and-corrupted)
+  (test-delete-one)
+  (check-report)
+) ;tm-define

--- a/devel/1284.md
+++ b/devel/1284.md
@@ -1,0 +1,82 @@
+# [1284] 将 chat-list.scm 的 JSON 库从 njson 迁移至 (liii json)
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [1281.md](1281.md) - 取消 tm-dialogue.scm 对 njson 的使用，直接改用 (liii json)
+- [1282.md](1282.md) - 将 shortcut-edit.scm 的 JSON 库从 njson 迁移至 (liii json)
+- [0194.md](0194.md) - 会话列表持久化设计
+- [0205.md](0205.md) - Chat 会话持久化与字段规范
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/llm/progs/llm/chat-list.scm`
+- `TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm`
+- `xmake.lua`
+
+## 3 如何测试
+
+### 3.1 纯逻辑单元测试（自动化，headless）
+
+```bash
+xmake b stem && xmake r chat-list-test
+```
+
+测试覆盖全部核心持久化逻辑：
+1. **条目构造与序列化测试**：
+   - 默认值与各个字段构造（`sessionId`、`title`、`model`、`archived`、`createdAt`、`defaultExpandCount`、`thinking`、`search`、`updateAt`）；
+   - `archived` 布尔/字符串归一化（`"false"` / `"true"`）；
+   - `updateAt` 在缺省时自动回退到 `createdAt`；
+   - 显式 `thinking`、`search`、`updateAt` 属性设置；
+   - 生成的标准 alist 可直接通过 `json->string` 序列化为合规 JSON。
+2. **增量写入与更新测试**（`chat-persist-update-manifest`）：
+   - manifest 不存在时自动建档初始化（`{"version":1,"sessions":[...]}`）；
+   - 多次追加新会话记录，会话列表长度递增且顺序保持；
+   - 更新已有会话记录（同 `sessionId`），就地更新内容且不破坏其它条目与列表长度。
+3. **会话恢复与读取测试**（`chat-persist-load-all`）：
+   - 解析已有 manifest 并正确调用 C++ 恢复槽 `qt-chat-tab-restore-session`；
+   - 字段缺省与旧版本 manifest 兼容容错（`updateAt` 缺省回退到 `createdAt`，`defaultExpandCount` 缺省为 5，`thinking` / `search` 缺省为 `"disabled"`）；
+   - manifest 文件不存在或内容损坏时平稳容错，不抛出异常。
+4. **会话删除测试**（`chat-persist-delete-one`）：
+   - 删除指定 `sessionId` 的会话目录与消息文件；
+   - 从 manifest 中移除该条目并回写磁盘；
+   - 删除不存在的 `sessionId` 具有幂等性。
+
+### 3.2 手动测试（GUI）
+
+1. 启动程序：
+   ```bash
+   xmake r stem
+   ```
+2. 打开 AI Chat 侧边栏/标签页：
+   - 新建若干会话，发送消息；
+   - 检查 `$TEXMACS_HOME_PATH/system/ai-chat-sessions/manifest.json`，验证保存出的内容为标准合规的 JSON 格式；
+   - 退出软件并重新启动，侧边栏能够完整恢复历史会话列表；
+   - 删除一个会话，确认 manifest 中该会话被移除，磁盘对应目录被清理。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git add devel/1284.md
+git commit -m "[1284] 更新任务文档"
+# 代码修改与单测添加后：
+git add xmake.lua TeXmacs/plugins/llm/progs/llm/chat-list.scm TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm
+git commit -m "[1284] 将 chat-list.scm 的 JSON 库从 njson 迁移至 (liii json)"
+```
+
+## 5 What
+- 将 `TeXmacs/plugins/llm/progs/llm/chat-list.scm` 对 `(liii njson)` 的依赖完全迁移为 `(liii json)`；
+- 移除所有 C++ handle 绑定调用（`string->njson`、`file->njson`、`njson->file`、`njson-set!`、`njson-append!`、`njson-drop!`、`njson-ref`、`njson-array->list`、`json->njson`、`njson-free`）；
+- 采用 TDD 方式，新增 `TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm` 纯逻辑单元测试，并在 `xmake.lua` 中支持该测试 target 自动发现。
+
+## 6 Why
+- `(liii njson)` 是包装 C++ nlohmann-json handle 的不透明指针，要求调用端手动管理内存并调用 `njson-free`，极易造成句柄泄漏或悬空句柄；
+- `(liii json)` 基于 Scheme 原生数据结构（对象为 alist，数组为 vector），由 GC 自动管理生命周期，安全、轻量且无泄漏风险；
+- 在 `chat-list.scm` 中，增删改查会话记录使用 Scheme 原生高阶函数（`map`、`filter`）即可简洁明了地表达，代码可维护性大幅提高。
+
+## 7 How
+- 将 `(import (liii njson))` 替换为 `(import (liii json))`；
+- `chat-persist-make-entry` 直接返回字段键值对 alist；
+- `chat-persist-load-all` 使用 `string-load` + `string->json` 解析，使用 `json-ref-string`、`json-ref-integer` 安全提取字段并做默认值回退；
+- `chat-persist-update-manifest` 和 `chat-persist-delete-one` 使用原生列表操作更新 sessions 向量，通过 `json->string` + `string-save` 持久化；
+- 在 `xmake.lua` 中添加 `TeXmacs/plugins/llm/**/*-test.scm` 测试发现规则；
+- 按照 TDD 流程，先编写并运行 `chat-list-test.scm` 确认测试就位，再实施重构，确保全部测试通过。

--- a/xmake.lua
+++ b/xmake.lua
@@ -143,6 +143,10 @@ if has_config("qt_frontend") then
         add_target_scheme_test(filepath, INSTALL_DIR, RUN_ENVS)
     end
 
+    for _, filepath in ipairs(os.files("TeXmacs/plugins/llm/**/*-test.scm")) do
+        add_target_scheme_test(filepath, INSTALL_DIR, RUN_ENVS)
+    end
+
     -- Integration tests
     for _, filepath in ipairs(os.files("TeXmacs/tests/*.scm")) do
         add_target_integration_test(filepath, INSTALL_DIR, RUN_ENVS)


### PR DESCRIPTION
## 任务相关的代码文件
- `TeXmacs/plugins/llm/progs/llm/chat-list.scm`
- `TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm`
- `xmake.lua`
- `devel/1284.md`

## 单元测试
```bash
xmake b stem && xmake r chat-list-test
```
（74 项断言全部通过）

## What
- 将 `TeXmacs/plugins/llm/progs/llm/chat-list.scm` 对 `(liii njson)` 的依赖完全迁移为 `(liii json)`；
- 移除所有 C++ handle 绑定调用与手动 `njson-free` 释放，内存完全由 GC 管理；
- 采用 TDD 方式新增 `TeXmacs/plugins/llm/progs/llm/tests/chat-list-test.scm` 纯逻辑单元测试，并在 `xmake.lua` 中支持该测试目标自动发现。

## Why
- `(liii njson)` 是包装 C++ nlohmann-json handle 的不透明指针，要求调用端手动管理内存并调用 `njson-free`，极易造成句柄泄漏或悬空句柄；
- `(liii json)` 基于 Scheme 原生数据结构（对象为 alist，数组为 vector），轻量安全且生命周期由 GC 自动管理；
- 使用 Scheme 原生高阶函数（`map`、`filter`）进行增量更新，代码可读性与可维护性更好。

## How
- 将 `(import (liii njson))` 替换为 `(import (liii json))`；
- `chat-persist-make-entry` 直接构造 Scheme alist 原生结构；
- `chat-persist-load-all` 使用 `string-load` + `string->json` 解析，使用 `json-ref-string`、`json-ref-integer` 安全提取字段并保持旧版本缺省字段兼容；
- `chat-persist-update-manifest` 和 `chat-persist-delete-one` 使用原生列表操作更新 sessions 向量，通过 `json->string` + `string-save` 持久化；
- 在 `xmake.lua` 中补充 `TeXmacs/plugins/llm/**/*-test.scm` 测试发现规则。