### PR TITLE
[1289] 导出样式文件/包宏名称使用 utf8->herk 修复中文乱码

### DIFF
--- a/TeXmacs/progs/source/source-edit.scm
+++ b/TeXmacs/progs/source/source-edit.scm
@@ -120,7 +120,7 @@
   (let* ((tag (if style? 'src-style-file 'src-package))
          (what (if style? "style file" "style package"))
          (purpose (string-append "Automatically generated " what "."))
-         (name (url-basename (current-buffer)))
+         (name (utf8->herk (url-basename (current-buffer))))
         ) ;
     `(active* (document (src-title (document (,tag
                                               ,(string-append name "-macros")

--- a/devel/1289.md
+++ b/devel/1289.md
@@ -1,0 +1,44 @@
+# 1289: 修复中文文档导出样式文件/样式包头部乱码
+
+## 任务需求
+
+打开一个标题（文件名）是中文的 tmu，然后使用「工具 → 宏命令 → 导出样式包」或「导出样式文件」会新建一个标签，里面的内容在头部会乱码。
+
+## 现状分析与根因
+
+在 `TeXmacs/progs/source/source-edit.scm` 中，`extract-style-file` 通过 `extract-source-title` 提取当前文档的名称作为样式包/样式文件的宏名称：
+
+```scheme
+(define (extract-source-title style?)
+  (let* ((tag (if style? 'src-style-file 'src-package))
+         (what (if style? "style file" "style package"))
+         (purpose (string-append "Automatically generated " what "."))
+         (name (url-basename (current-buffer)))
+        ) ;
+    `(active* (document (src-title (document (,tag
+                                              ,(string-append name "-macros")
+                                              ,"1.0")
+                                     (src-purpose ,purpose)))))
+  ) ;let*
+) ;define
+```
+
+- `(url-basename (current-buffer))` 返回的是文件系统的原始 UTF-8 字符串（如 `"测试"`）。
+- Mogan 内部文档树的文本节点要求为 Herk 编码（中文为 `<#XXXX>` 转义序列）。
+- 未经 `utf8->herk` 转换的原始 UTF-8 字节直接拼入文档树并在新建 buffer 中排版渲染时，UTF-8 多字节序列被当作单字节字符渲染，导致样式头部显示为乱码。
+
+## What
+
+在提取样式文件/包标题时，对当前 buffer 的 basename 进行 Herk 编码转换。
+
+## Why
+
+保证拼入文档树中的字符串符合 Herk 编码契约，避免中文在渲染时出现乱码。
+
+## How
+
+将 `(name (url-basename (current-buffer)))` 修改为 `(name (utf8->herk (url-basename (current-buffer))))`。
+
+## 涉及文件
+
+- `TeXmacs/progs/source/source-edit.scm`


### PR DESCRIPTION
## 描述

打开标题或文件名是中文的 .tmu 文件时，使用「工具 → 宏命令 → 导出样式包」或「导出样式文件」新建的标签头部宏名称会出现乱码。

## 根因

`extract-source-title` 中通过 `(url-basename (current-buffer))` 获得的文件名为原始 UTF-8 字符串，而内部文档树排版要求文本节点使用 Herk 编码（中文为 `<#XXXX>` 转义）。未转换的原始 UTF-8 字节直接拼入文档树导致头部被当作单字节字符渲染出现乱码。

## 解决

在 `extract-source-title` 中使用 `(utf8->herk (url-basename (current-buffer)))`，确保生成的宏名称符合 Herk 编码契约。