### PR TITLE
[1290] 采用带左侧装饰竖条现代样式重构 quote-env 引用块环境

### DIFF
--- a/TeXmacs/packages/standard/std-markup.stem
+++ b/TeXmacs/packages/standard/std-markup.stem
@@ -320,25 +320,48 @@
           (assign "tab-length" (macro "1.5fn"))
           (assign "quote-left-indentation" "2tab")
           (assign "quote-right-indentation" "2tab")
-          (assign "quote-interparagraph" "0.25fn")
+          (assign "quote-interparagraph" "0.5fn")
+          (assign "quote-bar-color" "#d0d9e0")
+          (assign "quote-text-color" "#5d6065")
+          (assign "quote-bar-width" "2pt")
+          (assign "quote-hpadding" "1.2em")
+          (assign "quote-vpadding" "0.5em")
           (assign "verse-hangover" "1tab")
           (assign "jump-in-hangover" "1tab")
           ""
           (assign "quote-env"
             (macro "body"
-              (document (padded (document (indent-both (value "quote-left-indentation")
-                                            (value "quote-right-indentation")
-                                            (document (with "par-first"
-                                                        "0fn"
-                                                        "par-par-sep"
-                                                        (value "quote-interparagraph")
-                                                        (arg "body")
-                                                      ) ;with
-                                            ) ;document
-                                          ) ;indent-both
-                                ) ;document
-                        ) ;padded
-              ) ;document
+              (with "par-first"
+                "0fn"
+                (padded (with "par-left"
+                          (plus (value "par-left") (value "quote-bar-width"))
+                          "ornament-shape"
+                          "classic"
+                          "ornament-color"
+                          ""
+                          "ornament-border"
+                          (tuple (value "quote-bar-width") "0pt" "0pt" "0pt")
+                          "ornament-sunny-color"
+                          (value "quote-bar-color")
+                          "ornament-shadow-color"
+                          (value "quote-bar-color")
+                          "ornament-hpadding"
+                          (tuple (value "quote-hpadding") "0em")
+                          "ornament-vpadding"
+                          (tuple (value "quote-vpadding") (value "quote-vpadding"))
+                          (ornament (wide-normal (with "par-first"
+                                                   "0fn"
+                                                   "par-par-sep"
+                                                   (value "quote-interparagraph")
+                                                   "color"
+                                                   (value "quote-text-color")
+                                                   (arg "body")
+                                                 ) ;with
+                                    ) ;wide-normal
+                          ) ;ornament
+                        ) ;with
+                ) ;padded
+              ) ;with
             ) ;macro
           ) ;assign
           (assign "quotation"

--- a/TeXmacs/packages/themes/dark/dark.ts
+++ b/TeXmacs/packages/themes/dark/dark.ts
@@ -138,6 +138,9 @@
 
   <assign|script-status-font-color|#cfe0ff>
 
+  <assign|quote-bar-color|#8b949e>
+
+  <assign|quote-text-color|#9198a1>
   \;
 </body>
 

--- a/TeXmacs/tests/python/1290.py
+++ b/TeXmacs/tests/python/1290.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+| Tester                  | Platform    | Status |
+| ----------------------- | ----------- | ------ |
+| Darcy Shen <da@liii.pro>| Linux (X11) | Passed |
+
+Automated UI test and screenshot utility for issue 1290:
+Verify modern blockquote style (<quote-env>) with left decorative bar in Mogan STEM.
+
+Usage:
+  python3 1290.py [path/to/doc.tmu] [output_screenshot.png]
+"""
+
+import os
+import sys
+import time
+import tempfile
+import subprocess
+from PIL import ImageGrab
+
+# Fallback: import pynput from ~/git/pynput/lib if not installed system-wide
+try:
+    import pynput
+except ImportError:
+    pynput_path = os.path.expanduser("~/git/pynput/lib")
+    if os.path.exists(pynput_path):
+        sys.path.insert(0, pynput_path)
+    import pynput
+
+from pynput.keyboard import Key, Controller as KeyboardController
+from pynput.mouse import Button, Controller as MouseController
+
+IS_WINDOWS = sys.platform == "win32"
+IS_DARWIN = sys.platform == "darwin"
+
+
+def find_repo_root():
+    cur = os.path.abspath(os.path.dirname(__file__))
+    while cur != "/" and cur != os.path.dirname(cur):
+        if os.path.exists(os.path.join(cur, "TeXmacs")) and os.path.exists(os.path.join(cur, "src")):
+            return cur
+        cur = os.path.dirname(cur)
+    return os.path.abspath(".")
+
+
+def find_mogan_binary(repo_root):
+    candidates = [
+        os.path.join(repo_root, "build/linux/x86_64/releasedbg/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/release/moganstem"),
+        os.path.join(repo_root, "build/linux/x86_64/debug/moganstem"),
+        os.path.join(repo_root, "build/packages/stem/data/bin/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/windows/x64/releasedbg/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/windows/x64/release/MoganSTEM.exe"),
+        os.path.join(repo_root, "build/macosx/arm64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/arm64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/releasedbg/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+        os.path.join(repo_root, "build/macosx/x86_64/release/MoganSTEM.app/Contents/MacOS/MoganSTEM"),
+    ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    raise FileNotFoundError("Mogan binary not found. Please build stem first (xmake b stem).")
+
+
+def get_mogan_window_rect():
+    """Returns (x, y, w, h) of Mogan window, or default full screen."""
+    if not IS_DARWIN and not IS_WINDOWS:
+        try:
+            import Xlib.display
+            d = Xlib.display.Display()
+            root = d.screen().root
+
+            def find_win(win):
+                try:
+                    cls = win.get_wm_class()
+                    if cls and "mogan" in cls[0].lower():
+                        return win
+                    name = win.get_wm_name()
+                    if name and ("Mogan" in name or "STEM" in name):
+                        return win
+                    for child in win.query_tree().children:
+                        res = find_win(child)
+                        if res:
+                            return res
+                except Exception:
+                    pass
+                return None
+
+            w = find_win(root)
+            if w:
+                geom = w.get_geometry()
+                coords = w.translate_coords(root, 0, 0)
+                return (coords.x, coords.y, geom.width, geom.height)
+        except Exception:
+            pass
+
+    img = ImageGrab.grab()
+    return (0, 0, img.size[0], img.size[1])
+
+
+def focus_mogan_window():
+    """Ensure Mogan window is raised and focused across platforms."""
+    if IS_DARWIN:
+        try:
+            import AppKit
+            for app in AppKit.NSWorkspace.sharedWorkspace().runningApplications():
+                if "Mogan" in (app.localizedName() or ""):
+                    app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
+                    return
+        except Exception:
+            pass
+        subprocess.run(
+            ["osascript", "-e", 'tell application "System Events" to set frontmost of first process whose name contains "Mogan" to true'],
+            capture_output=True,
+        )
+        return
+
+    if IS_WINDOWS:
+        try:
+            import ctypes
+            from ctypes import wintypes
+            user32 = ctypes.windll.user32
+
+            def callback(hwnd, _lparam):
+                if user32.IsWindowVisible(hwnd):
+                    n = user32.GetWindowTextLengthW(hwnd)
+                    buf = ctypes.create_unicode_buffer(n + 1)
+                    user32.GetWindowTextW(hwnd, buf, n + 1)
+                    if "STEM" in buf.value or "Mogan" in buf.value:
+                        user32.ShowWindow(hwnd, 9)
+                        user32.SetForegroundWindow(hwnd)
+                        return False
+                return True
+
+            EnumWindowsProc = ctypes.WINFUNCTYPE(ctypes.c_bool, wintypes.HWND, wintypes.LPARAM)
+            user32.EnumWindows(EnumWindowsProc(callback), 0)
+        except Exception:
+            pass
+        return
+
+    # Linux (X11)
+    try:
+        import Xlib.display
+        import Xlib.X
+        import Xlib.protocol.event
+
+        d = Xlib.display.Display()
+        root = d.screen().root
+
+        def find_mogan(win):
+            try:
+                cls = win.get_wm_class()
+                if cls and "mogan" in cls[0].lower():
+                    return win
+                name = win.get_wm_name()
+                if name and ("Mogan" in name or "STEM" in name):
+                    return win
+                for child in win.query_tree().children:
+                    res = find_mogan(child)
+                    if res:
+                        return res
+            except Exception:
+                pass
+            return None
+
+        w = find_mogan(root)
+        if w:
+            net_active = d.intern_atom("_NET_ACTIVE_WINDOW")
+            cm = Xlib.protocol.event.ClientMessage(
+                window=w,
+                client_type=net_active,
+                data=(32, [2, Xlib.X.CurrentTime, 0, 0, 0]),
+            )
+            root.send_event(
+                cm,
+                event_mask=Xlib.X.SubstructureRedirectMask | Xlib.X.SubstructureNotifyMask,
+            )
+            w.set_input_focus(Xlib.X.RevertToParent, Xlib.X.CurrentTime)
+            w.configure(stack_mode=Xlib.X.Above)
+            d.sync()
+    except Exception:
+        pass
+
+
+def capture_quote_env(doc_path=None, output_path=None):
+    repo_root = find_repo_root()
+    bin_path = find_mogan_binary(repo_root)
+
+    if doc_path is None:
+        default_candidates = [
+            os.path.join(repo_root, "TeXmacs", "tests", "tmu", "1290.tmu"),
+            os.path.join(repo_root, "1290.tmu"),
+        ]
+        for c in default_candidates:
+            if os.path.exists(c):
+                doc_path = c
+                break
+        if doc_path is None:
+            doc_path = default_candidates[0]
+
+    if output_path is None:
+        output_path = os.path.join(tempfile.gettempdir(), "1290.png")
+
+    print(f"[1290] Target document: {doc_path}")
+    print(f"[1290] Output screenshot: {output_path}")
+    print(f"[1290] Using Mogan binary: {bin_path}")
+
+    env = os.environ.copy()
+    env["TEXMACS_PATH"] = os.path.join(repo_root, "TeXmacs")
+
+    print("[1290] Step 1: Launching Mogan STEM...")
+    proc = subprocess.Popen([bin_path, doc_path], env=env, cwd=repo_root)
+
+    try:
+        time.sleep(3.5)
+        ret = proc.poll()
+        if ret is not None:
+            print(f"[1290] ERROR: Mogan exited prematurely with code {ret}")
+            return 1
+
+        print("[1290] Step 2: Focusing Mogan window...")
+        focus_mogan_window()
+        time.sleep(0.5)
+
+        wx, wy, ww, wh = get_mogan_window_rect()
+        print(f"[1290] Mogan window bounds: ({wx}, {wy}, {ww}, {wh})")
+
+        mouse = MouseController()
+        kb = KeyboardController()
+
+        click_x = wx + ww // 2
+        click_y = wy + wh // 2
+        print(f"[1290] Step 3: Using pynput to click document area at ({click_x}, {click_y})...")
+        mouse.position = (click_x, click_y)
+        time.sleep(0.3)
+        mouse.click(Button.left)
+        time.sleep(1.0)
+
+        print("[1290] Step 4: Capturing screenshot...")
+        if ww > 100 and wh > 100:
+            bbox = (wx, wy, wx + ww, wy + wh)
+            screenshot = ImageGrab.grab(bbox=bbox)
+        else:
+            screenshot = ImageGrab.grab()
+
+        screenshot.save(output_path)
+        print(f"[1290] Screenshot successfully saved to: {output_path}")
+
+        print("[1290] Step 5: Using pynput to close Mogan (Ctrl+Q)...")
+        modifier = Key.cmd if IS_DARWIN else Key.ctrl
+        with kb.pressed(modifier):
+            kb.press("q")
+            kb.release("q")
+        time.sleep(1.0)
+
+        ret = proc.poll()
+        if ret is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        print("[1290] Verification completed successfully.")
+        return 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    doc = None
+    out = None
+    for arg in sys.argv[1:]:
+        if arg.endswith(".tmu") or arg.endswith(".tm"):
+            doc = arg
+        elif arg.endswith(".png"):
+            out = arg
+        elif doc is None:
+            doc = arg
+        else:
+            out = arg
+    sys.exit(capture_quote_env(doc, out))

--- a/TeXmacs/tests/tmu/1290.tmu
+++ b/TeXmacs/tests/tmu/1290.tmu
@@ -1,0 +1,52 @@
+<TMU|<tuple|1.1.0|2026.3.0>>
+
+<style|<tuple|generic|chinese|doc-tmu>>
+
+<\body>
+  <doc-data|<doc-title|引用块样式测试（Issue 1290）>>
+
+  <section|引用块样式展示>
+
+  在技术文档和日常写作中，引用块常用于标注引用文本、重要提示或引言。修改后的 <markup|quote-env> 环境呈现具有现代感的左侧装饰竖条风格。
+
+  这是引用块外部的第一段普通正文。下面是一个使用美化后的 <markup|quote-env> 环境的单段引用示例：
+
+  <\quote-env>
+    千里之行，始于足下。不积跬步，无以至千里；不积小流，无以成江海。——《荀子·劝学》
+  </quote-env>
+
+  接下来测试包含多个段落的引用块，以检验内部段间距（<markup|quote-interparagraph>）和首行缩进（<markup|par-first> 为 0fn）的效果：
+
+  <\quote-env>
+    学而时习之，不亦说乎？有朋自远方来，不亦乐乎？人不知而不愠，不亦君子乎？
+
+    知之为知之，不知为不知，是知也。温故而知新，可以为师矣。——《论语》
+  </quote-env>
+
+  这是引用块外部的正文段落，用于验证引用块结束后的排版、边距与正文字体颜色正常恢复。
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-height|auto>
+    <associate|page-orientation|portrait>
+    <associate|page-screen-margin|false>
+    <associate|page-type|a4>
+    <associate|page-width|auto>
+    <associate|preamble|false>
+  </collection>
+</initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|1|?>>
+  </collection>
+</references>
+
+<\auxiliary>
+  <\collection>
+    <\associate|toc>
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|1<space|2spc>引用块样式展示><datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.05fn>.<space|0.05fn>>>>>|<htab|5mm>><no-break><pageref|auto-1><vspace|0.5fn>
+    </associate>
+  </collection>
+</auxiliary>

--- a/devel/1290.md
+++ b/devel/1290.md
@@ -43,3 +43,26 @@
 
 1. 执行 `python3 TeXmacs/tests/python/1290.py`：自动启动 Mogan 渲染 `TeXmacs/tests/tmu/1290.tmu`，通过 `pynput` 聚焦并点击文档区域，截屏保存，随后安全退出；
 2. 视觉核验：`1290.png` 中 `quote-env` 左侧显示浅灰色竖装饰条，正文呈现灰度，段间距及首行不缩进正常生效，引块前后正文排版恢复正常。
+
+## 后续改进：quote-env 适配黑暗模式（dark theme）
+
+### What
+在深色主题包 `TeXmacs/packages/themes/dark/dark.ts` 中为 `quote-env` 配置专用的装饰竖条色和文字颜色：
+- `quote-bar-color`: `#8b949e`
+- `quote-text-color`: `#9198a1`
+
+### Why
+浅色模式下 `quote-bar-color` 为 `#d0d9e0`，`quote-text-color` 为 `#5d6065`。在深色模式下背景色为 `#404040`，此时 `#5d6065` 的文字与背景几乎融为一体、对比度严重不足，而 `#d0d9e0` 的浅色竖条过于显眼。在 `dark.ts` 中单独覆盖这两个样式变量，即可在深色模式下呈现协调、舒适且清晰易读的现代引用块效果，同时不影响浅色模式。
+
+### How
+在 `TeXmacs/packages/themes/dark/dark.ts` 中添加：
+```scheme
+  <assign|quote-bar-color|#8b949e>
+
+  <assign|quote-text-color|#9198a1>
+```
+
+### 涉及文件
+- `TeXmacs/packages/themes/dark/dark.ts`
+- `devel/1290.md`
+

--- a/devel/1290.md
+++ b/devel/1290.md
@@ -1,0 +1,45 @@
+# 1290: 美化引用块（quote-env）环境样式
+
+## 任务需求
+
+使用 `/home/da/git/liii/templates/quote_env.stem` 里面 `quote-env` 的实现，替换掉 `std-markup.stem` 里面的实现。并新建 `1290.tmu` 测试文档，使用 `pynput` 编写截图验证脚本 `1290.py`。
+
+## 现状分析
+
+- Mogan 原有的 `quote-env`（定义于 `TeXmacs/packages/standard/std-markup.stem`）采用双侧缩进（`indent-both`，左右各缩进 `2tab`），在视觉上较为单调，且没有现代技术文档或 Markdown 中常见的左侧竖线装饰条。
+- 在 `/home/da/git/liii/templates/quote_env.stem` 中，提供了一套基于 `ornament` 的现代化引用块实现：
+  - 左侧配有 `2pt` 宽度的装饰竖条（颜色为 `#d0d9e0`）；
+  - 引用块文字颜色使用低对比度暗灰色（`#5d6065`）；
+  - 左侧设置了 `1.2em` 水平内边距，上下设置了 `0.5em` 垂直内边距；
+  - 引用块内部首行缩进归零（`par-first` 为 `0fn`），段间距（`quote-interparagraph`）设置为 `0.5fn`。
+
+## What
+
+1. 将 `TeXmacs/packages/standard/std-markup.stem` 中的 `quote-env` 宏及其参数配置替换为 `quote_env.stem` 中的现代引用块实现；
+2. 新建测试文档 `TeXmacs/tests/tmu/1290.tmu`，展示单段与多段引用块的渲染效果；
+3. 编写基于 `pynput` 的自动化截图脚本 `TeXmacs/tests/python/1290.py`，用于启动 Mogan、聚焦窗口、点击激活排版并截取运行效果图。
+
+## Why
+
+传统的双侧缩进引用样式在现代排版中辨识度较低，改用左侧装饰竖条（border）加文字灰度与内边距的现代样式，视觉体验更清晰美观，与主流 Markdown 和现代排版风格一致。
+
+## How
+
+1. 在 `TeXmacs/packages/standard/std-markup.stem` 中：
+   - 保留 `quotation` 与 `verse` 所需的 `quote-left-indentation`、`quote-right-indentation`、`verse-hangover`、`jump-in-hangover` 等变量；
+   - 引入配置变量：`quote-bar-color`（`#d0d9e0`）、`quote-text-color`（`#5d6065`）、`quote-bar-width`（`2pt`）、`quote-hpadding`（`1.2em`）、`quote-vpadding`（`0.5em`），将 `quote-interparagraph` 设置为 `0.5fn`；
+   - 将 `quote-env` 宏替换为使用 `padded` + `ornament`（`ornament-border` 仅左边有宽度、`ornament-sunny-color`/`ornament-shadow-color` 为竖条颜色）+ `wide-normal` 的现代实现。
+2. 创建测试文档 `TeXmacs/tests/tmu/1290.tmu`，包含单段引用与多段引用测试用例。
+3. 编写 `TeXmacs/tests/python/1290.py`，使用 `pynput` 控制鼠标键盘、`PIL.ImageGrab` 截屏保存为测试截图。
+
+## 涉及文件
+
+- `TeXmacs/packages/standard/std-markup.stem`
+- `TeXmacs/tests/tmu/1290.tmu`
+- `TeXmacs/tests/python/1290.py`
+- `devel/1290.md`
+
+## 验证
+
+1. 执行 `python3 TeXmacs/tests/python/1290.py`：自动启动 Mogan 渲染 `TeXmacs/tests/tmu/1290.tmu`，通过 `pynput` 聚焦并点击文档区域，截屏保存，随后安全退出；
+2. 视觉核验：`1290.png` 中 `quote-env` 左侧显示浅灰色竖装饰条，正文呈现灰度，段间距及首行不缩进正常生效，引块前后正文排版恢复正常。


### PR DESCRIPTION
## 任务描述

参考 `templates/quote_env.stem` 中的现代引用块实现，重构 `std-markup.stem` 中的 `quote-env`：
- 左侧增加 2pt 浅灰色装饰竖条（`#d0d9e0`）
- 引用块正文使用暗灰字体（`#5d6065`）
- 设置水平内边距（1.2em）与垂直内边距（0.5em）及内部段间距（0.5fn）
- 首行缩进置为 0fn
- 保留 `quotation`、`verse` 等其它环境所依赖的既有变量定义

## 测试与验证

- 编写了测试文档 `TeXmacs/tests/tmu/1290.tmu`
- 编写了基于 `pynput` 的端到端自动化测试与截图脚本 `TeXmacs/tests/python/1290.py`
- 本地自动化测试与截图视觉审查通过