### PR TITLE
[0973] 默认模型从 kimi-k3 改为 deepseek-v4-flash

### DIFF
--- a/TeXmacs/plugins/llm/data/liii_llm_menu.json
+++ b/TeXmacs/plugins/llm/data/liii_llm_menu.json
@@ -1,5 +1,5 @@
 {
-  "default": "kimi-k3",
+  "default": "deepseek-v4-flash",
   "models": [
     {
       "model": "kimi-k3",

--- a/devel/0973.md
+++ b/devel/0973.md
@@ -1,0 +1,26 @@
+# 0973 将默认模型从 kimi 改成 deepseek-flash
+
+## What
+
+将 LLM 插件模型清单的默认模型从 `kimi-k3` 改为 `deepseek-v4-flash`。
+
+## Why
+
+产品要求默认模型切换为 deepseek-flash（清单中对应条目 `deepseek-v4-flash`）。
+
+## How
+
+`qt_chat_model.cpp` 的 `resolve_default_key` 优先读取清单顶层 `default` 字段，
+因此只需修改 `TeXmacs/plugins/llm/data/liii_llm_menu.json` 的 `"default"` 值为
+`"deepseek-v4-flash"`。`qt_chat_model.cpp` 中的兜底清单（Kimi-VLM 单条目）仅在
+清单文件缺失/解析失败时启用，属于既有兜底行为，不在本任务范围内。
+
+## 涉及文件
+
+- `TeXmacs/plugins/llm/data/liii_llm_menu.json`：`"default": "kimi-k3"` → `"deepseek-v4-flash"`
+- `devel/0973.md`：任务文档
+
+## 测试
+
+- `xmake b qt_chat_model_test && xmake r qt_chat_model_test`：验证默认 key 解析
+  逻辑（显式 default 优先）不受影响。


### PR DESCRIPTION
## What

将 LLM 插件模型清单的默认模型从 `kimi-k3` 改为 `deepseek-v4-flash`。

## Why

产品要求默认模型切换为 deepseek-flash。

## How

`qt_chat_model.cpp` 的 `resolve_default_key` 优先读取清单顶层 `default` 字段，因此只需将 `TeXmacs/plugins/llm/data/liii_llm_menu.json` 的 `"default"` 值改为 `"deepseek-v4-flash"`（清单中已有该条目）。`qt_chat_model.cpp` 中的 Kimi-VLM 兜底清单仅在清单文件缺失/解析失败时启用，属既有兜底行为，不在本任务范围内。

## 涉及文件

- `TeXmacs/plugins/llm/data/liii_llm_menu.json`：`"default": "kimi-k3"` → `"deepseek-v4-flash"`
- `devel/0973.md`：任务文档

## 验证

- JSON 语法校验 + default 键在 models 清单内：通过
- `xmake b qt_chat_model_test && xmake r qt_chat_model_test`：19 passed, 0 failed
- GUI 验证未运行（改动仅为数据文件默认值）
