### PR TITLE
[0977] 修复打开 AI 侧边栏后关闭当前标签页不立即生效

### DIFF
--- a/devel/0977.md
+++ b/devel/0977.md
@@ -1,0 +1,54 @@
+# 0977 修复打开 AI 侧边栏后关闭当前标签页不立即生效
+
+## What
+
+文档中打开 AI 侧边栏后，点击当前文档标签页的关闭按钮，标签页不能立刻关闭，
+必须点击其他标签页后才消失。修复为：无论焦点在哪个视图，关闭窗口中正在显示的
+标签页都立即 detach/attach 切换并刷新 tab 栏。
+
+## Why
+
+打开 AI 侧边栏时，`sync_chat_sidebar_mode` 会调用 `focusInput()` 把 Qt 焦点交给
+聊天输入框；聊天输入框是嵌入编辑器（buffer 形如 `tmfs://chat/<sid>/input`），
+其 focusInEvent 经 `handle_keyboard_focus` → `focus_on_this_editor` 把全局当前
+视图（`the_view`）切到该嵌入视图。该嵌入视图的 `win_tabpage` 为空，且
+`should_update_menu` 对 chat input buffer 只允许重建 ICONS_MODE。
+
+`kill_tabpage` 原来用 `get_current_view_safe() == u` 判断「关闭的是否当前标签页」。
+焦点在聊天输入框时该判断为 false，正在显示的标签被误判成非当前标签：
+
+1. 跳过 detach/attach——窗口不切换到其他视图，仍显示已删除的编辑器；
+2. 末尾的强制刷新走「当前焦点视图」分支，但聊天输入视图 `win_tabpage` 为空，
+   条件不满足，tab 栏不重建。
+
+于是已关闭的 tab 仍显示在 tab 栏，直到点击其他标签触发 `window-set-view` 才消失。
+
+## How
+
+`src/Texmacs/Data/new_view.cpp` 的 `kill_tabpage`：
+
+1. `is_current` 改为以视图是否附着在窗口上（`vw->win != NULL`，即正在窗口中
+   显示）判定，不再依赖全局焦点视图。这样焦点在聊天输入框（或其他窗口）时，
+   关闭正在显示的标签页仍会走 detach/attach 分支：`window_set_view` 切换到本
+   tabpage 窗口的下一个视图并 `set_current_view`，其 `resume()` 触发
+   `update_menus(MENU_ALL)` 重建 tab 栏。
+2. 关闭非当前标签页后的强制刷新，同样不再取全局焦点视图，改为取该 tabpage
+   窗口实际显示的视图（`window_to_view (abstract_window (win_tabpage))`）做
+   suspend/resume，修复「侧边栏焦点下关闭后台标签页 tab 栏也不刷新」的同类
+   问题。
+
+## 涉及文件
+
+- `src/Texmacs/Data/new_view.cpp`：`kill_tabpage` 的 `is_current` 判定与非当前
+  标签刷新目标视图
+- `devel/0977.md`：任务文档
+
+## 测试
+
+- `xmake b stem`：编译通过。
+- GUI 手工验证（用户自测）：
+  1. 打开两个文档标签页，在其中一个文档中打开 AI 侧边栏（焦点自动进入聊天
+     输入框）；
+  2. 点击该文档标签页的关闭按钮，标签页应立即关闭并切换到其他标签页；
+  3. 再次打开 AI 侧边栏后，关闭一个后台（非当前）标签页，该标签应立即从
+     tab 栏消失。

