### PR TITLE
[1285] 将 telemetry 的 JSON 库从 njson 迁移至 (liii json)

### DIFF
--- a/TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm
+++ b/TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm
@@ -15,7 +15,7 @@
 
 (import (scheme base)
   (liii base)
-  (liii njson)
+  (liii json)
   (liii path)
   (liii string)
   (liii uuid)
@@ -205,7 +205,7 @@
 ) ;define-public
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Meta file helpers (using njson for reliability)
+;; Meta file helpers (using (liii json) for reliability)
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-public (telemetry-read-meta)
@@ -213,8 +213,8 @@
     (lambda ()
       (let ((path (telemetry-meta-path)))
         (if (path-exists? path)
-          (let ((njson-data (file->njson path)))
-            (vector->list (njson->json njson-data))
+          (let ((data (string->json (path-read-text path))))
+            (if (vector? data) (vector->list data) '())
           ) ;let
           '()
         ) ;if
@@ -229,7 +229,7 @@
          (tmp-path (path->string (path-with-suffix path ".json.tmp")))
         ) ;
     (define (try-write)
-      (njson->file tmp-path (json->njson (list->vector entries)))
+      (path-write-text tmp-path (json->string (list->vector entries)))
       (when (path-exists? path)
         (path-unlink path)
       ) ;when

--- a/TeXmacs/tests/1285.scm
+++ b/TeXmacs/tests/1285.scm
@@ -1,0 +1,126 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 1285.scm
+;; DESCRIPTION : Telemetry meta (liii json) refactor unit tests
+;; COPYRIGHT   : (C) 2026  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT NO WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check) (liii json) (liii path))
+
+(use-modules (telemetry telemetry-utils))
+
+(check-set-mode! 'report-failed)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 1. 读写往返与标准 JSON 格式验证
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-meta-roundtrip)
+  (display "Testing telemetry meta roundtrip and json structure...\n")
+  (let ((meta-path (telemetry-meta-path)))
+    ;; 写入空列表
+    (check (telemetry-write-meta '()) => #t)
+    (check (telemetry-read-meta) => '())
+    (check (path-read-text meta-path) => "[]")
+
+    ;; 写入多条元数据记录
+    (let ((test-entries '((("filename" . "detail-1.jsonl") ("timestamp" . 1000))
+                          (("filename" . "detail-2.jsonl") ("timestamp" . 2000)))
+          ) ;test-entries
+         ) ;
+      (check (telemetry-write-meta test-entries) => #t)
+      (check (telemetry-read-meta) => test-entries)
+
+      ;; 验证磁盘实际存储为符合 (liii json) 规范的 JSON 数组
+      (let* ((raw (path-read-text meta-path)) (data (string->json raw)))
+        (check (vector? data) => #t)
+        (check (vector-length data) => 2)
+        (check (json-ref (vector-ref data 0) "filename") => "detail-1.jsonl")
+        (check (json-ref (vector-ref data 0) "timestamp") => 1000)
+        (check (json-ref (vector-ref data 1) "filename") => "detail-2.jsonl")
+        (check (json-ref (vector-ref data 1) "timestamp") => 2000)
+      ) ;let*
+    ) ;let
+  ) ;let
+  (display "telemetry meta roundtrip passed!\n")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 2. 异常数据容错与安全回退测试
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-meta-fallback)
+  (display "Testing telemetry meta error fallback...\n")
+  (let ((meta-path (telemetry-meta-path)))
+    ;; 文件不存在时回退为 '()
+    (when (path-exists? meta-path)
+      (path-unlink meta-path)
+    ) ;when
+    (check (telemetry-read-meta) => '())
+
+    ;; 文件内容为空字符串时回退为 '()
+    (path-write-text meta-path "")
+    (check (telemetry-read-meta) => '())
+
+    ;; 文件内容为损坏的畸形 JSON 时安全捕获并回退为 '()
+    (path-write-text meta-path "{invalid json: ")
+    (check (telemetry-read-meta) => '())
+
+    ;; 文件内容为非数组 JSON（如单个对象或标量）时安全回退为 '()
+    (path-write-text meta-path "{\"meta\":1}")
+    (check (telemetry-read-meta) => '())
+
+    (path-write-text meta-path "42")
+    (check (telemetry-read-meta) => '())
+  ) ;let
+  (display "telemetry meta fallback passed!\n")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 3. telemetry-meta-add-entry 增量添加测试
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (test-meta-add-entry)
+  (display "Testing telemetry-meta-add-entry...\n")
+  (telemetry-write-meta '())
+  (check (telemetry-read-meta) => '())
+
+  ;; 添加第一项
+  (telemetry-meta-add-entry "detail-test-a.jsonl")
+  (let ((m1 (telemetry-read-meta)))
+    (check (length m1) => 1)
+    (check (assoc-ref (car m1) "filename") => "detail-test-a.jsonl")
+    (check (number? (assoc-ref (car m1) "timestamp")) => #t)
+  ) ;let
+
+  ;; 添加第二项，最新项排在最前
+  (telemetry-meta-add-entry "detail-test-b.jsonl")
+  (let ((m2 (telemetry-read-meta)))
+    (check (length m2) => 2)
+    (check (assoc-ref (car m2) "filename") => "detail-test-b.jsonl")
+    (check (assoc-ref (cadr m2) "filename") => "detail-test-a.jsonl")
+  ) ;let
+
+  (display "telemetry-meta-add-entry passed!\n")
+) ;define
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; 测试入口
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (test_1285)
+  (display "Running test_1285...\n")
+  (let ((orig-meta (telemetry-read-meta)))
+    (test-meta-roundtrip)
+    (test-meta-fallback)
+    (test-meta-add-entry)
+    ;; 恢复原有 meta
+    (telemetry-write-meta orig-meta)
+  ) ;let
+  (check-report)
+) ;tm-define

--- a/devel/1285.md
+++ b/devel/1285.md
@@ -1,0 +1,63 @@
+# [1285] telemetry 里面的 njson 相关代码重构为 (liii json)
+
+## 1 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [200_64.md](200_64.md) - Telemetry（埋点）系统
+- [2013.md](2013.md) - 用 (liii path) 改造 telemetry-utils.scm 的路径处理
+- [1281.md](1281.md) - 取消 tm-dialogue.scm 对 njson 的使用，直接改用 (liii json)
+- [1282.md](1282.md) - 将 shortcut-edit.scm 的 JSON 库从 njson 迁移至 (liii json)
+
+## 2 任务相关的代码文件
+- `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm`
+- `TeXmacs/tests/1285.scm`
+
+## 3 如何测试
+
+### 3.1 自动化测试
+```bash
+xmake r 1285
+xmake r 200_64
+xmake r 2013
+```
+
+- `1285.scm` 专项测试 `telemetry-read-meta` 与 `telemetry-write-meta`：
+  - 写入与读取的往返一致性；
+  - 元数据文件不存在时安全回退为空列表 `'()`；
+  - 元数据文件内容损坏（畸形 JSON、空文件、非数组结构）时的安全回退容错；
+  - 标准 `(liii json)` 格式读写与滚动记录（`telemetry-meta-add-entry`）。
+- `200_64.scm` 与 `2013.scm` 确保 telemetry 完整链路（事件构建、flush 落盘、meta 滚动）无回归。
+
+### 3.2 手动测试
+1. 启动 Mogan：`xmake r stem`；
+2. 触发一次 telemetry 事件（例如软件启动后查看 `$TEXMACS_HOME_PATH/system/telemetry/main/` 目录）；
+3. 打开 `main-telemetry.json`，确认文件内容为合法的 JSON 数组格式（如 `[{"filename":"...","timestamp":...}]`）；
+4. 退出软件并验证 `main-telemetry.json` 能够正常被更新与读取。
+
+## 4 如何提交
+
+```bash
+gf fmt --changed-since=main
+git add devel/1285.md
+git commit -m "[1285] 更新任务文档"
+# 代码与测试修改后：
+git add TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm TeXmacs/tests/1285.scm
+git commit -m "[1285] telemetry 里面的 njson 相关代码重构为 (liii json)"
+```
+
+## 5 What
+- 将 `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm` 中的 `(liii njson)` 依赖替换为 `(liii json)`；
+- 采用 TDD 方式，新增 `TeXmacs/tests/1285.scm` 测试 `telemetry-read-meta` 与 `telemetry-write-meta` 的序列化、反序列化及容错逻辑；
+- 移除 `file->njson`、`njson->json`、`njson->file`、`json->njson` 等 C++ handle 相关调用，改用 `(liii json)` 的原生 Scheme 数据结构与 `(liii path)` 的文本读写。
+
+## 6 Why
+1. `(liii njson)` 基于 C++ nlohmann-json handle，在 Scheme 层需要小心管理指针与内存，而 `(liii json)` 直接使用 Scheme 原生类型（列表、向量、alist），生命周期由 GC 自动管理，更加安全可靠；
+2. Telemetry 的元数据（`main-telemetry.json`）仅为小规模数组结构（记录最近 200 个分片文件名与时间戳），使用纯 Scheme 的 `(liii json)` 与 `(liii path)` 进行读写更加轻量且跨平台行为一致，避免与 goldfish 子进程间的文件句柄竞争。
+
+## 7 How
+1. **TDD 测试先行**：
+   - 编写 `TeXmacs/tests/1285.scm`，针对 `telemetry-read-meta`、`telemetry-write-meta`、`telemetry-meta-add-entry` 以及畸形 JSON / 缺失文件容错进行测试。
+2. **模块依赖调整**：
+   - 在 `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm` 的 import 列表中，将 `(liii njson)` 替换为 `(liii json)`。
+3. **数据读写重构**：
+   - `telemetry-read-meta`：使用 `(path-read-text path)` 配合 `string->json`，解析后将向量转为列表，捕获所有异常并回退为空列表；
+   - `telemetry-write-meta`：使用 `(json->string (list->vector entries))` 配合 `(path-write-text tmp-path ...)` 写入临时文件，再原子重命名覆盖目标文件。


### PR DESCRIPTION
## What
- 将 `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm` 中的 `(liii njson)` 依赖完全迁移为 `(liii json)`；
- 采用 TDD 方式，新增 `TeXmacs/tests/1285.scm` 测试 `telemetry-read-meta` 与 `telemetry-write-meta` 的序列化、反序列化及容错逻辑；
- 移除 `file->njson`、`njson->json`、`njson->file`、`json->njson` 等 C++ handle 相关调用，改用 `(liii json)` 的原生 Scheme 数据结构与 `(liii path)` 的文本读写。

## Why
1. `(liii njson)` 基于 C++ nlohmann-json handle，在 Scheme 层需要小心管理指针与内存，而 `(liii json)` 直接使用 Scheme 原生类型（列表、向量、alist），生命周期由 GC 自动管理，更加安全可靠；
2. Telemetry 的元数据（`main-telemetry.json`）仅为小规模数组结构（记录最近 200 个分片文件名与时间戳），使用纯 Scheme 的 `(liii json)` 与 `(liii path)` 进行读写更加轻量且跨平台行为一致，避免与 goldfish 子进程间的文件句柄竞争。

## How
1. **TDD 测试先行**：
   - 编写 `TeXmacs/tests/1285.scm`，覆盖 `telemetry-read-meta`、`telemetry-write-meta`、`telemetry-meta-add-entry` 以及畸形 JSON / 缺失文件容错。
2. **模块依赖调整**：
   - 在 `TeXmacs/plugins/telemetry/progs/telemetry/telemetry-utils.scm` 的 import 列表中，将 `(liii njson)` 替换为 `(liii json)`。
3. **数据读写重构**：
   - `telemetry-read-meta`：使用 `(path-read-text path)` 配合 `string->json`，解析后将向量转为列表，捕获所有异常并回退为空列表；
   - `telemetry-write-meta`：使用 `(json->string (list->vector entries))` 配合 `(path-write-text tmp-path ...)` 写入临时文件，再原子重命名覆盖目标文件。

## Tests
```bash
xmake r 1285    # 23 correct, 0 failed
xmake r 200_64  # 92 correct, 0 failed
xmake r 2013    # 9 correct, 0 failed
```