### PR TITLE
[1296] 修复样式环境计算丢失文档上下文导致嵌套 use-package 解析失败

### DIFF
--- a/devel/1296.md
+++ b/devel/1296.md
@@ -6,6 +6,8 @@
 
 ## 2 任务相关的代码文件
 - `src/Typeset/Env/env_exec.cpp` — `exec_use_package` 带路径包名（含 `/`）的解析逻辑
+- `src/Data/Document/new_style.cpp` — 样式环境计算（`compute_env_and_drd`）与样式缓存
+- `src/Edit/Editor/edit_typeset.cpp` — `typeset_style_use_cache`，样式环境的排版入口
 
 ## 3 如何测试
 
@@ -19,6 +21,11 @@
   3. 验证首页 title-slide（`title-slide` 宏来自 beamer/daxue_beamer.stem，经
      ccnu_beamer.stem 的 `use-package "beamer/daxue_beamer"` 引入）排版正常；
   4. 同法验证 `南方科技大学幻灯片模板.stem`。
+- **headless 导出验证**：
+  `xmake r stem -c ~/git/liii-templates/stem/华中师范大学幻灯片模板.stem /tmp/x.pdf`，
+  首页应为居中的 title-slide 封面；`title-slide` 宏缺失时会渲染成红色
+  `⟨title-slide⟩` 标记。注意失败结果会写入磁盘样式缓存（`~/.cache/MoganLab/<版本>/`
+  下 md5 命名的 `.scm`），重验前需先删除。
 
 ## 4 如何提交
 ```bash
@@ -66,4 +73,27 @@ git commit -m "[1296] 补充任务文档"
   1. `local` 变量及相关判断移除，直接使用 `base_file_name` 解析本地包；
   2. 移除包体执行窗口对 `cur_file_name` 与 `secure` 的覆盖与还原逻辑。
 - 涉及文件：`src/Typeset/Env/env_exec.cpp`
+
+## 10 样式环境计算传入文档 master（2026-09-11）
+- What：`compute_env_and_drd` / `get_style_env` / `get_style_drd` 增加 `url master`
+  参数，样式环境计算的临时 env 以文档 master（缺省 `$PWD/none`）为 `base_file_name`。
+- Why：样式宏环境经 `typeset_style_use_cache` → `get_style_env` 计算，临时 env 的
+  `base_file_name` 恒为 `$PWD/none`，§9 的本地优先解析在样式包内嵌套
+  `use-package`（如 ccnu_beamer.stem 的 `(use-package "beamer/daxue_beamer")`）时以
+  当前工作目录为基准必然 miss，`title-slide` 等宏缺失；且失败结果会写入磁盘样式
+  缓存（`style_set_cache` 仅在缓存文件不存在时写入）长期固化，表现为导出 PDF 中
+  宏渲染为红色 `⟨title-slide⟩` 标记。`edit_typeset` 传入 `buf->buf->master` 后，
+  嵌套引用可按文档目录树解析。
+- How：
+  1. 三个函数签名加 `url master`，临时 env 的 base 取
+     `is_none (master) ? $PWD/none : master`；
+  2. 调用方：`edit_typeset.cpp` 传 `buf->buf->master`；`tm_button.cpp`（无 buffer
+     上下文）与 `get_document_drd` 传 `url_none ()`；
+  3. 删除 `tree_analyze.cpp` 中 `get_style_drd` 的过期重复声明。
+- 涉及文件：`src/Data/Document/new_style.hpp`、`src/Data/Document/new_style.cpp`、
+  `src/Edit/Editor/edit_typeset.cpp`、`src/Texmacs/Window/tm_button.cpp`、
+  `src/Data/Tree/tree_analyze.cpp`
+- 已知取舍：样式缓存 key（`cache_file_name`）含解析后的样式绝对路径但不含 master，
+  同一绝对路径样式被不同目录文档共享时，嵌套相对 `use-package` 的解析结果以首次
+  计算为准；旧版本写入的坏缓存需手动清理（缓存目录按版本号隔离，发版即自然失效）。
 

--- a/devel/1296.md
+++ b/devel/1296.md
@@ -60,8 +60,8 @@ git commit -m "[1296] 补充任务文档"
   （如 http）的 buffer 上，无路径包名不再探测 `head (base_file_name)`。
 
 ## 9 仅按文档 buffer 目录解析本地包（2026-09-11）
-- What：移除 `exec_use_package` 对 `cur_file_name` 的引入与修改，非 `TEXMACS_PATH` 下的内容仅按相关 buffer 所在目录（`base_file_name`）及其父祖目录解析。
-- Why：对于非 `TEXMACS_PATH` 下的内容，样式包从属于当前排版 buffer 的上下文环境，应当且仅当以相关 buffer 所在目录为基准解析本地包，不应该看当前执行文件（`cur_file_name`）。`cur_file_name` 在内核中专用于多部件文档的 `<include>` 标签（跟踪标签定义来源），在 `use-package` 中篡改 `cur_file_name` 概念不当；同时与 `resolve_style` 只看 `master` buffer 保持语义一致。
+- What：移除 `exec_use_package` 对 `cur_file_name` 的引入与修改，本地包仅按相关 buffer 所在目录（`base_file_name`）及其父祖目录解析（限 default 根 buffer）。
+- Why：样式包从属于当前排版 buffer 的上下文环境，应当且仅当以相关 buffer 所在目录为基准解析本地包，不应该看当前执行文件（`cur_file_name`）。`cur_file_name` 在内核中专用于多部件文档的 `<include>` 标签（跟踪标签定义来源），在 `use-package` 中篡改 `cur_file_name` 概念不当；同时与 `resolve_style` 只看 `master` buffer 保持语义一致。
 - How：
   1. `local` 变量及相关判断移除，直接使用 `base_file_name` 解析本地包；
   2. 移除包体执行窗口对 `cur_file_name` 与 `secure` 的覆盖与还原逻辑。

--- a/src/Data/Document/new_style.cpp
+++ b/src/Data/Document/new_style.cpp
@@ -241,6 +241,12 @@ style_get_cache (tree style, hashmap<string, tree>& H, tree& t, bool& f) {
  * Get environment and drd of style files
  ******************************************************************************/
 
+// 样式环境计算脱离具体 buffer 时的兜底 base
+static url
+dummy_base_url () {
+  return url ("$PWD/none");
+}
+
 bool
 compute_env_and_drd (tree style, url master) {
   init_style_data ();
@@ -255,9 +261,9 @@ compute_env_and_drd (tree style, url master) {
   // cout << "Get environment of " << style << INDENT << LF;
   hashmap<string, tree> H;
   drd_info              drd ("none", std_drd);
-  // 样式环境计算脱离具体 buffer，base 取文档 master（缺省 $PWD/none），
+  // base 取文档 master（缺省 $PWD/none），
   // 使样式包内嵌套的 use-package 仍能按文档目录相对解析
-  url                   base= is_none (master) ? url ("$PWD/none") : master;
+  url                   base= is_none (master) ? dummy_base_url () : master;
   hashmap<string, tree> lref;
   hashmap<string, tree> gref;
   hashmap<string, tree> laux;
@@ -339,11 +345,11 @@ get_document_drd (tree doc) {
     style= tree (TUPLE, "generic");
   }
   // cout << "style= " << style << "\n";
-  drd_info drd= get_style_drd (style, url_none ());
+  drd_info drd= get_style_drd (style);
   tree     p  = get_document_preamble (doc);
   if (p != "") {
     drd                       = drd_info ("preamble", drd);
-    url                   none= url ("$PWD/none");
+    url                   none= dummy_base_url ();
     hashmap<string, tree> lref;
     hashmap<string, tree> gref;
     hashmap<string, tree> laux;

--- a/src/Data/Document/new_style.cpp
+++ b/src/Data/Document/new_style.cpp
@@ -242,7 +242,7 @@ style_get_cache (tree style, hashmap<string, tree>& H, tree& t, bool& f) {
  ******************************************************************************/
 
 bool
-compute_env_and_drd (tree style) {
+compute_env_and_drd (tree style, url master) {
   init_style_data ();
   ASSERT (is_tuple (style), "style tuple expected");
   bool busy= false;
@@ -255,14 +255,16 @@ compute_env_and_drd (tree style) {
   // cout << "Get environment of " << style << INDENT << LF;
   hashmap<string, tree> H;
   drd_info              drd ("none", std_drd);
-  url                   none= url ("$PWD/none");
+  // 样式环境计算脱离具体 buffer，base 取文档 master（缺省 $PWD/none），
+  // 使样式包内嵌套的 use-package 仍能按文档目录相对解析
+  url                   base= is_none (master) ? url ("$PWD/none") : master;
   hashmap<string, tree> lref;
   hashmap<string, tree> gref;
   hashmap<string, tree> laux;
   hashmap<string, tree> gaux;
   hashmap<string, tree> latt;
   hashmap<string, tree> gatt;
-  edit_env              env (drd, none, lref, gref, laux, gaux, latt, gatt);
+  edit_env              env (drd, base, lref, gref, laux, gaux, latt, gatt);
   if (!busy) {
     tree t;
     bool ok;
@@ -287,11 +289,11 @@ compute_env_and_drd (tree style) {
 }
 
 hashmap<string, tree>
-get_style_env (tree style) {
+get_style_env (tree style, url master) {
   // cout << "get_style_env " << style << "\n";
   init_style_data ();
   if (sd->style_cached->contains (style)) return sd->style_cached[style];
-  else if (compute_env_and_drd (style)) return sd->style_cached[style];
+  else if (compute_env_and_drd (style, master)) return sd->style_cached[style];
   else {
     // cout << "Busy style: " << style << "\n";
     return hashmap<string, tree> ();
@@ -299,12 +301,12 @@ get_style_env (tree style) {
 }
 
 drd_info
-get_style_drd (tree style) {
+get_style_drd (tree style, url master) {
   // cout << "get_style_drd " << style << "\n";
   init_style_data ();
   init_std_drd ();
   if (sd->drd_cached->contains (style)) return sd->drd_cached[style];
-  else if (compute_env_and_drd (style)) return sd->drd_cached[style];
+  else if (compute_env_and_drd (style, master)) return sd->drd_cached[style];
   else {
     // cout << "Busy drd: " << style << "\n";
     return std_drd;
@@ -337,7 +339,7 @@ get_document_drd (tree doc) {
     style= tree (TUPLE, "generic");
   }
   // cout << "style= " << style << "\n";
-  drd_info drd= get_style_drd (style);
+  drd_info drd= get_style_drd (style, url_none ());
   tree     p  = get_document_preamble (doc);
   if (p != "") {
     drd                       = drd_info ("preamble", drd);

--- a/src/Data/Document/new_style.hpp
+++ b/src/Data/Document/new_style.hpp
@@ -26,9 +26,9 @@ void style_invalidate_cache ();
 void style_set_cache (tree style, hashmap<string, tree> H, tree t);
 void style_get_cache (tree style, hashmap<string, tree>& H, tree& t, bool& f);
 
-bool                  compute_env_and_drd (tree style);
-hashmap<string, tree> get_style_env (tree style);
-drd_info              get_style_drd (tree style);
+bool                  compute_env_and_drd (tree style, url master);
+hashmap<string, tree> get_style_env (tree style, url master);
+drd_info              get_style_drd (tree style, url master);
 tree                  get_document_preamble (tree t);
 drd_info              get_document_drd (tree doc);
 

--- a/src/Data/Document/new_style.hpp
+++ b/src/Data/Document/new_style.hpp
@@ -26,9 +26,9 @@ void style_invalidate_cache ();
 void style_set_cache (tree style, hashmap<string, tree> H, tree t);
 void style_get_cache (tree style, hashmap<string, tree>& H, tree& t, bool& f);
 
-bool                  compute_env_and_drd (tree style, url master);
-hashmap<string, tree> get_style_env (tree style, url master);
-drd_info              get_style_drd (tree style, url master);
+bool                  compute_env_and_drd (tree style, url master= url_none ());
+hashmap<string, tree> get_style_env (tree style, url master= url_none ());
+drd_info              get_style_drd (tree style, url master= url_none ());
 tree                  get_document_preamble (tree t);
 drd_info              get_document_drd (tree doc);
 

--- a/src/Data/Tree/tree_analyze.cpp
+++ b/src/Data/Tree/tree_analyze.cpp
@@ -16,8 +16,6 @@
 using namespace moebius;
 using moebius::drd::the_drd;
 
-drd_info get_style_drd (tree style);
-
 /******************************************************************************
  * Tokenize mathematical concats and recomposition
  ******************************************************************************/

--- a/src/Edit/Editor/edit_typeset.cpp
+++ b/src/Edit/Editor/edit_typeset.cpp
@@ -344,8 +344,8 @@ edit_typeset_rep::typeset_style_use_cache (tree styles_orig) {
   if (!ok) {
     // cout << "Typeset without cache " << style << LF;
     if (!is_tuple (styles)) TM_FAILED ("tuple expected as style");
-    H  = get_style_env (styles);
-    drd= get_style_drd (styles);
+    H  = get_style_env (styles, buf->buf->master);
+    drd= get_style_drd (styles, buf->buf->master);
     style_set_cache (styles, H, drd->get_locals ());
     env->patch_env (H);
     drd->set_environment (H);

--- a/src/Texmacs/Window/tm_button.cpp
+++ b/src/Texmacs/Window/tm_button.cpp
@@ -60,8 +60,8 @@ initialize_environment (edit_env& env, tree doc, drd_info& drd) {
   }
   if (!ok) {
     if (!is_tuple (style)) TM_FAILED ("tuple expected as style");
-    H  = get_style_env (style);
-    drd= get_style_drd (style);
+    H  = get_style_env (style, url_none ());
+    drd= get_style_drd (style, url_none ());
     style_set_cache (style, H, drd->get_locals ());
     env->patch_env (H);
     drd->set_environment (H);

--- a/src/Texmacs/Window/tm_button.cpp
+++ b/src/Texmacs/Window/tm_button.cpp
@@ -60,8 +60,8 @@ initialize_environment (edit_env& env, tree doc, drd_info& drd) {
   }
   if (!ok) {
     if (!is_tuple (style)) TM_FAILED ("tuple expected as style");
-    H  = get_style_env (style, url_none ());
-    drd= get_style_drd (style, url_none ());
+    H  = get_style_env (style);
+    drd= get_style_drd (style);
     style_set_cache (style, H, drd->get_locals ());
     env->patch_env (H);
     drd->set_environment (H);


### PR DESCRIPTION
## What

1. 修正 devel/1296.md §9 限定条件：本地包解析对 default 根 buffer 一律按 buffer 所在目录及其父祖目录本地优先，不区分是否在 `$TEXMACS_PATH` 下
2. **修复 #4547 合入后仍渲染失败的根因**：样式宏环境经 `typeset_style_use_cache` → `get_style_env` → `compute_env_and_drd` 计算，临时 env 的 `base_file_name` 恒为 `$PWD/none`（当前工作目录），本地优先解析在样式包内嵌套 `use-package`（如 `ccnu_beamer.stem` 的 `(use-package "beamer/daxue_beamer")`）时必然 miss，`title-slide` 等宏缺失，且失败结果被磁盘样式缓存固化（`style_set_cache` 仅在缓存文件不存在时写入）

## How

- `compute_env_and_drd` / `get_style_env` / `get_style_drd` 增加 `url master` 参数，临时 env 的 base 取 `is_none (master) ? $PWD/none : master`
- `edit_typeset.cpp` 传 `buf->buf->master`；`tm_button.cpp`（无 buffer 上下文）与 `get_document_drd` 传 `url_none ()`
- 删除 `tree_analyze.cpp` 中 `get_style_drd` 的过期重复声明

## 验证

```bash
rm ~/.cache/MoganLab/2026.3.5/*.scm  # 清除失败结果固化的样式缓存
xmake r stem -c ~/git/liii-templates/stem/华中师范大学幻灯片模板.stem /tmp/x.pdf
```

首页 title-slide 封面渲染正确（修复前渲染为红色 `⟨title-slide⟩` 标记）；南方科技大学模板同法验证通过。

## 已知取舍

样式缓存 key 含解析后的样式绝对路径但不含 master，同一绝对路径样式被不同目录文档共享时，嵌套相对 `use-package` 的解析结果以首次计算为准；旧版本写入的坏缓存需手动清理（缓存目录按版本号隔离，发版即自然失效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)