--- a/src/Texmacs/Data/new_view.cpp
+++ b/src/Texmacs/Data/new_view.cpp
@@ -524,8 +524,12 @@ kill_tabpage (url win_u, url u) {
   tm_window win_tabpage= vw->win_tabpage;
   if (win_tabpage == NULL) return;
   if (win == NULL) win= win_tabpage;
-  url  current_u                     = get_current_view_safe ();
-  bool is_current                    = (!is_none (current_u) && current_u == u);
+  // 「当前标签页」以是否附着在窗口上（即正在窗口中显示）为准，而非全局焦点
+  // 视图：AI 侧边栏打开时焦点在聊天输入框（tmfs://chat/<sid>/input 嵌入视
+  // 图），get_current_view_safe() 并非窗口中显示的文档视图，按焦点判定会
+  // 把正在显示的标签误判成非当前标签，跳过 detach/attach，导致关闭后 tab
+  // 栏不刷新、窗口仍显示已删除的视图（需点击其他标签才消失）。
+  bool is_current                    = (vw->win != NULL);
   bool refresh_tabbar_for_non_current= !is_current;
 
   // 第一步: 设定 win_tabpage
@@ -598,15 +602,18 @@ kill_tabpage (url win_u, url u) {
   }
 
   // 关闭非当前标签页时，可能不会立即触发标签栏刷新。
-  // 对同一 tabpage 窗口中的当前编辑器执行 suspend/resume，
-  // 以强制触发一次 UI 更新。
+  // 对该 tabpage 窗口中正在显示的编辑器执行 suspend/resume，
+  // 以强制触发一次 UI 更新。这里取窗口实际显示的视图而非全局焦点视图：
+  // AI 侧边栏打开时焦点在聊天输入框的嵌入视图（win_tabpage 为空），
+  // 按焦点视图取会跳过刷新，tab 栏同样不更新。
   if (refresh_tabbar_for_non_current) {
-    tm_view current_vw= concrete_view (get_current_view_safe ());
-    if (current_vw != NULL && current_vw->win_tabpage == win_tabpage) {
-      editor current_ed= current_vw->ed;
-      if (current_ed != NULL) {
-        current_ed->suspend ();
-        current_ed->resume ();
+    tm_view shown_vw=
+        concrete_view (window_to_view (abstract_window (win_tabpage)));
+    if (shown_vw != NULL) {
+      editor shown_ed= shown_vw->ed;
+      if (shown_ed != NULL) {
+        shown_ed->suspend ();
+        shown_ed->resume ();
       }
     }
   }


### PR DESCRIPTION
## What

修复：文档中打开 AI 侧边栏后，点击当前文档标签页的关闭按钮，标签页不能立刻关闭，必须点击其他标签页后才消失。

## Why（根因）

打开 AI 侧边栏时，`sync_chat_sidebar_mode` 会调用 `focusInput()` 把 Qt 焦点交给聊天输入框；聊天输入框是嵌入编辑器（buffer 形如 `tmfs://chat/<sid>/input`），其 focusInEvent 经 `handle_keyboard_focus` → `focus_on_this_editor` 把全局当前视图（`the_view`）切到该嵌入视图。该嵌入视图的 `win_tabpage` 为空，且 `should_update_menu` 对 chat input buffer 只允许重建 ICONS_MODE。

`kill_tabpage` 原来用 `get_current_view_safe() == u` 判断「关闭的是否当前标签页」。焦点在聊天输入框时该判断为 false，正在显示的标签被误判成非当前标签：

1. 跳过 detach/attach——窗口不切换到其他视图，仍显示已删除的编辑器；
2. 末尾的强制刷新走「当前焦点视图」分支，但聊天输入视图 `win_tabpage` 为空，条件不满足，tab 栏不重建。

于是已关闭的 tab 仍显示在 tab 栏，直到点击其他标签触发 `window-set-view` 才消失。

## How

`src/Texmacs/Data/new_view.cpp` 的 `kill_tabpage`：

1. `is_current` 改为以视图是否附着在窗口上（`vw->win != NULL`，即正在窗口中显示）判定，不再依赖全局焦点视图。这样焦点在聊天输入框（或其他窗口）时，关闭正在显示的标签页仍会走 detach/attach 分支：`window_set_view` 切换到本 tabpage 窗口的下一个视图并 `set_current_view`，其 `resume()` 触发 `update_menus(MENU_ALL)` 重建 tab 栏；
2. 关闭非当前（后台）标签页后的强制刷新，同样不再取全局焦点视图，改为取该 tabpage 窗口实际显示的视图（`window_to_view (abstract_window (win_tabpage))`）做 suspend/resume，修复「侧边栏焦点下关闭后台标签页 tab 栏也不刷新」的同类问题。

## 涉及文件

- `src/Texmacs/Data/new_view.cpp`：`kill_tabpage` 的 `is_current` 判定与非当前标签刷新目标视图
- `devel/0977.md`：任务文档

## 验证

- `gf fmt --changed-since=main`：无需改动；
- `xmake b stem`：构建通过。

## 手工验证（待确认）

GUI 行为待用户手工验证：

1. 打开两个文档标签页，在其中一个文档中打开 AI 侧边栏（焦点自动进入聊天输入框）；
2. 点击该文档标签页的关闭按钮，标签页应立即关闭并切换到其他标签页；
3. 再次打开 AI 侧边栏后，关闭一个后台（非当前）标签页，该标签应立即从 tab 栏消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
