### PR TITLE
[1288] 修复首次点击登录按钮看不到登录信息

### DIFF
--- a/devel/1288.md
+++ b/devel/1288.md
@@ -1,0 +1,52 @@
+# 1288: 修复首次点击登录按钮看不到登录信息
+
+## 任务需求
+
+标题栏「领取会员」按钮右侧的登录（用户中心）按钮，第一次点击弹出的用户
+弹窗看不到登录信息（显示的是「未登录/非会员」占位内容），第二次点击才能
+看到登录信息。
+
+## 现状分析
+
+- `LoginDialog` 为惰性创建（`ensureLoginDialog`，创建耗时 ~100ms，为不拖慢
+  首屏而推迟到首次使用，见 `qt_tm_widget.cpp` 中登录按钮的注释）。
+- 点击登录按钮走 `checkLocalTokenAndLogin`：本地有 token 时调用
+  `fetchUserInfo (token, true)` 异步请求用户信息。
+- 网络回调中先 `updateDialogContent`（往 `nameLabel`/`accountIdLabel` 等
+  标签写用户信息），之后才 `ensureLoginDialog` 创建弹窗。首次点击时这些
+  标签还是 `nullptr`，写入被 `if (nameLabel)` 守卫全部跳过，随后创建的
+  弹窗只能显示 `setupLoginDialog` 里的默认占位内容。
+- 第二次点击时弹窗已存在，标签可正常写入，故能显示登录信息。
+- `handleError` 分支同构：`showNotLoggedInDialog` 写错误信息到
+  `accountIdLabel` 时标签尚未创建，首次点击丢失错误提示。
+
+## What
+
+1. `fetchUserInfo` 网络回调的成功分支：`showDialog` 为 true 时先
+   `ensureLoginDialog ()` 创建弹窗，再 `updateDialogContent`，最后
+   `show_login_dialog_at_button` 复用已创建的 `m_loginDialog`。
+2. `handleError`：同样先 `ensureLoginDialog ()` 再写错误内容再显示。
+3. 后台刷新路径（`refreshMembershipInfoInBackground` →
+   `fetchUserInfo (token, false)`）行为不变：仍不提前创建弹窗，保持惰性
+   创建优化；弹窗内容的准确性由每次点击时的重新拉取保证。
+
+## Why
+
+弹窗内容控件（标签）随弹窗一起惰性创建，先更新内容后创建弹窗的顺序使
+首次显示必然丢失内容。
+
+## How
+
+调整 `fetchUserInfo` 回调中「创建弹窗 → 更新内容 → 显示」的顺序，并把
+显示入口从 `ensureLoginDialog ()` 改为直接传 `m_loginDialog`（此时必已
+创建）。
+
+## 涉及文件
+
+- `src/Plugins/Qt/qt_tm_widget.cpp`：`fetchUserInfo` 回调的成功分支与
+  `handleError` 各提前一次 `ensureLoginDialog ()`。
+
+## 验证
+
+- `xmake b stem` 增量编译通过。
+- `gf fmt --changed-since=main` 无格式问题。

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -3241,10 +3241,12 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
           manager->deleteLater ();
           return;
         }
-        // 定义统一的错误处理逻辑
+        // 定义统一的错误处理逻辑。弹窗为惰性创建，须先 ensureLoginDialog
+        // 生成标签，showNotLoggedInDialog 才能把错误信息写进 accountIdLabel
         auto handleError= [this] (const QString& errorMessage) {
+          ensureLoginDialog ();
           showNotLoggedInDialog (qt_translate (from_qstring (errorMessage)));
-          show_login_dialog_at_button (ensureLoginDialog (), loginButton);
+          show_login_dialog_at_button (m_loginDialog, loginButton);
         };
 
         if (reply->error () == QNetworkReply::NoError) {
@@ -3270,6 +3272,12 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
             QString productType=
                 userData["productType"].toString ("Subscribe Now");
 
+            // 首次点击时弹窗尚未创建（惰性创建），标签为空会导致
+            // updateDialogContent 写不进用户信息，须先创建弹窗再更新内容
+            if (showDialog) {
+              ensureLoginDialog ();
+            }
+
             // 更新弹窗内容
             updateDialogContent (true, userName, accountEmail, avatarText,
                                  memberType, periodLabel, periodLabelColor,
@@ -3280,7 +3288,7 @@ qt_tm_widget_rep::fetchUserInfo (const QString& token, bool showDialog) {
                                            periodLabelColor, productType);
 
             if (showDialog) {
-              show_login_dialog_at_button (ensureLoginDialog (), loginButton);
+              show_login_dialog_at_button (m_loginDialog, loginButton);
             }
           }
           else {


### PR DESCRIPTION
## 问题

标题栏「领取会员」按钮右侧的登录（用户中心）按钮，第一次点击弹出的用户弹窗看不到登录信息（显示「未登录/非会员」占位内容），第二次点击才能看到登录信息。

## 根因

登录弹窗 `LoginDialog` 为惰性创建（`ensureLoginDialog()`，约 100ms 开销，为不拖慢首屏而推迟到首次使用）。`fetchUserInfo` 的网络回调里顺序反了：先 `updateDialogContent`（往 `nameLabel`/`accountIdLabel` 等标签写用户信息），之后才 `ensureLoginDialog()` 创建弹窗。

- 首次点击时标签尚未创建（`nullptr`），写入被 `if (nameLabel)` 守卫全部跳过，弹窗只能显示默认占位内容；
- 第二次点击时弹窗已存在，标签可正常写入，故能显示登录信息。

`handleError` 分支同构：`showNotLoggedInDialog` 写错误提示时标签也未创建，首次点击同样丢失「请重新登录」等错误信息。

## 修复

- `fetchUserInfo` 回调成功分支：`showDialog` 为 true 时先 `ensureLoginDialog()`，再 `updateDialogContent`，最后用已创建的 `m_loginDialog` 显示；
- `handleError`：同样先创建弹窗再写内容再显示；
- 后台刷新路径（`showDialog=false`）行为不变，仍保持惰性创建优化。

## 验证

- `xmake b stem` 增量编译通过；
- `gf fmt --changed-since=main` 无格式问题；
- 任务文档见 `devel/1288.md`。